### PR TITLE
Removes Helm Chart v1.3.0-rc1

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -140,29 +140,6 @@ entries:
     - https://kyverno.github.io/kyverno/kyverno-v1.3.0-rc11.tgz
     version: v1.3.0-rc11
   - apiVersion: v1
-    appVersion: v1.3.0-rc1
-    created: "2020-11-19T23:11:00.55684536Z"
-    description: Kubernetes Native Policy Management
-    digest: 6d1f811eab772ef3dbd4bb52ffb8c06302149c68a057ff81b8e0a3f221f2ee49
-    home: https://kyverno.io/
-    icon: https://github.com/kyverno/kyverno/blob/main/img/Kyverno_Horizontal.png
-    keywords:
-    - kubernetes
-    - nirmata
-    - policy agent
-    - validating webhook
-    - admissions controller
-    kubeVersion: '>=1.10.0-0'
-    maintainers:
-    - name: Nirmata
-      url: https://kyverno.io/
-    name: kyverno
-    sources:
-    - https://github.com/kyverno/kyverno
-    urls:
-    - kyverno-v1.3.0-rc1.tgz
-    version: v1.3.0-rc1
-  - apiVersion: v1
     appVersion: v1.2.1
     created: "2020-11-19T23:11:00.555350935Z"
     description: Kubernetes Native Policy Management


### PR DESCRIPTION
Signed-off-by: Shuting Zhao <shutting06@gmail.com>

Removes v1.3.0-rc1 as ArtifacHub reports the chart is missing.
```
error preparing package: error loading chart (https://kyverno.github.io/kyverno/kyverno-v1.3.0-rc1.tgz): unexpected status code received: 404 (package: kyverno version: v1.3.0-rc1)
```