### PR TITLE
Disable auto-gen when a rule has mixed of kinds: pod & pod controllers

### DIFF
--- a/pkg/policy/validate_test.go
+++ b/pkg/policy/validate_test.go
@@ -1293,39 +1293,24 @@ func Test_checkAutoGenRules(t *testing.T) {
 		expectedResult bool
 	}{
 		{
-			name:           "rule-with-match-name",
-			policy:         []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"test","match":{"resources":{"kinds":["Namespace"],"name":"*"}}}]}}`),
-			expectedResult: false,
-		},
-		{
-			name:           "rule-with-match-selector",
-			policy:         []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test-getcontrollers"},"spec":{"background":false,"rules":[{"name":"test-getcontrollers","match":{"resources":{"kinds":["Pod"],"selector":{"matchLabels":{"foo":"bar"}}}}}]}}`),
-			expectedResult: false,
-		},
-		{
-			name:           "rule-with-exclude-name",
-			policy:         []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test-getcontrollers"},"spec":{"background":false,"rules":[{"name":"test-getcontrollers","match":{"resources":{"kinds":["Pod"]}},"exclude":{"resources":{"name":"test"}}}]}}`),
-			expectedResult: false,
-		},
-		{
-			name:           "rule-with-exclude-selector",
-			policy:         []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test-getcontrollers"},"spec":{"background":false,"rules":[{"name":"test-getcontrollers","match":{"resources":{"kinds":["Pod"]}},"exclude":{"resources":{"selector":{"matchLabels":{"foo":"bar"}}}}}]}}`),
-			expectedResult: false,
-		},
-		{
-			name:           "rule-with-deny",
-			policy:         []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"require-network-policy","match":{"resources":{"kinds":["Pod"]}},"validate":{"message":"testpolicy","deny":{"conditions":[{"key":"{{request.object.metadata.labels.foo}}","operator":"Equals","value":"bar"}]}}}]}}`),
-			expectedResult: false,
-		},
-		{
-			name:           "rule-with-match-kinds-pod-only",
-			policy:         []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"require-network-policy","match":{"resources":{"kinds":["Pod"]}},"validate":{"message":"testpolicy","pattern":{"metadata":{"labels":{"foo":"bar"}}}}}]}}`),
+			name:           "rule-missing-autogen-cronjob",
+			policy:         []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test","annotations":{"pod-policies.kyverno.io/autogen-controllers":"Deployment,CronJob"}},"spec":{"rules":[{"match":{"resources":{"kinds":["Pod"]}},"name":"block-old-flux","validate":{"message":"CannotuseoldFluxv1annotation.","pattern":{"metadata":{"=(annotations)":{"X(fluxcd.io/*)":"*?"}}}}},{"match":{"resources":{"kinds":["Deployment"]}},"name":"autogen-block-old-flux","validate":{"message":"CannotuseoldFluxv1annotation.","pattern":{"spec":{"template":{"metadata":{"=(annotations)":{"X(fluxcd.io/*)":"*?"}}}}}}}]}}`),
 			expectedResult: true,
 		},
 		{
-			name:           "rule-with-exclude-kinds-pod-only",
-			policy:         []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"require-network-policy","match":{"resources":{"kinds":["Pod"]}},"exclude":{"resources":{"kinds":["Pod"],"namespaces":["test"]}},"validate":{"message":"testpolicy","pattern":{"metadata":{"labels":{"foo":"bar"}}}}}]}}`),
+			name:           "rule-missing-autogen-deployment",
+			policy:         []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test","annotations":{"pod-policies.kyverno.io/autogen-controllers":"Deployment,CronJob"}},"spec":{"rules":[{"match":{"resources":{"kinds":["Pod"]}},"name":"block-old-flux","validate":{"message":"CannotuseoldFluxv1annotation.","pattern":{"metadata":{"=(annotations)":{"X(fluxcd.io/*)":"*?"}}}}},{"match":{"resources":{"kinds":["CronJob"]}},"name":"autogen-cronjob-block-old-flux","validate":{"message":"CannotuseoldFluxv1annotation.","pattern":{"spec":{"jobTemplate":{"spec":{"template":{"metadata":{"=(annotations)":{"X(fluxcd.io/*)":"*?"}}}}}}}}}]}}`),
 			expectedResult: true,
+		},
+		{
+			name:           "rule-missing-autogen-all",
+			policy:         []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test","annotations":{"pod-policies.kyverno.io/autogen-controllers":"Deployment,CronJob,StatefulSet,Job,DaemonSet"}},"spec":{"rules":[{"match":{"resources":{"kinds":["Pod"]}},"name":"block-old-flux","validate":{"message":"CannotuseoldFluxv1annotation.","pattern":{"metadata":{"=(annotations)":{"X(fluxcd.io/*)":"*?"}}}}}]}}`),
+			expectedResult: true,
+		},
+		{
+			name:           "rule-with-autogen-disabled",
+			policy:         []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test","annotations":{"pod-policies.kyverno.io/autogen-controllers":"none"}},"spec":{"rules":[{"match":{"resources":{"kinds":["Pod"]}},"name":"block-old-flux","validate":{"message":"CannotuseoldFluxv1annotation.","pattern":{"metadata":{"=(annotations)":{"X(fluxcd.io/*)":"*?"}}}}}]}}`),
+			expectedResult: false,
 		},
 	}
 
@@ -1334,7 +1319,7 @@ func Test_checkAutoGenRules(t *testing.T) {
 		err := json.Unmarshal(test.policy, &policy)
 		assert.NilError(t, err)
 
-		res := checkAutoGenRules(&policy, log.Log)
+		res := missingAutoGenRules(&policy, log.Log)
 		assert.Equal(t, test.expectedResult, res, fmt.Sprintf("test %s failed", test.name))
 	}
 }

--- a/pkg/policymutation/policymutation.go
+++ b/pkg/policymutation/policymutation.go
@@ -219,40 +219,50 @@ func defaultvalidationFailureAction(policy *kyverno.ClusterPolicy, log logr.Logg
 
 // GeneratePodControllerRule returns two patches: rulePatches and annotation patch(if necessary)
 func GeneratePodControllerRule(policy kyverno.ClusterPolicy, log logr.Logger) (patches [][]byte, errs []error) {
-	ann := policy.GetAnnotations()
-	controllers, ok := ann[engine.PodControllersAnnotation]
+	applyAutoGen, desiredControllers := CanAutoGen(&policy, log)
 
-	// scenario A
-	if !ok {
-		controllers = GetControllers(&policy, log)
-		annPatch, err := defaultPodControllerAnnotation(ann, controllers)
+	ann := policy.GetAnnotations()
+	actualControllers, ok := ann[engine.PodControllersAnnotation]
+
+	// - scenario A
+	// - predefined controllers are invalid, overwrite the value
+	if !ok || !applyAutoGen {
+		actualControllers = desiredControllers
+		annPatch, err := defaultPodControllerAnnotation(ann, actualControllers)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to generate pod controller annotation for policy '%s': %v", policy.Name, err))
 		} else {
 			patches = append(patches, annPatch)
 		}
+	} else {
+		fmt.Println("===applyAutoGen", applyAutoGen)
+		if !applyAutoGen {
+			actualControllers = desiredControllers
+			fmt.Println("===expected ", actualControllers)
+		}
 	}
 
 	// scenario B
-	if controllers == "none" {
+	if actualControllers == "none" {
 		return patches, nil
 	}
 
-	log.V(3).Info("auto generating rule for pod controllers", "controllers", controllers)
+	log.V(3).Info("auto generating rule for pod controllers", "controllers", actualControllers)
 
-	p, err := generateRulePatches(policy, controllers, log)
+	p, err := generateRulePatches(policy, actualControllers, log)
 	patches = append(patches, p...)
 	errs = append(errs, err...)
 	return
 }
 
-// getControllers gets applicable pod controllers, it returns
+// CanAutoGen checks whether the rule(s) (in policy) can be applied to Pod controllers
+// returns controllers as:
 // - "none" if:
 //          - name or selector is defined
 //          - mixed kinds (Pod + pod controller) is defined
 //          - mutate.Patches/mutate.PatchesJSON6902/validate.deny/generate rule is defined
 // - otherwise it returns all pod controllers
-func GetControllers(policy *kyverno.ClusterPolicy, log logr.Logger) string {
+func CanAutoGen(policy *kyverno.ClusterPolicy, log logr.Logger) (applyAutoGen bool, controllers string) {
 	for _, rule := range policy.Spec.Rules {
 		match := rule.MatchResources
 		exclude := rule.ExcludeResources
@@ -260,21 +270,21 @@ func GetControllers(policy *kyverno.ClusterPolicy, log logr.Logger) string {
 		if match.ResourceDescription.Name != "" || match.ResourceDescription.Selector != nil ||
 			exclude.ResourceDescription.Name != "" || exclude.ResourceDescription.Selector != nil {
 			log.Info("skip generating rule on pod controllers: Name / Selector in resource description may not be applicable.", "rule", rule.Name)
-			return "none"
+			return false, "none"
 		}
 
 		if (len(match.Kinds) > 1 && utils.ContainsString(match.Kinds, "Pod")) ||
 			(len(exclude.Kinds) > 1 && utils.ContainsString(exclude.Kinds, "Pod")) {
-			return "none"
+			return false, "none"
 		}
 
 		if rule.Mutation.Patches != nil || rule.Mutation.PatchesJSON6902 != "" ||
 			rule.Validation.Deny != nil || rule.HasGenerate() {
-			return "none"
+			return false, "none"
 		}
 	}
 
-	return engine.PodControllers
+	return true, engine.PodControllers
 }
 
 func createRuleMap(rules []kyverno.Rule) map[string]kyvernoRule {

--- a/pkg/policymutation/policymutation_test.go
+++ b/pkg/policymutation/policymutation_test.go
@@ -1,12 +1,15 @@
 package policymutation
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/engine"
 	"github.com/kyverno/kyverno/pkg/utils"
 	"gotest.tools/assert"
@@ -151,4 +154,78 @@ func Test_CronJobAndDeployment(t *testing.T) {
 	}
 
 	assert.DeepEqual(t, rulePatches, expectedPatches)
+}
+
+func Test_getControllers(t *testing.T) {
+	testCases := []struct {
+		name                string
+		policy              []byte
+		expectedControllers string
+	}{
+		{
+			name:                "rule-with-match-name",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"test","match":{"resources":{"kinds":["Namespace"],"name":"*"}}}]}}`),
+			expectedControllers: "none",
+		},
+		{
+			name:                "rule-with-match-selector",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test-getcontrollers"},"spec":{"background":false,"rules":[{"name":"test-getcontrollers","match":{"resources":{"kinds":["Pod"],"selector":{"matchLabels":{"foo":"bar"}}}}}]}}`),
+			expectedControllers: "none",
+		},
+		{
+			name:                "rule-with-exclude-name",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test-getcontrollers"},"spec":{"background":false,"rules":[{"name":"test-getcontrollers","match":{"resources":{"kinds":["Pod"]}},"exclude":{"resources":{"name":"test"}}}]}}`),
+			expectedControllers: "none",
+		},
+		{
+			name:                "rule-with-exclude-selector",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test-getcontrollers"},"spec":{"background":false,"rules":[{"name":"test-getcontrollers","match":{"resources":{"kinds":["Pod"]}},"exclude":{"resources":{"selector":{"matchLabels":{"foo":"bar"}}}}}]}}`),
+			expectedControllers: "none",
+		},
+		{
+			name:                "rule-with-deny",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"require-network-policy","match":{"resources":{"kinds":["Pod"]}},"validate":{"message":"testpolicy","deny":{"conditions":[{"key":"{{request.object.metadata.labels.foo}}","operator":"Equals","value":"bar"}]}}}]}}`),
+			expectedControllers: "none",
+		},
+
+		{
+			name:                "rule-with-match-mixed-kinds-pod-podcontrollers",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"set-service-labels-env"},"spec":{"background":false,"rules":[{"name":"set-service-label","match":{"resources":{"kinds":["Pod","Deployment"]}},"preconditions":{"any":[{"key":"{{request.operation}}","operator":"Equals","value":"CREATE"}]},"mutate":{"patchStrategicMerge":{"metadata":{"labels":{"+(service)":"{{request.object.spec.template.metadata.labels.app}}"}}}}}]}}`),
+			expectedControllers: "none",
+		},
+		{
+			name:                "rule-with-exclude-mixed-kinds-pod-podcontrollers",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"set-service-labels-env"},"spec":{"background":false,"rules":[{"name":"set-service-label","match":{"resources":{"kinds":["Pod"]}},"exclude":{"resources":{"kinds":["Pod","Deployment"]}},"mutate":{"patchStrategicMerge":{"metadata":{"labels":{"+(service)":"{{request.object.spec.template.metadata.labels.app}}"}}}}}]}}`),
+			expectedControllers: "none",
+		},
+		{
+			name:                "rule-with-match-kinds-pod-only",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"require-network-policy","match":{"resources":{"kinds":["Pod"]}},"validate":{"message":"testpolicy","pattern":{"metadata":{"labels":{"foo":"bar"}}}}}]}}`),
+			expectedControllers: engine.PodControllers,
+		},
+		{
+			name:                "rule-with-exclude-kinds-pod-only",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"require-network-policy","match":{"resources":{"kinds":["Pod"]}},"exclude":{"resources":{"kinds":["Pod"],"namespaces":["test"]}},"validate":{"message":"testpolicy","pattern":{"metadata":{"labels":{"foo":"bar"}}}}}]}}`),
+			expectedControllers: engine.PodControllers,
+		},
+		{
+			name:                "rule-with-mutate-patches",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"test","match":{"resources":{"kinds":["Pod"]}},"mutate":{"patchesJson6902":"-op:add\npath:/spec/containers/0/env/-1\nvalue:{\"name\":\"SERVICE\",\"value\":{{request.object.spec.template.metadata.labels.app}}}"}}]}}`),
+			expectedControllers: "none",
+		},
+		{
+			name:                "rule-with-generate",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"add-networkpolicy"},"spec":{"rules":[{"name":"default-deny-ingress","match":{"resources":{"kinds":["Namespace"],"name":"*"}},"exclude":{"resources":{"namespaces":["kube-system","default","kube-public","kyverno"]}},"generate":{"kind":"NetworkPolicy","name":"default-deny-ingress","namespace":"{{request.object.metadata.name}}","synchronize":true,"data":{"spec":{"podSelector":{},"policyTypes":["Ingress"]}}}}]}}`),
+			expectedControllers: "none",
+		},
+	}
+
+	for _, test := range testCases {
+		var policy kyverno.ClusterPolicy
+		err := json.Unmarshal(test.policy, &policy)
+		assert.NilError(t, err)
+
+		controllers := getControllers(&policy, log.Log)
+		assert.Equal(t, test.expectedControllers, controllers, fmt.Sprintf("test %s failed", test.name))
+	}
 }


### PR DESCRIPTION
Signed-off-by: Shuting Zhao <shutting06@gmail.com>

## Related issue

Closes https://github.com/kyverno/kyverno/issues/1805.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this
> /kind bug

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
When there are mixed kinds (Pod & Pod controllers) defined in `match.resources.kinds` or `exclude.resources.kinds`,  the auto-gen is disabled.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Create the following policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: block-old-flux
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: block-old-flux
    match:
      resources:
        kinds:
        - Deployment
        - CronJob
        - Job
        - StatefulSet
        - DaemonSet
        - Pod
    validate:
      message: Cannot use old Flux v1 annotation.
      pattern:
        metadata:
          =(annotations):
            X(fluxcd.io/*): "*?"
```
The auto-gen is automatically disabled by `pod-policies.kyverno.io/autogen-controllers: none`:
```yaml
✗ kg cpol block-old-flux -o yaml | k neat
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  annotations:
    pod-policies.kyverno.io/autogen-controllers: none
  name: block-old-flux
spec:
  background: false
  rules:
  - match:
      resources:
        kinds:
        - Deployment
        - CronJob
        - Job
        - StatefulSet
        - DaemonSet
        - Pod
    name: block-old-flux
    validate:
      message: Cannot use old Flux v1 annotation.
      pattern:
        metadata:
          =(annotations):
            X(fluxcd.io/*): '*?'
  validationFailureAction: enforce
```



<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
