### PR TITLE
feat(operators): support subset checking for in and notin

### DIFF
--- a/pkg/engine/variables/operator/notin.go
+++ b/pkg/engine/variables/operator/notin.go
@@ -57,6 +57,16 @@ func (nin NotInHandler) validateValueWithStringPattern(key string, value interfa
 	return !keyExists
 }
 
+func (nin NotInHandler) validateValueWithStringSetPattern(key []string, value interface{}) bool {
+	invalidType, keyExists := setExistsInArray(key, value, nin.log)
+	if invalidType {
+		nin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		return false
+	}
+
+	return !keyExists
+}
+
 func (nin NotInHandler) validateValueWithBoolPattern(_ bool, _ interface{}) bool {
 	return false
 }

--- a/pkg/engine/variables/operator/notin.go
+++ b/pkg/engine/variables/operator/notin.go
@@ -58,13 +58,31 @@ func (nin NotInHandler) validateValueWithStringPattern(key string, value interfa
 }
 
 func (nin NotInHandler) validateValueWithStringSetPattern(key []string, value interface{}) bool {
-	invalidType, keyExists := setExistsInArray(key, value, nin.log)
+	invalidType, keyExists := setExistsInArray(key, value, nin.log, true)
 	if invalidType {
 		nin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
 	return !keyExists
+}
+
+// checkInSubsetForNotIn checks if ANY of the values of S1 is in S2
+func checkInSubsetForNotIn(key []string, value []string) bool {
+	set := make(map[string]int)
+
+	for _, val := range value {
+		set[val]++
+	}
+
+	for _, val := range key {
+		_, found := set[val]
+		if found {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (nin NotInHandler) validateValueWithBoolPattern(_ bool, _ interface{}) bool {


### PR DESCRIPTION
Signed-off-by: Arsh Sharma <arshsharma461@gmail.com>

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyvrno Slack Channel](https://kubernetes.slack.com/).
-->
Fixes #1367 

**What type of PR is this?**
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
> /kind feature

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
Added checking if a set of strings is in an allowed list of strings when using `In` and `NotIn` operators
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](documentation/).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
I wrote the [setExistsInArray](https://github.com/kyverno/kyverno/compare/main...RinkiyaKeDad:operator-add?expand=1#diff-38948620ce7b14acdfbdedbfdae0ca0213aa0b84b9ca81515bc9499720ef26c6R119) function based on [keyExistsInArray](https://github.com/kyverno/kyverno/blob/main/pkg/engine/variables/operator/in.go#L65) function already present. I had a doubt here, if we have a return statement in [default case](https://github.com/kyverno/kyverno/blob/main/pkg/engine/variables/operator/in.go#L100) wouldn't this mean that the return statement [outside the switch block](https://github.com/kyverno/kyverno/blob/main/pkg/engine/variables/operator/in.go#L103) will never get executed? 
Shouldn't we simply just have this is the default case:
```
default:
	return true, false
```
I'm a bit new to Golang so sorry if this is something obvious 😅 Thanks!