### PR TITLE
Skip generate requests for spec being same in old and updated policy

### DIFF
--- a/pkg/generate/generate_controller.go
+++ b/pkg/generate/generate_controller.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	"reflect"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -173,6 +174,10 @@ func (c *Controller) updatePolicy(old, cur interface{}) {
 		if rule.HasGenerate() {
 			policyHasGenerate = true
 		}
+	}
+
+	if reflect.DeepEqual(curP.Spec, oldP.Spec) {
+		policyHasGenerate = false
 	}
 
 	if !policyHasGenerate {


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue
closes https://github.com/kyverno/kyverno/issues/1720

## What type of PR is this
> /kind bug

## Proposed changes
Skipping enqueueing generate requests for the policies where the spec is same in old and updated policies.

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] I have added or changed [the documentation](https://github.com/kyverno/website).
  - If not, I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
