### PR TITLE
Support AllowMissingPathOnRemove and EnsurePathExistsOnAdd in patchesJSON6902

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cornelk/hashmap v1.0.1
-	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/evanphx/json-patch/v5 v5.2.0
 	github.com/fatih/color v1.9.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/gardener/controller-manager-library v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5I
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch/v5 v5.2.0 h1:8ozOH5xxoMYDt5/u+yMTsVXydVCbTORFnOOoq2lumco=
+github.com/evanphx/json-patch/v5 v5.2.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=

--- a/pkg/engine/context/context.go
+++ b/pkg/engine/context/context.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/go-logr/logr"
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"k8s.io/api/admission/v1beta1"

--- a/pkg/engine/mutate/mutation.go
+++ b/pkg/engine/mutate/mutation.go
@@ -113,7 +113,15 @@ func (h patchesJSON6902Handler) Handle() (resp response.RuleResponse, patchedRes
 	resp.Name = h.ruleName
 	resp.Type = utils.Mutation.String()
 
-	skip, err := preProcessJSONPatches(*h.mutation, h.patchedResource, h.logger)
+	patchesJSON6902, err := convertPatchesToJSON(h.mutation.PatchesJSON6902)
+	if err != nil {
+		resp.Success = false
+		h.logger.Error(err, "error in type conversion")
+		resp.Message = err.Error()
+		return resp, h.patchedResource
+	}
+
+	skip, err := preProcessJSONPatches(patchesJSON6902, h.patchedResource, h.logger)
 	if err != nil {
 		h.logger.Error(err, "failed to preProcessJSONPatches")
 	}
@@ -123,7 +131,7 @@ func (h patchesJSON6902Handler) Handle() (resp response.RuleResponse, patchedRes
 		return resp, h.patchedResource
 	}
 
-	return ProcessPatchJSON6902(h.ruleName, *h.mutation, h.patchedResource, h.logger)
+	return ProcessPatchJSON6902(h.ruleName, patchesJSON6902, h.patchedResource, h.logger)
 }
 
 func (h overlayHandler) Handle() (response.RuleResponse, unstructured.Unstructured) {
@@ -133,7 +141,7 @@ func (h overlayHandler) Handle() (response.RuleResponse, unstructured.Unstructur
 	// substitute the variables
 	var err error
 	if overlay, err = variables.SubstituteVars(h.logger, h.evalCtx, overlay); err != nil {
-		// variable subsitution failed
+		// variable substitution failed
 		ruleResponse.Success = false
 		ruleResponse.Message = err.Error()
 		return ruleResponse, h.patchedResource
@@ -165,7 +173,16 @@ func (h patchesHandler) Handle() (resp response.RuleResponse, patchedResource un
 	resp.Name = h.ruleName
 	resp.Type = utils.Mutation.String()
 
-	skip, err := preProcessJSONPatches(*h.mutation, h.patchedResource, h.logger)
+	// patches is already converted to patchesJSON6902
+	patchesJSON6902, err := convertPatchesToJSON(h.mutation.PatchesJSON6902)
+	if err != nil {
+		resp.Success = false
+		h.logger.Error(err, "error in type conversion")
+		resp.Message = err.Error()
+		return resp, h.patchedResource
+	}
+
+	skip, err := preProcessJSONPatches(patchesJSON6902, h.patchedResource, h.logger)
 	if err != nil {
 		h.logger.Error(err, "failed to preProcessJSONPatches")
 	}

--- a/pkg/engine/mutate/overlay.go
+++ b/pkg/engine/mutate/overlay.go
@@ -10,14 +10,13 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/go-logr/logr"
 	commonAnchors "github.com/kyverno/kyverno/pkg/engine/anchor/common"
 	"github.com/kyverno/kyverno/pkg/engine/response"
 	"github.com/kyverno/kyverno/pkg/engine/utils"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // ProcessOverlay processes mutation overlay on the resource

--- a/pkg/engine/mutate/overlayCondition.go
+++ b/pkg/engine/mutate/overlayCondition.go
@@ -26,6 +26,10 @@ func checkConditions(log logr.Logger, resource, overlay interface{}, path string
 	// return false if anchor exists in overlay
 	// condition never be true in this case
 	if reflect.TypeOf(resource) != reflect.TypeOf(overlay) {
+		if resource == nil {
+			return "", overlayError{}
+		}
+
 		if hasNestedAnchors(overlay) {
 			log.V(4).Info(fmt.Sprintf("element type mismatch at path %s: overlay %T, resource %T", path, overlay, resource))
 			return path, newOverlayError(conditionFailure,

--- a/pkg/engine/mutate/overlay_test.go
+++ b/pkg/engine/mutate/overlay_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/kyverno/kyverno/pkg/engine/utils"
 	"gotest.tools/assert"
 	"sigs.k8s.io/controller-runtime/pkg/log"

--- a/pkg/engine/mutate/patchJson6902.go
+++ b/pkg/engine/mutate/patchJson6902.go
@@ -1,25 +1,20 @@
 package mutate
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
-	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/go-logr/logr"
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/engine/response"
 	"github.com/kyverno/kyverno/pkg/engine/utils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	patchjson6902 "sigs.k8s.io/kustomize/api/filters/patchjson6902"
-	filtersutil "sigs.k8s.io/kustomize/kyaml/filtersutil"
 	"sigs.k8s.io/yaml"
 )
 
 // ProcessPatchJSON6902 ...
-func ProcessPatchJSON6902(ruleName string, mutation kyverno.Mutation, resource unstructured.Unstructured, log logr.Logger) (resp response.RuleResponse, patchedResource unstructured.Unstructured) {
+func ProcessPatchJSON6902(ruleName string, patchesJSON6902 []byte, resource unstructured.Unstructured, log logr.Logger) (resp response.RuleResponse, patchedResource unstructured.Unstructured) {
 	logger := log.WithValues("rule", ruleName)
 	startTime := time.Now()
 	logger.V(4).Info("started JSON6902 patch", "startTime", startTime)
@@ -38,7 +33,8 @@ func ProcessPatchJSON6902(ruleName string, mutation kyverno.Mutation, resource u
 		return resp, resource
 	}
 
-	patchedResourceRaw, err := patchJSON6902(string(resourceRaw), mutation.PatchesJSON6902)
+	patchedResourceRaw, err := utils.ApplyPatchNew(resourceRaw, patchesJSON6902)
+	// patchedResourceRaw, err := patchJSON6902(string(resourceRaw), mutation.PatchesJSON6902)
 	if err != nil {
 		resp.Success = false
 		logger.Error(err, "failed to process JSON6902 patches")
@@ -48,27 +44,14 @@ func ProcessPatchJSON6902(ruleName string, mutation kyverno.Mutation, resource u
 
 	err = patchedResource.UnmarshalJSON(patchedResourceRaw)
 	if err != nil {
-		logger.Error(err, "failed to unmmarshal resource")
+		logger.Error(err, "failed to unmarshal resource")
 		resp.Success = false
-		resp.Message = fmt.Sprintf("failed to unmmarshal resource: %v", err)
+		resp.Message = fmt.Sprintf("failed to unmarshal resource: %v", err)
 		return resp, resource
 	}
 
-	var op []byte
-	if mutation.PatchesJSON6902[0] != '[' {
-		// if it doesn't seem to be JSON, imagine
-		// it is YAML, and convert to JSON.
-		op, err = yaml.YAMLToJSON([]byte(mutation.PatchesJSON6902))
-		if err != nil {
-			resp.Success = false
-			resp.Message = fmt.Sprintf("failed to unmmarshal resource: %v", err)
-			return resp, resource
-		}
-		mutation.PatchesJSON6902 = string(op)
-	}
-
 	var decodedPatch []kyverno.Patch
-	err = json.Unmarshal(op, &decodedPatch)
+	err = json.Unmarshal(patchesJSON6902, &decodedPatch)
 	if err != nil {
 		resp.Success = false
 		resp.Message = err.Error()
@@ -94,32 +77,16 @@ func ProcessPatchJSON6902(ruleName string, mutation kyverno.Mutation, resource u
 	return resp, patchedResource
 }
 
-func patchJSON6902(base, patches string) ([]byte, error) {
-	f := patchjson6902.Filter{
-		Patch: patches,
-	}
-
-	baseObj := buffer{Buffer: bytes.NewBufferString(base)}
-	err := filtersutil.ApplyToJSON(f, baseObj)
-
-	return baseObj.Bytes(), err
-}
-
-func decodePatch(patch string) (jsonpatch.Patch, error) {
-	// If the patch doesn't look like a JSON6902 patch, we
-	// try to parse it to json.
-	if !strings.HasPrefix(patch, "[") {
-		p, err := yaml.YAMLToJSON([]byte(patch))
+func convertPatchesToJSON(patchesJSON6902 string) ([]byte, error) {
+	if patchesJSON6902[0] != '[' {
+		// If the patch doesn't look like a JSON6902 patch, we
+		// try to parse it to json.
+		op, err := yaml.YAMLToJSON([]byte(patchesJSON6902))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to convert patchesJSON6902 to JSON: %v", err)
 		}
-		patch = string(p)
+		return op, nil
 	}
 
-	decodedPatch, err := jsonpatch.DecodePatch([]byte(patch))
-	if err != nil {
-		return nil, err
-	}
-
-	return decodedPatch, nil
+	return []byte(patchesJSON6902), nil
 }

--- a/pkg/engine/mutate/patchJson6902.go
+++ b/pkg/engine/mutate/patchJson6902.go
@@ -72,7 +72,7 @@ func applyPatchesWithOptions(resource, patch []byte) ([]byte, error) {
 		return resource, fmt.Errorf("failed to decode patches: %v", err)
 	}
 
-	options := &jsonpatch.ApplyOptions{AllowMissingPathOnRemove: true, EnsurePathExistsOnAdd: true}
+	options := &jsonpatch.ApplyOptions{SupportNegativeIndices: true, AllowMissingPathOnRemove: true, EnsurePathExistsOnAdd: true}
 	patchedResource, err := patches.ApplyWithOptions(resource, options)
 	if err != nil {
 		return resource, err

--- a/pkg/engine/mutate/patchJson6902_test.go
+++ b/pkg/engine/mutate/patchJson6902_test.go
@@ -199,3 +199,179 @@ spec:
 		})
 	}
 }
+
+func Test_MissingPaths(t *testing.T) {
+	tests := []struct {
+		name            string
+		resource        string
+		patches         string
+		expectedPatches map[string]bool
+	}{
+		// test
+		{
+			name: "add-map-to-non-exist-path",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+`,
+			patches: `
+- path: "/spec/nodeSelector"
+  op: add 
+  value: {"node.kubernetes.io/role": "test"}
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"add","path":"/spec/nodeSelector","value":{"node.kubernetes.io/role":"test"}}`: true,
+			},
+		},
+		// test
+		{
+			name: "add-to-non-exist-array",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+`,
+			patches: `
+- path: "/spec/tolerations/0"
+  op: add
+  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
+			},
+		},
+		// test
+		{
+			name: "add-to-non-exist-array-2",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+`,
+			patches: `
+- path: "/spec/tolerations"
+  op: add
+  value: [{"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}]
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
+			},
+		},
+		// test
+		{
+			name: "add-to-non-exist-array-3",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+`,
+			patches: `
+- path: "/spec/tolerations/-1"
+  op: add
+  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
+			},
+		},
+		// test
+		{
+			name: "add-to-exist-array",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+`,
+			patches: `
+- path: "/spec/tolerations"
+  op: add
+  value: [{"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}]
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"replace","path":"/spec/tolerations/0/effect","value":"NoSchedule"}`:                true,
+				`{"op":"replace","path":"/spec/tolerations/0/key","value":"node-role.kubernetes.io/test"}`: true,
+				`{"op":"remove","path":"/spec/tolerations/0/tolerationSeconds"}`:                           true,
+			},
+		},
+		// test
+		{
+			name: "add-to-exist-array-2",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+`,
+			patches: `
+- path: "/spec/tolerations/-"
+  op: add
+  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"add","path":"/spec/tolerations/1","value":{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}}`: true,
+			},
+		},
+		// test
+		{
+			name: "add-to-exist-array-3",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - key: "node.kubernetes.io/unreachable"
+    operator: "Exists"
+    effect: "NoExecute"
+    tolerationSeconds: 6000
+`,
+			patches: `
+- path: "/spec/tolerations/-1"
+  op: add
+  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"add","path":"/spec/tolerations/2","value":{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}}`: true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		r, err := yaml.YAMLToJSON([]byte(test.resource))
+		assert.Nil(t, err)
+
+		patches, err := yaml.YAMLToJSON([]byte(test.patches))
+		assert.Nil(t, err)
+
+		patchedResource, err := applyPatchesWithOptions(r, patches)
+		assert.Nil(t, err)
+
+		generatedP, err := generatePatches(r, patchedResource)
+		assert.Nil(t, err)
+
+		for _, p := range generatedP {
+			assert.Equal(t, test.expectedPatches[string(p)], true,
+				fmt.Sprintf("test: %s\nunexpected patch: %s\nexpect one of: %v", test.name, string(p), test.expectedPatches))
+		}
+	}
+}

--- a/pkg/engine/mutate/patchJson6902_test.go
+++ b/pkg/engine/mutate/patchJson6902_test.go
@@ -1,31 +1,14 @@
 package mutate
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/ghodss/yaml"
-	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	assert "github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-const input = `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  replica: 2
-  template:
-    metadata:
-      labels:
-        old-label: old-value
-    spec:
-      containers:
-      - image: nginx
-        name: nginx
-`
 
 var inputBytes = []byte(`
 apiVersion: apps/v1
@@ -45,34 +28,34 @@ spec:
 `)
 
 func TestTypeConversion(t *testing.T) {
-
-	mutateRule := kyverno.Mutation{
-		PatchesJSON6902: `
+	patchesJSON6902 := []byte(`
 - op: replace
   path: /spec/template/spec/containers/0/name
   value: my-nginx
-`,
-	}
+`)
 
 	expectedPatches := [][]byte{
-		[]byte(`{"path":"/spec/template/spec/containers/0/name","op":"replace","value":"my-nginx"}`),
+		[]byte(`{"op":"replace","path":"/spec/template/spec/containers/0/name","value":"my-nginx"}`),
 	}
 
 	// serialize resource
-	inputJSONgo, err := yaml.YAMLToJSON(inputBytes)
+	inputJSON, err := yaml.YAMLToJSON(inputBytes)
 	assert.Nil(t, err)
 
 	var resource unstructured.Unstructured
-	err = resource.UnmarshalJSON(inputJSONgo)
+	err = resource.UnmarshalJSON(inputJSON)
 	assert.Nil(t, err)
 
+	jsonPatches, err := yaml.YAMLToJSON(patchesJSON6902)
+	assert.Nil(t, err)
 	// apply patches
-	resp, _ := ProcessPatchJSON6902("type-conversion", mutateRule, resource, log.Log)
+	resp, _ := ProcessPatchJSON6902("type-conversion", jsonPatches, resource, log.Log)
 	if !assert.Equal(t, true, resp.Success) {
 		t.Fatal(resp.Message)
 	}
 
-	assert.Equal(t, expectedPatches, resp.Patches)
+	assert.Equal(t, expectedPatches, resp.Patches,
+		fmt.Sprintf("expectedPatches: %s\ngeneratedPatches: %s", string(expectedPatches[0]), string(resp.Patches[0])))
 }
 
 func TestJsonPatch(t *testing.T) {
@@ -166,11 +149,11 @@ spec:
   path: /spec/replica
   value: 999
 - op: add
-  path: /spec/template/spec/containers/0/command
+  path: /spec/template/spec/volumes
   value:
-  - arg1
-  - arg2
-  - arg3
+  - emptyDir:
+      medium: Memory
+    name: vault-secret
 `,
 			expected: []byte(`
 apiVersion: apps/v1
@@ -185,12 +168,12 @@ spec:
         old-label: old-value
     spec:
       containers:
-      - command:
-        - arg1
-        - arg2
-        - arg3
-        image: nginx
+      - image: nginx
         name: my-nginx
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: vault-secret
 `),
 		},
 	}
@@ -201,9 +184,16 @@ spec:
 			expectedBytes, err := yaml.YAMLToJSON(testCase.expected)
 			assert.Nil(t, err)
 
-			out, err := patchJSON6902(input, testCase.patches)
+			inputBytes, err := yaml.YAMLToJSON(inputBytes)
+			assert.Nil(t, err)
 
-			if !assert.Equal(t, string(expectedBytes), string(out)) {
+			patches, err := yaml.YAMLToJSON([]byte(testCase.patches))
+			assert.Nil(t, err)
+
+			out, err := applyPatchesWithOptions(inputBytes, patches)
+			assert.Nil(t, err)
+
+			if !assert.Equal(t, string(expectedBytes), string(out), testCase.testName) {
 				t.FailNow()
 			}
 		})

--- a/pkg/engine/mutate/patchesUtils.go
+++ b/pkg/engine/mutate/patchesUtils.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	evanjsonpatch "github.com/evanphx/json-patch"
+	evanjsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/go-logr/logr"
 	"github.com/mattbaird/jsonpatch"
 	"github.com/minio/minio/pkg/wildcard"
@@ -18,8 +18,11 @@ import (
 func generatePatches(src, dst []byte) ([][]byte, error) {
 	var patchesBytes [][]byte
 	pp, err := jsonpatch.CreatePatch(src, dst)
-	sortedPatches := filterAndSortPatches(pp)
+	if err != nil {
+		return nil, err
+	}
 
+	sortedPatches := filterAndSortPatches(pp)
 	for _, p := range sortedPatches {
 		pbytes, err := p.MarshalJSON()
 		if err != nil {
@@ -186,13 +189,13 @@ func preProcessJSONPatches(patchesJSON6902 []byte, resource unstructured.Unstruc
 
 		resourceObj, err := getObject(path, resource.UnstructuredContent())
 		if err != nil {
-			log.V(4).Info("failed to get object by the given path", "path", path, "error", err.Error())
+			log.V(4).Info("unable to get object by the given path, proceed patchesJson6902 without preprocessing", "path", path, "error", err.Error())
 			continue
 		}
 
 		val, err := patch.ValueInterface()
 		if err != nil {
-			log.V(4).Info("failed to get value by the given path", "path", path, "error", err.Error())
+			log.V(4).Info("unable to get value by the given path, proceed patchesJson6902 without preprocessing", "path", path, "error", err.Error())
 			continue
 		}
 

--- a/pkg/engine/mutate/patchesUtils.go
+++ b/pkg/engine/mutate/patchesUtils.go
@@ -243,6 +243,9 @@ func getObject(path string, resource map[string]interface{}) (interface{}, error
 				if err != nil {
 					return nil, fmt.Errorf("cannot parse index in JSON Patch at %s: %v", strings.Join(paths[:i+1], "/"), err)
 				}
+				if idx < 0 {
+					idx = len(strippedResource.([]interface{})) - 1
+				}
 			}
 
 			if len(strippedResource.([]interface{})) <= idx {

--- a/pkg/engine/mutate/patchesUtils_test.go
+++ b/pkg/engine/mutate/patchesUtils_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	v1 "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
-	"github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/mattbaird/jsonpatch"
 	assertnew "github.com/stretchr/testify/assert"
 	"gotest.tools/assert"
@@ -20,28 +18,17 @@ func Test_GeneratePatches(t *testing.T) {
 	out, err := strategicMergePatch(string(baseBytes), string(overlayBytes))
 	assert.NilError(t, err)
 
+	expectedPatches := [][]byte{
+		[]byte(`{"op":"remove","path":"/spec/template/spec/containers/0"}`),
+		[]byte(`{"op":"add","path":"/spec/template/spec/containers/0","value":{"image":"nginx","name":"nginx"}}`),
+		[]byte(`{"op":"add","path":"/spec/template/spec/containers/1","value":{"env":[{"name":"WORDPRESS_DB_HOST","value":"$(MYSQL_SERVICE)"},{"name":"WORDPRESS_DB_PASSWORD","valueFrom":{"secretKeyRef":{"key":"password","name":"mysql-pass"}}}],"image":"wordpress:4.8-apache","name":"wordpress","ports":[{"containerPort":80,"name":"wordpress"}],"volumeMounts":[{"mountPath":"/var/www/html","name":"wordpress-persistent-storage"}]}}`),
+		[]byte(`{"op":"add","path":"/spec/template/spec/initContainers","value":[{"command":["echo $(WORDPRESS_SERVICE)","echo $(MYSQL_SERVICE)"],"image":"debian","name":"init-command"}]}`),
+	}
 	patches, err := generatePatches(baseBytes, out)
 	assert.NilError(t, err)
 
-	var overlay unstructured.Unstructured
-	err = json.Unmarshal(baseBytes, &overlay)
-	assert.NilError(t, err)
-
-	bb, err := json.Marshal(overlay.Object)
-	assert.NilError(t, err)
-
-	res, err := utils.ApplyPatches(bb, patches)
-	assert.NilError(t, err)
-
-	var ep unstructured.Unstructured
-	err = json.Unmarshal(expectBytes, &ep)
-	assert.NilError(t, err)
-
-	eb, err := json.Marshal(ep.Object)
-	assert.NilError(t, err)
-
-	if !assertnew.Equal(t, string(eb), string(res)) {
-		t.FailNow()
+	for i, expect := range expectedPatches {
+		assertnew.Equal(t, string(expect), string(patches[i]))
 	}
 }
 
@@ -175,79 +162,36 @@ var podBytes = []byte(`
 `)
 
 func Test_preProcessJSONPatches_skip(t *testing.T) {
-	var policyBytes = []byte(`
-{
-  "apiVersion": "kyverno.io/v1",
-  "kind": "ClusterPolicy",
-  "metadata": {
-      "name": "insert-container"
-  },
-  "spec": {
-      "rules": [
-          {
-              "name": "insert-container",
-              "match": {
-                  "resources": {
-                      "kinds": [
-                          "Pod"
-                      ]
-                  }
-              },
-              "mutate": {
-                  "patchesJson6902": "- op: add\n  path: /spec/containers/1\n  value: {\"name\":\"nginx-new\",\"image\":\"nginx:latest\"}"
-              }
-          }
-      ]
-  }
-}
+	patchesJSON6902 := []byte(`
+- op: add
+  path: /spec/containers/1
+  value: {"name":"nginx-new","image":"nginx:latest"}
 `)
-
 	var pod unstructured.Unstructured
-	var policy v1.ClusterPolicy
-
 	assertnew.Nil(t, json.Unmarshal(podBytes, &pod))
-	assertnew.Nil(t, yaml.Unmarshal(policyBytes, &policy))
 
-	skip, err := preProcessJSONPatches(policy.Spec.Rules[0].Mutation, pod, log.Log)
+	patches, err := yaml.YAMLToJSON(patchesJSON6902)
+	assertnew.Nil(t, err)
+
+	skip, err := preProcessJSONPatches(patches, pod, log.Log)
 	assertnew.Nil(t, err)
 	assertnew.Equal(t, true, skip)
 }
 
 func Test_preProcessJSONPatches_not_skip(t *testing.T) {
-	var policyBytes = []byte(`
-{
-  "apiVersion": "kyverno.io/v1",
-  "kind": "ClusterPolicy",
-  "metadata": {
-      "name": "insert-container"
-  },
-  "spec": {
-      "rules": [
-          {
-              "name": "insert-container",
-              "match": {
-                  "resources": {
-                      "kinds": [
-                          "Pod"
-                      ]
-                  }
-              },
-              "mutate": {
-                  "patchesJson6902": "- op: add\n  path: /spec/containers/1\n  value: {\"name\":\"my-new-container\",\"image\":\"nginx:latest\"}"
-              }
-          }
-      ]
-  }
-}
+	patchesJSON6902 := []byte(`
+- op: add
+  path: /spec/containers/1
+  value: {"name":"my-new-container","image":"nginx:latest"}
 `)
 
+	patches, err := yaml.YAMLToJSON(patchesJSON6902)
+	assertnew.Nil(t, err)
+
 	var pod unstructured.Unstructured
-	var policy v1.ClusterPolicy
-
 	assertnew.Nil(t, json.Unmarshal(podBytes, &pod))
-	assertnew.Nil(t, yaml.Unmarshal(policyBytes, &policy))
 
-	skip, err := preProcessJSONPatches(policy.Spec.Rules[0].Mutation, pod, log.Log)
+	skip, err := preProcessJSONPatches(patches, pod, log.Log)
 	assertnew.Nil(t, err)
 	assertnew.Equal(t, false, skip)
 }

--- a/pkg/engine/mutate/patchesUtils_test.go
+++ b/pkg/engine/mutate/patchesUtils_test.go
@@ -18,17 +18,17 @@ func Test_GeneratePatches(t *testing.T) {
 	out, err := strategicMergePatch(string(baseBytes), string(overlayBytes))
 	assert.NilError(t, err)
 
-	expectedPatches := [][]byte{
-		[]byte(`{"op":"remove","path":"/spec/template/spec/containers/0"}`),
-		[]byte(`{"op":"add","path":"/spec/template/spec/containers/0","value":{"image":"nginx","name":"nginx"}}`),
-		[]byte(`{"op":"add","path":"/spec/template/spec/containers/1","value":{"env":[{"name":"WORDPRESS_DB_HOST","value":"$(MYSQL_SERVICE)"},{"name":"WORDPRESS_DB_PASSWORD","valueFrom":{"secretKeyRef":{"key":"password","name":"mysql-pass"}}}],"image":"wordpress:4.8-apache","name":"wordpress","ports":[{"containerPort":80,"name":"wordpress"}],"volumeMounts":[{"mountPath":"/var/www/html","name":"wordpress-persistent-storage"}]}}`),
-		[]byte(`{"op":"add","path":"/spec/template/spec/initContainers","value":[{"command":["echo $(WORDPRESS_SERVICE)","echo $(MYSQL_SERVICE)"],"image":"debian","name":"init-command"}]}`),
+	expectedPatches := map[string]bool{
+		`{"op":"remove","path":"/spec/template/spec/containers/0"}`:                                       true,
+		`{"op":"add","path":"/spec/template/spec/containers/0","value":{"image":"nginx","name":"nginx"}}`: true,
+		`{"op":"add","path":"/spec/template/spec/containers/1","value":{"env":[{"name":"WORDPRESS_DB_HOST","value":"$(MYSQL_SERVICE)"},{"name":"WORDPRESS_DB_PASSWORD","valueFrom":{"secretKeyRef":{"key":"password","name":"mysql-pass"}}}],"image":"wordpress:4.8-apache","name":"wordpress","ports":[{"containerPort":80,"name":"wordpress"}],"volumeMounts":[{"mountPath":"/var/www/html","name":"wordpress-persistent-storage"}]}}`: true,
+		`{"op":"add","path":"/spec/template/spec/initContainers","value":[{"command":["echo $(WORDPRESS_SERVICE)","echo $(MYSQL_SERVICE)"],"image":"debian","name":"init-command"}]}`:                                                                                                                                                                                                                                                    true,
 	}
 	patches, err := generatePatches(baseBytes, out)
 	assert.NilError(t, err)
 
-	for i, expect := range expectedPatches {
-		assertnew.Equal(t, string(expect), string(patches[i]))
+	for _, p := range patches {
+		assertnew.Equal(t, expectedPatches[string(p)], true)
 	}
 }
 

--- a/pkg/engine/utils/utils.go
+++ b/pkg/engine/utils/utils.go
@@ -1,10 +1,7 @@
 package utils
 
 import (
-	"encoding/json"
-
-	jsonpatch "github.com/evanphx/json-patch"
-	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	commonAnchor "github.com/kyverno/kyverno/pkg/engine/anchor/common"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -57,12 +54,12 @@ func ApplyPatches(resource []byte, patches [][]byte) ([]byte, error) {
 func ApplyPatchNew(resource, patch []byte) ([]byte, error) {
 	jsonpatch, err := jsonpatch.DecodePatch(patch)
 	if err != nil {
-		return nil, err
+		return resource, err
 	}
 
 	patchedResource, err := jsonpatch.Apply(resource)
 	if err != nil {
-		return nil, err
+		return resource, err
 	}
 
 	return patchedResource, err
@@ -85,19 +82,6 @@ func JoinPatches(patches [][]byte) []byte {
 	}
 	result = append(result, []byte("\n]")...)
 	return result
-}
-
-// TransformPatches converts mutation.Patches to bytes array
-func TransformPatches(patches []kyverno.Patch) (patchesBytes [][]byte, err error) {
-	for _, patch := range patches {
-		patchRaw, err := json.Marshal(patch)
-		if err != nil {
-			return nil, err
-		}
-		patchesBytes = append(patchesBytes, patchRaw)
-	}
-
-	return patchesBytes, nil
 }
 
 //ConvertToUnstructured converts the resource to unstructured format

--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-logr/logr"
 	v1 "github.com/kyverno/kyverno/pkg/api/kyverno/v1"

--- a/pkg/policy/apply.go
+++ b/pkg/policy/apply.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/go-logr/logr"
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	client "github.com/kyverno/kyverno/pkg/dclient"

--- a/pkg/policymutation/policymutation.go
+++ b/pkg/policymutation/policymutation.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/go-logr/logr"
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/common"

--- a/pkg/webhooks/annotations.go
+++ b/pkg/webhooks/annotations.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/go-logr/logr"
 	"github.com/kyverno/kyverno/pkg/engine/response"
 	yamlv2 "gopkg.in/yaml.v2"


### PR DESCRIPTION
## Related issue

Fixes https://github.com/kyverno/kyverno/issues/1340.
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this
> /kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed changes

This PR adds support for [SupportNegativeIndices, AllowMissingPathOnRemove, and EnsurePathExistsOnAdd](https://github.com/evanphx/json-patch/tree/master#configuration) to `patchesJson6902`, here's the list of use cases:
1. add non-exist object:
```yaml
spec:
  containers:
  - name: nginx
    image: nginx:1.14.2
```
```yaml
- path: "/spec/nodeSelector"
  op: add 
  value: {"node.kubernetes.io/role": "test"}
```
2. add non-exist array
```yaml
spec:
  containers:
  - name: nginx
    image: nginx:1.14.2
```
```yaml
- path: "/spec/tolerations"
  op: add
  value: [{"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}]
```
3. append an element to the existing list:
```yaml
spec:
  containers:
  - name: nginx
    image: nginx:1.14.2
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
```
```yaml
- path: "/spec/tolerations/-"
  op: add
  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
```
4. add an element to the end of a list (use negative index `-1`):
   the key can be present, `tolerations` exists:
```yaml
spec:
  containers:
  - name: nginx
    image: nginx:1.14.2
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
```
  or, the key of the list can be empty, there's no `tolerations` defined:
```yaml
spec:
  containers:
  - name: nginx
    image: nginx:1.14.2
```

```yaml
- path: "/spec/tolerations/-1"
  op: add
  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
```
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] I have added or changed [the documentation](https://github.com/kyverno/website).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
