### PR TITLE
Check webhooks are present during liveness

### DIFF
--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -78,7 +78,7 @@ livenessProbe:
     port: 9443
     scheme: HTTPS
   initialDelaySeconds: 10
-  periodSeconds: 10
+  periodSeconds: 30
   timeoutSeconds: 5
   failureThreshold: 2
   successThreshold: 1

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -2443,13 +2443,13 @@ spec:
         image: ghcr.io/kyverno/kyverno:v1.3.5-rc1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 4
+          failureThreshold: 2
           httpGet:
             path: /health/liveness
             port: 9443
             scheme: HTTPS
-          initialDelaySeconds: 5
-          periodSeconds: 10
+          initialDelaySeconds: 10
+          periodSeconds: 30
           successThreshold: 1
           timeoutSeconds: 5
         name: kyverno

--- a/definitions/manifest/deployment.yaml
+++ b/definitions/manifest/deployment.yaml
@@ -76,10 +76,10 @@ spec:
               path: /health/liveness
               port: 9443
               scheme: HTTPS
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: 10
+            periodSeconds: 30
             timeoutSeconds: 5
-            failureThreshold: 4
+            failureThreshold: 2
             successThreshold: 1
           readinessProbe:
             httpGet:

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -221,7 +221,11 @@ func NewWebhookServer(
 	// Fail this request if Kubernetes should restart this instance
 	mux.HandlerFunc("GET", config.LivenessServicePath, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
-		w.WriteHeader(http.StatusOK)
+		if err := ws.webhookRegister.Check(); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
 	})
 
 	// Handle Readiness responds to a Kubernetes Readiness probe


### PR DESCRIPTION
## Related issue
Fixes #1747

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
-->

## Proposed changes
During liveness check, ensure webhooks are present.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/kyverno/website).
  - If not, I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further comments
I wasn't sure if better to reuse the existing `Check()` for webhooks or maybe instead just check the `kyverno.io/webhookActive` annotation.  I opted for 30s period for liveness check and failure count of 2 to hopefully make sure that the monitor loop could fix things before second failure occurs.

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
