### PR TITLE
Fix #1662: Avoid running with securityContext runAsUser: 1000

### DIFF
--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -2480,7 +2480,6 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 1000
       initContainers:
       - image: ghcr.io/kyverno/kyvernopre:v1.3.3
         imagePullPolicy: IfNotPresent
@@ -2493,7 +2492,6 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 1000
       securityContext:
         runAsNonRoot: true
       serviceAccountName: kyverno-service-account

--- a/definitions/manifest/deployment.yaml
+++ b/definitions/manifest/deployment.yaml
@@ -24,7 +24,6 @@ spec:
           image: ghcr.io/kyverno/kyvernopre:latest
           imagePullPolicy: IfNotPresent
           securityContext:
-            runAsUser: 1000
             runAsNonRoot: true
             privileged: false
             allowPrivilegeEscalation: false
@@ -57,7 +56,6 @@ spec:
             - name: KYVERNO_SVC
               value: kyverno-svc
           securityContext:
-            runAsUser: 1000
             runAsNonRoot: true
             privileged: false
             allowPrivilegeEscalation: false

--- a/definitions/release/install.yaml
+++ b/definitions/release/install.yaml
@@ -2478,7 +2478,6 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 1000
       initContainers:
       - image: ghcr.io/kyverno/kyvernopre:v1.3.3
         imagePullPolicy: IfNotPresent
@@ -2491,7 +2490,6 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 1000
       securityContext:
         runAsNonRoot: true
       serviceAccountName: kyverno-service-account


### PR DESCRIPTION
This will allow to install in constrained uid range environments such
as Openshift

Signed-off-by: Snir Sheriber <ssheribe@redhat.com>

## Related issue
#1662


## What type of PR is this

/kind bug

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] I have added or changed [the documentation](https://github.com/kyverno/website).

## Further comments

best practice for deploying to OpenShift is to avoid specifying runAsUser, AFAIK it shouldn't affect installation on other platforms, also note that I've removed runAsUser in all occurrences