### PR TITLE
added: hostNetwork toggle to the dep. and values manifests

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -68,9 +68,11 @@ Parameter | Description | Default
 `createSelfSignedCert` | generate a self signed cert and certificate authority. Kyverno defaults to using kube-controller-manager CA-signed certificate or existing cert secret if false. | `false`
 `config.existingConfig` | existing Kubernetes configmap to use for the resource filters configuration | `nil`
 `config.resourceFilters` | list of filter of resource types to be skipped by kyverno policy engine. See [documentation](https://github.com/kyverno/kyverno/blob/master/documentation/installation.md#filter-kubernetes-resources-that-admission-webhook-should-not-process) for details | `["[Event,*,*]","[*,kube-system,*]","[*,kube-public,*]","[*,kube-node-lease,*]","[Node,*,*]","[APIService,*,*]","[TokenReview,*,*]","[SubjectAccessReview,*,*]","[*,kyverno,*]"]`
+`dnsPolicy` | Sets the DNS Policy which determines the manner in which DNS resolution happens across the cluster. For further reference, see [the official docs](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) | `ClusterFirst`
 `extraArgs` | list of extra arguments to give the binary | `[]`
 `fullnameOverride` | override the expanded name of the chart | `nil`
 `generatecontrollerExtraResources` | extra resource type Kyverno is allowed to generate | `[]`
+`hostNetwork` | Use the host network's namespace. Set it to `true` when dealing with a custom CNI over Amazon EKS | `false`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.pullSecrets` | Specify image pull secrets | `[]` (does not add image pull secrets to deployed pods)
 `image.repository` | Image repository | `ghcr.io/kyverno/kyverno`

--- a/charts/kyverno/templates/deployment.yaml
+++ b/charts/kyverno/templates/deployment.yaml
@@ -37,6 +37,12 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
       initContainers:
         - name: kyverno-pre
           image: {{ .Values.initImage.repository }}:{{ default .Chart.AppVersion (default .Values.image.tag .Values.initImage.tag) }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -42,6 +42,16 @@ affinity: {}
 nodeSelector: {}
 tolerations: []
 
+# change hostNetwork to true when you want the kyverno's pod to share its host's network namespace
+# useful for situations like when you end up dealing with a custom CNI over Amazon EKS
+# update the 'dnsPolicy' accordingly as well to suit the host network mode
+hostNetwork: false
+
+# dnsPolicy determines the manner in which DNS resolution happens in the cluster
+# in case of hostNetwork: true, usually, the dnsPolicy is suitable to be "ClusterFirstWithHostNet"
+# for further reference: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+dnsPolicy: "ClusterFirst"
+
 extraArgs: []
 # - --webhooktimeout=4
 


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yash.kukreja.98@gmail.com>

## Related issue #1443 

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyvrno Slack Channel](https://kubernetes.slack.com/).
-->

**What type of PR is this?**
> /kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed changes
the `values.yaml`, when dealing with helm, also contains the `hostNetwork`(bool) field (default: false) will allow the kyverno pod to share the host network's namespace. This is useful is situations when dealing with a custom CNI over Amazon EKS.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](documentation/).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
