### PR TITLE
Allow generatecontroller to handle Roles

### DIFF
--- a/charts/kyverno/templates/clusterrole.yaml
+++ b/charts/kyverno/templates/clusterrole.yaml
@@ -133,6 +133,7 @@ rules:
   - resourcequotas
   - limitranges
   - clusterroles
+  - roles
   - rolebindings
   - namespaces
   - clusterrolebindings

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -2228,6 +2228,7 @@ rules:
   - configmaps
   - resourcequotas
   - limitranges
+  - roles
   - clusterroles
   - rolebindings
   - clusterrolebindings

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -2228,6 +2228,7 @@ rules:
   - configmaps
   - resourcequotas
   - limitranges
+  - roles
   - clusterroles
   - rolebindings
   - clusterrolebindings

--- a/definitions/k8s-resource/clusterroles.yaml
+++ b/definitions/k8s-resource/clusterroles.yaml
@@ -157,6 +157,7 @@ rules:
   - configmaps
   - resourcequotas
   - limitranges
+  - roles
   - clusterroles
   - rolebindings
   - clusterrolebindings

--- a/definitions/release/install.yaml
+++ b/definitions/release/install.yaml
@@ -2228,7 +2228,6 @@ rules:
   - configmaps
   - resourcequotas
   - limitranges
-  - roles
   - clusterroles
   - rolebindings
   - clusterrolebindings

--- a/definitions/release/install.yaml
+++ b/definitions/release/install.yaml
@@ -2228,6 +2228,7 @@ rules:
   - configmaps
   - resourcequotas
   - limitranges
+  - roles
   - clusterroles
   - rolebindings
   - clusterrolebindings


### PR DESCRIPTION
Signed-off-by: Yuto Takahashi <ytaka23dev@gmail.com>

## Related issue
#1733

## Proposed changes

Allow `kyverno:generatecontroller` to handle Roles by default. It has permission for ClusterRoleBindings, ClusterRole and RoleBindings, so should do for Roles too.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
