### PR TITLE
Allow some helm policies to be excluded

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -101,7 +101,8 @@ Parameter | Description | Default
 `service.type` | type of service | `ClusterIP`
 `tolerations` | list of node taints to tolerate | `[]`
 `securityContext` | security context configuration | `{}`
-`podSecurityStandard` | set desired pod security level `privileged`, `default`, `restricted`. Set to `restricted` for maximum security for your cluster. See:  https://kyverno.io/policies/pod-security/ | `default`
+`podSecurityStandard` | set desired pod security level `privileged`, `default`, `restricted`, `custom`. Set to `restricted` for maximum security for your cluster. See:  https://kyverno.io/policies/pod-security/ | `default`
+`podSecurityPolicies` | Policies to include when `podSecurityStandard` is set to `custom` | `[]`
 `validationFailureAction` | set to get response in failed validation check. Supported values- `audit`, `enforce`. See:  https://kyverno.io/docs/writing-policies/validate/ | `audit`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -70,3 +70,25 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     {{ default "default" .Values.rbac.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/* Set if a default policy is managed */}}
+{{- define "kyverno.podSecurityDefault" -}}
+{{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
+{{- true }}
+{{- else if and (eq .Values.podSecurityStandard "custom") (has .name .Values.podSecurityPolicies) }}
+{{- true }}
+{{- else -}}
+{{- false }}
+{{- end -}}
+{{- end -}}
+
+{{/* Set if a restricted policy is managed */}}
+{{- define "kyverno.podSecurityRestricted" -}}
+{{- if eq .Values.podSecurityStandard "restricted" }}
+{{- true }}
+{{- else if and (eq .Values.podSecurityStandard "custom") (has .name .Values.podSecurityPolicies) }}
+{{- true }}
+{{- else -}}
+{{- false }}
+{{- end -}}
+{{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-adding-capabilities.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-adding-capabilities.yaml
@@ -1,8 +1,10 @@
 {{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
+{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
+{{- if not (has $name .Values.podSecurityExclude) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: disallow-add-capabilities
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
     policies.kyverno.io/description: >-
@@ -32,4 +34,5 @@ spec:
           - =(securityContext):
               =(capabilities):
                 X(add): null
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-adding-capabilities.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-adding-capabilities.yaml
@@ -1,6 +1,5 @@
-{{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
-{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
-{{- if not (has $name .Values.podSecurityExclude) }}
+{{ $name := "disallow-add-capabilities" -}}
+{{- if eq (include "kyverno.podSecurityDefault" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -34,5 +33,4 @@ spec:
           - =(securityContext):
               =(capabilities):
                 X(add): null
-{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-host-namespaces.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-host-namespaces.yaml
@@ -1,8 +1,10 @@
 {{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
+{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
+{{- if not (has $name .Values.podSecurityExclude) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: disallow-host-namespaces
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
     policies.kyverno.io/description: >- 
@@ -27,4 +29,5 @@ spec:
           =(hostPID): "false"
           =(hostIPC): "false"
           =(hostNetwork): "false"
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-host-namespaces.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-host-namespaces.yaml
@@ -1,6 +1,5 @@
-{{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
-{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
-{{- if not (has $name .Values.podSecurityExclude) }}
+{{ $name := "disallow-host-namespaces" -}}
+{{- if eq (include "kyverno.podSecurityDefault" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -29,5 +28,4 @@ spec:
           =(hostPID): "false"
           =(hostIPC): "false"
           =(hostNetwork): "false"
-{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-host-path.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-host-path.yaml
@@ -1,8 +1,10 @@
 {{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
+{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
+{{- if not (has $name .Values.podSecurityExclude) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: disallow-host-path
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
     policies.kyverno.io/description: >-
@@ -25,4 +27,5 @@ spec:
         spec:
           =(volumes):
           - X(hostPath): "null"
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-host-path.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-host-path.yaml
@@ -1,6 +1,5 @@
-{{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
-{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
-{{- if not (has $name .Values.podSecurityExclude) }}
+{{ $name := "disallow-host-path" -}}
+{{- if eq (include "kyverno.podSecurityDefault" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -27,5 +26,4 @@ spec:
         spec:
           =(volumes):
           - X(hostPath): "null"
-{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-host-ports.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-host-ports.yaml
@@ -1,6 +1,5 @@
-{{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
-{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
-{{- if not (has $name .Values.podSecurityExclude) }}
+{{- $name := "disallow-host-ports" }}
+{{- if eq (include "kyverno.podSecurityDefault" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -31,5 +30,4 @@ spec:
           containers:
           - =(ports):
               - X(hostPort): 0
-{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-host-ports.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-host-ports.yaml
@@ -1,8 +1,10 @@
 {{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
+{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
+{{- if not (has $name .Values.podSecurityExclude) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: disallow-host-ports
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
     policies.kyverno.io/description: >-
@@ -29,4 +31,5 @@ spec:
           containers:
           - =(ports):
               - X(hostPort): 0
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-privileged-containers.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-privileged-containers.yaml
@@ -1,6 +1,5 @@
-{{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
-{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
-{{- if not (has $name .Values.podSecurityExclude) }}
+{{- $name := "disallow-privileged-containers" }}
+{{- if eq (include "kyverno.podSecurityDefault" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -30,5 +29,4 @@ spec:
           containers:
           - =(securityContext):
               =(privileged): "false"
-{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-privileged-containers.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-privileged-containers.yaml
@@ -1,8 +1,10 @@
 {{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
+{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
+{{- if not (has $name .Values.podSecurityExclude) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: disallow-privileged-containers
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
     policies.kyverno.io/description: >-
@@ -28,4 +30,5 @@ spec:
           containers:
           - =(securityContext):
               =(privileged): "false"
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-proc-mount.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-proc-mount.yaml
@@ -1,8 +1,10 @@
 {{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
+{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
+{{- if not (has $name .Values.podSecurityExclude) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: require-default-proc-mount
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
     policies.kyverno.io/description: >-
@@ -30,4 +32,5 @@ spec:
           containers:
           - =(securityContext):
               =(procMount): "Default"
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-proc-mount.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-proc-mount.yaml
@@ -1,6 +1,5 @@
-{{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
-{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
-{{- if not (has $name .Values.podSecurityExclude) }}
+{{- $name := "require-default-proc-mount" }}
+{{- if eq (include "kyverno.podSecurityDefault" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -32,5 +31,4 @@ spec:
           containers:
           - =(securityContext):
               =(procMount): "Default"
-{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-selinux.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-selinux.yaml
@@ -1,6 +1,5 @@
-{{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
-{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
-{{- if not (has $name .Values.podSecurityExclude) }}
+{{- $name := "disallow-selinux" }}
+{{- if eq (include "kyverno.podSecurityDefault" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -34,5 +33,4 @@ spec:
           containers:
           - =(securityContext):
               X(seLinuxOptions): "null"
-{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/disallow-selinux.yaml
+++ b/charts/kyverno/templates/policies/default/disallow-selinux.yaml
@@ -1,8 +1,10 @@
 {{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
+{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
+{{- if not (has $name .Values.podSecurityExclude) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: disallow-selinux
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/title: Disallow SELinux
     policies.kyverno.io/category: Pod Security Standards (Default)
@@ -32,4 +34,5 @@ spec:
           containers:
           - =(securityContext):
               X(seLinuxOptions): "null"
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/restrict-apparmor-profiles.yaml
+++ b/charts/kyverno/templates/policies/default/restrict-apparmor-profiles.yaml
@@ -1,8 +1,10 @@
 {{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
+{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
+{{- if not (has $name .Values.podSecurityExclude) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: restrict-apparmor-profiles
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/title: Restrict AppArmor
     policies.kyverno.io/category: Pod Security Standards (Default)
@@ -28,4 +30,5 @@ spec:
         metadata:
           =(annotations):
             =(container.apparmor.security.beta.kubernetes.io/*): "runtime/default"
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/restrict-apparmor-profiles.yaml
+++ b/charts/kyverno/templates/policies/default/restrict-apparmor-profiles.yaml
@@ -1,6 +1,5 @@
-{{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
-{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
-{{- if not (has $name .Values.podSecurityExclude) }}
+{{ $name := "restrict-apparmor-profiles" -}}
+{{- if eq (include "kyverno.podSecurityDefault" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -30,5 +29,4 @@ spec:
         metadata:
           =(annotations):
             =(container.apparmor.security.beta.kubernetes.io/*): "runtime/default"
-{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/default/restrict-sysctls.yaml
+++ b/charts/kyverno/templates/policies/default/restrict-sysctls.yaml
@@ -1,8 +1,9 @@
-{{- if or (eq .Values.podSecurityStandard "default") (eq .Values.podSecurityStandard "restricted") }}
+{{ $name := "restrict-sysctls" -}}
+{{- if eq (include "kyverno.podSecurityDefault" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: restrict-sysctls
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
     policies.kyverno.io/description: >-

--- a/charts/kyverno/templates/policies/restricted/deny-privilege-escalation.yaml
+++ b/charts/kyverno/templates/policies/restricted/deny-privilege-escalation.yaml
@@ -1,8 +1,10 @@
 {{- if eq .Values.podSecurityStandard "restricted" }}
+{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
+{{- if not (has $name .Values.podSecurityExclude) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: deny-privilege-escalation
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/description: >-
@@ -30,4 +32,5 @@ spec:
           containers:
           - =(securityContext):
               =(allowPrivilegeEscalation): "false"
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/restricted/deny-privilege-escalation.yaml
+++ b/charts/kyverno/templates/policies/restricted/deny-privilege-escalation.yaml
@@ -1,6 +1,5 @@
-{{- if eq .Values.podSecurityStandard "restricted" }}
-{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
-{{- if not (has $name .Values.podSecurityExclude) }}
+{{ $name := "deny-privilege-escalation" -}}
+{{- if eq (include "kyverno.podSecurityRestricted" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -32,5 +31,4 @@ spec:
           containers:
           - =(securityContext):
               =(allowPrivilegeEscalation): "false"
-{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/restricted/require-non-root-groups.yaml
+++ b/charts/kyverno/templates/policies/restricted/require-non-root-groups.yaml
@@ -1,8 +1,10 @@
 {{- if eq .Values.podSecurityStandard "restricted" }}
+{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
+{{- if not (has $name .Values.podSecurityExclude) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: require-non-root-groups
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/description: >-
@@ -58,4 +60,5 @@ spec:
           spec:
             =(securityContext):
               X(fsGroup): "*"
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/restricted/require-non-root-groups.yaml
+++ b/charts/kyverno/templates/policies/restricted/require-non-root-groups.yaml
@@ -1,6 +1,5 @@
-{{- if eq .Values.podSecurityStandard "restricted" }}
-{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
-{{- if not (has $name .Values.podSecurityExclude) }}
+{{ $name := "require-non-root-groups" -}}
+{{- if eq (include "kyverno.podSecurityRestricted" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -60,5 +59,4 @@ spec:
           spec:
             =(securityContext):
               X(fsGroup): "*"
-{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/restricted/require-run-as-nonroot.yaml
+++ b/charts/kyverno/templates/policies/restricted/require-run-as-nonroot.yaml
@@ -1,6 +1,5 @@
-{{- if eq .Values.podSecurityStandard "restricted" }}
-{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
-{{- if not (has $name .Values.podSecurityExclude) }}
+{{ $name := "require-run-as-non-root" -}}
+{{- if eq (include "kyverno.podSecurityRestricted" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -39,5 +38,4 @@ spec:
           =(initContainers):
           - securityContext:
               runAsNonRoot: true         
-{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/restricted/require-run-as-nonroot.yaml
+++ b/charts/kyverno/templates/policies/restricted/require-run-as-nonroot.yaml
@@ -1,8 +1,10 @@
 {{- if eq .Values.podSecurityStandard "restricted" }}
+{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
+{{- if not (has $name .Values.podSecurityExclude) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: require-run-as-non-root
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/description: Containers must be required to run as non-root users.
@@ -37,4 +39,5 @@ spec:
           =(initContainers):
           - securityContext:
               runAsNonRoot: true         
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/restricted/restrict-seccomp.yaml
+++ b/charts/kyverno/templates/policies/restricted/restrict-seccomp.yaml
@@ -1,8 +1,10 @@
 {{- if eq .Values.podSecurityStandard "restricted" }}
+{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
+{{- if not (has $name .Values.podSecurityExclude) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: restrict-seccomp
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/title: Restrict Seccomp
     policies.kyverno.io/category: Pod Security Standards (Restricted)
@@ -38,4 +40,5 @@ spec:
           - =(securityContext):
               =(seccompProfile):
                 =(type): "runtime/default"
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/restricted/restrict-seccomp.yaml
+++ b/charts/kyverno/templates/policies/restricted/restrict-seccomp.yaml
@@ -1,6 +1,5 @@
-{{- if eq .Values.podSecurityStandard "restricted" }}
-{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
-{{- if not (has $name .Values.podSecurityExclude) }}
+{{ $name := "restrict-seccomp" -}}
+{{- if eq (include "kyverno.podSecurityRestricted" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -40,5 +39,4 @@ spec:
           - =(securityContext):
               =(seccompProfile):
                 =(type): "runtime/default"
-{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/restricted/restrict-volume-types.yaml
+++ b/charts/kyverno/templates/policies/restricted/restrict-volume-types.yaml
@@ -1,6 +1,5 @@
-{{- if eq .Values.podSecurityStandard "restricted" }}
-{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
-{{- if not (has $name .Values.podSecurityExclude) }}
+{{ $name := "restrict-volume-types" -}}
+{{- if eq (include "kyverno.podSecurityRestricted" (merge (dict "name" $name) .)) "true" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -274,5 +273,4 @@ spec:
         spec:
           =(volumes):
           - X(csi): "null"
-{{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/policies/restricted/restrict-volume-types.yaml
+++ b/charts/kyverno/templates/policies/restricted/restrict-volume-types.yaml
@@ -1,8 +1,10 @@
 {{- if eq .Values.podSecurityStandard "restricted" }}
+{{ $name := trimSuffix (ext .Template.Name) (base .Template.Name) -}}
+{{- if not (has $name .Values.podSecurityExclude) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: restrict-volume-types
+  name: {{ $name }}
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/description: >-
@@ -272,4 +274,5 @@ spec:
         spec:
           =(volumes):
           - X(csi): "null"
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -4,6 +4,8 @@ namespace:
 # Supported- default/restricted/privileged
 # For more info- https://kyverno.io/policies/pod-security
 podSecurityStandard: default
+# Policies to exclude
+podSecurityExclude: []
 # Supported values- `audit`, `enforce`
 # For more info- https://kyverno.io/docs/writing-policies/validate/
 validationFailureAction: audit

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -1,11 +1,11 @@
 nameOverride:
 fullnameOverride:
 namespace:
-# Supported- default/restricted/privileged
+# Supported- default/restricted/privileged/custom
 # For more info- https://kyverno.io/policies/pod-security
 podSecurityStandard: default
-# Policies to exclude
-podSecurityExclude: []
+# Policies to include when podSecurityStandard is custom
+podSecurityPolicies: []
 # Supported values- `audit`, `enforce`
 # For more info- https://kyverno.io/docs/writing-policies/validate/
 validationFailureAction: audit


### PR DESCRIPTION
Signed-off-by: Trey Dockendorf <tdockendorf@osc.edu>

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
-->
/kind feature

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
I would like to deploy Kyverno with the Helm provided policies, except one or two of the charts won't work in my environment so I'd like to ideally exclude a few like so:

```yaml
podSecurityExclude:
- disallow-host-path
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] I have added or changed [the documentation](https://github.com/kyverno/website).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

I can add Helm CI tests is that's desired (seeing the checkbox above), but since none already existed I opted not to add any tests for Helm.

Also I think the only name issue is `disallow-proc-mount.yaml` and `require-run-as-nonroot.yaml` had a different name than the actual name in metadata, so if the previous name needs to remain the same I will have to remove the logic to use the template name as resource name. I could easily just hardcode `$name` in those cases to avoid changing the name for future deployments.