### PR TITLE
feat: added validation check for ensuring the existence of only 'any'/'all'

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -205,6 +205,26 @@ func SliceContains(slice []string, values ...string) bool {
 // and converts it into []kyverno.Condition or kyverno.AnyAllConditions according to its content.
 // it also helps in validating the condtions as it returns an error when the conditions are provided wrongfully by the user.
 func ApiextensionsJsonToKyvernoConditions(original apiextensions.JSON) (interface{}, error) {
+	path := "preconditions/validate.deny.conditions"
+
+	// checks for the existence any other field apart from 'any'/'all' under preconditions/validate.deny.conditions
+	unknownFieldChecker := func(jsonByteArr []byte, path string) error {
+		allowedKeys := map[string]bool{
+			"any": true,
+			"all": true,
+		}
+		var jsonDecoded map[string]interface{}
+		if err := json.Unmarshal(jsonByteArr, &jsonDecoded); err != nil {
+			return fmt.Errorf("error occurred while checking for unknown fields under %s: %+v", path, err)
+		}
+		for k := range jsonDecoded {
+			if !allowedKeys[k] {
+				return fmt.Errorf("unknown field '%s' found under %s", k, path)
+			}
+		}
+		return nil
+	}
+
 	// marshalling the abstract apiextensions.JSON back to JSON form
 	jsonByte, err := json.Marshal(original)
 
@@ -215,8 +235,12 @@ func ApiextensionsJsonToKyvernoConditions(original apiextensions.JSON) (interfac
 
 	var kyvernoAnyAllConditions kyverno.AnyAllConditions
 	if err = json.Unmarshal(jsonByte, &kyvernoAnyAllConditions); err == nil {
+		// checking if unknown fields exist or not
+		err = unknownFieldChecker(jsonByte, path)
+		if err != nil {
+			return nil, fmt.Errorf("error occurred while parsing %s: %+v", path, err)
+		}
 		return kyvernoAnyAllConditions, nil
 	}
-
-	return nil, fmt.Errorf("conditions filled wrongfully")
+	return nil, fmt.Errorf("error occurred while parsing %s: %+v", path, err)
 }


### PR DESCRIPTION
## Related issue
closes #1765 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this
> /kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed changes
**After this PR** 
If someone declares `preconditions` or `validate.deny.conditions` containing `any`/`all`, they won't be able to specify any other sub-field apart from `any`/`all`.
For example, the following policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: cluster-cm-array-example
spec:
  validationFailureAction: enforce 
  background: false 
  rules:
  - name: sample-rule
    context:
      - name: ops-cm
        configMap:
          name: ops-cm
          namespace: default
    match:
      resources:
        kinds:
        - Deployment
    validate:
      message: "The role {{ request.object.metadata.annotations.role }} is not in the allowed list of roles: {{ \"roles-dictionary\".data.\"allowed-roles\" }}."
      deny:
        conditions:
          any:
          - key: "{{ request.operation }}"
            operator: Equals
            value:  "{{ \"ops-cm\".data.\"deny-ops\"}}"
          foo:
          - key: "{{ request.operation }}"
            operator: Equals
            value:  "{{ \"ops-cm\".data.\"deny-ops\"}}"
```
When the above policy will be applied, the following error will be generated:
```
Error from server: error when creating "cpol.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: path: spec.rules[0].validate.deny.conditions: error occurred while parsing preconditions/validate.deny.conditions: unknown field 'foo' found under preconditions/validate.deny.conditions
```
**Before this PR**
If someone specified an ambiguous sub-field like `foo` under `preconditions` or `validate.deny.conditions`, kyverno wouldn't raise an error like above.
For example, the following policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: cluster-cm-array-example
spec:
  validationFailureAction: enforce 
  background: false 
  rules:
  - name: sample-rule
    context:
      - name: ops-cm
        configMap:
          name: ops-cm
          namespace: default
    match:
      resources:
        kinds:
        - Deployment
    validate:
      message: "The role {{ request.object.metadata.annotations.role }} is not in the allowed list of roles: {{ \"roles-dictionary\".data.\"allowed-roles\" }}."
      deny:
        conditions:
          any:
          - key: "{{ request.operation }}"
            operator: Equals
            value:  "{{ \"ops-cm\".data.\"deny-ops\"}}"
          foo:
          - key: "{{ request.operation }}"
            operator: Equals
            value:  "{{ \"ops-cm\".data.\"deny-ops\"}}"
```
On applying the above policy, kyverno wouldn't raise any error. And behind the scenes, whenever the above policy's rule will evaluate an admission request, it would simplpy ignore the conditions specified under ambiguous sub-fields like `foo` but that's not ideal because user might be under the wrong assumption that that condition specified under `foo` would still be evaluating the incoming admission requests and working fine, (this might occur if the user, while writing a policy, unknowingly wrote a type like `anyz` or `allz`)
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] I have added or changed [the documentation](https://github.com/kyverno/website).
  - If not, I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
