### PR TITLE
Fix Helm chart notes to use template values

### DIFF
--- a/charts/kyverno/templates/NOTES.txt
+++ b/charts/kyverno/templates/NOTES.txt
@@ -2,7 +2,7 @@ Thank you for installing {{ .Chart.Name }} 😀
 
 Your release is named {{ .Release.Name }}.
 
-We have installed the "default" profile of Pod Security Standards and set them in audit mode.
+We have installed the "{{ .Values.podSecurityStandard }}" profile of Pod Security Standards and set them in {{ .Values.validationFailureAction }} mode.
 
 Visit https://kyverno.io/policies/ to find more sample policies.
 


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind bug

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
This ensures the NOTES output when adding Helm chart actually describes what was setup, especially if sites don't deploy with the defaults.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] I have added or changed [the documentation](https://github.com/kyverno/website).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
