### PR TITLE
fix regex for allowed variable to support spaces

### DIFF
--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"log"
 	"os"
 	"path/filepath"
 	yaml_v2 "sigs.k8s.io/yaml"
@@ -108,7 +107,6 @@ func PolicyHasNonAllowedVariables(policy v1.ClusterPolicy) bool {
 			}
 		}
 
-		log.Printf("matches all %v, matches allowed %v %v", matchesAll, ALLOWED_VARIABLES, matchesAllowed)
 		return true
 	}
 

--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -7,13 +7,11 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"log"
+	"os"
+	"path/filepath"
 	yaml_v2 "sigs.k8s.io/yaml"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -91,29 +89,29 @@ func GetPoliciesValidation(policyPaths []string) ([]*v1.ClusterPolicy, error) {
 // PolicyHasVariables - check for variables in the policy
 func PolicyHasVariables(policy v1.ClusterPolicy) bool {
 	policyRaw, _ := json.Marshal(policy)
-	regex := regexp.MustCompile(`\{\{[^{}]*\}\}`)
-	return len(regex.FindAllStringSubmatch(string(policyRaw), -1)) > 0
+	matches := REGEX_VARIABLES.FindAllStringSubmatch(string(policyRaw), -1)
+	return len(matches) > 0
 }
 
-// PolicyHasNonAllowedVariables - checks for non whitelisted variables in the policy
+// PolicyHasNonAllowedVariables - checks for unexpected variables in the policy
 func PolicyHasNonAllowedVariables(policy v1.ClusterPolicy) bool {
 	policyRaw, _ := json.Marshal(policy)
 
-	allVarsRegex := regexp.MustCompile(`\{\{[^{}]*\}\}`)
+	matchesAll := REGEX_VARIABLES.FindAllStringSubmatch(string(policyRaw), -1)
+	matchesAllowed := ALLOWED_VARIABLES.FindAllStringSubmatch(string(policyRaw), -1)
 
-	allowedList := []string{`request\.`, `serviceAccountName`, `serviceAccountNamespace`}
-	regexStr := `\{\{(` + strings.Join(allowedList, "|") + `)[^{}]*\}\}`
-	matchedVarsRegex := regexp.MustCompile(regexStr)
-
-	if len(allVarsRegex.FindAllStringSubmatch(string(policyRaw), -1)) > len(matchedVarsRegex.FindAllStringSubmatch(string(policyRaw), -1)) {
+	if len(matchesAll) > len(matchesAllowed) {
 		// If rules contains Context then skip this validation
 		for _, rule := range policy.Spec.Rules {
 			if len(rule.Context) > 0 {
 				return false
 			}
 		}
+
+		log.Printf("matches all %v, matches allowed %v %v", matchesAll, ALLOWED_VARIABLES, matchesAllowed)
 		return true
 	}
+
 	return false
 }
 

--- a/pkg/kyverno/common/regex.go
+++ b/pkg/kyverno/common/regex.go
@@ -1,0 +1,12 @@
+package common
+
+import (
+	"regexp"
+	"strings"
+)
+
+var REGEX_VARIABLES = regexp.MustCompile(`\{\{[^{}]*\}\}`)
+
+var allowedList = []string{`request\..*`, `serviceAccountName`, `serviceAccountNamespace`}
+var regexStr = `\{\{\s*(` + strings.Join(allowedList, "|") + `)[^{}]\s*\}\}`
+var ALLOWED_VARIABLES = regexp.MustCompile(regexStr)

--- a/pkg/kyverno/common/regex.go
+++ b/pkg/kyverno/common/regex.go
@@ -2,11 +2,7 @@ package common
 
 import (
 	"regexp"
-	"strings"
 )
 
 var REGEX_VARIABLES = regexp.MustCompile(`\{\{[^{}]*\}\}`)
-
-var allowedList = []string{`request\..*`, `serviceAccountName`, `serviceAccountNamespace`}
-var regexStr = `\{\{\s*(` + strings.Join(allowedList, "|") + `)[^{}]\s*\}\}`
-var ALLOWED_VARIABLES = regexp.MustCompile(regexStr)
+var ALLOWED_VARIABLES = regexp.MustCompile(`\{\{\s*[request\.|serviceAccountName|serviceAccountNamespace][^{}]*\}\}`)

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -36,7 +36,7 @@ func Validate(policyRaw []byte, client *dclient.Client, mock bool, openAPIContro
 	}
 
 	if common.PolicyHasVariables(p) && common.PolicyHasNonAllowedVariables(p) {
-		return fmt.Errorf("policy contains reserved variables (serviceAccountName, serviceAccountNamespace)")
+		return fmt.Errorf("policy contains unknown variables")
 	}
 
 	if path, err := validateUniqueRuleName(p); err != nil {
@@ -458,7 +458,7 @@ func validateRuleContext(rule kyverno.Rule) (error) {
 		if entry.Name == ""{
 			return fmt.Errorf("a name is required for context entries")
 		}
-		
+
 		if entry.ConfigMap != nil {
 			if entry.ConfigMap.Name == "" {
 				return fmt.Errorf("a name is required for configMap context entry")


### PR DESCRIPTION
Policy with variable declaration with spaces was not allowed:

```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: add-service-annotation
spec:
  background: false
  rules:
  - name: add-annotation
    match:
      resources: 
        kinds:
        - Service
    preconditions:
    - key: "{{ request.object.spec.type }}"
      operator: Equal
      value: LoadBalancer
    mutate:
      overlay:
        metadata:
          labels:
            +(service/loadbalancer): "true"
```

Resource:

```
apiVersion: v1
kind: Service
metadata:
  name: example-service
spec:
  selector:
    app: example
  ports:
    - port: 8765
      targetPort: 9376
  type: LoadBalancer
```

Resulting error:

```
λ kubectl-kyverno apply C:\tmp\kyverno\policies\add_label_to_loadbalancer.yaml -r C:\tmp\kyverno\service-example.yaml

applying 1 policy to 1 resource
skipping policy add-service-annotation as it is not valid: policy contains unknown variables

pass: 0, fail: 0, warn: 0, error: 0, skip: 1
```



