### PR TITLE
fix: overwrite the output file when repetedly executing kyverno apply command

### DIFF
--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -537,9 +537,10 @@ func PrintMutatedOutput(mutateLogPath string, mutateLogPathIsDir bool, yaml stri
 	yaml = yaml + ("\n---\n\n")
 
 	if !mutateLogPathIsDir {
+		// truncation for the case when mutateLogPath is a file (not a directory) is handled under pkg/kyverno/apply/command.go
 		f, err = os.OpenFile(mutateLogPath, os.O_APPEND|os.O_WRONLY, 0644)
 	} else {
-		f, err = os.OpenFile(mutateLogPath+"/"+fileName+".yaml", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		f, err = os.OpenFile(mutateLogPath+"/"+fileName+".yaml", os.O_CREATE|os.O_WRONLY, 0644)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yash.kukreja.98@gmail.com>

## Related issue
closes #1659 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this
> /kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed changes
- If the value of `-o` is a directory path, then, simply write the output of mutated policies in overwrite-mode itself.  
- If the value of `-o` is a file path (path ending with .yaml or .yml), then, truncate/empty it in the first place in `pkg/kyverno/apply/command.go` and then, write the output of mutated policies in append-mode. (truncating/emptying followed appending will simulate an overwrite, basically).
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added or changed [the documentation](https://github.com/kyverno/website).

## Further comments
 If the value of `-o` is a file path (path ending with .yaml or .yml), then, truncate/empty it in the first place in `pkg/kyverno/apply/command.go` and then, write the output of mutated policies in append-mode. (truncating/emptying followed appending will simulate an overwrite, basically). Can't simply go for overwrite-mode in this case because that would produce false result when provided with multiple resources in the resource.yaml. For example,
policy.yaml
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: set-image-pull-policy
spec:
  rules:
    - name: set-image-pull-policy
      match:
        resources:
          kinds:
          - Pod
      mutate:
        overlay:
          spec:
            containers:
              # match images which end with :latest
              - (image): "*:latest"
                # set the imagePullPolicy to "IfNotPresent"
                imagePullPolicy: "IfNotPresent"
```
resource.yaml
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: image1
  namespace: pricing-pre-prod
  labels:
    allow-updates: "false"
    protected: "yes"
    allow-deletes: "false"
    tier: resentation
spec:
  containers:
  - name: nginx-pod-container
    image: image1:latest 
    ports:
      - containerPort: 80
---
apiVersion: v1
kind: Pod
metadata:
  name: image2
  namespace: pricing-pre-prod
  labels:
    allow-updates: "false"
    protected: "yes"
    allow-deletes: "false"
    tier: resentation
spec:
  containers:
  - name: nginx-pod-container
    image: image2:latest
    ports:
      - containerPort: 80
```

**Output when kyverno truncates the -o file first, then, appends content (right)**
```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    allow-deletes: "false"
    allow-updates: "false"
    protected: "yes"
    tier: resentation
  name: image1
  namespace: pricing-pre-prod
spec:
  containers:
  - image: image1:latest
    imagePullPolicy: IfNotPresent
    name: nginx-pod-container
    ports:
    - containerPort: 80

---

apiVersion: v1
kind: Pod
metadata:
  labels:
    allow-deletes: "false"
    allow-updates: "false"
    protected: "yes"
    tier: resentation
  name: image2
  namespace: pricing-pre-prod
spec:
  containers:
  - image: image2:latest
    imagePullPolicy: IfNotPresent
    name: nginx-pod-container
    ports:
    - containerPort: 80
---
```
**Output when Kyverno directly tries to this via overwrite-mode (Wrong)**
```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    allow-deletes: "false"
    allow-updates: "false"
    protected: "yes"
    tier: resentation
  name: image2
  namespace: pricing-pre-prod
spec:
  containers:
  - image: image2:latest
    imagePullPolicy: IfNotPresent
    name: nginx-pod-container
    ports:
    - containerPort: 80

---
```
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
