### PR TITLE
Removes check for strategicMergePatch in forceMutate

### DIFF
--- a/pkg/engine/forceMutate.go
+++ b/pkg/engine/forceMutate.go
@@ -88,14 +88,6 @@ func ForceMutate(ctx context.EvalInterface, policy kyverno.ClusterPolicy, resour
 			}
 		}
 
-		if rule.Mutation.PatchStrategicMerge != nil {
-			var resp response.RuleResponse
-			resp, resource = mutate.ProcessStrategicMergePatch(rule.Name, rule.Mutation.PatchStrategicMerge, resource, logger.WithValues("rule", rule.Name))
-			if !resp.Success {
-				return unstructured.Unstructured{}, fmt.Errorf(resp.Message)
-			}
-		}
-
 		if rule.Mutation.PatchesJSON6902 != "" {
 			var resp response.RuleResponse
 			jsonPatches, err := yaml.YAMLToJSON([]byte(rule.Mutation.PatchesJSON6902))

--- a/pkg/policycache/cache.go
+++ b/pkg/policycache/cache.go
@@ -39,8 +39,8 @@ type policyCache struct {
 type Interface interface {
 	Add(policy *kyverno.ClusterPolicy)
 	Remove(policy *kyverno.ClusterPolicy)
-	GetPolicyObject(pkey PolicyType, kind *string, nspace *string) []*kyverno.ClusterPolicy
-	get(pkey PolicyType, kind *string, nspace *string) []string
+	GetPolicyObject(pkey PolicyType, kind string, nspace string) []*kyverno.ClusterPolicy
+	get(pkey PolicyType, kind string, nspace string) []string
 }
 
 // newPolicyCache ...
@@ -70,10 +70,10 @@ func (pc *policyCache) Add(policy *kyverno.ClusterPolicy) {
 }
 
 // Get the list of matched policies
-func (pc *policyCache) get(pkey PolicyType, kind, nspace *string) []string {
+func (pc *policyCache) get(pkey PolicyType, kind, nspace string) []string {
 	return pc.pMap.get(pkey, kind, nspace)
 }
-func (pc *policyCache) GetPolicyObject(pkey PolicyType, kind, nspace *string) []*kyverno.ClusterPolicy {
+func (pc *policyCache) GetPolicyObject(pkey PolicyType, kind, nspace string) []*kyverno.ClusterPolicy {
 	return pc.getPolicyObject(pkey, kind, nspace)
 }
 
@@ -148,15 +148,15 @@ func (m *pMap) add(policy *kyverno.ClusterPolicy) {
 	m.nameCacheMap[Generate] = generateMap
 }
 
-func (pc *pMap) get(key PolicyType, kind, namespace *string) (names []string) {
+func (pc *pMap) get(key PolicyType, kind, namespace string) (names []string) {
 	pc.RLock()
 	defer pc.RUnlock()
-	for _, policyName := range pc.kindDataMap[*kind][key] {
+	for _, policyName := range pc.kindDataMap[kind][key] {
 		ns, key, isNamespacedPolicy := policy2.ParseNamespacedPolicy(policyName)
 		if !isNamespacedPolicy {
 			names = append(names, key)
 		} else {
-			if ns == *namespace {
+			if ns == namespace {
 				names = append(names, policyName)
 			}
 		}
@@ -195,7 +195,7 @@ func (m *pMap) remove(policy *kyverno.ClusterPolicy) {
 		}
 	}
 }
-func (m *policyCache) getPolicyObject(key PolicyType, kind *string, nspace *string) (policyObject []*kyverno.ClusterPolicy) {
+func (m *policyCache) getPolicyObject(key PolicyType, kind string, nspace string) (policyObject []*kyverno.ClusterPolicy) {
 	policyNames := m.pMap.get(key, kind, nspace)
 	for _, policyName := range policyNames {
 		var policy *kyverno.ClusterPolicy
@@ -203,7 +203,7 @@ func (m *policyCache) getPolicyObject(key PolicyType, kind *string, nspace *stri
 		if !isNamespacedPolicy {
 			policy, _ = m.pLister.Get(key)
 		} else {
-			if ns == *nspace {
+			if ns == nspace {
 				nspolicy, _ := m.npLister.Policies(ns).Get(key)
 				policy = policy2.ConvertPolicyToClusterPolicy(nspolicy)
 			}

--- a/pkg/policycache/cache_test.go
+++ b/pkg/policycache/cache_test.go
@@ -54,16 +54,16 @@ func Test_All(t *testing.T) {
 		for _, kind := range rule.MatchResources.Kinds {
 
 			// get
-			mutate := pCache.get(Mutate, &kind, nil)
+			mutate := pCache.get(Mutate, kind, "")
 			if len(mutate) != 1 {
 				t.Errorf("expected 1 mutate policy, found %v", len(mutate))
 			}
 
-			validateEnforce := pCache.get(ValidateEnforce, &kind, nil)
+			validateEnforce := pCache.get(ValidateEnforce, kind, "")
 			if len(validateEnforce) != 1 {
 				t.Errorf("expected 1 validate policy, found %v", len(validateEnforce))
 			}
-			generate := pCache.get(Generate, &kind, nil)
+			generate := pCache.get(Generate, kind, "")
 			if len(generate) != 1 {
 				t.Errorf("expected 1 generate policy, found %v", len(generate))
 			}
@@ -73,7 +73,7 @@ func Test_All(t *testing.T) {
 	// remove
 	pCache.Remove(policy)
 	kind := "pod"
-	validateEnforce := pCache.get(ValidateEnforce, &kind, nil)
+	validateEnforce := pCache.get(ValidateEnforce, kind, "")
 	assert.Assert(t, len(validateEnforce) == 0)
 }
 
@@ -86,16 +86,16 @@ func Test_Add_Duplicate_Policy(t *testing.T) {
 	for _, rule := range policy.Spec.Rules {
 		for _, kind := range rule.MatchResources.Kinds {
 
-			mutate := pCache.get(Mutate, &kind, nil)
+			mutate := pCache.get(Mutate, kind, "")
 			if len(mutate) != 1 {
 				t.Errorf("expected 1 mutate policy, found %v", len(mutate))
 			}
 
-			validateEnforce := pCache.get(ValidateEnforce, &kind, nil)
+			validateEnforce := pCache.get(ValidateEnforce, kind, "")
 			if len(validateEnforce) != 1 {
 				t.Errorf("expected 1 validate policy, found %v", len(validateEnforce))
 			}
-			generate := pCache.get(Generate, &kind, nil)
+			generate := pCache.get(Generate, kind, "")
 			if len(generate) != 1 {
 				t.Errorf("expected 1 generate policy, found %v", len(generate))
 			}
@@ -115,12 +115,12 @@ func Test_Add_Validate_Audit(t *testing.T) {
 	for _, rule := range policy.Spec.Rules {
 		for _, kind := range rule.MatchResources.Kinds {
 
-			validateEnforce := pCache.get(ValidateEnforce, &kind, nil)
+			validateEnforce := pCache.get(ValidateEnforce, kind, "")
 			if len(validateEnforce) != 1 {
 				t.Errorf("expected 1 mutate policy, found %v", len(validateEnforce))
 			}
 
-			validateAudit := pCache.get(ValidateAudit, &kind, nil)
+			validateAudit := pCache.get(ValidateAudit, kind, "")
 			if len(validateEnforce) != 1 {
 				t.Errorf("expected 1 validate policy, found %v", len(validateAudit))
 			}
@@ -133,13 +133,13 @@ func Test_Add_Remove(t *testing.T) {
 	policy := newPolicy(t)
 	kind := "Pod"
 	pCache.Add(policy)
-	validateEnforce := pCache.get(ValidateEnforce, &kind, nil)
+	validateEnforce := pCache.get(ValidateEnforce, kind, "")
 	if len(validateEnforce) != 1 {
 		t.Errorf("expected 1 validate enforce policy, found %v", len(validateEnforce))
 	}
 
 	pCache.Remove(policy)
-	deletedValidateEnforce := pCache.get(ValidateEnforce, &kind, nil)
+	deletedValidateEnforce := pCache.get(ValidateEnforce, kind, "")
 	if len(deletedValidateEnforce) != 0 {
 		t.Errorf("expected 0 validate enforce policy, found %v", len(deletedValidateEnforce))
 	}
@@ -378,16 +378,16 @@ func Test_Ns_All(t *testing.T) {
 		for _, kind := range rule.MatchResources.Kinds {
 
 			// get
-			mutate := pCache.get(Mutate, &kind, &nspace)
+			mutate := pCache.get(Mutate, kind, nspace)
 			if len(mutate) != 1 {
 				t.Errorf("expected 1 mutate policy, found %v", len(mutate))
 			}
 
-			validateEnforce := pCache.get(ValidateEnforce, &kind, &nspace)
+			validateEnforce := pCache.get(ValidateEnforce, kind, nspace)
 			if len(validateEnforce) != 1 {
 				t.Errorf("expected 1 validate policy, found %v", len(validateEnforce))
 			}
-			generate := pCache.get(Generate, &kind, &nspace)
+			generate := pCache.get(Generate, kind, nspace)
 			if len(generate) != 1 {
 				t.Errorf("expected 1 generate policy, found %v", len(generate))
 			}
@@ -396,7 +396,7 @@ func Test_Ns_All(t *testing.T) {
 	// remove
 	pCache.Remove(policy)
 	kind := "pod"
-	validateEnforce := pCache.get(ValidateEnforce, &kind, &nspace)
+	validateEnforce := pCache.get(ValidateEnforce, kind, nspace)
 	assert.Assert(t, len(validateEnforce) == 0)
 }
 
@@ -410,16 +410,16 @@ func Test_Ns_Add_Duplicate_Policy(t *testing.T) {
 	for _, rule := range policy.Spec.Rules {
 		for _, kind := range rule.MatchResources.Kinds {
 
-			mutate := pCache.get(Mutate, &kind, &nspace)
+			mutate := pCache.get(Mutate, kind, nspace)
 			if len(mutate) != 1 {
 				t.Errorf("expected 1 mutate policy, found %v", len(mutate))
 			}
 
-			validateEnforce := pCache.get(ValidateEnforce, &kind, &nspace)
+			validateEnforce := pCache.get(ValidateEnforce, kind, nspace)
 			if len(validateEnforce) != 1 {
 				t.Errorf("expected 1 validate policy, found %v", len(validateEnforce))
 			}
-			generate := pCache.get(Generate, &kind, &nspace)
+			generate := pCache.get(Generate, kind, nspace)
 			if len(generate) != 1 {
 				t.Errorf("expected 1 generate policy, found %v", len(generate))
 			}
@@ -439,12 +439,12 @@ func Test_Ns_Add_Validate_Audit(t *testing.T) {
 	for _, rule := range policy.Spec.Rules {
 		for _, kind := range rule.MatchResources.Kinds {
 
-			validateEnforce := pCache.get(ValidateEnforce, &kind, &nspace)
+			validateEnforce := pCache.get(ValidateEnforce, kind, nspace)
 			if len(validateEnforce) != 1 {
 				t.Errorf("expected 1 validate policy, found %v", len(validateEnforce))
 			}
 
-			validateAudit := pCache.get(ValidateAudit, &kind, &nspace)
+			validateAudit := pCache.get(ValidateAudit, kind, nspace)
 			if len(validateEnforce) != 1 {
 				t.Errorf("expected 1 validate policy, found %v", len(validateAudit))
 			}
@@ -458,13 +458,13 @@ func Test_Ns_Add_Remove(t *testing.T) {
 	nspace := policy.GetNamespace()
 	kind := "Pod"
 	pCache.Add(policy)
-	validateEnforce := pCache.get(ValidateEnforce, &kind, &nspace)
+	validateEnforce := pCache.get(ValidateEnforce, kind, nspace)
 	if len(validateEnforce) != 1 {
 		t.Errorf("expected 1 validate enforce policy, found %v", len(validateEnforce))
 	}
 
 	pCache.Remove(policy)
-	deletedValidateEnforce := pCache.get(ValidateEnforce, &kind, &nspace)
+	deletedValidateEnforce := pCache.get(ValidateEnforce, kind, nspace)
 	if len(deletedValidateEnforce) != 0 {
 		t.Errorf("expected 0 validate enforce policy, found %v", len(deletedValidateEnforce))
 	}

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -308,11 +308,11 @@ func (ws *WebhookServer) ResourceMutation(request *v1beta1.AdmissionRequest) *v1
 	}
 
 	logger.V(6).Info("received an admission request in mutating webhook")
-	mutatePolicies := ws.pCache.GetPolicyObject(policycache.Mutate, &request.Kind.Kind, nil)
-	generatePolicies := ws.pCache.GetPolicyObject(policycache.Generate, &request.Kind.Kind, nil)
+	mutatePolicies := ws.pCache.GetPolicyObject(policycache.Mutate, request.Kind.Kind, "")
+	generatePolicies := ws.pCache.GetPolicyObject(policycache.Generate, request.Kind.Kind, "")
 
 	// Get namespace policies from the cache for the requested resource namespace
-	nsMutatePolicies := ws.pCache.GetPolicyObject(policycache.Mutate, &request.Kind.Kind, &request.Namespace)
+	nsMutatePolicies := ws.pCache.GetPolicyObject(policycache.Mutate, request.Kind.Kind, request.Namespace)
 	mutatePolicies = append(mutatePolicies, nsMutatePolicies...)
 
 	// convert RAW to unstructured
@@ -395,9 +395,9 @@ func (ws *WebhookServer) resourceValidation(request *v1beta1.AdmissionRequest) *
 
 	logger.V(6).Info("received an admission request in validating webhook")
 
-	policies := ws.pCache.GetPolicyObject(policycache.ValidateEnforce, &request.Kind.Kind, nil)
+	policies := ws.pCache.GetPolicyObject(policycache.ValidateEnforce, request.Kind.Kind, "")
 	// Get namespace policies from the cache for the requested resource namespace
-	nsPolicies := ws.pCache.GetPolicyObject(policycache.ValidateEnforce, &request.Kind.Kind, &request.Namespace)
+	nsPolicies := ws.pCache.GetPolicyObject(policycache.ValidateEnforce, request.Kind.Kind, request.Namespace)
 	policies = append(policies, nsPolicies...)
 	if len(policies) == 0 {
 		// push admission request to audit handler, this won't block the admission request

--- a/pkg/webhooks/validate_audit.go
+++ b/pkg/webhooks/validate_audit.go
@@ -149,9 +149,9 @@ func (h *auditHandler) process(request *v1beta1.AdmissionRequest) error {
 	var err error
 
 	logger := h.log.WithName("process")
-	policies := h.pCache.GetPolicyObject(policycache.ValidateAudit, &request.Kind.Kind, nil)
+	policies := h.pCache.GetPolicyObject(policycache.ValidateAudit, request.Kind.Kind, "")
 	// Get namespace policies from the cache for the requested resource namespace
-	nsPolicies := h.pCache.GetPolicyObject(policycache.ValidateAudit, &request.Kind.Kind, &request.Namespace)
+	nsPolicies := h.pCache.GetPolicyObject(policycache.ValidateAudit, request.Kind.Kind, request.Namespace)
 	policies = append(policies, nsPolicies...)
 	// getRoleRef only if policy has roles/clusterroles defined
 	if containRBACInfo(policies) {


### PR DESCRIPTION
## Related issue

https://github.com/kyverno/kyverno/issues/1896

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this
/bug

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
I had to remove the validation check for `strategicMergePatch` in `forceMutate`, it seems like current logic cannot handle a policy with multiple rules. If I remove the second rule in this `test/best_practices/add_safe_to_evict.yaml` policy, the validation passes.

cc @kacejot 

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
