### PR TITLE
feat: validation of 'value' field under 'deny.conditions' in the rule object

### DIFF
--- a/pkg/policy/validate_test.go
+++ b/pkg/policy/validate_test.go
@@ -251,6 +251,155 @@ func Test_Validate_ResourceDescription_MatchedValid(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func Test_Validate_DenyConditions_KeyRequestOperation_Empty(t *testing.T) {
+	denyConditions := []byte(`[]`)
+
+	var dcs []kyverno.Condition
+	err := json.Unmarshal(denyConditions, &dcs)
+	assert.NilError(t, err)
+
+	_, err = validateConditions(dcs, "conditions")
+	assert.NilError(t, err)
+}
+
+func Test_Validate_Preconditions_KeyRequestOperation_Empty(t *testing.T) {
+	preConditions := []byte(`[]`)
+
+	var pcs []kyverno.Condition
+	err := json.Unmarshal(preConditions, &pcs)
+	assert.NilError(t, err)
+
+	_, err = validateConditions(pcs, "preconditions")
+	assert.NilError(t, err)
+}
+
+func Test_Validate_DenyConditionsValuesString_KeyRequestOperation_ExpectedValue(t *testing.T) {
+	denyConditions := []byte(`
+	[
+		{
+			"key":"{{request.operation}}",
+			"operator":"Equals",
+			"value":"DELETE"
+		},
+		{
+			"key":"{{request.operation}}",
+			"operator":"NotEquals",
+			"value":"CREATE"
+		},
+		{
+			"key":"{{request.operation}}",
+			"operator":"NotEquals",
+			"value":"CONNECT"
+		},
+		{
+			"key":"{{ request.operation }}",
+			"operator":"NotEquals",
+			"value":"UPDATE"
+		},
+		{
+			"key":"{{lbServiceCount}}",
+			"operator":"Equals",
+			"value":"2"
+		}
+	]
+	`)
+
+	var dcs []kyverno.Condition
+	err := json.Unmarshal(denyConditions, &dcs)
+	assert.NilError(t, err)
+
+	_, err = validateConditions(dcs, "conditions")
+	assert.NilError(t, err)
+}
+
+func Test_Validate_PreconditionsValuesString_KeyRequestOperation_UnknownValue(t *testing.T) {
+	preConditions := []byte(`
+	[
+		{
+			"key":"{{request.operation}}",
+			"operator":"Equals",
+			"value":"foobar"
+		},
+		{
+			"key": "{{request.operation}}",
+			"operator": "NotEquals",
+			"value": "CREATE"
+		}
+	]
+	`)
+
+	var pcs []kyverno.Condition
+	err := json.Unmarshal(preConditions, &pcs)
+	assert.NilError(t, err)
+
+	_, err = validateConditions(pcs, "preconditions")
+	assert.Assert(t, err != nil)
+}
+
+func Test_Validate_DenyConditionsValuesList_KeyRequestOperation_ExpectedItem(t *testing.T) {
+	denyConditions := []byte(`
+	[
+		{
+			"key":"{{request.operation}}",
+			"operator":"Equals",
+			"value": [
+				"CREATE",
+				"DELETE",
+				"CONNECT"
+			]
+		},
+		{
+			"key":"{{request.operation}}",
+			"operator":"NotEquals",
+			"value": [
+				"UPDATE"
+			]
+		},
+		{
+			"key": "{{lbServiceCount}}",
+			"operator": "Equals",
+			"value": "2"
+		}
+	]
+	`)
+
+	var dcs []kyverno.Condition
+	err := json.Unmarshal(denyConditions, &dcs)
+	assert.NilError(t, err)
+
+	_, err = validateConditions(dcs, "conditions")
+	assert.NilError(t, err)
+}
+
+func Test_Validate_PreconditionsValuesList_KeyRequestOperation_UnknownItem(t *testing.T) {
+	preConditions := []byte(`
+	[
+		{
+			"key":"{{request.operation}}",
+			"operator":"Equals",
+			"value": [
+				"foobar",
+				"CREATE"
+			]
+		},
+		{
+			"key":"{{request.operation}}",
+			"operator":"NotEquals",
+			"value": [
+				"foobar"
+			]
+		}
+	]
+	`)
+
+	var pcs []kyverno.Condition
+	err := json.Unmarshal(preConditions, &pcs)
+	assert.NilError(t, err)
+
+	_, err = validateConditions(pcs, "preconditions")
+	assert.Assert(t, err != nil)
+}
+
 func Test_Validate_ResourceDescription_MissingKindsOnExclude(t *testing.T) {
 	var err error
 	excludeResourcedescirption := []byte(`


### PR DESCRIPTION
## Related issue #1468 

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyvrno Slack Channel](https://kubernetes.slack.com/).
-->

**What type of PR is this?**
> /kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> 
-->

## Proposed changes
From now on, under any policy, under the `conditions.value` field nothing apart from the values ["CREATE", "UPDATE", "DELETE", "CONNECT"] will be allowed to be passed, when the `condition.key` is `{{request.operation}}`

**Sample Input 1**
```yaml
conditions:
  - key: "{{request.operation}}"
    operator: In
    value: 
    - CREATE
    - errrr
    - DELETE
```
**Output**
```
Error from server: error when creating "/home/yash1300/Desktop/kyverno-stuff/sample-ops-3.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: path: spec.rules[0].validate.deny.conditions[0].value[1]: unknown value 'errrr' found under the 'value' field. Only the following values are allowed: [CREATE, UPDATE, DELETE, CONNECT]
```
**Sample Input 2**
```yaml
conditions:
  - key: "{{request.operation}}"
    operator: Equals
    value: errrrzzzz
```
**Output**
```
Error from server: error when creating "/home/yash1300/Desktop/kyverno-stuff/sample-ops-3.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: path: spec.rules[0].validate.deny.conditions[0].value: unknown value 'errrrzzzz' found under the 'value' field. Only the following values are allowed: [CREATE, UPDATE, DELETE, CONNECT]
```

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](documentation/).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

This could have been done easily via kuebuilder's Enum validation markers but that would only validate for the cases when the `value` field would be provided as a string, for eg: `value: CREATE` and not the cases when the `value` field would be provided as a list, like
```yaml
value:
- CREATE
- UPDATE
```
Still though, for making the validations to take place when the `value` field is a list (latter case) , the CRD manifest can be manually edited like this
```yaml
...
    value:
      description: Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using using JMESPath.
      items:
        enum:
        - CREATE
        - UPDATE
        - DELETE
        - CONNECT
        type: string
...
```
But then, that would fail for the cases when the `value` field would be provided as a string like `value: FOO`.
Hence, the validation markers or editing the CRD manifest didn't seem to produce any silver bullet solution for our situation, hence, under the suggestion and help of @realshuting , I programmed the logic for the schema validation under `pkg/policy/validate.go`.

For more context, please checkout this thread on the \#kyverno channel: https://kubernetes.slack.com/archives/CLGR9BJU9/p1611953186167000