### PR TITLE
Add function label_match, to use matchLabel in JMESPath, usage: label…

### DIFF
--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -690,7 +690,13 @@ func validateAPICall(entry kyverno.ContextEntry) error {
 		return err
 	}
 
-	if entry.APICall.JMESPath != "" {
+	// If JMESPath contains variables, the validation will fail because it's not possible to infer which value
+	// will be inserted by the variable
+	// Skip validation if a variable is detected
+
+	jmesPath := variables.ReplaceAllVars(entry.APICall.JMESPath, func(s string) string { return "kyvernojmespathvariable" })
+
+	if !strings.Contains(jmesPath, "kyvernojmespathvariable") && entry.APICall.JMESPath != "" {
 		if _, err := jmespath.NewParser().Parse(entry.APICall.JMESPath); err != nil {
 			return fmt.Errorf("failed to parse JMESPath %s: %v", entry.APICall.JMESPath, err)
 		}


### PR DESCRIPTION
…_match(labels_from_network_policy, labels_from pod) bool, Remove validation for JMESPath

Signed-off-by: Thomas Rosenstein <thomas@thoro.at>

## Related issue

#1842 

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
-->

/kind feature

## Proposed Changes

Add a jmesPath function (label_match) that does a simple kubernetes label matching, so that NetworkPolicies, Services, PodDisruptionBudget, etc. can be checked via context and APICall.

Remove the validation for JMESPath if a variable is used inside of it.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

The following policy currently fails with 1.3.5, with this change it can be successfully created.

```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-network-policy
  annotations:
spec:
  validationFailureAction: audit
  rules:
  - name: require-network-policy
    match:
      resources:
        kinds:
        - Pod
    context:
    - name: policies_count
      apiCall:
        urlPath: "/apis/networking.k8s.io/v1/namespaces/{{request.namespace}}/networkpolicies"
        jmesPath: "items[?label_match(spec.podSelector.matchLabels, `{{request.object.metadata.labels}}`)] | length(@)"
    validate:
      message: "Every pod requires a matching network policy"
      deny:
        conditions:
        - key: "{{policies_count}}"
          operator: LessThan
          value: 1
```

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: policy-test
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: policy-test
      app.kubernetes.io/component: busybox
  template:
    metadata:
      labels:
        app.kubernetes.io/name: policy-test
        app.kubernetes.io/component: busybox
    spec:
      containers:
      - name: busybox
        image: busybox
        command: [ /bin/sleep ]
        args:
        - infinity
```
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: policy-test
  namespace: default
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/name: policy-test
  policyTypes:
  - Ingress
  - Egress
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](pr_documentation.md) and followed the process including adding proof manifests to this PR.

Currently it seems that JMESPath methods are not documented within the documentation.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
