### PR TITLE
Fix concurrent read/write when loading configmap data

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -308,7 +308,7 @@ func main() {
 			case <-registerTicker.C:
 				err = webhookCfg.Register()
 				if err != nil {
-					setupLog.Info("Failed to register admission control webhooks")
+					setupLog.V(3).Info("Failed to register admission control webhooks", "reason", err.Error())
 				} else {
 					break loop
 				}

--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -156,11 +156,7 @@ func substituteVariablesIfAny(log logr.Logger, ctx context.EvalInterface) jsonUt
 				variable = strings.TrimSpace(variable)
 
 				operation, err := ctx.Query("request.operation")
-				if err != nil {
-					return nil, fmt.Errorf("failed to check request.operation")
-				}
-
-				if operation == "DELETE" {
+				if err == nil && operation == "DELETE" {
 					variable = strings.ReplaceAll(variable, "request.object", "request.oldObject")
 				}
 

--- a/pkg/policy/background.go
+++ b/pkg/policy/background.go
@@ -27,10 +27,6 @@ func ContainsVariablesOtherThanObject(policy kyverno.ClusterPolicy) error {
 		filterVars := []string{"request.object", "request.namespace"}
 		ctx := context.NewContext(filterVars...)
 
-		if rule, err = variables.SubstituteAllInRule(log.Log, ctx, rule); !checkNotFoundErr(err) {
-			return fmt.Errorf("variable substitution failed for rule %s: %s", rule.Name, err.Error())
-		}
-
 		for _, contextEntry := range rule.Context {
 			if contextEntry.APICall != nil {
 				ctx.AddBuiltInVars(contextEntry.Name)
@@ -39,6 +35,10 @@ func ContainsVariablesOtherThanObject(policy kyverno.ClusterPolicy) error {
 			if contextEntry.ConfigMap != nil {
 				ctx.AddBuiltInVars(contextEntry.Name)
 			}
+		}
+
+		if rule, err = variables.SubstituteAllInRule(log.Log, ctx, rule); !checkNotFoundErr(err) {
+			return fmt.Errorf("variable substitution failed for rule %s: %s", rule.Name, err.Error())
 		}
 
 		if rule.AnyAllConditions != nil {

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -498,6 +498,6 @@ func (wrc *Register) checkEndpoint() error {
 		}
 	}
 	err = fmt.Errorf("Endpoint not ready")
-	wrc.log.Error(err, "Endpoint not ready", "ns", config.KyvernoNamespace, "name", config.KyvernoServiceName)
+	wrc.log.V(3).Info(err.Error(), "ns", config.KyvernoNamespace, "name", config.KyvernoServiceName)
 	return err
 }


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.


You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this
/kind bug

Fixes https://github.com/kyverno/kyverno/issues/1749.

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] I have added or changed [the documentation](https://github.com/kyverno/website).
  - If not, I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

I cannot reproduce the issue, but it's pretty suspicious that the lookup operates on the same configmap so the fatal happens. I changed to operate on the [copy](https://github.com/kyverno/kyverno/pull/1755/files#diff-9cf26ca6f0b2c8a0b141a28a138874442955a960e18c444f1dfb720989775150R197) of each configmap and generate the test image `ghcr.io/kyverno/kyverno:v1.3.5-rc1-dev-9-gcab81ead` to verify.