### PR TITLE
Print validationFailureAction with kubectl get

### DIFF
--- a/charts/kyverno/crds/crds.yaml
+++ b/charts/kyverno/crds/crds.yaml
@@ -10,8 +10,8 @@ spec:
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
-    description: ValidationFailureAction provides choice to enforce rules to resources
-      during policy application.
+    description: ValidationFailureAction controls if a policy failure should disallow
+      (enforce) or allow and report (audit) the admission review request.
     name: Validation Failure Action
     type: string
   group: kyverno.io
@@ -432,8 +432,8 @@ spec:
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
-    description: ValidationFailureAction controls if a policy failure should not disallow
-      an admission review request (enforce), or allow (audit) and report an error.
+    description: ValidationFailureAction controls if a policy failure should disallow
+      (enforce) or allow and report (audit) the admission review request.
     name: Validation Failure Action
     type: string
   group: kyverno.io

--- a/charts/kyverno/crds/crds.yaml
+++ b/charts/kyverno/crds/crds.yaml
@@ -5,13 +5,14 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.background
-    description: Background provides choice for applying rules to existing resources.
+    description: Background controls if rules are applied to existing resources during
+      a background scan.
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
     description: ValidationFailureAction provides choice to enforce rules to resources
       during policy application.
-    name: Validation FailureAction
+    name: Validation Failure Action
     type: string
   group: kyverno.io
   names:
@@ -426,13 +427,14 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.background
-    description: Background provides choice for applying rules to existing resources.
+    description: Background controls if rules are applied to existing resources during
+      a background scan.
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
-    description: ValidationFailureAction provides choice to enforce rules to resources
-      during policy application.
-    name: Validation FailureAction
+    description: ValidationFailureAction controls if a policy failure should not disallow
+      an admission review request (enforce), or allow (audit) and report an error.
+    name: Validation Failure Action
     type: string
   group: kyverno.io
   names:

--- a/charts/kyverno/crds/crds.yaml
+++ b/charts/kyverno/crds/crds.yaml
@@ -3,6 +3,16 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterpolicies.kyverno.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.background
+    description: Background provides choice for applying rules to existing resources.
+    name: Background
+    type: string
+  - JSONPath: .spec.validationFailureAction
+    description: ValidationFailureAction provides choice to enforce rules to resources
+      during policy application.
+    name: Validation FailureAction
+    type: string
   group: kyverno.io
   names:
     kind: ClusterPolicy
@@ -414,6 +424,16 @@ kind: CustomResourceDefinition
 metadata:
   name: policies.kyverno.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.background
+    description: Background provides choice for applying rules to existing resources.
+    name: Background
+    type: string
+  - JSONPath: .spec.validationFailureAction
+    description: ValidationFailureAction provides choice to enforce rules to resources
+      during policy application.
+    name: Validation FailureAction
+    type: string
   group: kyverno.io
   names:
     kind: Policy

--- a/definitions/crds/crds.yaml
+++ b/definitions/crds/crds.yaml
@@ -3,6 +3,15 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterpolicies.kyverno.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.background
+    description: Background provides choice for applying rules to existing resources.
+    name: Background
+    type: string
+  - JSONPath: .spec.validationFailureAction
+    description: ValidationFailureAction provides choice to enforce rules to resources during policy application.
+    name: Validation FailureAction
+    type: string
   group: kyverno.io
   versions:
     - name: v1
@@ -277,6 +286,15 @@ kind: CustomResourceDefinition
 metadata:
   name: policies.kyverno.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.background
+    description: Background provides choice for applying rules to existing resources.
+    name: Background
+    type: string
+  - JSONPath: .spec.validationFailureAction
+    description: ValidationFailureAction provides choice to enforce rules to resources during policy application.
+    name: Validation FailureAction
+    type: string
   group: kyverno.io
   versions:
     - name: v1

--- a/definitions/crds/crds.yaml
+++ b/definitions/crds/crds.yaml
@@ -9,7 +9,7 @@ spec:
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
-    description: ValidationFailureAction provides choice to enforce rules to resources during policy application.
+    description: ValidationFailureAction controls if a policy failure should disallow (enforce) or allow and report (audit) the admission review request.
     name: Validation Failure Action
     type: string
   group: kyverno.io
@@ -292,7 +292,7 @@ spec:
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
-    description: ValidationFailureAction controls if a policy failure should not disallow an admission review request (enforce), or allow (audit) and report an error.
+    description: ValidationFailureAction controls if a policy failure should disallow (enforce) or allow and report (audit) the admission review request.
     name: Validation Failure Action
     type: string
   group: kyverno.io

--- a/definitions/crds/crds.yaml
+++ b/definitions/crds/crds.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.background
-    description: Background provides choice for applying rules to existing resources.
+    description: Background controls if rules are applied to existing resources during a background scan.
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
     description: ValidationFailureAction provides choice to enforce rules to resources during policy application.
-    name: Validation FailureAction
+    name: Validation Failure Action
     type: string
   group: kyverno.io
   versions:
@@ -288,12 +288,12 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.background
-    description: Background provides choice for applying rules to existing resources.
+    description: Background controls if rules are applied to existing resources during a background scan.
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
-    description: ValidationFailureAction provides choice to enforce rules to resources during policy application.
-    name: Validation FailureAction
+    description: ValidationFailureAction controls if a policy failure should not disallow an admission review request (enforce), or allow (audit) and report an error.
+    name: Validation Failure Action
     type: string
   group: kyverno.io
   versions:

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -9,14 +9,15 @@ metadata:
   name: clusterpolicies.kyverno.io
 spec:
   additionalPrinterColumns:
+  - JSONPath: .spec.background
+    description: Background controls if rules are applied to existing resources during
+      a background scan.
+    name: Background
+    type: string
   - JSONPath: .spec.validationFailureAction
     description: ValidationFailureAction provides choice to enforce rules to resources
       during policy application.
-    name: Validation FailureAction
-    type: string
-  - JSONPath: .spec.background
-    description: Background provides choice for applying rules to existing resources.
-    name: Background
+    name: Validation Failure Action
     type: string
   group: kyverno.io
   names:
@@ -430,14 +431,15 @@ metadata:
   name: policies.kyverno.io
 spec:
   additionalPrinterColumns:
-  - JSONPath: .spec.validationFailureAction
-    description: ValidationFailureAction provides choice to enforce rules to resources
-      during policy application.
-    name: Validation FailureAction
-    type: string
   - JSONPath: .spec.background
-    description: Background provides choice for applying rules to existing resources.
+    description: Background controls if rules are applied to existing resources during
+      a background scan.
     name: Background
+    type: string
+  - JSONPath: .spec.validationFailureAction
+    description: ValidationFailureAction controls if a policy failure should not disallow
+      an admission review request (enforce), or allow (audit) and report an error.
+    name: Validation Failure Action
     type: string
   group: kyverno.io
   names:

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -8,6 +8,16 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterpolicies.kyverno.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.validationFailureAction
+    description: ValidationFailureAction provides choice to enforce rules to resources
+      during policy application.
+    name: Validation FailureAction
+    type: string
+  - JSONPath: .spec.background
+    description: Background provides choice for applying rules to existing resources.
+    name: Background
+    type: string
   group: kyverno.io
   names:
     kind: ClusterPolicy
@@ -419,6 +429,16 @@ kind: CustomResourceDefinition
 metadata:
   name: policies.kyverno.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.validationFailureAction
+    description: ValidationFailureAction provides choice to enforce rules to resources
+      during policy application.
+    name: Validation FailureAction
+    type: string
+  - JSONPath: .spec.background
+    description: Background provides choice for applying rules to existing resources.
+    name: Background
+    type: string
   group: kyverno.io
   names:
     kind: Policy

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -15,8 +15,8 @@ spec:
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
-    description: ValidationFailureAction provides choice to enforce rules to resources
-      during policy application.
+    description: ValidationFailureAction controls if a policy failure should disallow
+      (enforce) or allow and report (audit) the admission review request.
     name: Validation Failure Action
     type: string
   group: kyverno.io
@@ -437,8 +437,8 @@ spec:
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
-    description: ValidationFailureAction controls if a policy failure should not disallow
-      an admission review request (enforce), or allow (audit) and report an error.
+    description: ValidationFailureAction controls if a policy failure should disallow
+      (enforce) or allow and report (audit) the admission review request.
     name: Validation Failure Action
     type: string
   group: kyverno.io

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -8,6 +8,16 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterpolicies.kyverno.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.background
+    description: Background provides choice for applying rules to existing resources.
+    name: Background
+    type: string
+  - JSONPath: .spec.validationFailureAction
+    description: ValidationFailureAction provides choice to enforce rules to resources
+      during policy application.
+    name: Validation FailureAction
+    type: string
   group: kyverno.io
   names:
     kind: ClusterPolicy
@@ -419,6 +429,16 @@ kind: CustomResourceDefinition
 metadata:
   name: policies.kyverno.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.background
+    description: Background provides choice for applying rules to existing resources.
+    name: Background
+    type: string
+  - JSONPath: .spec.validationFailureAction
+    description: ValidationFailureAction provides choice to enforce rules to resources
+      during policy application.
+    name: Validation FailureAction
+    type: string
   group: kyverno.io
   names:
     kind: Policy

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -10,13 +10,14 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.background
-    description: Background provides choice for applying rules to existing resources.
+    description: Background controls if rules are applied to existing resources during
+      a background scan.
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
     description: ValidationFailureAction provides choice to enforce rules to resources
       during policy application.
-    name: Validation FailureAction
+    name: Validation Failure Action
     type: string
   group: kyverno.io
   names:
@@ -431,13 +432,14 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.background
-    description: Background provides choice for applying rules to existing resources.
+    description: Background controls if rules are applied to existing resources during
+      a background scan.
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
-    description: ValidationFailureAction provides choice to enforce rules to resources
-      during policy application.
-    name: Validation FailureAction
+    description: ValidationFailureAction controls if a policy failure should not disallow
+      an admission review request (enforce), or allow (audit) and report an error.
+    name: Validation Failure Action
     type: string
   group: kyverno.io
   names:

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -15,8 +15,8 @@ spec:
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
-    description: ValidationFailureAction provides choice to enforce rules to resources
-      during policy application.
+    description: ValidationFailureAction controls if a policy failure should disallow
+      (enforce) or allow and report (audit) the admission review request.
     name: Validation Failure Action
     type: string
   group: kyverno.io
@@ -437,8 +437,8 @@ spec:
     name: Background
     type: string
   - JSONPath: .spec.validationFailureAction
-    description: ValidationFailureAction controls if a policy failure should not disallow
-      an admission review request (enforce), or allow (audit) and report an error.
+    description: ValidationFailureAction controls if a policy failure should disallow
+      (enforce) or allow and report (audit) the admission review request.
     name: Validation Failure Action
     type: string
   group: kyverno.io

--- a/pkg/api/kyverno/v1/types.go
+++ b/pkg/api/kyverno/v1/types.go
@@ -148,10 +148,11 @@ type Policy struct {
 type Spec struct {
 	// Rules contains the list of rules to be applied to resources
 	Rules []Rule `json:"rules,omitempty" yaml:"rules,omitempty"`
-	// ValidationFailureAction provides choice to enforce rules to resources during policy application.
+	// ValidationFailureAction controls if a policy failure should not disallow
+	// an admission review request (enforce), or allow (audit) and report an error.
 	// Default value is "audit".
 	ValidationFailureAction string `json:"validationFailureAction,omitempty" yaml:"validationFailureAction,omitempty"`
-	// Background provides choice for applying rules to existing resources.
+	// Background controls if rules are applied to existing resources during a background scan.
 	// Default value is "true".
 	Background *bool `json:"background,omitempty" yaml:"background,omitempty"`
 }

--- a/pkg/api/kyverno/v1/types.go
+++ b/pkg/api/kyverno/v1/types.go
@@ -148,7 +148,7 @@ type Policy struct {
 type Spec struct {
 	// Rules contains the list of rules to be applied to resources
 	Rules []Rule `json:"rules,omitempty" yaml:"rules,omitempty"`
-	// ValidationFailureAction provides choice to enforce rules to resources during policy violations.
+	// ValidationFailureAction provides choice to enforce rules to resources during policy application.
 	// Default value is "audit".
 	ValidationFailureAction string `json:"validationFailureAction,omitempty" yaml:"validationFailureAction,omitempty"`
 	// Background provides choice for applying rules to existing resources.
@@ -193,7 +193,7 @@ type Rule struct {
 }
 
 type ContextEntry struct {
-	Name      string             `json:"name,omitempty" yaml:"name,omitempty"`
+	Name      string              `json:"name,omitempty" yaml:"name,omitempty"`
 	ConfigMap *ConfigMapReference `json:"configMap,omitempty" yaml:"configMap,omitempty"`
 }
 


### PR DESCRIPTION
Fixes #1220 .

Added `validationFailureAction` and `background` to kubectl additional printer columns.
```
$ kubectl get cpol

NAME             BACKGROUND   VALIDATION FAILURE ACTION
require-labels   true         audit
test-policy-1    false        audit
```
