### PR TITLE
Fix : 1657 (Update variable paths when auto generate the controller rules)  and 1615 ( kyverno apply pipe through to kubectl)

### DIFF
--- a/pkg/kyverno/apply/command.go
+++ b/pkg/kyverno/apply/command.go
@@ -107,7 +107,7 @@ More info: https://kyverno.io/docs/kyverno-cli/
 func Command() *cobra.Command {
 	var cmd *cobra.Command
 	var resourcePaths []string
-	var cluster, policyReport bool
+	var cluster, policyReport, stdin bool
 	var mutateLogPath, variablesString, valuesFile, namespace string
 
 	cmd = &cobra.Command{
@@ -124,12 +124,12 @@ func Command() *cobra.Command {
 				}
 			}()
 
-			validateEngineResponses, rc, resources, skippedPolicies, err := applyCommandHelper(resourcePaths, cluster, policyReport, mutateLogPath, variablesString, valuesFile, namespace, policyPaths)
+			validateEngineResponses, rc, resources, skippedPolicies, err := applyCommandHelper(resourcePaths, cluster, policyReport, mutateLogPath, variablesString, valuesFile, namespace, policyPaths, stdin)
 			if err != nil {
 				return err
 			}
 
-			printReportOrViolation(policyReport, validateEngineResponses, rc, resourcePaths, len(resources), skippedPolicies)
+			printReportOrViolation(policyReport, validateEngineResponses, rc, resourcePaths, len(resources), skippedPolicies, stdin)
 			return nil
 		},
 	}
@@ -141,11 +141,12 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVarP(&valuesFile, "values-file", "f", "", "File containing values for policy variables")
 	cmd.Flags().BoolVarP(&policyReport, "policy-report", "", false, "Generates policy report when passed (default policyviolation r")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Optional Policy parameter passed with cluster flag")
+	cmd.Flags().BoolVarP(&stdin, "stdin", "i", false, "Optional mutate policy parameter to pipe directly through to kubectl")
 	return cmd
 }
 
 func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool, mutateLogPath string,
-	variablesString string, valuesFile string, namespace string, policyPaths []string) (validateEngineResponses []*response.EngineResponse, rc *resultCounts, resources []*unstructured.Unstructured, skippedPolicies []SkippedPolicy, err error) {
+	variablesString string, valuesFile string, namespace string, policyPaths []string, stdin bool) (validateEngineResponses []*response.EngineResponse, rc *resultCounts, resources []*unstructured.Unstructured, skippedPolicies []SkippedPolicy, err error) {
 
 	kubernetesConfig := genericclioptions.NewConfigFlags(true)
 	fs := memfs.New()
@@ -241,7 +242,9 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 	}
 
 	if len(mutatedPolicies) > 0 && len(resources) > 0 {
-		fmt.Printf("\napplying %s to %s... \n", msgPolicies, msgResources)
+		if !stdin {
+			fmt.Printf("\napplying %s to %s... \n", msgPolicies, msgResources)
+		}
 	}
 
 	rc = &resultCounts{}
@@ -287,7 +290,7 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 				return validateEngineResponses, rc, resources, skippedPolicies, sanitizederror.NewWithError(fmt.Sprintf("policy %s have variables. pass the values for the variables using set/values_file flag", policy.Name), err)
 			}
 
-			ers, validateErs, responseError, rcErs, err := common.ApplyPolicyOnResource(policy, resource, mutateLogPath, mutateLogPathIsDir, thisPolicyResourceValues, policyReport, namespaceSelectorMap)
+			ers, validateErs, responseError, rcErs, err := common.ApplyPolicyOnResource(policy, resource, mutateLogPath, mutateLogPathIsDir, thisPolicyResourceValues, policyReport, namespaceSelectorMap, stdin)
 			if err != nil {
 				return validateEngineResponses, rc, resources, skippedPolicies, sanitizederror.NewWithError(fmt.Errorf("failed to apply policy %v on resource %v", policy.Name, resource.GetName()).Error(), err)
 			}
@@ -330,7 +333,7 @@ func checkMutateLogPath(mutateLogPath string) (mutateLogPathIsDir bool, err erro
 }
 
 // printReportOrViolation - printing policy report/violations
-func printReportOrViolation(policyReport bool, validateEngineResponses []*response.EngineResponse, rc *resultCounts, resourcePaths []string, resourcesLen int, skippedPolicies []SkippedPolicy) {
+func printReportOrViolation(policyReport bool, validateEngineResponses []*response.EngineResponse, rc *resultCounts, resourcePaths []string, resourcesLen int, skippedPolicies []SkippedPolicy, stdin bool) {
 	if policyReport {
 		os.Setenv("POLICY-TYPE", pkgCommon.PolicyReport)
 		resps := buildPolicyReports(validateEngineResponses, skippedPolicies)
@@ -347,9 +350,10 @@ func printReportOrViolation(policyReport bool, validateEngineResponses []*respon
 		if rcCount < len(resourcePaths) {
 			rc.skip += len(resourcePaths) - rcCount
 		}
-
-		fmt.Printf("\npass: %d, fail: %d, warn: %d, error: %d, skip: %d \n",
-			rc.pass, rc.fail, rc.warn, rc.error, rc.skip)
+		if !stdin {
+			fmt.Printf("\npass: %d, fail: %d, warn: %d, error: %d, skip: %d \n",
+				rc.pass, rc.fail, rc.warn, rc.error, rc.skip)
+		}
 
 		if rc.fail > 0 || rc.error > 0 {
 			os.Exit(1)

--- a/pkg/kyverno/apply/command_test.go
+++ b/pkg/kyverno/apply/command_test.go
@@ -56,7 +56,7 @@ func Test_Apply(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		validateEngineResponses, _, _, skippedPolicies, _ := applyCommandHelper(tc.ResourcePaths, false, true, "", "", "", "", tc.PolicyPaths)
+		validateEngineResponses, _, _, skippedPolicies, _ := applyCommandHelper(tc.ResourcePaths, false, true, "", "", "", "", tc.PolicyPaths, false)
 		resps := buildPolicyReports(validateEngineResponses, skippedPolicies)
 		for i, resp := range resps {
 			compareSummary(tc.expectedPolicyReports[i].Summary, resp.UnstructuredContent()["summary"].(map[string]interface{}))

--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -449,7 +449,6 @@ func ApplyPolicyOnResource(policy *v1.ClusterPolicy, resource *unstructured.Unst
 		responseError = true
 	} else {
 		if len(mutateResponse.PolicyResponse.Rules) > 0 {
-			//fmt.Printf("=========>mutateResponse.PatchedResource.Object %v", mutateResponse.PatchedResource.Object)
 			yamlEncodedResource, err := yamlv2.Marshal(mutateResponse.PatchedResource.Object)
 			if err != nil {
 				rcError = true

--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -380,7 +380,7 @@ func MutatePolices(policies []*v1.ClusterPolicy) ([]*v1.ClusterPolicy, error) {
 
 // ApplyPolicyOnResource - function to apply policy on resource
 func ApplyPolicyOnResource(policy *v1.ClusterPolicy, resource *unstructured.Unstructured,
-	mutateLogPath string, mutateLogPathIsDir bool, variables map[string]string, policyReport bool, namespaceSelectorMap map[string]map[string]string) ([]*response.EngineResponse, *response.EngineResponse, bool, bool, error) {
+	mutateLogPath string, mutateLogPathIsDir bool, variables map[string]string, policyReport bool, namespaceSelectorMap map[string]map[string]string, stdin bool) ([]*response.EngineResponse, *response.EngineResponse, bool, bool, error) {
 
 	responseError := false
 	rcError := false
@@ -449,15 +449,18 @@ func ApplyPolicyOnResource(policy *v1.ClusterPolicy, resource *unstructured.Unst
 		responseError = true
 	} else {
 		if len(mutateResponse.PolicyResponse.Rules) > 0 {
+			//fmt.Printf("=========>mutateResponse.PatchedResource.Object %v", mutateResponse.PatchedResource.Object)
 			yamlEncodedResource, err := yamlv2.Marshal(mutateResponse.PatchedResource.Object)
 			if err != nil {
 				rcError = true
 			}
 
 			if mutateLogPath == "" {
-				mutatedResource := string(yamlEncodedResource)
+				mutatedResource := string(yamlEncodedResource) + string("\n---")
 				if len(strings.TrimSpace(mutatedResource)) > 0 {
-					fmt.Printf("\nmutate policy %s applied to %s:", policy.Name, resPath)
+					if !stdin {
+						fmt.Printf("\nmutate policy %s applied to %s:", policy.Name, resPath)
+					}
 					fmt.Printf("\n" + mutatedResource)
 					fmt.Printf("\n")
 				}

--- a/pkg/kyverno/common/common_test.go
+++ b/pkg/kyverno/common/common_test.go
@@ -85,7 +85,7 @@ func Test_NamespaceSelector(t *testing.T) {
 	for _, tc := range testcases {
 		policyArray, _ := ut.GetPolicy(tc.policy)
 		resourceArray, _ := GetResource(tc.resource)
-		_, validateErs, _, _, _ := ApplyPolicyOnResource(policyArray[0], resourceArray[0], "", false, nil, false, tc.namespaceSelectorMap)
+		_, validateErs, _, _, _ := ApplyPolicyOnResource(policyArray[0], resourceArray[0], "", false, nil, false, tc.namespaceSelectorMap, false)
 		assert.Assert(t, tc.sucess == validateErs.IsSuccessful())
 	}
 }

--- a/pkg/kyverno/test/command.go
+++ b/pkg/kyverno/test/command.go
@@ -341,7 +341,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, valuesFile s
 				return sanitizederror.NewWithError(fmt.Sprintf("policy %s have variables. pass the values for the variables using set/values_file flag", policy.Name), err)
 			}
 
-			ers, validateErs, _, _, err := common.ApplyPolicyOnResource(policy, resource, "", false, thisPolicyResourceValues, true, namespaceSelectorMap)
+			ers, validateErs, _, _, err := common.ApplyPolicyOnResource(policy, resource, "", false, thisPolicyResourceValues, true, namespaceSelectorMap, false)
 			if err != nil {
 				return sanitizederror.NewWithError(fmt.Errorf("failed to apply policy %v on resource %v", policy.Name, resource.GetName()).Error(), err)
 			}

--- a/pkg/policymutation/policymutation.go
+++ b/pkg/policymutation/policymutation.go
@@ -272,6 +272,20 @@ func createRuleMap(rules []kyverno.Rule) map[string]kyvernoRule {
 	}
 	return ruleMap
 }
+func updateGenRuleByte(pbyte []byte, kind string, genRule kyvernoRule) (obj []byte) {
+	if err := json.Unmarshal(pbyte, &genRule); err != nil {
+		return obj
+	}
+	if len(*genRule.Context) > 0 {
+		if kind == "Pod" {
+			return []byte(strings.Replace(string(pbyte), "request.object.spec", "request.object.spec.template.spec", -1))
+		}
+		if kind == "Cronjob" {
+			return []byte(strings.Replace(string(pbyte), "request.object.spec", "request.object.spec.jobTemplate.spec.template.spec", -1))
+		}
+	}
+	return obj
+}
 
 // generateRulePatches generates rule for podControllers based on scenario A and C
 func generateRulePatches(policy kyverno.ClusterPolicy, controllers string, log logr.Logger) (rulePatches [][]byte, errs []error) {
@@ -327,6 +341,7 @@ func generateRulePatches(policy kyverno.ClusterPolicy, controllers string, log l
 		genRule := generateRuleForControllers(rule, stripCronJob(controllers), log)
 		if !reflect.DeepEqual(genRule, kyvernoRule{}) {
 			pbytes := convertToPatches(genRule, patchPostion)
+			pbytes = updateGenRuleByte(pbytes, "Pod", genRule)
 			if pbytes != nil {
 				rulePatches = append(rulePatches, pbytes)
 			}
@@ -338,6 +353,7 @@ func generateRulePatches(policy kyverno.ClusterPolicy, controllers string, log l
 		genRule = generateCronJobRule(rule, controllers, log)
 		if !reflect.DeepEqual(genRule, kyvernoRule{}) {
 			pbytes := convertToPatches(genRule, patchPostion)
+			pbytes = updateGenRuleByte(pbytes, "Cronjob", genRule)
 			if pbytes != nil {
 				rulePatches = append(rulePatches, pbytes)
 			}

--- a/pkg/policymutation/policymutation.go
+++ b/pkg/policymutation/policymutation.go
@@ -276,13 +276,11 @@ func updateGenRuleByte(pbyte []byte, kind string, genRule kyvernoRule) (obj []by
 	if err := json.Unmarshal(pbyte, &genRule); err != nil {
 		return obj
 	}
-	if len(*genRule.Context) > 0 {
-		if kind == "Pod" {
-			return []byte(strings.Replace(string(pbyte), "request.object.spec", "request.object.spec.template.spec", -1))
-		}
-		if kind == "Cronjob" {
-			return []byte(strings.Replace(string(pbyte), "request.object.spec", "request.object.spec.jobTemplate.spec.template.spec", -1))
-		}
+	if kind == "Pod" {
+		return []byte(strings.Replace(string(pbyte), "request.object.spec", "request.object.spec.template.spec", -1))
+	}
+	if kind == "Cronjob" {
+		return []byte(strings.Replace(string(pbyte), "request.object.spec", "request.object.spec.jobTemplate.spec.template.spec", -1))
 	}
 	return obj
 }


### PR DESCRIPTION
Signed-off-by: Vyankatesh <vyankateshkd@gmail.com>

## Related issue
closes #1657
closes #1615

## What type of PR is this

/kind bug

## Proposed changes

- For kyverno cli mutate policy, output option added for stdout 

`-i - | `

- Update variable paths when auto generate the controller rules

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/kyverno/website).
