### PR TITLE
fix: changed logic for In and NotIn for sets

### DIFF
--- a/pkg/engine/variables/evaluate_test.go
+++ b/pkg/engine/variables/evaluate_test.go
@@ -1069,7 +1069,7 @@ func Test_Eval_In_String_Set_Fail(t *testing.T) {
 // test passes if ALL of the values in "key" are NOT in "value" ("key" is not a subset of "value")
 func Test_Eval_NotIn_String_Set_Pass(t *testing.T) {
 	ctx := context.NewContext()
-	key := [2]string{"1.1.1.1", "4.4.4.4"}
+	key := [2]string{"4.4.4.4", "5.5.5.5"}
 	keyInterface := make([]interface{}, len(key), len(key))
 	for i := range key {
 		keyInterface[i] = key[i]
@@ -1094,7 +1094,7 @@ func Test_Eval_NotIn_String_Set_Pass(t *testing.T) {
 // test passes if ALL of the values in "key" are in "value" ("key" is a subset of "value")
 func Test_Eval_NotIn_String_Set_Fail(t *testing.T) {
 	ctx := context.NewContext()
-	key := [2]string{"1.1.1.1", "2.2.2.2"}
+	key := [2]string{"1.1.1.1", "4.4.4.4"}
 	keyInterface := make([]interface{}, len(key), len(key))
 	for i := range key {
 		keyInterface[i] = key[i]

--- a/pkg/engine/variables/operator/in.go
+++ b/pkg/engine/variables/operator/in.go
@@ -110,19 +110,20 @@ func keyExistsInArray(key string, value interface{}, log logr.Logger) (invalidTy
 }
 
 func (in InHandler) validateValueWithStringSetPattern(key []string, value interface{}) (keyExists bool) {
-	invalidType, keyExists := setExistsInArray(key, value, in.log)
+	invalidType, isIn := setExistsInArray(key, value, in.log, false)
 	if invalidType {
 		in.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
-	return keyExists
+	return isIn
 }
 
 // setExistsInArray checks if the key is a subset of value
 // The value can be a string, an array of strings, or a JSON format
 // array of strings (e.g. ["val1", "val2", "val3"].
-func setExistsInArray(key []string, value interface{}, log logr.Logger) (invalidType bool, keyExists bool) {
+// notIn argument if set to true will check for NotIn
+func setExistsInArray(key []string, value interface{}, log logr.Logger, notIn bool) (invalidType bool, keyExists bool) {
 	switch valuesAvailable := value.(type) {
 
 	case []interface{}:
@@ -134,8 +135,10 @@ func setExistsInArray(key []string, value interface{}, log logr.Logger) (invalid
 			}
 			valueSlice = append(valueSlice, v)
 		}
-
-		return false, isSubset(key, valueSlice)
+		if notIn {
+			return false, isNotIn(key, valueSlice)
+		}
+		return false, isIn(key, valueSlice)
 
 	case string:
 
@@ -148,30 +151,47 @@ func setExistsInArray(key []string, value interface{}, log logr.Logger) (invalid
 			log.Error(err, "failed to unmarshal value to JSON string array", "key", key, "value", value)
 			return true, false
 		}
+		if notIn {
+			return false, isNotIn(key, arr)
+		}
 
-		return false, isSubset(key, arr)
+		return false, isIn(key, arr)
 
 	default:
 		return true, false
 	}
 }
 
-// isSubset checks if S1 is a subset of S2 i.e. ALL values of S1 are in S2
-func isSubset(key []string, value []string) bool {
-	set := make(map[string]int)
+// isIn checks if all values in S1 are in S2
+func isIn(key []string, value []string) bool {
+	set := make(map[string]bool)
 
 	for _, val := range value {
-		set[val]++
+		set[val] = true
 	}
 
 	for _, val := range key {
-		count, found := set[val]
+		_, found := set[val]
 		if !found {
 			return false
-		} else if count < 1 {
+		}
+	}
+
+	return true
+}
+
+// isNotIn checks if none of the values in S1 is in S2
+func isNotIn(key []string, value []string) bool {
+	set := make(map[string]bool)
+
+	for _, val := range value {
+		set[val] = true
+	}
+
+	for _, val := range key {
+		_, found := set[val]
+		if found {
 			return false
-		} else {
-			set[val] = count - 1
 		}
 	}
 

--- a/pkg/engine/variables/operator/notin.go
+++ b/pkg/engine/variables/operator/notin.go
@@ -64,13 +64,13 @@ func (nin NotInHandler) validateValueWithStringPattern(key string, value interfa
 }
 
 func (nin NotInHandler) validateValueWithStringSetPattern(key []string, value interface{}) bool {
-	invalidType, keyExists := setExistsInArray(key, value, nin.log)
+	invalidType, isNotIn := setExistsInArray(key, value, nin.log, true)
 	if invalidType {
 		nin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
-	return !keyExists
+	return isNotIn
 }
 
 func (nin NotInHandler) validateValueWithBoolPattern(_ bool, _ interface{}) bool {


### PR DESCRIPTION
Signed-off-by: Arsh Sharma <arshsharma461@gmail.com>

## Related issue
Fixes #1689 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
-->
> /kind feature

## Proposed changes
Updated the `In` and `NotIn` functions as per new definitions and changed the tests.
New definitions:
`In`: S1 in S2 means all values of S1 are present in S2
Iterate through S1 and if any value in S1 is not found in S2 return false else return true in the end.

`NotIn`: S1 not in S2 means no value of S1 is present in S2
Iterate through S1 and if any value is found in S2 return false else return true in the end.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] I have added or changed [the documentation](https://github.com/kyverno/website).

## Further comments
Tests are passing locally. Also verified with a sample policy.
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
