### PR TITLE
Auto-recover policy report

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -36,10 +36,7 @@ import (
 	log "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const (
-	resyncPeriod                 = 15 * time.Minute
-	policyControllerResyncPeriod = time.Hour
-)
+const resyncPeriod = 15 * time.Minute
 
 var (
 	//TODO: this has been added to backward support command line arguments
@@ -56,21 +53,24 @@ var (
 
 	profile      bool
 	policyReport bool
-	setupLog     = log.Log.WithName("setup")
+
+	policyControllerResyncPeriod time.Duration
+	setupLog                     = log.Log.WithName("setup")
 )
 
 func main() {
 	klog.InitFlags(nil)
 	log.SetLogger(klogr.New())
-	flag.StringVar(&filterK8sResources, "filterK8sResources", "", "k8 resource in format [kind,namespace,name] where policy is not evaluated by the admission webhook. example --filterKind \"[Deployment, kyverno, kyverno]\" --filterKind \"[Deployment, kyverno, kyverno],[Events, *, *]\"")
+	flag.StringVar(&filterK8sResources, "filterK8sResources", "", "Resource in format [kind,namespace,name] where policy is not evaluated by the admission webhook. For example, --filterK8sResources \"[Deployment, kyverno, kyverno],[Events, *, *]\"")
 	flag.StringVar(&excludeGroupRole, "excludeGroupRole", "", "")
 	flag.StringVar(&excludeUsername, "excludeUsername", "", "")
-	flag.IntVar(&webhookTimeout, "webhooktimeout", 3, "timeout for webhook configurations")
-	flag.IntVar(&genWorkers, "gen-workers", 10, "workers for generate controller")
+	flag.IntVar(&webhookTimeout, "webhooktimeout", 3, "Timeout for webhook configurations")
+	flag.IntVar(&genWorkers, "gen-workers", 10, "Workers for generate controller")
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&serverIP, "serverIP", "", "IP address where Kyverno controller runs. Only required if out-of-cluster.")
 	flag.BoolVar(&profile, "profile", false, "Set this flag to 'true', to enable profiling.")
 	flag.StringVar(&profilePort, "profile-port", "6060", "Enable profiling at given port, default to 6060.")
+	flag.DurationVar(&policyControllerResyncPeriod, "background-scan", time.Hour, "Perform background scan every given interval, e.g., 30s, 15m, 1h. If set to 0, the background scan is disabled.")
 	if err := flag.Set("v", "2"); err != nil {
 		setupLog.Error(err, "failed to set log level")
 		os.Exit(1)

--- a/pkg/policy/report.go
+++ b/pkg/policy/report.go
@@ -1,13 +1,19 @@
 package policy
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
+	v1alpha1 "github.com/kyverno/kyverno/pkg/api/policyreport/v1alpha1"
+	kyvernoclient "github.com/kyverno/kyverno/pkg/client/clientset/versioned"
+	policyreportlister "github.com/kyverno/kyverno/pkg/client/listers/policyreport/v1alpha1"
 	"github.com/kyverno/kyverno/pkg/engine/response"
 	"github.com/kyverno/kyverno/pkg/event"
 	"github.com/kyverno/kyverno/pkg/policyreport"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -33,16 +39,60 @@ func (pc *PolicyController) forceReconciliation(reconcileCh <-chan bool, stopCh 
 		select {
 		case <-ticker.C:
 			logger.Info("performing the background scan", "scan interval", pc.reconcilePeriod.String())
+			if err := pc.policyReportEraser.EraseResultsEntries(eraseResultsEntries); err != nil {
+				logger.Error(err, "continue reconciling policy reports")
+			}
+
 			pc.requeuePolicies()
 
-		case <-reconcileCh:
-			logger.Info("received the reconcile signal, re-creating policy report")
+		case erase := <-reconcileCh:
+			logger.Info("received the reconcile signal, reconciling policy report")
+			if erase {
+				if err := pc.policyReportEraser.EraseResultsEntries(eraseResultsEntries); err != nil {
+					logger.Error(err, "continue reconciling policy reports")
+				}
+			}
+
 			pc.requeuePolicies()
 
 		case <-stopCh:
 			return
 		}
 	}
+}
+
+func eraseResultsEntries(pclient *kyvernoclient.Clientset, reportLister policyreportlister.PolicyReportLister, clusterReportLister policyreportlister.ClusterPolicyReportLister) error {
+	var errors []string
+
+	if polrs, err := reportLister.List(labels.Everything()); err != nil {
+		errors = append(errors, err.Error())
+	} else {
+		for _, polr := range polrs {
+			polr.Results = []*v1alpha1.PolicyReportResult{}
+			polr.Summary = v1alpha1.PolicyReportSummary{}
+			if _, err = pclient.Wgpolicyk8sV1alpha1().PolicyReports(polr.GetNamespace()).Update(context.TODO(), polr, metav1.UpdateOptions{}); err != nil {
+				errors = append(errors, fmt.Sprintf("%s/%s/%s: %v", polr.Kind, polr.Namespace, polr.Name, err))
+			}
+		}
+	}
+
+	if cpolrs, err := clusterReportLister.List(labels.Everything()); err != nil {
+		errors = append(errors, err.Error())
+	} else {
+		for _, cpolr := range cpolrs {
+			cpolr.Results = []*v1alpha1.PolicyReportResult{}
+			cpolr.Summary = v1alpha1.PolicyReportSummary{}
+			if _, err = pclient.Wgpolicyk8sV1alpha1().ClusterPolicyReports().Update(context.TODO(), cpolr, metav1.UpdateOptions{}); err != nil {
+				errors = append(errors, fmt.Sprintf("%s/%s: %v", cpolr.Kind, cpolr.Name, err))
+			}
+		}
+	}
+
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("failed to erase results entries %v", strings.Join(errors, ";"))
 }
 
 func (pc *PolicyController) requeuePolicies() {

--- a/pkg/policy/validate_controller.go
+++ b/pkg/policy/validate_controller.go
@@ -341,6 +341,10 @@ func (pc *PolicyController) enqueuePolicy(policy *kyverno.ClusterPolicy) {
 // Run begins watching and syncing.
 func (pc *PolicyController) Run(workers int, reconcileCh <-chan bool, stopCh <-chan struct{}) {
 	logger := pc.log
+	if pc.reconcilePeriod.String() == "0s" {
+		logger.Info("background scan is disabled")
+		return
+	}
 
 	defer utilruntime.HandleCrash()
 	defer pc.queue.ShutDown()

--- a/pkg/policyreport/policyreport.go
+++ b/pkg/policyreport/policyreport.go
@@ -8,8 +8,20 @@ import (
 	"github.com/cornelk/hashmap"
 	changerequest "github.com/kyverno/kyverno/pkg/api/kyverno/v1alpha1"
 	report "github.com/kyverno/kyverno/pkg/api/policyreport/v1alpha1"
+	kyvernoclient "github.com/kyverno/kyverno/pkg/client/clientset/versioned"
+	policyreportlister "github.com/kyverno/kyverno/pkg/client/listers/policyreport/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+type PolicyReportEraser interface {
+	EraseResultsEntries(erase EraseResultsEntries) error
+}
+
+type EraseResultsEntries = func(pclient *kyvernoclient.Clientset, reportLister policyreportlister.PolicyReportLister, clusterReportLister policyreportlister.ClusterPolicyReportLister) error
+
+func (g *ReportGenerator) EraseResultsEntries(erase EraseResultsEntries) error {
+	return erase(g.pclient, g.reportLister, g.clusterReportLister)
+}
 
 type deletedResource struct {
 	kind, ns, name string

--- a/pkg/policyreport/reportcontroller.go
+++ b/pkg/policyreport/reportcontroller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	changerequest "github.com/kyverno/kyverno/pkg/api/kyverno/v1alpha1"
 	report "github.com/kyverno/kyverno/pkg/api/policyreport/v1alpha1"
+	kyvernoclient "github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	requestinformer "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1alpha1"
 	policyreportinformer "github.com/kyverno/kyverno/pkg/client/informers/externalversions/policyreport/v1alpha1"
 	requestlister "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1alpha1"
@@ -37,6 +38,7 @@ const (
 
 // ReportGenerator creates policy report
 type ReportGenerator struct {
+	pclient *kyvernoclient.Clientset
 	dclient *dclient.Client
 
 	reportLister policyreport.PolicyReportLister
@@ -57,6 +59,7 @@ type ReportGenerator struct {
 	queue workqueue.RateLimitingInterface
 
 	// ReconcileCh sends a signal to policy controller to force the reconciliation of policy report
+	// if send true, the reports' results will be erased, this is used to recover from the invalid records
 	ReconcileCh chan bool
 
 	log logr.Logger
@@ -64,6 +67,7 @@ type ReportGenerator struct {
 
 // NewReportGenerator returns a new instance of policy report generator
 func NewReportGenerator(
+	pclient *kyvernoclient.Clientset,
 	dclient *dclient.Client,
 	clusterReportInformer policyreportinformer.ClusterPolicyReportInformer,
 	reportInformer policyreportinformer.PolicyReportInformer,
@@ -73,9 +77,10 @@ func NewReportGenerator(
 	log logr.Logger) *ReportGenerator {
 
 	gen := &ReportGenerator{
+		pclient:     pclient,
 		dclient:     dclient,
 		queue:       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), prWorkQueueName),
-		ReconcileCh: make(chan bool, 1),
+		ReconcileCh: make(chan bool, 10),
 		log:         log,
 	}
 
@@ -183,12 +188,12 @@ func (g *ReportGenerator) updateClusterReportChangeRequest(old interface{}, cur 
 func (g *ReportGenerator) deletePolicyReport(obj interface{}) {
 	report := obj.(*report.PolicyReport)
 	g.log.V(2).Info("PolicyReport deleted", "name", report.GetName())
-	g.ReconcileCh <- true
+	g.ReconcileCh <- false
 }
 
 func (g *ReportGenerator) deleteClusterPolicyReport(obj interface{}) {
 	g.log.V(2).Info("ClusterPolicyReport deleted")
-	g.ReconcileCh <- true
+	g.ReconcileCh <- false
 }
 
 // Run starts the workers

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -143,12 +143,12 @@ func (wrc *Register) cleanupKyvernoResource() bool {
 	logger := wrc.log.WithName("cleanupKyvernoResource")
 	deploy, err := wrc.client.GetResource("", "Deployment", deployNamespace, deployName)
 	if err != nil {
-		logger.Error(err, "failed to get deployment")
-		return false
+		logger.Error(err, "failed to get deployment, cleanup kyverno resources anyway")
+		return true
 	}
 
 	if deploy.GetDeletionTimestamp() != nil {
-		logger.Info("Kyverno is terminating, clean up Kyverno resources")
+		logger.Info("Kyverno is terminating, cleanup Kyverno resources")
 		return true
 	}
 
@@ -158,7 +158,7 @@ func (wrc *Register) cleanupKyvernoResource() bool {
 	}
 
 	if replicas == 0 {
-		logger.Info("Kyverno is scaled to zero, clean up Kyverno resources")
+		logger.Info("Kyverno is scaled to zero, cleanup Kyverno resources")
 		return true
 	}
 


### PR DESCRIPTION
Signed-off-by: Shuting Zhao <shutting06@gmail.com>

## Related issue
> /kind bug
> /kind feature

fixes https://github.com/kyverno/kyverno/issues/1577
fixes https://github.com/kyverno/kyverno/issues/1277
fixes https://github.com/kyverno/kyverno/issues/1682

This PR:
- allows users to configure background scan interval by flag `--background-scan`, the default is set to one hour. The allowed format can be 30s, 15m, 12h.
- reconciles policy reports at the given interval (background scan interval), refreshes the policy results entries, and removes invalid records
- re-creates policy report if it gets deleted
- reconciles policy reports if `resourceFilters` (configured in the Configmap) changes

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed changes


<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added or changed [the documentation](https://github.com/kyverno/website).
  - If not, I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update: https://github.com/kyverno/website/issues/120
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further comments
Ideally we want to refresh Cluster/policy cache to trigger the reconciliation of the policy controller, but there's a check to not re-queue the policy if the `spec` does not change. So this PR adds a ticker to trigger the reconciliation.

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
