### PR TITLE
allow fsGroup values greater than zero

### DIFF
--- a/charts/kyverno/templates/policies/restricted/require-non-root-groups.yaml
+++ b/charts/kyverno/templates/policies/restricted/require-non-root-groups.yaml
@@ -56,10 +56,10 @@ spec:
             - Pod
       validate:
         message: >-
-          Changing of file system groups is not allowed. The field	
-          spec.securityContext.fsGroup must not be defined.
+          Changing to root group ID is disallowed. The field
+          spec.securityContext.fsGroup must be empty or greater than zero.
         pattern:
           spec:
             =(securityContext):
-              X(fsGroup): "*"
+              =(fsGroup): ">0"
 {{- end -}}


### PR DESCRIPTION
change the policy require-non-root-groups to allow fsGroup values greater than zero

## Related issue
https://github.com/kyverno/policies/pull/49

## What type of PR is this

/kind bug
