### PR TITLE
Fix #1737: forceMutate does not handle StrategicMerge patchesJson6902

### DIFF
--- a/pkg/engine/forceMutate.go
+++ b/pkg/engine/forceMutate.go
@@ -3,8 +3,8 @@ package engine
 import (
 	"fmt"
 
-	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"github.com/ghodss/yaml"
+	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/engine/mutate"
 	"github.com/kyverno/kyverno/pkg/engine/response"
@@ -87,7 +87,7 @@ func ForceMutate(ctx context.EvalInterface, policy kyverno.ClusterPolicy, resour
 				return unstructured.Unstructured{}, fmt.Errorf(resp.Message)
 			}
 		}
-		
+
 		if rule.Mutation.PatchStrategicMerge != nil {
 			var resp response.RuleResponse
 			resp, resource = mutate.ProcessStrategicMergePatch(rule.Name, rule.Mutation.PatchStrategicMerge, resource, logger.WithValues("rule", rule.Name))
@@ -113,4 +113,3 @@ func ForceMutate(ctx context.EvalInterface, policy kyverno.ClusterPolicy, resour
 
 	return resource, nil
 }
-

--- a/pkg/engine/forceMutate_test.go
+++ b/pkg/engine/forceMutate_test.go
@@ -339,4 +339,3 @@ func Test_ForceMutateSubstituteVarsWithPatchesJson6902(t *testing.T) {
 
 	assert.DeepEqual(t, expectedResource.UnstructuredContent(), mutatedResource.UnstructuredContent())
 }
-

--- a/pkg/engine/forceMutate_test.go
+++ b/pkg/engine/forceMutate_test.go
@@ -256,7 +256,7 @@ func Test_ForceMutateSubstituteVarsWithPatchesJson6902(t *testing.T) {
 				}
 			  },
 			  "mutate": {
-				"patchesJson6902": "- op: add\n  path: \"/spec/template/spec/containers/0/command\"\n  value: ls"
+				"patchesJson6902": "- op: add\n  path: \"/spec/template/spec/containers/0/command/0\"\n  value: ls"
 			  }
 			}
 		  ]
@@ -282,6 +282,7 @@ func Test_ForceMutateSubstituteVarsWithPatchesJson6902(t *testing.T) {
 				"spec": {
 					"containers": [
 					{
+						"command": ["ll", "rm"],
 						"image": "nginx",
 						"name": "nginx"
 					}
@@ -310,7 +311,7 @@ func Test_ForceMutateSubstituteVarsWithPatchesJson6902(t *testing.T) {
 			"spec": {
 			  "containers": [
 				{
-				  "command": "ls",
+					"command": ["ls", "ll", "rm"],
 				  "image": "nginx",
 				  "name": "nginx"
 				}

--- a/pkg/engine/forceMutate_test.go
+++ b/pkg/engine/forceMutate_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/engine/utils"
 	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var rawPolicy = []byte(`
@@ -148,3 +149,194 @@ func Test_ForceMutateSubstituteVarsWithNilContext(t *testing.T) {
 
 	assert.DeepEqual(t, expectedResource, mutatedResource.UnstructuredContent())
 }
+
+func Test_ForceMutateSubstituteVarsWithPatchStrategicMerge(t *testing.T) {
+	rawPolicy := []byte(`
+	{
+		"apiVersion": "kyverno.io/v1",
+		"kind": "ClusterPolicy",
+		"metadata": {
+		  "name": "strategic-merge-patch"
+		},
+		"spec": {
+		  "rules": [
+			{
+			  "name": "set-image-pull-policy-add-command",
+			  "match": {
+				"resources": {
+				  "kinds": [
+					"Pod"
+				  ]
+				}
+			  },
+			  "mutate": {
+					"patchStrategicMerge": {
+					  "spec": {
+						"volumes": [
+						  {
+							"emptyDir": {
+							  "medium": "Memory"
+							},
+							"name": "cache-volume"
+						  }
+						]
+					  }
+					}
+			  }
+			}
+		  ]
+		}
+	  }
+`)
+
+	rawResource := []byte(`
+{
+	"apiVersion": "v1",
+	"kind": "Pod",
+	"metadata": {
+		"name": "check-root-user"
+	},
+	"spec": {
+		"volumes": [
+			{
+				"name": "cache-volume",
+				"emptyDir": { }
+			  },
+			  {
+				"name": "cache-volume2",
+				"emptyDir": {
+				  "medium": "Memory"
+				}
+			  }
+		]
+	}
+}
+`)
+
+	expectedRawResource := []byte(`
+	{"apiVersion":"v1","kind":"Pod","metadata":{"name":"check-root-user"},"spec":{"volumes":[{"emptyDir":{"medium":"Memory"},"name":"cache-volume"},{"emptyDir":{"medium":"Memory"},"name":"cache-volume2"}]}}
+	  `)
+
+	var expectedResource interface{}
+	assert.NilError(t, json.Unmarshal(expectedRawResource, &expectedResource))
+
+	var policy kyverno.ClusterPolicy
+	err := json.Unmarshal(rawPolicy, &policy)
+	assert.NilError(t, err)
+
+	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	assert.NilError(t, err)
+	ctx := context.NewContext()
+	err = ctx.AddResource(rawResource)
+	assert.NilError(t, err)
+
+	mutatedResource, err := ForceMutate(ctx, policy, *resourceUnstructured)
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, expectedResource, mutatedResource.UnstructuredContent())
+}
+
+func Test_ForceMutateSubstituteVarsWithPatchesJson6902(t *testing.T) {
+	rawPolicy := []byte(`
+	{
+		"apiVersion": "kyverno.io/v1",
+		"kind": "ClusterPolicy",
+		"metadata": {
+		  "name": "insert-container"
+		},
+		"spec": {
+		  "rules": [
+			{
+			  "name": "insert-container",
+			  "match": {
+				"resources": {
+				  "kinds": [
+					"Pod"
+				  ]
+				}
+			  },
+			  "mutate": {
+				"patchesJson6902": "- op: add\n  path: \"/spec/template/spec/containers/0/command\"\n  value: ls"
+			  }
+			}
+		  ]
+		}
+	  }
+	`)
+
+	rawResource := []byte(`
+		{
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
+			"metadata": {
+				"name": "myDeploy"
+			},
+			"spec": {
+				"replica": 2,
+				"template": {
+				"metadata": {
+					"labels": {
+					"old-label": "old-value"
+					}
+				},
+				"spec": {
+					"containers": [
+					{
+						"image": "nginx",
+						"name": "nginx"
+					}
+					]
+				}
+				}
+			}
+		}
+	`)
+
+	rawExpected := []byte(`
+	{
+		"apiVersion": "apps/v1",
+		"kind": "Deployment",
+		"metadata": {
+		  "name": "myDeploy"
+		},
+		"spec": {
+		  "replica": 2,
+		  "template": {
+			"metadata": {
+			  "labels": {
+				"old-label": "old-value"
+			  }
+			},
+			"spec": {
+			  "containers": [
+				{
+				  "command": "ls",
+				  "image": "nginx",
+				  "name": "nginx"
+				}
+			  ]
+			}
+		  }
+		}
+	  }
+	`)
+
+	var expectedResource unstructured.Unstructured
+	assert.NilError(t, json.Unmarshal(rawExpected, &expectedResource))
+
+	var policy kyverno.ClusterPolicy
+	err := json.Unmarshal(rawPolicy, &policy)
+	assert.NilError(t, err)
+
+	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	assert.NilError(t, err)
+	ctx := context.NewContext()
+	err = ctx.AddResource(rawResource)
+	assert.NilError(t, err)
+
+	mutatedResource, err := ForceMutate(ctx, policy, *resourceUnstructured)
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, expectedResource.UnstructuredContent(), mutatedResource.UnstructuredContent())
+}
+


### PR DESCRIPTION
Signed-off-by: Max Goncharenko <kacejot@fex.net>

## Related issue
Fixes #1737

## What type of PR is this

/kind bug
## Proposed changes
Added two handlers to forceMutate: patchStrategicMerge and patchesJson6902

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/kyverno/website).