### PR TITLE
extends match / exclude to use apiGroup and apiVersion (#1218)

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/go-logr/logr"
 	enginutils "github.com/kyverno/kyverno/pkg/engine/utils"
@@ -61,4 +62,17 @@ func GetNamespaceLabels(namespaceObj *v1.Namespace, logger logr.Logger) map[stri
 		logger.Error(err, "failed to convert object resource to unstructured format")
 	}
 	return namespaceUnstructured.GetLabels()
+}
+
+// SplitGVK - from GVK
+func SplitGVK(str, sep string) []string {
+	return strings.Split(str, sep)
+}
+
+// GetKindFromGVK - get kind from GVK
+func GetKindFromGVK(str string) string {
+	if strings.Count(str, "/") == 0 {
+		return str
+	}
+	return SplitGVK(str, "/")[2]
 }

--- a/pkg/kyverno/common/fetch.go
+++ b/pkg/kyverno/common/fetch.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-git/go-billy/v5"
 	v1 "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
+	pkgcommon "github.com/kyverno/kyverno/pkg/common"
 	client "github.com/kyverno/kyverno/pkg/dclient"
 	engineutils "github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/kyverno/kyverno/pkg/utils"
@@ -33,7 +34,7 @@ func GetResources(policies []*v1.ClusterPolicy, resourcePaths []string, dClient 
 	for _, policy := range policies {
 		for _, rule := range policy.Spec.Rules {
 			for _, kind := range rule.MatchResources.Kinds {
-				resourceTypesMap[kind] = true
+				resourceTypesMap[pkgcommon.GetKindFromGVK(kind)] = true
 			}
 		}
 	}

--- a/pkg/policy/existing.go
+++ b/pkg/policy/existing.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/common"
+	pkgcommon "github.com/kyverno/kyverno/pkg/common"
 	"github.com/kyverno/kyverno/pkg/engine"
 	"github.com/kyverno/kyverno/pkg/engine/response"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -26,7 +27,8 @@ func (pc *PolicyController) processExistingResources(policy *kyverno.ClusterPoli
 			continue
 		}
 
-		for _, k := range rule.MatchResources.Kinds {
+		for _, kind := range rule.MatchResources.Kinds {
+			k := pkgcommon.GetKindFromGVK(kind)
 			logger = logger.WithValues("rule", rule.Name, "kind", k)
 			namespaced, err := pc.rm.GetScope(k)
 			if err != nil {

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/jmespath/go-jmespath"
+	pkgcommon "github.com/kyverno/kyverno/pkg/common"
 	"github.com/kyverno/kyverno/pkg/engine"
 	"github.com/kyverno/kyverno/pkg/kyverno/common"
 
@@ -193,7 +194,7 @@ func doMatchAndExcludeConflict(rule kyverno.Rule) bool {
 
 	excludeKinds := make(map[string]bool)
 	for _, kind := range rule.ExcludeResources.ResourceDescription.Kinds {
-		excludeKinds[kind] = true
+		excludeKinds[pkgcommon.GetKindFromGVK(kind)] = true
 	}
 
 	excludeNamespaces := make(map[string]bool)
@@ -278,7 +279,7 @@ func doMatchAndExcludeConflict(rule kyverno.Rule) bool {
 		}
 
 		for _, kind := range rule.MatchResources.ResourceDescription.Kinds {
-			if !excludeKinds[kind] {
+			if !excludeKinds[pkgcommon.GetKindFromGVK(kind)] {
 				return false
 			}
 		}


### PR DESCRIPTION
## Related issue
Issue:
https://github.com/kyverno/kyverno/issues/1218

Expansion to ResourceDescription to allow for groups/api version in addition to kinds

**Supported Format**
- Group/Version/Kind
- Group /*/Kind 
- Kind
 