### PR TITLE
1398 - Reduce RCR throttling requests

### DIFF
--- a/charts/kyverno/crds/crds.yaml
+++ b/charts/kyverno/crds/crds.yaml
@@ -224,9 +224,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specified the source resource used to
-                            populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -236,9 +237,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource manifest to used
-                            to populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -251,7 +253,10 @@ spec:
                           type: string
                         synchronize:
                           description: Synchronize controls if generated resources
-                            should be kept in-sync with their source resource. Optional.
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
                             Defaults to "false" if not specified.
                           type: boolean
                       type: object
@@ -959,6 +964,8 @@ spec:
     kind: ClusterReportChangeRequest
     listKind: ClusterReportChangeRequestList
     plural: clusterreportchangerequests
+    shortNames:
+    - crcr
     singular: clusterreportchangerequest
   scope: Cluster
   versions:
@@ -1688,9 +1695,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specified the source resource used to
-                            populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -1700,9 +1708,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource manifest to used
-                            to populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -1715,7 +1724,10 @@ spec:
                           type: string
                         synchronize:
                           description: Synchronize controls if generated resources
-                            should be kept in-sync with their source resource. Optional.
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
                             Defaults to "false" if not specified.
                           type: boolean
                       type: object

--- a/cmd/initContainer/main.go
+++ b/cmd/initContainer/main.go
@@ -308,12 +308,10 @@ func removeReportChangeRequest(client *client.Client, kind string) error {
 		return nil
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(len(rcrList.Items))
 	for _, rcr := range rcrList.Items {
-		go deleteResource(client, rcr.GetAPIVersion(), rcr.GetKind(), rcr.GetNamespace(), rcr.GetName(), &wg)
+		deleteResource(client, rcr.GetAPIVersion(), rcr.GetKind(), rcr.GetNamespace(), rcr.GetName(), nil)
 	}
-	wg.Wait()
+
 	return nil
 }
 

--- a/definitions/crds/kyverno.io_clusterpolicies.yaml
+++ b/definitions/crds/kyverno.io_clusterpolicies.yaml
@@ -226,9 +226,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specified the source resource used to
-                            populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -238,9 +239,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource manifest to used
-                            to populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -253,7 +255,10 @@ spec:
                           type: string
                         synchronize:
                           description: Synchronize controls if generated resources
-                            should be kept in-sync with their source resource. Optional.
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
                             Defaults to "false" if not specified.
                           type: boolean
                       type: object

--- a/definitions/crds/kyverno.io_clusterreportchangerequests.yaml
+++ b/definitions/crds/kyverno.io_clusterreportchangerequests.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ClusterReportChangeRequest
     listKind: ClusterReportChangeRequestList
     plural: clusterreportchangerequests
+    shortNames:
+    - crcr
     singular: clusterreportchangerequest
   scope: Cluster
   versions:

--- a/definitions/crds/kyverno.io_policies.yaml
+++ b/definitions/crds/kyverno.io_policies.yaml
@@ -227,9 +227,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specified the source resource used to
-                            populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -239,9 +240,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource manifest to used
-                            to populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -254,7 +256,10 @@ spec:
                           type: string
                         synchronize:
                           description: Synchronize controls if generated resources
-                            should be kept in-sync with their source resource. Optional.
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
                             Defaults to "false" if not specified.
                           type: boolean
                       type: object

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -229,9 +229,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specified the source resource used to
-                            populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -241,9 +242,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource manifest to used
-                            to populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -256,7 +258,10 @@ spec:
                           type: string
                         synchronize:
                           description: Synchronize controls if generated resources
-                            should be kept in-sync with their source resource. Optional.
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
                             Defaults to "false" if not specified.
                           type: boolean
                       type: object
@@ -964,6 +969,8 @@ spec:
     kind: ClusterReportChangeRequest
     listKind: ClusterReportChangeRequestList
     plural: clusterreportchangerequests
+    shortNames:
+    - crcr
     singular: clusterreportchangerequest
   scope: Cluster
   versions:
@@ -1693,9 +1700,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specified the source resource used to
-                            populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -1705,9 +1713,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource manifest to used
-                            to populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -1720,7 +1729,10 @@ spec:
                           type: string
                         synchronize:
                           description: Synchronize controls if generated resources
-                            should be kept in-sync with their source resource. Optional.
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
                             Defaults to "false" if not specified.
                           type: boolean
                       type: object

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -229,9 +229,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specified the source resource used to
-                            populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -241,9 +242,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource manifest to used
-                            to populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -256,7 +258,10 @@ spec:
                           type: string
                         synchronize:
                           description: Synchronize controls if generated resources
-                            should be kept in-sync with their source resource. Optional.
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
                             Defaults to "false" if not specified.
                           type: boolean
                       type: object
@@ -964,6 +969,8 @@ spec:
     kind: ClusterReportChangeRequest
     listKind: ClusterReportChangeRequestList
     plural: clusterreportchangerequests
+    shortNames:
+    - crcr
     singular: clusterreportchangerequest
   scope: Cluster
   versions:
@@ -1693,9 +1700,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specified the source resource used to
-                            populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -1705,9 +1713,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource manifest to used
-                            to populate each generated resource. Exactly one of Data
-                            or Clone must be specified.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -1720,7 +1729,10 @@ spec:
                           type: string
                         synchronize:
                           description: Synchronize controls if generated resources
-                            should be kept in-sync with their source resource. Optional.
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
                             Defaults to "false" if not specified.
                           type: boolean
                       type: object

--- a/pkg/api/kyverno/v1alpha1/clusterreportchangerequest_types.go
+++ b/pkg/api/kyverno/v1alpha1/clusterreportchangerequest_types.go
@@ -30,7 +30,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=clusterreportchangerequests
+// +kubebuilder:resource:path=clusterreportchangerequests,scope="Cluster",shortName=crcr
 // +kubebuilder:printcolumn:name="Kind",type=string,JSONPath=`.scope.kind`,priority=1
 // +kubebuilder:printcolumn:name="Name",type=string,JSONPath=`.scope.name`,priority=1
 // +kubebuilder:printcolumn:name="Pass",type=integer,JSONPath=`.summary.pass`
@@ -39,8 +39,6 @@ import (
 // +kubebuilder:printcolumn:name="Error",type=integer,JSONPath=`.summary.error`
 // +kubebuilder:printcolumn:name="Skip",type=integer,JSONPath=`.summary.skip`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:shortName=crcr
-// +kubebuilder:resource:scope=Cluster
 type ClusterReportChangeRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/config/dynamicconfig.go
+++ b/pkg/config/dynamicconfig.go
@@ -42,6 +42,13 @@ func (cd *ConfigData) ToFilter(kind, namespace, name string) bool {
 		if wildcard.Match(f.Kind, kind) && wildcard.Match(f.Namespace, namespace) && wildcard.Match(f.Name, name) {
 			return true
 		}
+
+		if kind == "Namespace" {
+			// [Namespace,kube-system,*] || [*,kube-system,*]
+			if (f.Kind == "Namespace" || f.Kind == "*") && wildcard.Match(f.Namespace, name) {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/pkg/engine/response/response.go
+++ b/pkg/engine/response/response.go
@@ -31,11 +31,14 @@ type PolicyResponse struct {
 
 //ResourceSpec resource action applied on
 type ResourceSpec struct {
-	//TODO: support ApiVersion
 	Kind       string `json:"kind"`
 	APIVersion string `json:"apiVersion"`
 	Namespace  string `json:"namespace"`
 	Name       string `json:"name"`
+
+	// UID is not used to build the unique identifier
+	// optional
+	UID string `json:"uid"`
 }
 
 //GetKey returns the key
@@ -108,6 +111,17 @@ func (er EngineResponse) GetFailedRules() []string {
 //GetSuccessRules returns success rules
 func (er EngineResponse) GetSuccessRules() []string {
 	return er.getRules(true)
+}
+
+// GetResourceSpec returns resourceSpec of er
+func (er EngineResponse) GetResourceSpec() ResourceSpec {
+	return ResourceSpec{
+		Kind:       er.PatchedResource.GetKind(),
+		APIVersion: er.PatchedResource.GetAPIVersion(),
+		Namespace:  er.PatchedResource.GetNamespace(),
+		Name:       er.PatchedResource.GetName(),
+		UID:        string(er.PatchedResource.GetUID()),
+	}
 }
 
 func (er EngineResponse) getRules(success bool) []string {

--- a/pkg/engine/response/response.go
+++ b/pkg/engine/response/response.go
@@ -54,7 +54,7 @@ type PolicyStats struct {
 	RulesAppliedCount int `json:"rulesAppliedCount"`
 }
 
-//RuleResponse details for each rule applicatino
+//RuleResponse details for each rule application
 type RuleResponse struct {
 	// rule name specified in policy
 	Name string `json:"name"`

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -32,7 +32,7 @@ func (c *Controller) processGR(gr *kyverno.GenerateRequest) error {
 	// 1 - Check if the resource exists
 	resource, err = getResource(c.client, gr.Spec.Resource)
 	if err != nil {
-		// Dont update status
+		// Don't update status
 		logger.V(3).Info("resource does not exist or is pending creation, re-queueing", "details", err.Error())
 		return err
 	}

--- a/pkg/kyverno/apply/report.go
+++ b/pkg/kyverno/apply/report.go
@@ -44,7 +44,7 @@ func buildPolicyReports(resps []response.EngineResponse, skippedPolicies []Skipp
 			}
 
 			if raw, err = json.Marshal(report); err != nil {
-				log.Log.V(3).Info("failed to serilize policy report", "error", err)
+				log.Log.V(3).Info("failed to serialize policy report", "error", err)
 				continue
 			}
 
@@ -72,7 +72,7 @@ func buildPolicyReports(resps []response.EngineResponse, skippedPolicies []Skipp
 
 			report.SetName(scope)
 			if raw, err = json.Marshal(report); err != nil {
-				log.Log.V(3).Info("failed to serilize policy report", "name", report.Name, "scope", scope, "error", err)
+				log.Log.V(3).Info("failed to serialize policy report", "name", report.Name, "scope", scope, "error", err)
 			}
 		} else {
 			report := &report.PolicyReport{
@@ -89,7 +89,7 @@ func buildPolicyReports(resps []response.EngineResponse, skippedPolicies []Skipp
 			report.SetNamespace(ns)
 
 			if raw, err = json.Marshal(report); err != nil {
-				log.Log.V(3).Info("failed to serilize policy report", "name", report.Name, "scope", scope, "error", err)
+				log.Log.V(3).Info("failed to serialize policy report", "name", report.Name, "scope", scope, "error", err)
 			}
 		}
 

--- a/pkg/kyverno/apply/report_test.go
+++ b/pkg/kyverno/apply/report_test.go
@@ -8,6 +8,7 @@ import (
 	report "github.com/kyverno/kyverno/pkg/api/policyreport/v1alpha1"
 	"github.com/kyverno/kyverno/pkg/common"
 	"github.com/kyverno/kyverno/pkg/engine/response"
+	"github.com/kyverno/kyverno/pkg/engine/utils"
 	"gotest.tools/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -30,10 +31,12 @@ var engineResponses = []response.EngineResponse{
 			Rules: []response.RuleResponse{
 				{
 					Name:    "policy1-rule1",
+					Type:    utils.Validation.String(),
 					Success: true,
 				},
 				{
 					Name:    "policy1-rule2",
+					Type:    utils.Validation.String(),
 					Success: false,
 				},
 			},
@@ -54,10 +57,12 @@ var engineResponses = []response.EngineResponse{
 			Rules: []response.RuleResponse{
 				{
 					Name:    "clusterpolicy2-rule1",
+					Type:    utils.Validation.String(),
 					Success: true,
 				},
 				{
 					Name:    "clusterpolicy2-rule2",
+					Type:    utils.Validation.String(),
 					Success: false,
 				},
 			},

--- a/pkg/policy/common.go
+++ b/pkg/policy/common.go
@@ -92,7 +92,7 @@ func ExcludePod(resourceMap map[string]unstructured.Unstructured, log logr.Logge
 	return resourceMap
 }
 
-// GetNamespacesForRule gets the matched namespacse list for the given rule
+// GetNamespacesForRule gets the matched namespaces list for the given rule
 func GetNamespacesForRule(rule *kyverno.Rule, nslister listerv1.NamespaceLister, log logr.Logger) []string {
 	if len(rule.MatchResources.Namespaces) == 0 {
 		return GetAllNamespaces(nslister, log)

--- a/pkg/policy/common.go
+++ b/pkg/policy/common.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-logr/logr"
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/config"
-	client "github.com/kyverno/kyverno/pkg/dclient"
 	"github.com/kyverno/kyverno/pkg/utils"
 	"github.com/minio/minio/pkg/wildcard"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -160,7 +159,7 @@ func GetAllNamespaces(nslister listerv1.NamespaceLister, log logr.Logger) []stri
 }
 
 // GetResourcesPerNamespace ...
-func GetResourcesPerNamespace(kind string, client *client.Client, namespace string, rule kyverno.Rule, configHandler config.Interface, log logr.Logger) map[string]unstructured.Unstructured {
+func (pc *PolicyController) getResourcesPerNamespace(kind string, namespace string, rule kyverno.Rule, log logr.Logger) map[string]unstructured.Unstructured {
 	resourceMap := map[string]unstructured.Unstructured{}
 	ls := rule.MatchResources.Selector
 
@@ -168,7 +167,7 @@ func GetResourcesPerNamespace(kind string, client *client.Client, namespace stri
 		namespace = ""
 	}
 
-	list, err := client.ListResource("", kind, namespace, ls)
+	list, err := pc.client.ListResource("", kind, namespace, ls)
 	if err != nil {
 		log.Error(err, "failed to list resources", "kind", kind, "namespace", namespace)
 		return nil
@@ -192,7 +191,7 @@ func GetResourcesPerNamespace(kind string, client *client.Client, namespace stri
 			}
 		}
 		// Skip the filtered resources
-		if configHandler.ToFilter(r.GetKind(), r.GetNamespace(), r.GetName()) {
+		if pc.configHandler.ToFilter(r.GetKind(), r.GetNamespace(), r.GetName()) {
 			continue
 		}
 
@@ -202,12 +201,12 @@ func GetResourcesPerNamespace(kind string, client *client.Client, namespace stri
 
 	// exclude the resources
 	// skip resources to be filtered
-	ExcludeResources(resourceMap, rule.ExcludeResources.ResourceDescription, configHandler, log)
+	excludeResources(resourceMap, rule.ExcludeResources.ResourceDescription, pc.configHandler, log)
 	return resourceMap
 }
 
 // ExcludeResources ...
-func ExcludeResources(included map[string]unstructured.Unstructured, exclude kyverno.ResourceDescription, configHandler config.Interface, log logr.Logger) {
+func excludeResources(included map[string]unstructured.Unstructured, exclude kyverno.ResourceDescription, configHandler config.Interface, log logr.Logger) {
 	if reflect.DeepEqual(exclude, (kyverno.ResourceDescription{})) {
 		return
 	}
@@ -270,7 +269,7 @@ func ExcludeResources(included map[string]unstructured.Unstructured, exclude kyv
 
 	// check exclude condition for each resource
 	for uid, resource := range included {
-		// 0 -> dont check
+		// 0 -> don't check
 		// 1 -> is not to be exclude
 		// 2 -> to be exclude
 		excludeEval := []Condition{}

--- a/pkg/policy/report.go
+++ b/pkg/policy/report.go
@@ -19,7 +19,7 @@ func (pc *PolicyController) report(policy string, engineResponses []response.Eng
 	// we can merge pvInfos into a single object to reduce update frequency (throttling request) on RCR
 	info := mergePvInfos(pvInfos)
 	pc.prGenerator.Add(info)
-	logger.V(4).Info("added a request RCR generator", "key", info.ToKey())
+	logger.V(4).Info("added a request to RCR generator", "key", info.ToKey())
 }
 
 func generateEvents(log logr.Logger, ers []response.EngineResponse) []event.Info {

--- a/pkg/policy/report.go
+++ b/pkg/policy/report.go
@@ -9,9 +9,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/policyreport"
 )
 
-func (pc *PolicyController) report(policy string, engineResponses []response.EngineResponse) {
-	logger := pc.log.WithValues("policy", policy)
-
+func (pc *PolicyController) report(policy string, engineResponses []response.EngineResponse, logger logr.Logger) {
 	eventInfos := generateEvents(logger, engineResponses)
 	pc.eventGen.Add(eventInfos...)
 
@@ -21,7 +19,7 @@ func (pc *PolicyController) report(policy string, engineResponses []response.Eng
 	// we can merge pvInfos into a single object to reduce update frequency (throttling request) on RCR
 	info := mergePvInfos(pvInfos)
 	pc.prGenerator.Add(info)
-	logger.V(4).Info("added info to report change request generator", "key", info.ToKey())
+	logger.V(4).Info("added a request RCR generator", "key", info.ToKey())
 }
 
 func generateEvents(log logr.Logger, ers []response.EngineResponse) []event.Info {

--- a/pkg/policy/validate_controller.go
+++ b/pkg/policy/validate_controller.go
@@ -50,7 +50,7 @@ type PolicyController struct {
 	eventGen      event.Interface
 	eventRecorder record.EventRecorder
 
-	// Policys that need to be synced
+	// Policies that need to be synced
 	queue workqueue.RateLimitingInterface
 
 	// pLister can list/get policy from the shared informer's store
@@ -62,7 +62,7 @@ type PolicyController struct {
 	// grLister can list/get generate request from the shared informer's store
 	grLister kyvernolister.GenerateRequestLister
 
-	// nsLister can list/get namespacecs from the shared informer's store
+	// nsLister can list/get namespaces from the shared informer's store
 	nsLister listerv1.NamespaceLister
 
 	// pListerSynced returns true if the cluster policy store has been synced at least once
@@ -82,6 +82,7 @@ type PolicyController struct {
 
 	// grListerSynced returns true if the generate request store has been synced at least once
 	grListerSynced cache.InformerSynced
+
 	// Resource manager, manages the mapping for already processed resource
 	rm resourceManager
 
@@ -267,7 +268,7 @@ func (pc *PolicyController) deleteNsPolicy(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			logger.Info("couldnt get object from tomstone", "obj", obj)
+			logger.Info("couldn't get object from tomstone", "obj", obj)
 			return
 		}
 
@@ -295,8 +296,12 @@ func (pc *PolicyController) enqueueDeletedRule(old, cur *kyverno.ClusterPolicy) 
 		if !curRule[rule.Name] {
 			pc.prGenerator.Add(policyreport.Info{
 				PolicyName: cur.GetName(),
-				Rules: []kyverno.ViolatedRule{
-					{Name: rule.Name},
+				Results: []policyreport.EngineResponseResult{
+					{
+						Rules: []kyverno.ViolatedRule{
+							{Name: rule.Name},
+						},
+					},
 				},
 			})
 		}
@@ -426,8 +431,7 @@ func (pc *PolicyController) syncPolicy(key string) error {
 		}
 	}
 
-	engineResponses := pc.processExistingResources(policy)
-	pc.cleanupAndReport(engineResponses)
+	pc.processExistingResources(policy)
 	return nil
 }
 

--- a/pkg/policy/validate_controller.go
+++ b/pkg/policy/validate_controller.go
@@ -204,7 +204,7 @@ func (pc *PolicyController) updatePolicy(old, cur interface{}) {
 
 	logger.V(4).Info("updating policy", "name", oldP.Name)
 
-	pc.enqueueRcrDeletedRule(oldP, curP)
+	pc.enqueueRCRDeletedRule(oldP, curP)
 	pc.enqueuePolicy(curP)
 }
 
@@ -214,7 +214,7 @@ func (pc *PolicyController) deletePolicy(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			logger.Info("couldn't get object from tomstone", "obj", obj)
+			logger.Info("couldn't get object from tombstone", "obj", obj)
 			return
 		}
 
@@ -230,7 +230,7 @@ func (pc *PolicyController) deletePolicy(obj interface{}) {
 	// we process policies that are not set of background processing
 	// as we need to clean up GRs when a policy is deleted
 	pc.enqueuePolicy(p)
-	pc.enqueueRcrDeletedPolicy(p.Name)
+	pc.enqueueRCRDeletedPolicy(p.Name)
 }
 
 func (pc *PolicyController) addNsPolicy(obj interface{}) {
@@ -259,7 +259,7 @@ func (pc *PolicyController) updateNsPolicy(old, cur interface{}) {
 
 	logger.V(4).Info("updating namespace policy", "namespace", oldP.Namespace, "name", oldP.Name)
 
-	pc.enqueueRcrDeletedRule(ConvertPolicyToClusterPolicy(oldP), ncurP)
+	pc.enqueueRCRDeletedRule(ConvertPolicyToClusterPolicy(oldP), ncurP)
 	pc.enqueuePolicy(ncurP)
 }
 
@@ -269,7 +269,7 @@ func (pc *PolicyController) deleteNsPolicy(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			logger.Info("couldn't get object from tomstone", "obj", obj)
+			logger.Info("couldn't get object from tombstone", "obj", obj)
 			return
 		}
 
@@ -285,10 +285,10 @@ func (pc *PolicyController) deleteNsPolicy(obj interface{}) {
 	// we process policies that are not set of background processing
 	// as we need to clean up GRs when a policy is deleted
 	pc.enqueuePolicy(pol)
-	pc.enqueueRcrDeletedPolicy(p.Name)
+	pc.enqueueRCRDeletedPolicy(p.Name)
 }
 
-func (pc *PolicyController) enqueueRcrDeletedRule(old, cur *kyverno.ClusterPolicy) {
+func (pc *PolicyController) enqueueRCRDeletedRule(old, cur *kyverno.ClusterPolicy) {
 	curRule := make(map[string]bool)
 	for _, rule := range cur.Spec.Rules {
 		curRule[rule.Name] = true
@@ -310,7 +310,7 @@ func (pc *PolicyController) enqueueRcrDeletedRule(old, cur *kyverno.ClusterPolic
 	}
 }
 
-func (pc *PolicyController) enqueueRcrDeletedPolicy(policyName string) {
+func (pc *PolicyController) enqueueRCRDeletedPolicy(policyName string) {
 	pc.prGenerator.Add(policyreport.Info{
 		PolicyName: policyName,
 	})

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -145,7 +145,6 @@ func (builder *requestBuilder) buildRcrResult(policy string, resource response.R
 }
 
 func set(obj *unstructured.Unstructured, info Info) {
-	obj.SetNamespace(config.KyvernoNamespace)
 	obj.SetAPIVersion(request.SchemeGroupVersion.Group + "/" + request.SchemeGroupVersion.Version)
 
 	if info.Namespace == "" {
@@ -154,6 +153,7 @@ func set(obj *unstructured.Unstructured, info Info) {
 	} else {
 		obj.SetGenerateName("rcr-")
 		obj.SetKind("ReportChangeRequest")
+		obj.SetNamespace(config.KyvernoNamespace)
 	}
 
 	obj.SetLabels(map[string]string{

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -80,7 +80,7 @@ func (builder *requestBuilder) build(info Info) (req *unstructured.Unstructured,
 				continue
 			}
 
-			result := builder.buildRcrResult(info.PolicyName, infoResult.Resource, rule)
+			result := builder.buildRCRResult(info.PolicyName, infoResult.Resource, rule)
 			results = append(results, result)
 		}
 	}
@@ -122,7 +122,7 @@ func (builder *requestBuilder) build(info Info) (req *unstructured.Unstructured,
 	return req, nil
 }
 
-func (builder *requestBuilder) buildRcrResult(policy string, resource response.ResourceSpec, rule kyverno.ViolatedRule) *report.PolicyReportResult {
+func (builder *requestBuilder) buildRCRResult(policy string, resource response.ResourceSpec, rule kyverno.ViolatedRule) *report.PolicyReportResult {
 	result := &report.PolicyReportResult{
 		Policy: policy,
 		Resources: []*v1.ObjectReference{

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -15,14 +15,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
 	clusterreportchangerequest string = "clusterreportchangerequest"
-	resourceLabelName          string = "kyverno.io/resource.name"
-	resourceLabelKind          string = "kyverno.io/resource.kind"
 	resourceLabelNamespace     string = "kyverno.io/resource.namespace"
-	policyLabel                string = "kyverno.io/policy"
 	deletedLabelResource       string = "kyverno.io/delete.resource"
 	deletedLabelResourceKind   string = "kyverno.io/delete.resource.kind"
 	deletedLabelPolicy         string = "kyverno.io/delete.policy"
@@ -76,33 +74,18 @@ func NewBuilder(cpolLister kyvernolister.ClusterPolicyLister, polLister kyvernol
 
 func (builder *requestBuilder) build(info Info) (req *unstructured.Unstructured, err error) {
 	results := []*report.PolicyReportResult{}
-	for _, rule := range info.Rules {
-		if rule.Type != utils.Validation.String() {
-			continue
-		}
+	for _, infoResult := range info.Results {
+		for _, rule := range infoResult.Rules {
+			if rule.Type != utils.Validation.String() {
+				continue
+			}
 
-		result := &report.PolicyReportResult{
-			Policy: info.PolicyName,
-			Resources: []*v1.ObjectReference{
-				{
-					Kind:       info.Resource.GetKind(),
-					Namespace:  info.Resource.GetNamespace(),
-					APIVersion: info.Resource.GetAPIVersion(),
-					Name:       info.Resource.GetName(),
-					UID:        info.Resource.GetUID(),
-				},
-			},
-			Scored:   true,
-			Category: builder.fetchCategory(info.PolicyName, info.Resource.GetNamespace()),
+			result := builder.buildRcrResult(info.PolicyName, infoResult.Resource, rule)
+			results = append(results, result)
 		}
-
-		result.Rule = rule.Name
-		result.Message = rule.Message
-		result.Status = report.PolicyStatus(rule.Check)
-		results = append(results, result)
 	}
 
-	if info.Resource.GetNamespace() != "" {
+	if info.Namespace != "" {
 		rr := &request.ReportChangeRequest{
 			Summary: calculateSummary(results),
 			Results: results,
@@ -129,39 +112,42 @@ func (builder *requestBuilder) build(info Info) (req *unstructured.Unstructured,
 		set(req, info)
 	}
 
-	// deletion of a result entry
-	if len(info.Rules) == 0 && info.PolicyName == "" { // on resource deleteion
-		req.SetLabels(map[string]string{
-			resourceLabelNamespace:   info.Resource.GetNamespace(),
-			deletedLabelResource:     info.Resource.GetName(),
-			deletedLabelResourceKind: info.Resource.GetKind()})
-	} else if info.PolicyName != "" && reflect.DeepEqual(info.Resource, unstructured.Unstructured{}) { // on policy deleteion
-		req.SetKind("ReportChangeRequest")
-
-		if len(info.Rules) == 0 {
-			req.SetLabels(map[string]string{
-				deletedLabelPolicy: info.PolicyName})
-
-			req.SetName(fmt.Sprintf("reportchangerequest-%s", info.PolicyName))
-		} else {
-			req.SetLabels(map[string]string{
-				deletedLabelPolicy: info.PolicyName,
-				deletedLabelRule:   info.Rules[0].Name})
-			req.SetName(fmt.Sprintf("reportchangerequest-%s-%s", info.PolicyName, info.Rules[0].Name))
-		}
-	} else if len(results) == 0 {
+	if len(results) == 0 {
 		// return nil on empty result without a deletion
 		return nil, nil
 	}
 
+	setRequestLabels(req, info)
 	return req, nil
 }
 
+func (builder *requestBuilder) buildRcrResult(policy string, resource response.ResourceSpec, rule kyverno.ViolatedRule) *report.PolicyReportResult {
+	result := &report.PolicyReportResult{
+		Policy: policy,
+		Resources: []*v1.ObjectReference{
+			{
+				Kind:       resource.Kind,
+				Namespace:  resource.Namespace,
+				APIVersion: resource.APIVersion,
+				Name:       resource.Name,
+				UID:        types.UID(resource.UID),
+			},
+		},
+		Scored:   true,
+		Category: builder.fetchCategory(policy, resource.Namespace),
+	}
+
+	result.Rule = rule.Name
+	result.Message = rule.Message
+	result.Status = report.PolicyStatus(rule.Check)
+	return result
+}
+
 func set(obj *unstructured.Unstructured, info Info) {
-	resource := info.Resource
 	obj.SetNamespace(config.KyvernoNamespace)
 	obj.SetAPIVersion(request.SchemeGroupVersion.Group + "/" + request.SchemeGroupVersion.Version)
-	if resource.GetNamespace() == "" {
+
+	if info.Namespace == "" {
 		obj.SetGenerateName(clusterreportchangerequest + "-")
 		obj.SetKind("ClusterReportChangeRequest")
 	} else {
@@ -170,16 +156,33 @@ func set(obj *unstructured.Unstructured, info Info) {
 	}
 
 	obj.SetLabels(map[string]string{
-		resourceLabelNamespace: resource.GetNamespace(),
-		resourceLabelName:      resource.GetName(),
-		resourceLabelKind:      resource.GetKind(),
-		policyLabel:            info.PolicyName,
+		resourceLabelNamespace: info.Namespace,
 	})
+}
 
-	if info.FromSync {
-		obj.SetAnnotations(map[string]string{
-			"fromSync": "true",
+func setRequestLabels(req *unstructured.Unstructured, info Info) {
+	switch {
+	case isResourceDeletion(info):
+		req.SetLabels(map[string]string{
+			resourceLabelNamespace:   info.Results[0].Resource.Namespace,
+			deletedLabelResource:     info.Results[0].Resource.Name,
+			deletedLabelResourceKind: info.Results[0].Resource.Kind,
 		})
+
+	case isPolicyDeletion(info):
+		req.SetKind("ReportChangeRequest")
+		req.SetName(fmt.Sprintf("reportchangerequest-%s", info.PolicyName))
+		req.SetLabels(map[string]string{
+			deletedLabelPolicy: info.PolicyName},
+		)
+
+	case isRuleDeletion(info):
+		req.SetKind("ReportChangeRequest")
+		req.SetName(fmt.Sprintf("reportchangerequest-%s-%s", info.PolicyName, info.Results[0].Rules[0].Name))
+		req.SetLabels(map[string]string{
+			deletedLabelPolicy: info.PolicyName,
+			deletedLabelRule:   info.Results[0].Rules[0].Name},
+		)
 	}
 }
 
@@ -204,8 +207,13 @@ func calculateSummary(results []*report.PolicyReportResult) (summary report.Poli
 func buildPVInfo(er response.EngineResponse) Info {
 	info := Info{
 		PolicyName: er.PolicyResponse.Policy,
-		Resource:   er.PatchedResource,
-		Rules:      buildViolatedRules(er),
+		Namespace:  er.PatchedResource.GetNamespace(),
+		Results: []EngineResponseResult{
+			{
+				Resource: er.GetResourceSpec(),
+				Rules:    buildViolatedRules(er),
+			},
+		},
 	}
 	return info
 }
@@ -245,4 +253,22 @@ func (builder *requestBuilder) fetchCategory(policy, ns string) string {
 	}
 
 	return ""
+}
+
+func isResourceDeletion(info Info) bool {
+	return info.PolicyName == "" && len(info.Results) == 1 && info.GetRuleLength() == 0
+}
+
+func isPolicyDeletion(info Info) bool {
+	return info.PolicyName != "" && len(info.Results) == 0
+}
+
+func isRuleDeletion(info Info) bool {
+	if info.PolicyName != "" && len(info.Results) == 1 {
+		result := info.Results[0]
+		if len(result.Rules) == 0 && reflect.DeepEqual(result.Resource, response.ResourceSpec{}) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/policyreport/reportrequest.go
+++ b/pkg/policyreport/reportrequest.go
@@ -242,7 +242,7 @@ func (gen *Generator) processNextWorkItem() bool {
 		info := gen.dataStore.lookup(keyHash)
 		if reflect.DeepEqual(info, Info{}) {
 			gen.queue.Forget(obj)
-			logger.V(3).Info("empty key")
+			logger.V(4).Info("empty key")
 			return nil
 		}
 

--- a/pkg/webhooks/validation.go
+++ b/pkg/webhooks/validation.go
@@ -130,20 +130,25 @@ func HandleValidation(
 	prGenerator.Add(prInfos...)
 
 	if request.Operation == v1beta1.Delete {
-		prGenerator.Add(policyreport.Info{
-			Resource: unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"kind": oldR.GetKind(),
-					"metadata": map[string]interface{}{
-						"name":      oldR.GetName(),
-						"namespace": oldR.GetNamespace(),
-					},
-				},
-			},
-		})
+		prGenerator.Add(buildDeletionPrInfo(oldR))
 	}
 
 	return true, ""
+}
+
+func buildDeletionPrInfo(oldR unstructured.Unstructured) policyreport.Info {
+	return policyreport.Info{
+		Namespace: oldR.GetNamespace(),
+		Results: []policyreport.EngineResponseResult{
+			{Resource: response.ResourceSpec{
+				Kind:       oldR.GetKind(),
+				APIVersion: oldR.GetAPIVersion(),
+				Namespace:  oldR.GetNamespace(),
+				Name:       oldR.GetName(),
+				UID:        string(oldR.GetUID()),
+			}},
+		},
+	}
 }
 
 type validateStats struct {


### PR DESCRIPTION
This PR:
- fixes #1398, reduces RCR throttling requests
- reduces throttling requests when getting resources, by adding a [scope map](https://github.com/realshuting/kyverno/blob/a97fbb8f863157dd072d1f35917964eacf9c157a/pkg/policy/existing.go#L29-L38) to cache resource's scope
- stops updating policy status from the background controller
- updates resourcesFilter to exclude `Namespace` itself when it has `[*,<namespace name>,*]`