### PR TITLE
Make validateAPICall work with special characters in variables

### DIFF
--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -18,6 +18,11 @@ func IsVariable(element string) bool {
 	return len(groups) != 0
 }
 
+//ReplaceAllVars replaces all variables with the value defined in the replacement function
+func ReplaceAllVars(src string, repl func(string) string) string {
+	return regexVariables.ReplaceAllStringFunc(src, repl)
+}
+
 //SubstituteVars replaces the variables with the values defined in the context
 // - if any variable is invalid or has nil value, it is considered as a failed variable substitution
 func SubstituteVars(log logr.Logger, ctx context.EvalInterface, pattern interface{}) (interface{}, error) {

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jmespath/go-jmespath"
 	"github.com/kyverno/kyverno/pkg/engine"
+	"github.com/kyverno/kyverno/pkg/engine/variables"
 	"github.com/kyverno/kyverno/pkg/kyverno/common"
 
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
@@ -681,7 +682,10 @@ func validateAPICall(entry kyverno.ContextEntry) error {
 		return fmt.Errorf("both configMap and apiCall are not allowed in a context entry")
 	}
 
-	if _, err := engine.NewAPIPath(entry.APICall.URLPath); err != nil {
+	// Replace all variables to prevent validation failing on variable keys.
+	urlPath := variables.ReplaceAllVars(entry.APICall.URLPath, func(s string) string { return "variable" })
+
+	if _, err := engine.NewAPIPath(urlPath); err != nil {
 		return err
 	}
 

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -683,7 +683,7 @@ func validateAPICall(entry kyverno.ContextEntry) error {
 	}
 
 	// Replace all variables to prevent validation failing on variable keys.
-	urlPath := variables.ReplaceAllVars(entry.APICall.URLPath, func(s string) string { return "variable" })
+	urlPath := variables.ReplaceAllVars(entry.APICall.URLPath, func(s string) string { return "kyvernoapicallvariable" })
 
 	if _, err := engine.NewAPIPath(urlPath); err != nil {
 		return err


### PR DESCRIPTION
## Related issue

None - I went straight for the PR for now.

## What type of PR is this

/kind bug


## Proposed changes

This fixes an issue where `validateAPICall` fails if a variable contains `/` and therefore exceeds the limit of 7 parts in the path.

Example of such a circumstance (falsely failing validation):
```
apiCall:
        urlPath: "/apis/cluster.x-k8s.io/v1alpha3/namespaces/{{ request.object.metadata.namespace }}/clusters/{{ request.object.metadata.labels.\"cluster.x-k8s.io/cluster-name\" }}"
```

The solution I went for, is to replace all variables with a simple string during validation.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added or changed [the documentation](https://github.com/kyverno/website).

## Further comments

I am not sure how valuable this validation is at all. It is easy to construct cases where a variable might be templated into a string containing one or multiple `/` during execution of a `ClusterPolicy`.

The benefit of this change is that values from labels and annotations are treated correctly for now at least.

I am open to add unit tests if reviewers think it's sensible.
