### PR TITLE
adds cpu limit to pod requests limits example

### DIFF
--- a/samples/RequirePodRequestsLimits.md
+++ b/samples/RequirePodRequestsLimits.md
@@ -1,6 +1,6 @@
 # Require pod resource requests and limits
 
-Application workloads share cluster resources. Hence, it is important to manage resources assigned to each pod.  It is recommended that `resources.requests` and `resources.limits` are configured per pod and include CPU and memory resources. Other resources such as GPUs may also be specified as needed.
+Application workloads share cluster resources. Hence, it is important to manage resources assigned to each pod.  It is recommended that `resources.requests.cpu`, `resources.requests.memory` and `resources.limits.memory` are configured per pod. Other resources such as GPUs may also be specified as needed.
 
 If a namespace level request or limit is specified, defaults will automatically be applied to each pod based on the `LimitRange` configuration.
 

--- a/samples/best_practices/require_pod_requests_limits.yaml
+++ b/samples/best_practices/require_pod_requests_limits.yaml
@@ -6,7 +6,7 @@ metadata:
     policies.kyverno.io/category: Workload Management
     policies.kyverno.io/description: As application workloads share cluster resources, it is important 
       to limit resources requested and consumed by each pod. It is recommended to require 
-      'resources.requests' and 'resources.limits' per pod. If a namespace level request or limit is 
+      'resources.requests' and 'resources.limits.memory' per pod. If a namespace level request or limit is 
       specified, defaults will automatically be applied to each pod based on the 'LimitRange' configuration.
 spec:
   validationFailureAction: audit


### PR DESCRIPTION
## Related issue

none, just saw the key/value missing and wanted to contribute a fix.

**What type of PR is this?**
/kind documentation


## Proposed changes

The example for requests and limits on pods was missing a check for cpu limits existence. I added they key/value pair just like the one for memory limits.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](documentation/).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
