### PR TITLE
Bug Fix #1679; Set Version to Group/Version for /apis/* URLs

### DIFF
--- a/pkg/engine/apiPath.go
+++ b/pkg/engine/apiPath.go
@@ -81,7 +81,7 @@ func NewAPIPath(path string) (*APIPath, error) {
 		return &APIPath{
 			Root:         paths[0],
 			Group:        paths[1],
-			Version:      paths[2],
+			Version:      paths[1] + "/" + paths[2],
 			ResourceType: paths[3],
 		}, nil
 	}
@@ -91,7 +91,7 @@ func NewAPIPath(path string) (*APIPath, error) {
 		return &APIPath{
 			Root:         paths[0],
 			Group:        paths[1],
-			Version:      paths[2],
+			Version:      paths[1] + "/" + paths[2],
 			ResourceType: paths[3],
 			Name:         paths[4],
 		}, nil
@@ -102,7 +102,7 @@ func NewAPIPath(path string) (*APIPath, error) {
 		return &APIPath{
 			Root:         paths[0],
 			Group:        paths[1],
-			Version:      paths[2],
+			Version:      paths[1] + "/" + paths[2],
 			Namespace:    paths[4],
 			ResourceType: paths[5],
 		}, nil
@@ -113,7 +113,7 @@ func NewAPIPath(path string) (*APIPath, error) {
 		return &APIPath{
 			Root:         paths[0],
 			Group:        paths[1],
-			Version:      paths[2],
+			Version:      paths[1] + "/" + paths[2],
 			Namespace:    paths[4],
 			ResourceType: paths[5],
 			Name:         paths[6],
@@ -125,17 +125,33 @@ func NewAPIPath(path string) (*APIPath, error) {
 
 func (a *APIPath) String() string {
 	var paths []string
-	if a.Namespace != "" {
-		if a.Name == "" {
-			paths = []string{a.Root, a.Group, a.Version, "namespaces", a.Namespace, a.ResourceType}
+	if a.Root == "apis" {
+		if a.Namespace != "" {
+			if a.Name == "" {
+				paths = []string{a.Root, a.Version, "namespaces", a.Namespace, a.ResourceType}
+			} else {
+				paths = []string{a.Root, a.Version, "namespaces", a.Namespace, a.ResourceType, a.Name}
+			}
 		} else {
-			paths = []string{a.Root, a.Group, a.Version, "namespaces", a.Namespace, a.ResourceType, a.Name}
+			if a.Name != "" {
+				paths = []string{a.Root, a.Version, a.ResourceType, a.Name}
+			} else {
+				paths = []string{a.Root, a.Version, a.ResourceType}
+			}
 		}
 	} else {
-		if a.Name != "" {
-			paths = []string{a.Root, a.Group, a.Version, a.ResourceType, a.Name}
+		if a.Namespace != "" {
+			if a.Name == "" {
+				paths = []string{a.Root, a.Group, "namespaces", a.Namespace, a.ResourceType}
+			} else {
+				paths = []string{a.Root, a.Group, "namespaces", a.Namespace, a.ResourceType, a.Name}
+			}
 		} else {
-			paths = []string{a.Root, a.Group, a.Version, a.ResourceType}
+			if a.Name != "" {
+				paths = []string{a.Root, a.Group, a.ResourceType, a.Name}
+			} else {
+				paths = []string{a.Root, a.Group, a.ResourceType}
+			}
 		}
 	}
 

--- a/pkg/engine/apiPath_test.go
+++ b/pkg/engine/apiPath_test.go
@@ -26,3 +26,26 @@ func Test_Paths(t *testing.T) {
 	f("/apis/gloo.solo.io/v1/namespaces/gloo-system/upstreams/  ", "/apis/gloo.solo.io/v1/namespaces/gloo-system/upstreams")
 	f("  /apis/gloo.solo.io/v1/namespaces/gloo-system/upstreams", "/apis/gloo.solo.io/v1/namespaces/gloo-system/upstreams")
 }
+
+func Test_GroupVersions(t *testing.T) {
+	f := func(path, expected string) {
+		p, err := NewAPIPath(path)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		if p.Root == "api" {
+			if p.Group != expected {
+				t.Errorf("expected %s got %s", expected, p.Group)
+			}
+		} else {
+			if p.Version != expected {
+				t.Errorf("expected %s got %s", expected, p.Version)
+			}
+		}
+	}
+
+	f("/api/v1/namespace/{{ request.namespace }}", "v1")
+	f("/apis/extensions/v1beta1/namespaces/example/ingresses", "extensions/v1beta1")
+}


### PR DESCRIPTION
Signed-off-by: Joshua Snider <jsnider@mtu.edu>

## Related issue

#1679 

## What type of PR is this

/kind bug

## Proposed changes

URL paths of format "/apis/GROUP/VERSION/*" should have Version set to GROUP/VERSION part of the path instead of just VERSION. So the URL "/apis/extensions/v1beta1/namespaces/example/ingresses" should have Version set to "extensions/v1beta1"

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] I have added or changed [the documentation](https://github.com/kyverno/website).

## Further comments

Tested on Kubernetes 1.19:
```
I0306 06:41:19.146674       1 validate_controller.go:185] PolicyController "msg"="policy created event"  "kind"="ClusterPolicy" "policy_name"="upstream-must-exist" "uid"="fb0caf50-80e1-4cd3-9bbb-52f42ae64c18"
I0306 06:41:19.266289       1 jsonContext.go:80] EngineValidate "msg"="added APICall context entry" "kind"="RouteTable" "name"="example-external-qa" "namespace"="example-qa" "policy"="upstream-must-exist" "rule"="upstream-must-exist" "data"={"ingressList":["app-qa-example"]}
```
