### PR TITLE
Enable image substitution in the background mode

### DIFF
--- a/pkg/policy/apply.go
+++ b/pkg/policy/apply.go
@@ -50,6 +50,10 @@ func applyPolicy(policy kyverno.ClusterPolicy, resource unstructured.Unstructure
 		logger.Error(err, "failed to add namespace to ctx")
 	}
 
+	if err := ctx.AddImageInfo(&resource); err != nil {
+		logger.Error(err, "unable to add image info to variables context")
+	}
+
 	engineResponseMutation, err = mutation(policy, resource, logger, resCache, ctx, namespaceLabels)
 	if err != nil {
 		logger.Error(err, "failed to process mutation rule")

--- a/pkg/policy/background.go
+++ b/pkg/policy/background.go
@@ -24,7 +24,7 @@ func ContainsVariablesOtherThanObject(policy kyverno.ClusterPolicy) error {
 			return fmt.Errorf("invalid variable used at path: spec/rules[%d]/exclude/%s", idx, path)
 		}
 
-		filterVars := []string{"request.object", "request.namespace"}
+		filterVars := []string{"request.object", "request.namespace", "images"}
 		ctx := context.NewContext(filterVars...)
 
 		for _, contextEntry := range rule.Context {

--- a/pkg/policy/background_test.go
+++ b/pkg/policy/background_test.go
@@ -133,5 +133,5 @@ func Test_Validation_invalid_backgroundPolicy(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 	err = ContainsVariablesOtherThanObject(policy)
-	assert.Assert(t, strings.Contains(err.Error(), "variable serviceAccountName cannot be used, allowed variables: [request.object request.namespace mycm]"))
+	assert.Assert(t, strings.Contains(err.Error(), "variable serviceAccountName cannot be used, allowed variables: [request.object request.namespace images mycm]"))
 }


### PR DESCRIPTION
Signed-off-by: Shuting Zhao <shutting06@gmail.com>

## Related issue

Closes https://github.com/kyverno/kyverno/issues/1812.
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this
> /kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
The following policy has no `background` set, which means by default the policy will apply in the background mode.
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-network-policy
  annotations:
    pod-policies.kyverno.io/autogen-controllers: none
spec:
  validationFailureAction: enforce
  rules:
  - name: require-network-policy
    match:
      resources:
        kinds:
        - Pod
    validate:
      message: "Tag 'latest' is not allowed for 'nginx' container. "
      deny:
        conditions:
        - key: "{{ images.containers.nginx.tag}}"
          operator: Equals
          value: latest
```

I have 2 pods (nginx and nginx-8669ff8c97-fbcjr ) with `nginx` container in the cluster
```
✗ kg pod
NAME                             READY   STATUS    RESTARTS   AGE
example-6f7555bb94-7plf9         1/1     Running   0          19h
example-6f7555bb94-b545z         1/1     Running   0          19h
example-6f7555bb94-rvv9d         1/1     Running   0          19h
kyvernodeploy-5c74fc9dd6-8h2xj   1/1     Running   0          4d21h
myapp                            1/1     Running   0          12d
nginx                            1/1     Running   0          27m
nginx-8669ff8c97-fbcjr           1/1     Running   0          2d2h
```

You can see there are 2 violations in the policy report
```
✗ kg polr
NAME              PASS   FAIL   WARN   ERROR   SKIP   AGE
polr-ns-default   5      2      0      0       0      21m
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
