### PR TITLE
Add Support for policies.kyverno.io/severity annotation

### DIFF
--- a/pkg/api/policyreport/v1alpha1/policyreport_types.go
+++ b/pkg/api/policyreport/v1alpha1/policyreport_types.go
@@ -30,6 +30,13 @@ const (
 	StatusSkip  = "skip"
 )
 
+// Severity specifies priority of a policy result
+const (
+	SeverityHigh   = "high"
+	SeverityMedium = "medium"
+	SeverityLow    = "low"
+)
+
 // PolicyReportSummary provides a status count summary
 type PolicyReportSummary struct {
 

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -132,6 +132,8 @@ func (builder *requestBuilder) build(info Info) (req *unstructured.Unstructured,
 }
 
 func (builder *requestBuilder) buildRCRResult(policy string, resource response.ResourceSpec, rule kyverno.ViolatedRule) *report.PolicyReportResult {
+	av := builder.fetchAnnoationValues(policy, resource.Namespace)
+
 	result := &report.PolicyReportResult{
 		Policy: policy,
 		Resources: []*v1.ObjectReference{
@@ -144,7 +146,8 @@ func (builder *requestBuilder) buildRCRResult(policy string, resource response.R
 			},
 		},
 		Scored:   true,
-		Category: builder.fetchCategory(policy, resource.Namespace),
+		Category: av.category,
+		Severity: av.severity,
 	}
 
 	result.Rule = rule.Name
@@ -254,23 +257,54 @@ func buildViolatedRules(er *response.EngineResponse) []kyverno.ViolatedRule {
 }
 
 const categoryLabel string = "policies.kyverno.io/category"
+const severityLabel string = "policies.kyverno.io/severity"
 
-func (builder *requestBuilder) fetchCategory(policy, ns string) string {
+type annotationValues struct {
+	category string
+	severity report.PolicySeverity
+}
+
+func (av *annotationValues) setSeverityFromString(severity string) {
+	switch severity {
+	case report.SeverityHigh:
+		av.severity = report.SeverityHigh
+	case report.SeverityMedium:
+		av.severity = report.SeverityMedium
+	case report.SeverityLow:
+		av.severity = report.SeverityLow
+	}
+}
+
+func (builder *requestBuilder) fetchAnnoationValues(policy, ns string) annotationValues {
+	av := annotationValues{}
+	ann := builder.fetchAnnoations(policy, ns)
+
+	if category, ok := ann[categoryLabel]; ok {
+		av.category = category
+	}
+	if severity, ok := ann[severityLabel]; ok {
+		av.setSeverityFromString(severity)
+	}
+
+	return av
+}
+
+func (builder *requestBuilder) fetchAnnoations(policy, ns string) map[string]string {
 	cpol, err := builder.cpolLister.Get(policy)
 	if err == nil {
 		if ann := cpol.GetAnnotations(); ann != nil {
-			return ann[categoryLabel]
+			return ann
 		}
 	}
 
 	pol, err := builder.polLister.Policies(ns).Get(policy)
 	if err == nil {
 		if ann := pol.GetAnnotations(); ann != nil {
-			return ann[categoryLabel]
+			return ann
 		}
 	}
 
-	return ""
+	return make(map[string]string, 0)
 }
 
 func isResourceDeletion(info Info) bool {


### PR DESCRIPTION
Signed-off-by: Frank Jogeleit <frank.jogeleit@web.de>

## Related issue

#1760 @JimBugwadia @realshuting 

## What type of PR is this

/kind feature

## Proposed changes

Add support for a now annotion "policies.kyverno.io/severity" to support severity for PolicyResults

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/kyverno/website).
  - If not, I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update:

## Further comments

I changed the logic to collect all annotation values from one fetch instead of fetching the annotations for each value. This makes it easier to extend the logic for further annotations.
