### PR TITLE
Fix variable substitution in NumericOperatorHandler

### DIFF
--- a/pkg/api/kyverno/v1/utils.go
+++ b/pkg/api/kyverno/v1/utils.go
@@ -3,13 +3,18 @@ package v1
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 )
 
 // HasAutoGenAnnotation checks if a policy has auto-gen annotation
 func (p *ClusterPolicy) HasAutoGenAnnotation() bool {
 	annotations := p.GetAnnotations()
-	_, ok := annotations["pod-policies.kyverno.io/autogen-controllers"]
-	return ok
+	val, ok := annotations["pod-policies.kyverno.io/autogen-controllers"]
+	if ok && strings.ToLower(val) != "none" {
+		return true
+	}
+
+	return false
 }
 
 //HasMutateOrValidateOrGenerate checks for rule types

--- a/pkg/engine/variables/operator/numeric.go
+++ b/pkg/engine/variables/operator/numeric.go
@@ -45,12 +45,13 @@ func compareByCondition(key float64, value float64, op kyverno.ConditionOperator
 }
 
 func (noh NumericOperatorHandler) Evaluate(key, value interface{}) bool {
-	if key, err := noh.subHandler(noh.log, noh.ctx, key); err != nil {
+	var err error
+	if key, err = noh.subHandler(noh.log, noh.ctx, key); err != nil {
 		// Failed to resolve the variable
 		noh.log.Error(err, "Failed to resolve variable", "variable", key)
 		return false
 	}
-	if value, err := noh.subHandler(noh.log, noh.ctx, value); err != nil {
+	if value, err = noh.subHandler(noh.log, noh.ctx, value); err != nil {
 		// Failed to resolve the variable
 		noh.log.Error(err, "Failed to resolve variable", "variable", value)
 		return false
@@ -133,7 +134,7 @@ func (noh NumericOperatorHandler) validateValueWithStringPattern(key string, val
 	if err == nil {
 		return noh.validateValueWithIntPattern(int64key, value)
 	}
-	noh.log.Error(fmt.Errorf("Parse Error: "), "Failed to parse both float64 and int64 from the string keyt")
+	noh.log.Error(err, "Failed to parse both float64 and int64 from the string keyt")
 	return false
 }
 


### PR DESCRIPTION
Signed-off-by: Shuting Zhao <shutting06@gmail.com>

The following policy restrict pod count per k8s node, this PR fixes the variable substitution in NumericOperatorHandler.
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: restrict-pod-count
  annotations:
    pod-policies.kyverno.io/autogen-controllers: None
spec:
  validationFailureAction: enforce
  background: false
  rules:
    - name: restrict-pod-count
      match:
        resources:
          kinds:
            - Pod
      context:
        - name: podcounts
          apiCall:
            urlPath: "/api/v1/pods"
            jmesPath: "items[?spec.nodeName=='minikube'] | length(@)"
      preconditions:
        - key: "{{ request.operation }}"
          operator: Equals
          value: "CREATE"
      validate:
        message: "restrict pod counts to be no more than 12 on node minikube"
        deny:
          conditions:
            - key: "{{ podcounts }}"
              operator: GreaterThanOrEquals
              value: 12
```

Validate the work:
```
✗ k run pod --image=nginx:latest
Error from server: admission webhook "validate.kyverno.svc" denied the request:
resource Pod/default/pod was blocked due to the following policies
restrict-pod-count:
  restrict-pod-count: restrict pod counts to be no more than 12 on node minikube
```

```
 ✗ k get deploy test
NAME   READY   UP-TO-DATE   AVAILABLE   AGE
test   0/1     0            0           6m26s
✗ k describe rs test-6bb9bd79b7
...
Events:
  Type     Reason        Age    From                   Message
  ----     ------        ----   ----                   -------
  Warning  FailedCreate  6m18s  replicaset-controller  Error creating: admission webhook "validate.kyverno.svc" denied the request:
resource Pod/default/test-6bb9bd79b7-22jc6 was blocked due to the following policies
restrict-pod-count:
  restrict-pod-count: restrict pod counts to be no more than 12 on node minikube
  Warning  FailedCreate  6m18s  replicaset-controller  Error creating: admission webhook "validate.kyverno.svc" denied the request:
```