### PR TITLE
Revet GitHub action change for krew

### DIFF
--- a/.github/workflows/krew.yaml
+++ b/.github/workflows/krew.yaml
@@ -1,8 +1,10 @@
 name: release kyverno-cli plugin
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - 'v*'
+      - '!v*-rc*'
+
 jobs:
   release-cli-via-krew:
     runs-on: ubuntu-latest
@@ -14,5 +16,4 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Update new version in krew-index
-        if: "!github.event.release.prerelease"
         uses: rajatjindal/krew-release-bot@v0.0.38


### PR DESCRIPTION
Signed-off-by: Shuting Zhao <shutting06@gmail.com>

[The previous](https://github.com/realshuting/kyverno/commit/5ecdfda4e093efc9c20027acb34c29b19c6f1e27#diff-f3965722a67b62a317529747e0618a47fce629078f1e97b42ded57438a77e4a6) change for krew was not triggered when publishing a new release, this PR revert the changes to the working solution.