### PR TITLE
feat: added functionality for delimiting multi-line block by newline characters

### DIFF
--- a/pkg/engine/jsonContext.go
+++ b/pkg/engine/jsonContext.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/resourcecache"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic/dynamiclister"
+	"strings"
 )
 
 // LoadContext - Fetches and adds external data to the Context.
@@ -183,6 +184,9 @@ func fetchConfigMap(entry kyverno.ContextEntry, lister dynamiclister.Lister) ([]
 		return nil, fmt.Errorf("failed to convert configmap %s/%s: %v", namespace, name, err)
 	}
 
+	// update the unstructuredObj["data"] to delimit and split the string value (containing "\n") with "\n"
+	unstructuredObj["data"] = parseMultilineBlockBody(unstructuredObj["data"].(map[string]interface{}))
+
 	// extract configmap data
 	contextData["data"] = unstructuredObj["data"]
 	contextData["metadata"] = unstructuredObj["metadata"]
@@ -194,4 +198,26 @@ func fetchConfigMap(entry kyverno.ContextEntry, lister dynamiclister.Lister) ([]
 	}
 
 	return data, nil
+}
+
+// parseMultilineBlockBody recursively iterates through a map and updates its values in the following way
+// whenever it encounters a string value containing "\n",
+// it converts it into a []string by splitting it by "\n"
+func parseMultilineBlockBody(m map[string]interface{}) map[string]interface{} {
+	for k, v := range m {
+		switch typedValue := v.(type) {
+		case string:
+			trimmedTypedValue := strings.Trim(typedValue, "\n")
+			if strings.Contains(trimmedTypedValue, "\n") {
+				m[k] = strings.Split(trimmedTypedValue, "\n")
+			} else {
+				m[k] = trimmedTypedValue // trimming a str if it has trailing newline characters
+			}
+		case map[string]interface{}:
+			m[k] = parseMultilineBlockBody(typedValue)
+		default:
+			continue
+		}
+	}
+	return m
 }

--- a/pkg/engine/jsonContext_test.go
+++ b/pkg/engine/jsonContext_test.go
@@ -1,0 +1,71 @@
+package engine
+
+import (
+	"bytes"
+	"encoding/json"
+	"gotest.tools/assert"
+	"testing"
+)
+
+func Test_parseMultilineBlockBody(t *testing.T) {
+	tcs := []struct {
+		multilineBlockRaw         []byte
+		expectedMultilineBlockRaw []byte
+		expectedErr               bool
+	}{
+		{
+			multilineBlockRaw: []byte(`{
+				"key1": "value",
+				"key2": "value2",
+				"key3": "word1\nword2\nword3",
+				"key4": "word4\n"
+			}`),
+			expectedMultilineBlockRaw: []byte(`{"key1":"value","key2":"value2","key3":["word1","word2","word3"],"key4":"word4"}`),
+			expectedErr:               false,
+		},
+		{
+			multilineBlockRaw: []byte(`{
+				"key1": "value",
+				"key2": "value2",
+				"key3": "word1\nword2\nword3",
+				"key4": "word4"
+			}`),
+			expectedMultilineBlockRaw: []byte(`{"key1":"value","key2":"value2","key3":["word1","word2","word3"],"key4":"word4"}`),
+			expectedErr:               false,
+		},
+		{
+			multilineBlockRaw: []byte(`{
+				"key1": "value1",
+				"key2": "value2\n",
+				"key3": "word1",
+				"key4": "word2"
+			}`),
+			expectedMultilineBlockRaw: []byte(`{"key1":"value1","key2":["value2",""]}`),
+			expectedErr:               true,
+		},
+		{
+			multilineBlockRaw: []byte(`{
+				"key1": "value1",
+				"key2": "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
+			}`),
+			expectedMultilineBlockRaw: []byte(`{"key1":"value1","key2":"[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"}`),
+			expectedErr:               false,
+		},
+	}
+
+	for _, tc := range tcs {
+		var multilineBlock map[string]interface{}
+		err := json.Unmarshal(tc.multilineBlockRaw, &multilineBlock)
+		assert.NilError(t, err)
+
+		parsedMultilineBlock := parseMultilineBlockBody(multilineBlock)
+		parsedMultilineBlockRaw, err := json.Marshal(parsedMultilineBlock)
+		assert.NilError(t, err)
+
+		if tc.expectedErr {
+			assert.Assert(t, bytes.Compare(parsedMultilineBlockRaw, tc.expectedMultilineBlockRaw) != 0)
+		} else {
+			assert.Assert(t, bytes.Compare(parsedMultilineBlockRaw, tc.expectedMultilineBlockRaw) == 0)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yash.kukreja.98@gmail.com>

## Related issue
closes #1242 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this
> /kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed changes
In the situations where certain values are passed from a configmap to the cluster policy, the multi-line block present in the configmap (if present) will be interpreted as a `[]string` corresponding to that multi-line block split by `\n`, instead of being interpreted as a multi-line single string literal.
```yaml
data:
  key: |-
    CREATE
    UPDATE
    DELETE
```
Here, after this PR, the value of `data.key` would be interpreted as `["CREATE", "UPDATE", "DELETE"]` unlike previously where it would have been interpreted as `"CREATE\nUPDATE\nDELETE"`
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] I have added or changed [the documentation](https://github.com/kyverno/website).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
As of now, this is WIP because it still does not perform in the idealistic manner when fed with two kinds of theoretical edge cases.
For example, 
1. The current implementation, in some cases, can't identify between multi-line blocks of literal (`|-`) and folded(`>-`) folded block scalars. For eg: the below two configmaps will seem identical to the current implementation. 
```yaml
data:
  key: |-
    the quick brown
    fox jumps over the lazy dog
```
```yaml
data:
  key: >-
    the quick brown

    fox jumps 
    over the lazy 
    dog
```
The `key`'s value will be interpreted as `["the quick brown", "fox jumps over the lazy dog"]` in both the cases by Kyverno.

2. The current implementation can't identify between a literal `key: value` and a multi-line block of just one line. For eg: the below three configmaps will seem identical to the current implementation
```yaml
data:
  key: hello-world
``` 
```yaml
data:
  key: |-
    hello-world
```
```yaml
data:
  key: >-
    hello-world
```
The `key`'s value will be interpreted as `"hello-world"` in all the above three cases by Kyverno. Instead it should have been interpreted as `"hello-world"` only for the first case and `["hello-world"]` for the second and third case.




