### PR TITLE
Bug Fix: #1585 issue; validate on DELETE the oldResource

### DIFF
--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -94,6 +94,16 @@ func subValR(log logr.Logger, ctx context.EvalInterface, valuePattern string, pa
 			variable := strings.ReplaceAll(v, "{{", "")
 			variable = strings.ReplaceAll(variable, "}}", "")
 			variable = strings.TrimSpace(variable)
+
+			var substitutedVar interface{}
+			if operation, err := ctx.Query("request.operation"); err != nil {
+				return nil, fmt.Errorf("failed to resolve %v at path %s", variable, path)
+			} else {
+				if operation == "DELETE" {
+					variable = strings.ReplaceAll(variable, "request.object", "request.oldObject")
+				}
+			}
+
 			substitutedVar, err := ctx.Query(variable)
 			if err != nil {
 				switch err.(type) {


### PR DESCRIPTION
## Related issue
fixes #1585

## What type of PR is this

/kind bug

## Proposed changes
The reason of the issue was invalid validation process during DELETE operation. JSON path could not be resolved because we needed to validate oldResource instead of resource (validation context has no resource). So I just added substitution for the resource name and it works.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/kyverno/website).
