### PR TITLE
allow only supplementalGroups greater 0

### DIFF
--- a/charts/kyverno/templates/policies/restricted/require-non-root-groups.yaml
+++ b/charts/kyverno/templates/policies/restricted/require-non-root-groups.yaml
@@ -48,7 +48,7 @@ spec:
         pattern:
           spec:
             =(securityContext):
-              =(supplementalGroups): ["null"]
+              =(supplementalGroups): ">0"
     - name: check-fsGroup
       match:
         resources:


### PR DESCRIPTION
## Related issue

there is no issue @github. We discussed this in slack: https://kubernetes.slack.com/archives/CLGR9BJU9/p1620493463206200?thread_ts=1620454770.199000&cid=CLGR9BJU9

## What type of PR is this
/kind bug

## Proposed Changes
supplementalGroups with a value greater than 0 should be allowed.
