### PR TITLE
feat: support for numeric operators

### DIFF
--- a/pkg/api/kyverno/v1/policy_types.go
+++ b/pkg/api/kyverno/v1/policy_types.go
@@ -170,6 +170,14 @@ const (
 	In ConditionOperator = "In"
 	// NotIn evaluates if the key is not contained in the set of values.
 	NotIn ConditionOperator = "NotIn"
+	// GreaterThanOrEquals evaluates if the key (numeric) is greater than or equal to the value (numeric).
+	GreaterThanOrEquals ConditionOperator = "GreaterThanOrEquals"
+	// GreaterThan evaluates if the key (numeric) is greater than the value (numeric).
+	GreaterThan ConditionOperator = "GreaterThan"
+	// LessThan evaluates if the key (numeric) is less than or equal to the value (numeric).
+	LessThanOrEquals ConditionOperator = "LessThanOrEquals"
+	// LessThan evaluates if the key (numeric) is less than the value (numeric).
+	LessThan ConditionOperator = "LessThan"
 )
 
 // MatchResources is used to specify resource and admission review request data for

--- a/pkg/engine/variables/evaluate_test.go
+++ b/pkg/engine/variables/evaluate_test.go
@@ -66,6 +66,150 @@ func Test_Eval_NoEqual_Const_String_Fail(t *testing.T) {
 	}
 }
 
+func Test_Eval_GreaterThanOrEquals_Const_string_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1",
+		Operator: kyverno.GreaterThanOrEquals,
+		Value:    1.0,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_GreaterThanOrEquals_Const_string_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1",
+		Operator: kyverno.GreaterThanOrEquals,
+		Value:    0,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_GreaterThanOrEquals_Const_string_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1.1",
+		Operator: kyverno.GreaterThanOrEquals,
+		Value:    "2",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_GreaterThan_Const_string_Equal_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1",
+		Operator: kyverno.GreaterThan,
+		Value:    1.0,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_GreaterThan_Const_string_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1",
+		Operator: kyverno.GreaterThan,
+		Value:    0,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_GreaterThan_Const_string_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1.1",
+		Operator: kyverno.GreaterThan,
+		Value:    "2",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_LessThanOrEquals_Const_string_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1",
+		Operator: kyverno.LessThanOrEquals,
+		Value:    1.0,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_LessThanOrEquals_Const_string_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "0",
+		Operator: kyverno.LessThanOrEquals,
+		Value:    1,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_LessThanOrEquals_Const_string_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "2.0",
+		Operator: kyverno.LessThanOrEquals,
+		Value:    "1.1",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_LessThan_Const_string_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1",
+		Operator: kyverno.LessThan,
+		Value:    1.0,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_LessThan_Const_string_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "0",
+		Operator: kyverno.LessThan,
+		Value:    1,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_LessThan_Const_string_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "2.0",
+		Operator: kyverno.LessThan,
+		Value:    "1.1",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
 //Bool
 
 func Test_Eval_Equal_Const_Bool_Pass(t *testing.T) {
@@ -181,6 +325,150 @@ func Test_Eval_NoEqual_Const_int_Fail(t *testing.T) {
 	}
 }
 
+func Test_Eval_GreaterThanOrEquals_Const_int_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1,
+		Operator: kyverno.GreaterThanOrEquals,
+		Value:    1.0,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_GreaterThanOrEquals_Const_int_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1,
+		Operator: kyverno.GreaterThanOrEquals,
+		Value:    0,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_GreaterThanOrEquals_Const_int_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1,
+		Operator: kyverno.GreaterThanOrEquals,
+		Value:    "2",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_GreaterThan_Const_int_Equal_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1,
+		Operator: kyverno.GreaterThan,
+		Value:    1.0,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_GreaterThan_Const_int_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1,
+		Operator: kyverno.GreaterThan,
+		Value:    0,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_GreaterThan_Const_int_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1,
+		Operator: kyverno.GreaterThan,
+		Value:    "2",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_LessThanOrEquals_Const_int_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1,
+		Operator: kyverno.LessThanOrEquals,
+		Value:    1.0,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_LessThanOrEquals_Const_int_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      0,
+		Operator: kyverno.LessThanOrEquals,
+		Value:    1,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_LessThanOrEquals_Const_int_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      2,
+		Operator: kyverno.LessThanOrEquals,
+		Value:    "1",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_LessThan_Const_int_Equal_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1,
+		Operator: kyverno.LessThan,
+		Value:    1.0,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_LessThan_Const_int_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      0,
+		Operator: kyverno.LessThan,
+		Value:    1,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_LessThan_Const_int_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      2,
+		Operator: kyverno.LessThan,
+		Value:    "1",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
 // int64
 func Test_Eval_Equal_Const_int64_Pass(t *testing.T) {
 	ctx := context.NewContext()
@@ -291,6 +579,150 @@ func Test_Eval_NoEqual_Const_float64_Fail(t *testing.T) {
 		Value:    1.5,
 	}
 
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_GreaterThanOrEquals_Const_float64_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1.0,
+		Operator: kyverno.GreaterThanOrEquals,
+		Value:    1.0,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_GreaterThanOrEquals_Const_float64_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1.5,
+		Operator: kyverno.GreaterThanOrEquals,
+		Value:    0,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_GreaterThanOrEquals_Const_float64_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1.95,
+		Operator: kyverno.GreaterThanOrEquals,
+		Value:    "2",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_GreaterThan_Const_float64_Equal_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1.0,
+		Operator: kyverno.GreaterThan,
+		Value:    1.0,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_GreaterThan_Const_float64_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1.5,
+		Operator: kyverno.GreaterThan,
+		Value:    "0",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_GreaterThan_Const_float64_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1.95,
+		Operator: kyverno.GreaterThan,
+		Value:    "2.5",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_LessThanOrEquals_Const_float64_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1.0,
+		Operator: kyverno.LessThanOrEquals,
+		Value:    1.0,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_LessThanOrEquals_Const_float64_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      0.5,
+		Operator: kyverno.LessThanOrEquals,
+		Value:    1,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_LessThanOrEquals_Const_float64_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      2.0,
+		Operator: kyverno.LessThanOrEquals,
+		Value:    "1.95",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_LessThan_Const_float64_Equal_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      1.0,
+		Operator: kyverno.LessThan,
+		Value:    1.0,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_LessThan_Const_float64_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      0.5,
+		Operator: kyverno.LessThan,
+		Value:    "1.5",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_LessThan_Const_float64_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      2.5,
+		Operator: kyverno.LessThan,
+		Value:    1.95,
+	}
 	if Evaluate(log.Log, ctx, condition) {
 		t.Error("expected to fail")
 	}

--- a/pkg/engine/variables/operator/numeric.go
+++ b/pkg/engine/variables/operator/numeric.go
@@ -1,0 +1,150 @@
+package operator
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/engine/context"
+)
+
+//NewNumericOperatorHandler returns handler to manage the provided numeric operations (>, >=, <=, <)
+func NewNumericOperatorHandler(log logr.Logger, ctx context.EvalInterface, subHandler VariableSubstitutionHandler, op kyverno.ConditionOperator) OperatorHandler {
+	return NumericOperatorHandler{
+		ctx:        ctx,
+		subHandler: subHandler,
+		log:        log,
+		condition:  op,
+	}
+}
+
+//NumericOperatorHandler provides implementation to handle Numeric Operations associated with policies
+type NumericOperatorHandler struct {
+	ctx        context.EvalInterface
+	subHandler VariableSubstitutionHandler
+	log        logr.Logger
+	condition  kyverno.ConditionOperator
+}
+
+// compareByCondition compares a float64 key with a float64 value on the basis of the provided operator
+func compareByCondition(key float64, value float64, op kyverno.ConditionOperator, log *logr.Logger) bool {
+	switch op {
+	case kyverno.GreaterThanOrEquals:
+		return key >= value
+	case kyverno.GreaterThan:
+		return key > value
+	case kyverno.LessThanOrEquals:
+		return key <= value
+	case kyverno.LessThan:
+		return key < value
+	default:
+		(*log).Info(fmt.Sprintf("Expected operator, one of [GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan], found %s", op))
+		return false
+	}
+}
+
+func (noh NumericOperatorHandler) Evaluate(key, value interface{}) bool {
+	if key, err := noh.subHandler(noh.log, noh.ctx, key); err != nil {
+		// Failed to resolve the variable
+		noh.log.Error(err, "Failed to resolve variable", "variable", key)
+		return false
+	}
+	if value, err := noh.subHandler(noh.log, noh.ctx, value); err != nil {
+		// Failed to resolve the variable
+		noh.log.Error(err, "Failed to resolve variable", "variable", value)
+		return false
+	}
+
+	switch typedKey := key.(type) {
+	case int:
+		return noh.validateValueWithIntPattern(int64(typedKey), value)
+	case int64:
+		return noh.validateValueWithIntPattern(typedKey, value)
+	case float64:
+		return noh.validateValueWithFloatPattern(typedKey, value)
+	case string:
+		return noh.validateValueWithStringPattern(typedKey, value)
+	default:
+		noh.log.Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		return false
+	}
+}
+
+func (noh NumericOperatorHandler) validateValueWithIntPattern(key int64, value interface{}) bool {
+	switch typedValue := value.(type) {
+	case int:
+		return compareByCondition(float64(key), float64(typedValue), noh.condition, &noh.log)
+	case int64:
+		return compareByCondition(float64(key), float64(typedValue), noh.condition, &noh.log)
+	case float64:
+		return compareByCondition(float64(key), typedValue, noh.condition, &noh.log)
+	case string:
+		// extract float64 and (if that fails) then, int64 from the string
+		float64val, err := strconv.ParseFloat(typedValue, 64)
+		if err == nil {
+			return compareByCondition(float64(key), float64val, noh.condition, &noh.log)
+		}
+		int64val, err := strconv.ParseInt(typedValue, 10, 64)
+		if err == nil {
+			return compareByCondition(float64(key), float64(int64val), noh.condition, &noh.log)
+		}
+		noh.log.Error(fmt.Errorf("Parse Error: "), "Failed to parse both float64 and int64 from the string value")
+		return false
+	default:
+		noh.log.Info("Expected type int", "value", value, "type", fmt.Sprintf("%T", value))
+		return false
+	}
+}
+
+func (noh NumericOperatorHandler) validateValueWithFloatPattern(key float64, value interface{}) bool {
+	switch typedValue := value.(type) {
+	case int:
+		return compareByCondition(key, float64(typedValue), noh.condition, &noh.log)
+	case int64:
+		return compareByCondition(key, float64(typedValue), noh.condition, &noh.log)
+	case float64:
+		return compareByCondition(key, typedValue, noh.condition, &noh.log)
+	case string:
+		float64val, err := strconv.ParseFloat(typedValue, 64)
+		if err == nil {
+			return compareByCondition(key, float64val, noh.condition, &noh.log)
+		}
+		int64val, err := strconv.ParseInt(typedValue, 10, 64)
+		if err == nil {
+			return compareByCondition(key, float64(int64val), noh.condition, &noh.log)
+		}
+		noh.log.Error(fmt.Errorf("Parse Error: "), "Failed to parse both float64 and int64 from the string value")
+		return false
+	default:
+		noh.log.Info("Expected type float", "value", value, "type", fmt.Sprintf("%T", value))
+		return false
+	}
+}
+
+func (noh NumericOperatorHandler) validateValueWithStringPattern(key string, value interface{}) bool {
+	// extracting float64 from the string key
+	float64key, err := strconv.ParseFloat(key, 64)
+	if err == nil {
+		return noh.validateValueWithFloatPattern(float64key, value)
+	}
+	// extracting int64 from the string because float64 extraction failed
+	int64key, err := strconv.ParseInt(key, 10, 64)
+	if err == nil {
+		return noh.validateValueWithIntPattern(int64key, value)
+	}
+	noh.log.Error(fmt.Errorf("Parse Error: "), "Failed to parse both float64 and int64 from the string keyt")
+	return false
+}
+
+// the following functions are unreachable because the key is strictly supposed to be numeric
+// still the following functions are just created to make NumericOperatorHandler struct implement OperatorHandler interface
+func (noh NumericOperatorHandler) validateValueWithBoolPattern(key bool, value interface{}) bool {
+	return false
+}
+func (noh NumericOperatorHandler) validateValueWithMapPattern(key map[string]interface{}, value interface{}) bool {
+	return false
+}
+func (noh NumericOperatorHandler) validateValueWithSlicePattern(key []interface{}, value interface{}) bool {
+	return false
+}

--- a/pkg/engine/variables/operator/operator.go
+++ b/pkg/engine/variables/operator/operator.go
@@ -1,10 +1,11 @@
 package operator
 
 import (
+	"strings"
+
 	"github.com/go-logr/logr"
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/engine/context"
-	"strings"
 )
 
 //OperatorHandler provides interface to manage types
@@ -43,6 +44,12 @@ func CreateOperatorHandler(log logr.Logger, ctx context.EvalInterface, op kyvern
 
 	case strings.ToLower(string(kyverno.NotIn)):
 		return NewNotInHandler(log, ctx, subHandler)
+
+	case strings.ToLower(string(kyverno.GreaterThanOrEquals)),
+		strings.ToLower(string(kyverno.GreaterThan)),
+		strings.ToLower(string(kyverno.LessThanOrEquals)),
+		strings.ToLower(string(kyverno.LessThan)):
+		return NewNumericOperatorHandler(log, ctx, subHandler, op)
 
 	default:
 		log.Info("operator not supported", "operator", str)


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yash.kukreja.98@gmail.com>

## Related issue
#1512 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyvrno Slack Channel](https://kubernetes.slack.com/).
-->

**What type of PR is this?**
> /kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed changes
The newly added operators which can be applied to `validate.deny.conditions` and `preconditions` over kyverno policy rules are the following:
- `GreaterThanOrEquals` : key >= value?
- `GreaterThan` : key > value?
- `LessThanOrEquals` : key <= value?
- `LessThan` : key < value?
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](documentation/).

## Further comments
Here, the key will only be expected to be int, int64, float, float64, string (for the cases like "2", "2.4" only)
In rest of the cases, an error with saying "Unknown key type found" would be generated because clearly, these are numeric operators and these operations can't be applied on types which can't be casted to int or float.
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
