### PR TITLE
Panic fix in generation.go

### DIFF
--- a/pkg/webhooks/generation.go
+++ b/pkg/webhooks/generation.go
@@ -187,13 +187,16 @@ func (ws *WebhookServer) handleUpdateTargetResource(request *v1beta1.AdmissionRe
 
 //stripNonPolicyFields - remove feilds which get updated with each request by kyverno and are non policy fields
 func stripNonPolicyFields(obj, newRes map[string]interface{}, logger logr.Logger) (map[string]interface{}, map[string]interface{}) {
-
-	delete(obj["metadata"].(map[string]interface{})["annotations"].(map[string]interface{}), "kubectl.kubernetes.io/last-applied-configuration")
-	delete(obj["metadata"].(map[string]interface{})["labels"].(map[string]interface{}), "generate.kyverno.io/clone-policy-name")
-
 	requiredMetadataInObj := make(map[string]interface{})
-	requiredMetadataInObj["annotations"] = obj["metadata"].(map[string]interface{})["annotations"]
-	requiredMetadataInObj["labels"] = obj["metadata"].(map[string]interface{})["labels"]
+	if _, found := obj["metadata"].(map[string]interface{})["annotations"]; found {
+		delete(obj["metadata"].(map[string]interface{})["annotations"].(map[string]interface{}), "kubectl.kubernetes.io/last-applied-configuration")
+		requiredMetadataInObj["annotations"] = obj["metadata"].(map[string]interface{})["annotations"]
+	}
+
+	if _, found := newRes["metadata"].(map[string]interface{})["labels"]; found {
+		delete(obj["metadata"].(map[string]interface{})["labels"].(map[string]interface{}), "generate.kyverno.io/clone-policy-name")
+		requiredMetadataInObj["labels"] = obj["metadata"].(map[string]interface{})["labels"]
+	}
 	obj["metadata"] = requiredMetadataInObj
 
 	requiredMetadataInNewRes := make(map[string]interface{})

--- a/pkg/webhooks/generation.go
+++ b/pkg/webhooks/generation.go
@@ -187,26 +187,32 @@ func (ws *WebhookServer) handleUpdateTargetResource(request *v1beta1.AdmissionRe
 
 //stripNonPolicyFields - remove feilds which get updated with each request by kyverno and are non policy fields
 func stripNonPolicyFields(obj, newRes map[string]interface{}, logger logr.Logger) (map[string]interface{}, map[string]interface{}) {
-	requiredMetadataInObj := make(map[string]interface{})
-	if _, found := obj["metadata"].(map[string]interface{})["annotations"]; found {
-		delete(obj["metadata"].(map[string]interface{})["annotations"].(map[string]interface{}), "kubectl.kubernetes.io/last-applied-configuration")
-		requiredMetadataInObj["annotations"] = obj["metadata"].(map[string]interface{})["annotations"]
+
+	delete(obj["metadata"].(map[string]interface{})["annotations"].(map[string]interface{}), "kubectl.kubernetes.io/last-applied-configuration")
+	delete(obj["metadata"].(map[string]interface{})["labels"].(map[string]interface{}), "generate.kyverno.io/clone-policy-name")
+
+	if _, found := obj["metadata"]; found {
+		requiredMetadataInObj := make(map[string]interface{})
+		if _, found := obj["metadata"].(map[string]interface{})["annotations"]; found {
+			requiredMetadataInObj["annotations"] = obj["metadata"].(map[string]interface{})["annotations"]
+		}
+
+		if _, found := newRes["metadata"].(map[string]interface{})["labels"]; found {
+			requiredMetadataInObj["labels"] = obj["metadata"].(map[string]interface{})["labels"]
+		}
+		obj["metadata"] = requiredMetadataInObj
 	}
 
-	if _, found := newRes["metadata"].(map[string]interface{})["labels"]; found {
-		delete(obj["metadata"].(map[string]interface{})["labels"].(map[string]interface{}), "generate.kyverno.io/clone-policy-name")
-		requiredMetadataInObj["labels"] = obj["metadata"].(map[string]interface{})["labels"]
+	if _, found := newRes["metadata"]; found {
+		requiredMetadataInNewRes := make(map[string]interface{})
+		if _, found := newRes["metadata"].(map[string]interface{})["annotations"]; found {
+			requiredMetadataInNewRes["annotations"] = newRes["metadata"].(map[string]interface{})["annotations"]
+		}
+		if _, found := newRes["metadata"].(map[string]interface{})["labels"]; found {
+			requiredMetadataInNewRes["labels"] = newRes["metadata"].(map[string]interface{})["labels"]
+		}
+		newRes["metadata"] = requiredMetadataInNewRes
 	}
-	obj["metadata"] = requiredMetadataInObj
-
-	requiredMetadataInNewRes := make(map[string]interface{})
-	if _, found := newRes["metadata"].(map[string]interface{})["annotations"]; found {
-		requiredMetadataInNewRes["annotations"] = newRes["metadata"].(map[string]interface{})["annotations"]
-	}
-	if _, found := newRes["metadata"].(map[string]interface{})["labels"]; found {
-		requiredMetadataInNewRes["labels"] = newRes["metadata"].(map[string]interface{})["labels"]
-	}
-	newRes["metadata"] = requiredMetadataInNewRes
 
 	if _, found := obj["status"]; found {
 		delete(obj, "status")

--- a/pkg/webhooks/generation_test.go
+++ b/pkg/webhooks/generation_test.go
@@ -62,7 +62,6 @@ func Test_updateFeildsInSourceAndUpdatedResource(t *testing.T) {
 					"annotations": map[string]interface{}{
 						"imageregistry": "https://hub.docker.com/",
 					},
-					"labels": map[string]interface{}{},
 				},
 			},
 


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue
Fixed generation.go interface conversion panic:

```
panic: interface conversion: interface {} is nil, not map[string]interface {}
goroutine 17228 [running]:
github.com/kyverno/kyverno/pkg/webhooks.stripNonPolicyFields(0xc0056462d0, 0xc0011c6b40, 0x211b700, 0xc0011c6960, 0x4, 0xc00597ab57)
	/Users/shutingzhao/go/src/github.com/realshuting/kyverno/pkg/webhooks/generation.go:191 +0xfd9
github.com/kyverno/kyverno/pkg/webhooks.(*WebhookServer).handleUpdateTargetResource(0xc000b13c80, 0xc00010f520, 0xc0038f64a8, 0x1, 0x1, 0xc0011c6ab0, 0x211b700, 0xc0011c6960)
	/Users/shutingzhao/go/src/github.com/realshuting/kyverno/pkg/webhooks/generation.go:165 +0x6af
github.com/kyverno/kyverno/pkg/webhooks.(*WebhookServer).handleUpdate(0xc000b13c80, 0xc00010f520, 0xc0038f64a8, 0x1, 0x1)
	/Users/shutingzhao/go/src/github.com/realshuting/kyverno/pkg/webhooks/generation.go:110 +0x4c5
github.com/kyverno/kyverno/pkg/webhooks.(*WebhookServer).HandleGenerate(0xc000b13c80, 0xc00010f520, 0xc0038f64a8, 0x1, 0x1, 0xc0000d9500, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/shutingzhao/go/src/github.com/realshuting/kyverno/pkg/webhooks/generation.go:92 +0xd86
created by github.com/kyverno/kyverno/pkg/webhooks.(*WebhookServer).ResourceMutation
	/Users/shutingzhao/go/src/github.com/realshuting/kyverno/pkg/webhooks/server.go:379 +0xdb3
rpc error: code = Unknown desc = Error: No such container: e7aa7f0473911a3cb684d1037bb228df90908449c44d13172cecb8b190d0ade5%
```

**What type of PR is this?**
> /kind bug

## Proposed changes
Added if condition before conversion.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](documentation/).

