### PR TITLE
Update to use gvk to store OpenAPI schema 

### DIFF
--- a/api/apiResources.go
+++ b/api/apiResources.go
@@ -1,0 +1,3413 @@
+package data
+
+// k8s version 1.20.2
+const APIResourceLists = `
+[
+  {
+    "kind": "APIResourceList",
+    "groupVersion": "v1",
+    "resources": [
+      {
+        "name": "bindings",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Binding",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "componentstatuses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "ComponentStatus",
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "shortNames": [
+          "cs"
+        ]
+      },
+      {
+        "name": "configmaps",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ConfigMap",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "cm"
+        ],
+        "storageVersionHash": "qFsyl6wFWjQ="
+      },
+      {
+        "name": "endpoints",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Endpoints",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ep"
+        ],
+        "storageVersionHash": "fWeeMqaN/OA="
+      },
+      {
+        "name": "events",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Event",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ev"
+        ],
+        "storageVersionHash": "r2yiGXH7wu8="
+      },
+      {
+        "name": "limitranges",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "LimitRange",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "limits"
+        ],
+        "storageVersionHash": "EBKMFVe6cwo="
+      },
+      {
+        "name": "namespaces",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "Namespace",
+        "verbs": [
+          "create",
+          "delete",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ns"
+        ],
+        "storageVersionHash": "Q3oi5N2YM8M="
+      },
+      {
+        "name": "namespaces/finalize",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "Namespace",
+        "verbs": [
+          "update"
+        ]
+      },
+      {
+        "name": "namespaces/status",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "Namespace",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "nodes",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "Node",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "no"
+        ],
+        "storageVersionHash": "XwShjMxG9Fs="
+      },
+      {
+        "name": "nodes/proxy",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "NodeProxyOptions",
+        "verbs": [
+          "create",
+          "delete",
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "nodes/status",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "Node",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "persistentvolumeclaims",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PersistentVolumeClaim",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "pvc"
+        ],
+        "storageVersionHash": "QWTyNDq0dC4="
+      },
+      {
+        "name": "persistentvolumeclaims/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PersistentVolumeClaim",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "persistentvolumes",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "PersistentVolume",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "pv"
+        ],
+        "storageVersionHash": "HN/zwEC+JgM="
+      },
+      {
+        "name": "persistentvolumes/status",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "PersistentVolume",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "pods",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Pod",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "po"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "xPOwRZ+Yhw8="
+      },
+      {
+        "name": "pods/attach",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PodAttachOptions",
+        "verbs": [
+          "create",
+          "get"
+        ]
+      },
+      {
+        "name": "pods/binding",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Binding",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "pods/eviction",
+        "singularName": "",
+        "namespaced": true,
+        "group": "policy",
+        "version": "v1beta1",
+        "kind": "Eviction",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "pods/exec",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PodExecOptions",
+        "verbs": [
+          "create",
+          "get"
+        ]
+      },
+      {
+        "name": "pods/log",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Pod",
+        "verbs": [
+          "get"
+        ]
+      },
+      {
+        "name": "pods/portforward",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PodPortForwardOptions",
+        "verbs": [
+          "create",
+          "get"
+        ]
+      },
+      {
+        "name": "pods/proxy",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PodProxyOptions",
+        "verbs": [
+          "create",
+          "delete",
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "pods/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Pod",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "podtemplates",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PodTemplate",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "LIXB2x4IFpk="
+      },
+      {
+        "name": "replicationcontrollers",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ReplicationController",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "rc"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "Jond2If31h0="
+      },
+      {
+        "name": "replicationcontrollers/scale",
+        "singularName": "",
+        "namespaced": true,
+        "group": "autoscaling",
+        "version": "v1",
+        "kind": "Scale",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "replicationcontrollers/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ReplicationController",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "resourcequotas",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ResourceQuota",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "quota"
+        ],
+        "storageVersionHash": "8uhSgffRX6w="
+      },
+      {
+        "name": "resourcequotas/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ResourceQuota",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "secrets",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Secret",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "S6u1pOWzb84="
+      },
+      {
+        "name": "serviceaccounts",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ServiceAccount",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "sa"
+        ],
+        "storageVersionHash": "pbx9ZvyFpBE="
+      },
+      {
+        "name": "serviceaccounts/token",
+        "singularName": "",
+        "namespaced": true,
+        "group": "authentication.k8s.io",
+        "version": "v1",
+        "kind": "TokenRequest",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "services",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Service",
+        "verbs": [
+          "create",
+          "delete",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "svc"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "0/CO1lhkEBI="
+      },
+      {
+        "name": "services/proxy",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ServiceProxyOptions",
+        "verbs": [
+          "create",
+          "delete",
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "services/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Service",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "apiregistration.k8s.io/v1",
+    "resources": [
+      {
+        "name": "apiservices",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "APIService",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "api-extensions"
+        ],
+        "storageVersionHash": "C+s2HXXP47k="
+      },
+      {
+        "name": "apiservices/status",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "APIService",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "apiregistration.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "apiservices",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "APIService",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "api-extensions"
+        ],
+        "storageVersionHash": "C+s2HXXP47k="
+      },
+      {
+        "name": "apiservices/status",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "APIService",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "apps/v1",
+    "resources": [
+      {
+        "name": "controllerrevisions",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ControllerRevision",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "85nkx63pcBU="
+      },
+      {
+        "name": "daemonsets",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "DaemonSet",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ds"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "dd7pWHUlMKQ="
+      },
+      {
+        "name": "daemonsets/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "DaemonSet",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "deployments",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Deployment",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "deploy"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "8aSe+NMegvE="
+      },
+      {
+        "name": "deployments/scale",
+        "singularName": "",
+        "namespaced": true,
+        "group": "autoscaling",
+        "version": "v1",
+        "kind": "Scale",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "deployments/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Deployment",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "replicasets",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ReplicaSet",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "rs"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "P1RzHs8/mWQ="
+      },
+      {
+        "name": "replicasets/scale",
+        "singularName": "",
+        "namespaced": true,
+        "group": "autoscaling",
+        "version": "v1",
+        "kind": "Scale",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "replicasets/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ReplicaSet",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "statefulsets",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "StatefulSet",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "sts"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "H+vl74LkKdo="
+      },
+      {
+        "name": "statefulsets/scale",
+        "singularName": "",
+        "namespaced": true,
+        "group": "autoscaling",
+        "version": "v1",
+        "kind": "Scale",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "statefulsets/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "StatefulSet",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "events.k8s.io/v1",
+    "resources": [
+      {
+        "name": "events",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Event",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ev"
+        ],
+        "storageVersionHash": "r2yiGXH7wu8="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "events.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "events",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Event",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ev"
+        ],
+        "storageVersionHash": "r2yiGXH7wu8="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "authentication.k8s.io/v1",
+    "resources": [
+      {
+        "name": "tokenreviews",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "TokenReview",
+        "verbs": [
+          "create"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "authentication.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "tokenreviews",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "TokenReview",
+        "verbs": [
+          "create"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "authorization.k8s.io/v1",
+    "resources": [
+      {
+        "name": "localsubjectaccessreviews",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "LocalSubjectAccessReview",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "selfsubjectaccessreviews",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "SelfSubjectAccessReview",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "selfsubjectrulesreviews",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "SelfSubjectRulesReview",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "subjectaccessreviews",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "SubjectAccessReview",
+        "verbs": [
+          "create"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "authorization.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "localsubjectaccessreviews",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "LocalSubjectAccessReview",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "selfsubjectaccessreviews",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "SelfSubjectAccessReview",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "selfsubjectrulesreviews",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "SelfSubjectRulesReview",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "subjectaccessreviews",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "SubjectAccessReview",
+        "verbs": [
+          "create"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "autoscaling/v1",
+    "resources": [
+      {
+        "name": "horizontalpodautoscalers",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "HorizontalPodAutoscaler",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "hpa"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "oQlkt7f5j/A="
+      },
+      {
+        "name": "horizontalpodautoscalers/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "HorizontalPodAutoscaler",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "autoscaling/v2beta1",
+    "resources": [
+      {
+        "name": "horizontalpodautoscalers",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "HorizontalPodAutoscaler",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "hpa"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "oQlkt7f5j/A="
+      },
+      {
+        "name": "horizontalpodautoscalers/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "HorizontalPodAutoscaler",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "autoscaling/v2beta2",
+    "resources": [
+      {
+        "name": "horizontalpodautoscalers",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "HorizontalPodAutoscaler",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "hpa"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "oQlkt7f5j/A="
+      },
+      {
+        "name": "horizontalpodautoscalers/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "HorizontalPodAutoscaler",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "batch/v1",
+    "resources": [
+      {
+        "name": "jobs",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Job",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "mudhfqk/qZY="
+      },
+      {
+        "name": "jobs/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Job",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "batch/v1beta1",
+    "resources": [
+      {
+        "name": "cronjobs",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "CronJob",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "cj"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "h/JlFAZkyyY="
+      },
+      {
+        "name": "cronjobs/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "CronJob",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "certificates.k8s.io/v1",
+    "resources": [
+      {
+        "name": "certificatesigningrequests",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CertificateSigningRequest",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "csr"
+        ],
+        "storageVersionHash": "UQh3YTCDIf0="
+      },
+      {
+        "name": "certificatesigningrequests/approval",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CertificateSigningRequest",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "certificatesigningrequests/status",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CertificateSigningRequest",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "certificates.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "certificatesigningrequests",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CertificateSigningRequest",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "csr"
+        ],
+        "storageVersionHash": "UQh3YTCDIf0="
+      },
+      {
+        "name": "certificatesigningrequests/approval",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CertificateSigningRequest",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "certificatesigningrequests/status",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CertificateSigningRequest",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "networking.k8s.io/v1",
+    "resources": [
+      {
+        "name": "ingressclasses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "IngressClass",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "6upRfBq0FOI="
+      },
+      {
+        "name": "ingresses",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Ingress",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ing"
+        ],
+        "storageVersionHash": "ZOAfGflaKd0="
+      },
+      {
+        "name": "ingresses/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Ingress",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "networkpolicies",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "NetworkPolicy",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "netpol"
+        ],
+        "storageVersionHash": "YpfwF18m1G8="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "networking.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "ingressclasses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "IngressClass",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "6upRfBq0FOI="
+      },
+      {
+        "name": "ingresses",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Ingress",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ing"
+        ],
+        "storageVersionHash": "ZOAfGflaKd0="
+      },
+      {
+        "name": "ingresses/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Ingress",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "groupVersion": "extensions/v1beta1",
+    "resources": [
+      {
+        "name": "ingresses",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Ingress",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ing"
+        ],
+        "storageVersionHash": "ZOAfGflaKd0="
+      },
+      {
+        "name": "ingresses/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Ingress",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "policy/v1beta1",
+    "resources": [
+      {
+        "name": "poddisruptionbudgets",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PodDisruptionBudget",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "pdb"
+        ],
+        "storageVersionHash": "6BGBu0kpHtk="
+      },
+      {
+        "name": "poddisruptionbudgets/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PodDisruptionBudget",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "podsecuritypolicies",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "PodSecurityPolicy",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "psp"
+        ],
+        "storageVersionHash": "khBLobUXkqA="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "rbac.authorization.k8s.io/v1",
+    "resources": [
+      {
+        "name": "clusterrolebindings",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "ClusterRoleBinding",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "48tpQ8gZHFc="
+      },
+      {
+        "name": "clusterroles",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "ClusterRole",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "bYE5ZWDrJ44="
+      },
+      {
+        "name": "rolebindings",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "RoleBinding",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "eGsCzGH6b1g="
+      },
+      {
+        "name": "roles",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Role",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "7FuwZcIIItM="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "rbac.authorization.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "clusterrolebindings",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "ClusterRoleBinding",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "48tpQ8gZHFc="
+      },
+      {
+        "name": "clusterroles",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "ClusterRole",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "bYE5ZWDrJ44="
+      },
+      {
+        "name": "rolebindings",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "RoleBinding",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "eGsCzGH6b1g="
+      },
+      {
+        "name": "roles",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Role",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "7FuwZcIIItM="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "storage.k8s.io/v1",
+    "resources": [
+      {
+        "name": "csidrivers",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CSIDriver",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "Z7aeXSiaYTw="
+      },
+      {
+        "name": "csinodes",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CSINode",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "Pe62DkZtjuo="
+      },
+      {
+        "name": "storageclasses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "StorageClass",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "sc"
+        ],
+        "storageVersionHash": "K+m6uJwbjGY="
+      },
+      {
+        "name": "volumeattachments",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "VolumeAttachment",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "tJx/ezt6UDU="
+      },
+      {
+        "name": "volumeattachments/status",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "VolumeAttachment",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "storage.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "csidrivers",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CSIDriver",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "Z7aeXSiaYTw="
+      },
+      {
+        "name": "csinodes",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CSINode",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "Pe62DkZtjuo="
+      },
+      {
+        "name": "storageclasses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "StorageClass",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "sc"
+        ],
+        "storageVersionHash": "K+m6uJwbjGY="
+      },
+      {
+        "name": "volumeattachments",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "VolumeAttachment",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "tJx/ezt6UDU="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "admissionregistration.k8s.io/v1",
+    "resources": [
+      {
+        "name": "mutatingwebhookconfigurations",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "MutatingWebhookConfiguration",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "api-extensions"
+        ],
+        "storageVersionHash": "yxW1cpLtfp8="
+      },
+      {
+        "name": "validatingwebhookconfigurations",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "ValidatingWebhookConfiguration",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "api-extensions"
+        ],
+        "storageVersionHash": "P9NhrezfnWE="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "admissionregistration.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "mutatingwebhookconfigurations",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "MutatingWebhookConfiguration",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "api-extensions"
+        ],
+        "storageVersionHash": "yxW1cpLtfp8="
+      },
+      {
+        "name": "validatingwebhookconfigurations",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "ValidatingWebhookConfiguration",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "api-extensions"
+        ],
+        "storageVersionHash": "P9NhrezfnWE="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "apiextensions.k8s.io/v1",
+    "resources": [
+      {
+        "name": "customresourcedefinitions",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CustomResourceDefinition",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "crd",
+          "crds"
+        ],
+        "categories": [
+          "api-extensions"
+        ],
+        "storageVersionHash": "jfWCUB31mvA="
+      },
+      {
+        "name": "customresourcedefinitions/status",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CustomResourceDefinition",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "apiextensions.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "customresourcedefinitions",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CustomResourceDefinition",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "crd",
+          "crds"
+        ],
+        "categories": [
+          "api-extensions"
+        ],
+        "storageVersionHash": "jfWCUB31mvA="
+      },
+      {
+        "name": "customresourcedefinitions/status",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CustomResourceDefinition",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "scheduling.k8s.io/v1",
+    "resources": [
+      {
+        "name": "priorityclasses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "PriorityClass",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "pc"
+        ],
+        "storageVersionHash": "1QwjyaZjj3Y="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "scheduling.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "priorityclasses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "PriorityClass",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "pc"
+        ],
+        "storageVersionHash": "1QwjyaZjj3Y="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "coordination.k8s.io/v1",
+    "resources": [
+      {
+        "name": "leases",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Lease",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "/sY7hl8ol1U="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "coordination.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "leases",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Lease",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "/sY7hl8ol1U="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "node.k8s.io/v1",
+    "resources": [
+      {
+        "name": "runtimeclasses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "RuntimeClass",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "8nMHWqj34s0="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "node.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "runtimeclasses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "RuntimeClass",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "8nMHWqj34s0="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "discovery.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "endpointslices",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "EndpointSlice",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "Nx3SIv6I0mE="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "flowcontrol.apiserver.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "flowschemas",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "FlowSchema",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "9bSnTLYweJ0="
+      },
+      {
+        "name": "flowschemas/status",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "FlowSchema",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "prioritylevelconfigurations",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "PriorityLevelConfiguration",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "BFVwf8eYnsw="
+      },
+      {
+        "name": "prioritylevelconfigurations/status",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "PriorityLevelConfiguration",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "kyverno.io/v1",
+    "resources": [
+      {
+        "name": "clusterpolicies",
+        "singularName": "clusterpolicy",
+        "namespaced": false,
+        "kind": "ClusterPolicy",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "cpol"
+        ],
+        "storageVersionHash": "uhKMxCLP2EM="
+      },
+      {
+        "name": "clusterpolicies/status",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "ClusterPolicy",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "policies",
+        "singularName": "policy",
+        "namespaced": true,
+        "kind": "Policy",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "pol"
+        ],
+        "storageVersionHash": "vgwy0+LsB2g="
+      },
+      {
+        "name": "policies/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Policy",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "generaterequests",
+        "singularName": "generaterequest",
+        "namespaced": true,
+        "kind": "GenerateRequest",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "gr"
+        ],
+        "storageVersionHash": "TeMup732PSY="
+      },
+      {
+        "name": "generaterequests/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "GenerateRequest",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "kyverno.io/v1alpha1",
+    "resources": [
+      {
+        "name": "reportchangerequests",
+        "singularName": "reportchangerequest",
+        "namespaced": true,
+        "kind": "ReportChangeRequest",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "rcr"
+        ],
+        "storageVersionHash": "vIx0JC9u2UM="
+      },
+      {
+        "name": "clusterreportchangerequests",
+        "singularName": "clusterreportchangerequest",
+        "namespaced": false,
+        "kind": "ClusterReportChangeRequest",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "crcr"
+        ],
+        "storageVersionHash": "joW3CYySVD4="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "telemetry.istio.io/v1alpha1",
+    "resources": [
+      {
+        "name": "telemetries",
+        "singularName": "telemetry",
+        "namespaced": true,
+        "kind": "Telemetry",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "telemetry"
+        ],
+        "categories": [
+          "istio-io",
+          "telemetry-istio-io"
+        ],
+        "storageVersionHash": "d44J/hig0n8="
+      },
+      {
+        "name": "telemetries/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Telemetry",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "wgpolicyk8s.io/v1alpha1",
+    "resources": [
+      {
+        "name": "clusterpolicyreports",
+        "singularName": "clusterpolicyreport",
+        "namespaced": false,
+        "kind": "ClusterPolicyReport",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "cpolr"
+        ],
+        "storageVersionHash": "jpUwkNR0RFs="
+      },
+      {
+        "name": "policyreports",
+        "singularName": "policyreport",
+        "namespaced": true,
+        "kind": "PolicyReport",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "polr"
+        ],
+        "storageVersionHash": "lh+/wBaRsd0="
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "networking.istio.io/v1beta1",
+    "resources": [
+      {
+        "name": "gateways",
+        "singularName": "gateway",
+        "namespaced": true,
+        "kind": "Gateway",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "gw"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "/mjmih7j52A="
+      },
+      {
+        "name": "gateways/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Gateway",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "serviceentries",
+        "singularName": "serviceentry",
+        "namespaced": true,
+        "kind": "ServiceEntry",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "se"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "tY6rFaYqFTs="
+      },
+      {
+        "name": "serviceentries/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ServiceEntry",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "workloadentries",
+        "singularName": "workloadentry",
+        "namespaced": true,
+        "kind": "WorkloadEntry",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "we"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "ZyZMEVHubgI="
+      },
+      {
+        "name": "workloadentries/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "WorkloadEntry",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "destinationrules",
+        "singularName": "destinationrule",
+        "namespaced": true,
+        "kind": "DestinationRule",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "dr"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "RTFbwVKZLVo="
+      },
+      {
+        "name": "destinationrules/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "DestinationRule",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "sidecars",
+        "singularName": "sidecar",
+        "namespaced": true,
+        "kind": "Sidecar",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "nU5Up7P+Lx0="
+      },
+      {
+        "name": "sidecars/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Sidecar",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "virtualservices",
+        "singularName": "virtualservice",
+        "namespaced": true,
+        "kind": "VirtualService",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "vs"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "OQjiBwfKPL4="
+      },
+      {
+        "name": "virtualservices/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "VirtualService",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "networking.istio.io/v1alpha3",
+    "resources": [
+      {
+        "name": "workloadgroups",
+        "singularName": "workloadgroup",
+        "namespaced": true,
+        "kind": "WorkloadGroup",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "wg"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "tPPh8TtfDAQ="
+      },
+      {
+        "name": "workloadgroups/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "WorkloadGroup",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "sidecars",
+        "singularName": "sidecar",
+        "namespaced": true,
+        "kind": "Sidecar",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "nU5Up7P+Lx0="
+      },
+      {
+        "name": "sidecars/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Sidecar",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "virtualservices",
+        "singularName": "virtualservice",
+        "namespaced": true,
+        "kind": "VirtualService",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "vs"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "OQjiBwfKPL4="
+      },
+      {
+        "name": "virtualservices/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "VirtualService",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "envoyfilters",
+        "singularName": "envoyfilter",
+        "namespaced": true,
+        "kind": "EnvoyFilter",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "cC04AzOKdkE="
+      },
+      {
+        "name": "envoyfilters/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "EnvoyFilter",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "gateways",
+        "singularName": "gateway",
+        "namespaced": true,
+        "kind": "Gateway",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "gw"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "/mjmih7j52A="
+      },
+      {
+        "name": "gateways/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Gateway",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "serviceentries",
+        "singularName": "serviceentry",
+        "namespaced": true,
+        "kind": "ServiceEntry",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "se"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "tY6rFaYqFTs="
+      },
+      {
+        "name": "serviceentries/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ServiceEntry",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "workloadentries",
+        "singularName": "workloadentry",
+        "namespaced": true,
+        "kind": "WorkloadEntry",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "we"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "ZyZMEVHubgI="
+      },
+      {
+        "name": "workloadentries/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "WorkloadEntry",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "destinationrules",
+        "singularName": "destinationrule",
+        "namespaced": true,
+        "kind": "DestinationRule",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "dr"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "RTFbwVKZLVo="
+      },
+      {
+        "name": "destinationrules/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "DestinationRule",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "kustomize.toolkit.fluxcd.io/v1beta1",
+    "resources": [
+      {
+        "name": "kustomizations",
+        "singularName": "kustomization",
+        "namespaced": true,
+        "kind": "Kustomization",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ks"
+        ],
+        "storageVersionHash": "OUKv7t9A3G4="
+      },
+      {
+        "name": "kustomizations/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Kustomization",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "notification.toolkit.fluxcd.io/v1beta1",
+    "resources": [
+      {
+        "name": "receivers",
+        "singularName": "receiver",
+        "namespaced": true,
+        "kind": "Receiver",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "vYnkEiRiL40="
+      },
+      {
+        "name": "receivers/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Receiver",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "providers",
+        "singularName": "provider",
+        "namespaced": true,
+        "kind": "Provider",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "z8f1NmxfWgI="
+      },
+      {
+        "name": "providers/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Provider",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "alerts",
+        "singularName": "alert",
+        "namespaced": true,
+        "kind": "Alert",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "R+8Re3cbWcQ="
+      },
+      {
+        "name": "alerts/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Alert",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "security.istio.io/v1beta1",
+    "resources": [
+      {
+        "name": "peerauthentications",
+        "singularName": "peerauthentication",
+        "namespaced": true,
+        "kind": "PeerAuthentication",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "pa"
+        ],
+        "categories": [
+          "istio-io",
+          "security-istio-io"
+        ],
+        "storageVersionHash": "0IW8zQBF4Qc="
+      },
+      {
+        "name": "peerauthentications/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PeerAuthentication",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "authorizationpolicies",
+        "singularName": "authorizationpolicy",
+        "namespaced": true,
+        "kind": "AuthorizationPolicy",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "istio-io",
+          "security-istio-io"
+        ],
+        "storageVersionHash": "djwd/cy0e/E="
+      },
+      {
+        "name": "authorizationpolicies/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "AuthorizationPolicy",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "requestauthentications",
+        "singularName": "requestauthentication",
+        "namespaced": true,
+        "kind": "RequestAuthentication",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ra"
+        ],
+        "categories": [
+          "istio-io",
+          "security-istio-io"
+        ],
+        "storageVersionHash": "mr+dytYVwr8="
+      },
+      {
+        "name": "requestauthentications/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "RequestAuthentication",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "source.toolkit.fluxcd.io/v1beta1",
+    "resources": [
+      {
+        "name": "helmcharts",
+        "singularName": "helmchart",
+        "namespaced": true,
+        "kind": "HelmChart",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "8ObbA6cw8Ew="
+      },
+      {
+        "name": "helmcharts/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "HelmChart",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "buckets",
+        "singularName": "bucket",
+        "namespaced": true,
+        "kind": "Bucket",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "BCjTQxWiRt4="
+      },
+      {
+        "name": "buckets/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Bucket",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "helmrepositories",
+        "singularName": "helmrepository",
+        "namespaced": true,
+        "kind": "HelmRepository",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "eR2pCs+OX/8="
+      },
+      {
+        "name": "helmrepositories/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "HelmRepository",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      },
+      {
+        "name": "gitrepositories",
+        "singularName": "gitrepository",
+        "namespaced": true,
+        "kind": "GitRepository",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "tU3NG5lZ/ZI="
+      },
+      {
+        "name": "gitrepositories/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "GitRepository",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "helm.toolkit.fluxcd.io/v2beta1",
+    "resources": [
+      {
+        "name": "helmreleases",
+        "singularName": "helmrelease",
+        "namespaced": true,
+        "kind": "HelmRelease",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "hr"
+        ],
+        "storageVersionHash": "08YCiPNyiSQ="
+      },
+      {
+        "name": "helmreleases/status",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "HelmRelease",
+        "verbs": [
+          "get",
+          "patch",
+          "update"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "APIResourceList",
+    "apiVersion": "v1",
+    "groupVersion": "metrics.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "nodes",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "NodeMetrics",
+        "verbs": [
+          "get",
+          "list"
+        ]
+      },
+      {
+        "name": "pods",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PodMetrics",
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+]
+`

--- a/api/preferredResources.go
+++ b/api/preferredResources.go
@@ -1,0 +1,1863 @@
+package data
+
+// k8s version 1.20.2
+const PreferredAPIResourceLists = `
+[
+  {
+    "groupVersion": "v1",
+    "resources": [
+      {
+        "name": "services",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Service",
+        "verbs": [
+          "create",
+          "delete",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "svc"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "0/CO1lhkEBI="
+      },
+      {
+        "name": "replicationcontrollers",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ReplicationController",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "rc"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "Jond2If31h0="
+      },
+      {
+        "name": "limitranges",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "LimitRange",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "limits"
+        ],
+        "storageVersionHash": "EBKMFVe6cwo="
+      },
+      {
+        "name": "resourcequotas",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ResourceQuota",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "quota"
+        ],
+        "storageVersionHash": "8uhSgffRX6w="
+      },
+      {
+        "name": "bindings",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Binding",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "configmaps",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ConfigMap",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "cm"
+        ],
+        "storageVersionHash": "qFsyl6wFWjQ="
+      },
+      {
+        "name": "events",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Event",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ev"
+        ],
+        "storageVersionHash": "r2yiGXH7wu8="
+      },
+      {
+        "name": "persistentvolumes",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "PersistentVolume",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "pv"
+        ],
+        "storageVersionHash": "HN/zwEC+JgM="
+      },
+      {
+        "name": "secrets",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Secret",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "S6u1pOWzb84="
+      },
+      {
+        "name": "persistentvolumeclaims",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PersistentVolumeClaim",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "pvc"
+        ],
+        "storageVersionHash": "QWTyNDq0dC4="
+      },
+      {
+        "name": "serviceaccounts",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ServiceAccount",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "sa"
+        ],
+        "storageVersionHash": "pbx9ZvyFpBE="
+      },
+      {
+        "name": "pods",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Pod",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "po"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "xPOwRZ+Yhw8="
+      },
+      {
+        "name": "namespaces",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "Namespace",
+        "verbs": [
+          "create",
+          "delete",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ns"
+        ],
+        "storageVersionHash": "Q3oi5N2YM8M="
+      },
+      {
+        "name": "podtemplates",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PodTemplate",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "LIXB2x4IFpk="
+      },
+      {
+        "name": "componentstatuses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "ComponentStatus",
+        "verbs": [
+          "get",
+          "list"
+        ],
+        "shortNames": [
+          "cs"
+        ]
+      },
+      {
+        "name": "endpoints",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Endpoints",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ep"
+        ],
+        "storageVersionHash": "fWeeMqaN/OA="
+      },
+      {
+        "name": "nodes",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "Node",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "no"
+        ],
+        "storageVersionHash": "XwShjMxG9Fs="
+      }
+    ]
+  },
+  {
+    "groupVersion": "apiregistration.k8s.io/v1",
+    "resources": [
+      {
+        "name": "apiservices",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "APIService",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "api-extensions"
+        ],
+        "storageVersionHash": "C+s2HXXP47k="
+      }
+    ]
+  },
+  {
+    "groupVersion": "apiregistration.k8s.io/v1beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "apps/v1",
+    "resources": [
+      {
+        "name": "replicasets",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ReplicaSet",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "rs"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "P1RzHs8/mWQ="
+      },
+      {
+        "name": "deployments",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Deployment",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "deploy"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "8aSe+NMegvE="
+      },
+      {
+        "name": "statefulsets",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "StatefulSet",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "sts"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "H+vl74LkKdo="
+      },
+      {
+        "name": "controllerrevisions",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "ControllerRevision",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "85nkx63pcBU="
+      },
+      {
+        "name": "daemonsets",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "DaemonSet",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ds"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "dd7pWHUlMKQ="
+      }
+    ]
+  },
+  {
+    "groupVersion": "events.k8s.io/v1",
+    "resources": [
+      {
+        "name": "events",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Event",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ev"
+        ],
+        "storageVersionHash": "r2yiGXH7wu8="
+      }
+    ]
+  },
+  {
+    "groupVersion": "events.k8s.io/v1beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "authentication.k8s.io/v1",
+    "resources": [
+      {
+        "name": "tokenreviews",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "TokenReview",
+        "verbs": [
+          "create"
+        ]
+      }
+    ]
+  },
+  {
+    "groupVersion": "authentication.k8s.io/v1beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "authorization.k8s.io/v1",
+    "resources": [
+      {
+        "name": "localsubjectaccessreviews",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "LocalSubjectAccessReview",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "selfsubjectaccessreviews",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "SelfSubjectAccessReview",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "subjectaccessreviews",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "SubjectAccessReview",
+        "verbs": [
+          "create"
+        ]
+      },
+      {
+        "name": "selfsubjectrulesreviews",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "SelfSubjectRulesReview",
+        "verbs": [
+          "create"
+        ]
+      }
+    ]
+  },
+  {
+    "groupVersion": "authorization.k8s.io/v1beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "autoscaling/v1",
+    "resources": [
+      {
+        "name": "horizontalpodautoscalers",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "HorizontalPodAutoscaler",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "hpa"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "oQlkt7f5j/A="
+      }
+    ]
+  },
+  {
+    "groupVersion": "autoscaling/v2beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "autoscaling/v2beta2",
+    "resources": null
+  },
+  {
+    "groupVersion": "batch/v1",
+    "resources": [
+      {
+        "name": "jobs",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Job",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "mudhfqk/qZY="
+      }
+    ]
+  },
+  {
+    "groupVersion": "batch/v1beta1",
+    "resources": [
+      {
+        "name": "cronjobs",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "CronJob",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "cj"
+        ],
+        "categories": [
+          "all"
+        ],
+        "storageVersionHash": "h/JlFAZkyyY="
+      }
+    ]
+  },
+  {
+    "groupVersion": "certificates.k8s.io/v1",
+    "resources": [
+      {
+        "name": "certificatesigningrequests",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CertificateSigningRequest",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "csr"
+        ],
+        "storageVersionHash": "UQh3YTCDIf0="
+      }
+    ]
+  },
+  {
+    "groupVersion": "certificates.k8s.io/v1beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "networking.k8s.io/v1",
+    "resources": [
+      {
+        "name": "networkpolicies",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "NetworkPolicy",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "netpol"
+        ],
+        "storageVersionHash": "YpfwF18m1G8="
+      },
+      {
+        "name": "ingressclasses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "IngressClass",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "6upRfBq0FOI="
+      },
+      {
+        "name": "ingresses",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Ingress",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ing"
+        ],
+        "storageVersionHash": "ZOAfGflaKd0="
+      }
+    ]
+  },
+  {
+    "groupVersion": "networking.k8s.io/v1beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "extensions/v1beta1",
+    "resources": [
+      {
+        "name": "ingresses",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Ingress",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ing"
+        ],
+        "storageVersionHash": "ZOAfGflaKd0="
+      }
+    ]
+  },
+  {
+    "groupVersion": "policy/v1beta1",
+    "resources": [
+      {
+        "name": "podsecuritypolicies",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "PodSecurityPolicy",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "psp"
+        ],
+        "storageVersionHash": "khBLobUXkqA="
+      },
+      {
+        "name": "poddisruptionbudgets",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PodDisruptionBudget",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "pdb"
+        ],
+        "storageVersionHash": "6BGBu0kpHtk="
+      }
+    ]
+  },
+  {
+    "groupVersion": "rbac.authorization.k8s.io/v1",
+    "resources": [
+      {
+        "name": "clusterrolebindings",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "ClusterRoleBinding",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "48tpQ8gZHFc="
+      },
+      {
+        "name": "clusterroles",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "ClusterRole",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "bYE5ZWDrJ44="
+      },
+      {
+        "name": "roles",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Role",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "7FuwZcIIItM="
+      },
+      {
+        "name": "rolebindings",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "RoleBinding",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "eGsCzGH6b1g="
+      }
+    ]
+  },
+  {
+    "groupVersion": "rbac.authorization.k8s.io/v1beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "storage.k8s.io/v1",
+    "resources": [
+      {
+        "name": "csinodes",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CSINode",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "Pe62DkZtjuo="
+      },
+      {
+        "name": "volumeattachments",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "VolumeAttachment",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "tJx/ezt6UDU="
+      },
+      {
+        "name": "storageclasses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "StorageClass",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "sc"
+        ],
+        "storageVersionHash": "K+m6uJwbjGY="
+      },
+      {
+        "name": "csidrivers",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CSIDriver",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "Z7aeXSiaYTw="
+      }
+    ]
+  },
+  {
+    "groupVersion": "storage.k8s.io/v1beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "admissionregistration.k8s.io/v1",
+    "resources": [
+      {
+        "name": "mutatingwebhookconfigurations",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "MutatingWebhookConfiguration",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "api-extensions"
+        ],
+        "storageVersionHash": "yxW1cpLtfp8="
+      },
+      {
+        "name": "validatingwebhookconfigurations",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "ValidatingWebhookConfiguration",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "api-extensions"
+        ],
+        "storageVersionHash": "P9NhrezfnWE="
+      }
+    ]
+  },
+  {
+    "groupVersion": "admissionregistration.k8s.io/v1beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "apiextensions.k8s.io/v1",
+    "resources": [
+      {
+        "name": "customresourcedefinitions",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "CustomResourceDefinition",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "crd",
+          "crds"
+        ],
+        "categories": [
+          "api-extensions"
+        ],
+        "storageVersionHash": "jfWCUB31mvA="
+      }
+    ]
+  },
+  {
+    "groupVersion": "apiextensions.k8s.io/v1beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "scheduling.k8s.io/v1",
+    "resources": [
+      {
+        "name": "priorityclasses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "PriorityClass",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "pc"
+        ],
+        "storageVersionHash": "1QwjyaZjj3Y="
+      }
+    ]
+  },
+  {
+    "groupVersion": "scheduling.k8s.io/v1beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "coordination.k8s.io/v1",
+    "resources": [
+      {
+        "name": "leases",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "Lease",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "/sY7hl8ol1U="
+      }
+    ]
+  },
+  {
+    "groupVersion": "coordination.k8s.io/v1beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "node.k8s.io/v1",
+    "resources": [
+      {
+        "name": "runtimeclasses",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "RuntimeClass",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "8nMHWqj34s0="
+      }
+    ]
+  },
+  {
+    "groupVersion": "node.k8s.io/v1beta1",
+    "resources": null
+  },
+  {
+    "groupVersion": "discovery.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "endpointslices",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "EndpointSlice",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "Nx3SIv6I0mE="
+      }
+    ]
+  },
+  {
+    "groupVersion": "flowcontrol.apiserver.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "flowschemas",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "FlowSchema",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "9bSnTLYweJ0="
+      },
+      {
+        "name": "prioritylevelconfigurations",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "PriorityLevelConfiguration",
+        "verbs": [
+          "create",
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "BFVwf8eYnsw="
+      }
+    ]
+  },
+  {
+    "groupVersion": "kyverno.io/v1",
+    "resources": [
+      {
+        "name": "policies",
+        "singularName": "policy",
+        "namespaced": true,
+        "kind": "Policy",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "pol"
+        ],
+        "storageVersionHash": "vgwy0+LsB2g="
+      },
+      {
+        "name": "generaterequests",
+        "singularName": "generaterequest",
+        "namespaced": true,
+        "kind": "GenerateRequest",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "gr"
+        ],
+        "storageVersionHash": "TeMup732PSY="
+      },
+      {
+        "name": "clusterpolicies",
+        "singularName": "clusterpolicy",
+        "namespaced": false,
+        "kind": "ClusterPolicy",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "cpol"
+        ],
+        "storageVersionHash": "uhKMxCLP2EM="
+      }
+    ]
+  },
+  {
+    "groupVersion": "kyverno.io/v1alpha1",
+    "resources": [
+      {
+        "name": "clusterreportchangerequests",
+        "singularName": "clusterreportchangerequest",
+        "namespaced": false,
+        "kind": "ClusterReportChangeRequest",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "crcr"
+        ],
+        "storageVersionHash": "joW3CYySVD4="
+      },
+      {
+        "name": "reportchangerequests",
+        "singularName": "reportchangerequest",
+        "namespaced": true,
+        "kind": "ReportChangeRequest",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "rcr"
+        ],
+        "storageVersionHash": "vIx0JC9u2UM="
+      }
+    ]
+  },
+  {
+    "groupVersion": "telemetry.istio.io/v1alpha1",
+    "resources": [
+      {
+        "name": "telemetries",
+        "singularName": "telemetry",
+        "namespaced": true,
+        "kind": "Telemetry",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "telemetry"
+        ],
+        "categories": [
+          "istio-io",
+          "telemetry-istio-io"
+        ],
+        "storageVersionHash": "d44J/hig0n8="
+      }
+    ]
+  },
+  {
+    "groupVersion": "wgpolicyk8s.io/v1alpha1",
+    "resources": [
+      {
+        "name": "policyreports",
+        "singularName": "policyreport",
+        "namespaced": true,
+        "kind": "PolicyReport",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "polr"
+        ],
+        "storageVersionHash": "lh+/wBaRsd0="
+      },
+      {
+        "name": "clusterpolicyreports",
+        "singularName": "clusterpolicyreport",
+        "namespaced": false,
+        "kind": "ClusterPolicyReport",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "cpolr"
+        ],
+        "storageVersionHash": "jpUwkNR0RFs="
+      }
+    ]
+  },
+  {
+    "groupVersion": "networking.istio.io/v1beta1",
+    "resources": [
+      {
+        "name": "serviceentries",
+        "singularName": "serviceentry",
+        "namespaced": true,
+        "kind": "ServiceEntry",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "se"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "tY6rFaYqFTs="
+      },
+      {
+        "name": "sidecars",
+        "singularName": "sidecar",
+        "namespaced": true,
+        "kind": "Sidecar",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "nU5Up7P+Lx0="
+      },
+      {
+        "name": "workloadentries",
+        "singularName": "workloadentry",
+        "namespaced": true,
+        "kind": "WorkloadEntry",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "we"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "ZyZMEVHubgI="
+      },
+      {
+        "name": "gateways",
+        "singularName": "gateway",
+        "namespaced": true,
+        "kind": "Gateway",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "gw"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "/mjmih7j52A="
+      },
+      {
+        "name": "virtualservices",
+        "singularName": "virtualservice",
+        "namespaced": true,
+        "kind": "VirtualService",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "vs"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "OQjiBwfKPL4="
+      },
+      {
+        "name": "destinationrules",
+        "singularName": "destinationrule",
+        "namespaced": true,
+        "kind": "DestinationRule",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "dr"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "RTFbwVKZLVo="
+      }
+    ]
+  },
+  {
+    "groupVersion": "networking.istio.io/v1alpha3",
+    "resources": [
+      {
+        "name": "workloadgroups",
+        "singularName": "workloadgroup",
+        "namespaced": true,
+        "kind": "WorkloadGroup",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "wg"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "tPPh8TtfDAQ="
+      },
+      {
+        "name": "envoyfilters",
+        "singularName": "envoyfilter",
+        "namespaced": true,
+        "kind": "EnvoyFilter",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "istio-io",
+          "networking-istio-io"
+        ],
+        "storageVersionHash": "cC04AzOKdkE="
+      }
+    ]
+  },
+  {
+    "groupVersion": "kustomize.toolkit.fluxcd.io/v1beta1",
+    "resources": [
+      {
+        "name": "kustomizations",
+        "singularName": "kustomization",
+        "namespaced": true,
+        "kind": "Kustomization",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ks"
+        ],
+        "storageVersionHash": "OUKv7t9A3G4="
+      }
+    ]
+  },
+  {
+    "groupVersion": "notification.toolkit.fluxcd.io/v1beta1",
+    "resources": [
+      {
+        "name": "alerts",
+        "singularName": "alert",
+        "namespaced": true,
+        "kind": "Alert",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "R+8Re3cbWcQ="
+      },
+      {
+        "name": "receivers",
+        "singularName": "receiver",
+        "namespaced": true,
+        "kind": "Receiver",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "vYnkEiRiL40="
+      },
+      {
+        "name": "providers",
+        "singularName": "provider",
+        "namespaced": true,
+        "kind": "Provider",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "z8f1NmxfWgI="
+      }
+    ]
+  },
+  {
+    "groupVersion": "security.istio.io/v1beta1",
+    "resources": [
+      {
+        "name": "authorizationpolicies",
+        "singularName": "authorizationpolicy",
+        "namespaced": true,
+        "kind": "AuthorizationPolicy",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "categories": [
+          "istio-io",
+          "security-istio-io"
+        ],
+        "storageVersionHash": "djwd/cy0e/E="
+      },
+      {
+        "name": "requestauthentications",
+        "singularName": "requestauthentication",
+        "namespaced": true,
+        "kind": "RequestAuthentication",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "ra"
+        ],
+        "categories": [
+          "istio-io",
+          "security-istio-io"
+        ],
+        "storageVersionHash": "mr+dytYVwr8="
+      },
+      {
+        "name": "peerauthentications",
+        "singularName": "peerauthentication",
+        "namespaced": true,
+        "kind": "PeerAuthentication",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "pa"
+        ],
+        "categories": [
+          "istio-io",
+          "security-istio-io"
+        ],
+        "storageVersionHash": "0IW8zQBF4Qc="
+      }
+    ]
+  },
+  {
+    "groupVersion": "source.toolkit.fluxcd.io/v1beta1",
+    "resources": [
+      {
+        "name": "helmrepositories",
+        "singularName": "helmrepository",
+        "namespaced": true,
+        "kind": "HelmRepository",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "eR2pCs+OX/8="
+      },
+      {
+        "name": "gitrepositories",
+        "singularName": "gitrepository",
+        "namespaced": true,
+        "kind": "GitRepository",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "tU3NG5lZ/ZI="
+      },
+      {
+        "name": "buckets",
+        "singularName": "bucket",
+        "namespaced": true,
+        "kind": "Bucket",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "BCjTQxWiRt4="
+      },
+      {
+        "name": "helmcharts",
+        "singularName": "helmchart",
+        "namespaced": true,
+        "kind": "HelmChart",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "storageVersionHash": "8ObbA6cw8Ew="
+      }
+    ]
+  },
+  {
+    "groupVersion": "helm.toolkit.fluxcd.io/v2beta1",
+    "resources": [
+      {
+        "name": "helmreleases",
+        "singularName": "helmrelease",
+        "namespaced": true,
+        "kind": "HelmRelease",
+        "verbs": [
+          "delete",
+          "deletecollection",
+          "get",
+          "list",
+          "patch",
+          "create",
+          "update",
+          "watch"
+        ],
+        "shortNames": [
+          "hr"
+        ],
+        "storageVersionHash": "08YCiPNyiSQ="
+      }
+    ]
+  },
+  {
+    "groupVersion": "metrics.k8s.io/v1beta1",
+    "resources": [
+      {
+        "name": "pods",
+        "singularName": "",
+        "namespaced": true,
+        "kind": "PodMetrics",
+        "verbs": [
+          "get",
+          "list"
+        ]
+      },
+      {
+        "name": "nodes",
+        "singularName": "",
+        "namespaced": false,
+        "kind": "NodeMetrics",
+        "verbs": [
+          "get",
+          "list"
+        ]
+      }
+    ]
+  }
+]
+`

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.0.0
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/go-logr/logr v0.4.0
+	github.com/google/uuid v1.1.2
 	github.com/googleapis/gnostic v0.5.4
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/julienschmidt/httprouter v1.3.0

--- a/pkg/openapi/crdSync.go
+++ b/pkg/openapi/crdSync.go
@@ -109,7 +109,7 @@ func (c *crdSync) sync() {
 }
 
 func (c *crdSync) updateInClusterKindToAPIVersions() error {
-	apiResourceLists, err := c.client.DiscoveryClient.DiscoveryCache().ServerResources()
+	_, apiResourceLists, err := c.client.DiscoveryClient.DiscoveryCache().ServerGroupsAndResources()
 	if err != nil {
 		return fmt.Errorf("unable to fetch apiResourceLists: %v", err)
 	}

--- a/pkg/openapi/validation.go
+++ b/pkg/openapi/validation.go
@@ -208,10 +208,6 @@ func (o *Controller) useOpenAPIDocument(doc *openapiv2.Document) error {
 }
 
 func (o *Controller) getGVKByDefinitionName(definitionName string) (gvk string, preferredGVK bool, err error) {
-	if o.kindToAPIVersions.IsEmpty() {
-		// TODO: embed static apiDocs
-	}
-
 	paths := strings.Split(definitionName, ".")
 	kind := paths[len(paths)-1]
 	versions, ok := o.kindToAPIVersions.Get(kind)

--- a/pkg/openapi/validation.go
+++ b/pkg/openapi/validation.go
@@ -12,9 +12,12 @@ import (
 	data "github.com/kyverno/kyverno/api"
 	v1 "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/engine"
+	"github.com/kyverno/kyverno/pkg/utils"
 	cmap "github.com/orcaman/concurrent-map"
 	"gopkg.in/yaml.v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/discovery"
 	"k8s.io/kube-openapi/pkg/util/proto"
 	"k8s.io/kube-openapi/pkg/util/proto/validation"
 	log "sigs.k8s.io/controller-runtime/pkg/log"
@@ -24,13 +27,28 @@ type concurrentMap struct{ cmap.ConcurrentMap }
 
 // Controller represents OpenAPIController
 type Controller struct {
-	// definitions holds the kind - *openapiv2.Schema map
+	// definitions holds the map of {definitionName: *openapiv2.Schema}
 	definitions concurrentMap
-	// kindToDefinitionName holds the kind - definition map
-	// i.e. - Namespace: io.k8s.api.core.v1.Namespace
-	kindToDefinitionName concurrentMap
-	crdList              []string
-	models               proto.Models
+
+	// kindToDefinitionName holds the map of {(group/version/)kind: definitionName}
+	// i.e. with k8s 1.20.2
+	// - Ingress: io.k8s.api.networking.v1.Ingress (preferred version)
+	// - networking.k8s.io/v1/Ingress: io.k8s.api.networking.v1.Ingress
+	// - networking.k8s.io/v1beta1/Ingress: io.k8s.api.networking.v1beta1.Ingress
+	// - extension/v1beta1/Ingress: io.k8s.api.extensions.v1beta1.Ingress
+	gvkToDefinitionName concurrentMap
+
+	crdList []string
+	models  proto.Models
+
+	// kindToAPIVersions stores the Kind and all its available apiVersions, {kind: apiVersions}
+	kindToAPIVersions concurrentMap
+}
+
+// apiVersions stores all available gvks for a kind, a gvk is "/" seperated string
+type apiVersions struct {
+	serverPreferredGVK string
+	gvks               []string
 }
 
 func newConcurrentMap() concurrentMap {
@@ -58,8 +76,9 @@ func (m concurrentMap) GetSchema(key string) *openapiv2.Schema {
 // NewOpenAPIController initializes a new instance of OpenAPIController
 func NewOpenAPIController() (*Controller, error) {
 	controller := &Controller{
-		definitions:          newConcurrentMap(),
-		kindToDefinitionName: newConcurrentMap(),
+		definitions:         newConcurrentMap(),
+		gvkToDefinitionName: newConcurrentMap(),
+		kindToAPIVersions:   newConcurrentMap(),
 	}
 
 	defaultDoc, err := getSchemaDocument()
@@ -81,10 +100,15 @@ func (o *Controller) ValidatePolicyFields(policy v1.ClusterPolicy) error {
 }
 
 // ValidateResource ...
-func (o *Controller) ValidateResource(patchedResource unstructured.Unstructured, kind string) error {
+func (o *Controller) ValidateResource(patchedResource unstructured.Unstructured, apiVersion, kind string) error {
 	var err error
 
-	kind = o.kindToDefinitionName.GetKind(kind)
+	gvk := kind
+	if apiVersion != "" {
+		gvk = apiVersion + "/" + kind
+	}
+
+	kind = o.gvkToDefinitionName.GetKind(gvk)
 	schema := o.models.LookupModel(kind)
 	if schema == nil {
 		// Check if kind is a CRD
@@ -121,7 +145,7 @@ func (o *Controller) ValidatePolicyMutation(policy v1.ClusterPolicy) error {
 	for kind, rules := range kindToRules {
 		newPolicy := *policy.DeepCopy()
 		newPolicy.Spec.Rules = rules
-		k := o.kindToDefinitionName.GetKind(kind)
+		k := o.gvkToDefinitionName.GetKind(kind)
 		resource, _ := o.generateEmptyResource(o.definitions.GetSchema(k)).(map[string]interface{})
 		if resource == nil || len(resource) == 0 {
 			log.Log.V(2).Info("unable to validate resource. OpenApi definition not found", "kind", kind)
@@ -136,7 +160,7 @@ func (o *Controller) ValidatePolicyMutation(policy v1.ClusterPolicy) error {
 			return err
 		}
 
-		err = o.ValidateResource(*patchedResource.DeepCopy(), kind)
+		err = o.ValidateResource(*patchedResource.DeepCopy(), "", kind)
 		if err != nil {
 			return err
 		}
@@ -147,15 +171,128 @@ func (o *Controller) ValidatePolicyMutation(policy v1.ClusterPolicy) error {
 
 func (o *Controller) useOpenAPIDocument(doc *openapiv2.Document) error {
 	for _, definition := range doc.GetDefinitions().AdditionalProperties {
-		o.definitions.Set(definition.GetName(), definition.GetValue())
-		path := strings.Split(definition.GetName(), ".")
-		o.kindToDefinitionName.Set(path[len(path)-1], definition.GetName())
+		definitionName := definition.GetName()
+		o.definitions.Set(definitionName, definition.GetValue())
+
+		gvk, preferredGVK, err := o.getGVKByDefinitionName(definitionName)
+		if err != nil {
+			log.Log.Error(err, "failed to cache OpenAPISchema", "definitionName", definitionName)
+			continue
+		}
+
+		if preferredGVK {
+			paths := strings.Split(definitionName, ".")
+			kind := paths[len(paths)-1]
+			o.gvkToDefinitionName.Set(kind, definitionName)
+		}
+
+		if gvk != "" {
+			o.gvkToDefinitionName.Set(gvk, definitionName)
+		}
 	}
 
 	var err error
 	o.models, err = proto.NewOpenAPIData(doc)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (o *Controller) getGVKByDefinitionName(definitionName string) (gvk string, preferredGVK bool, err error) {
+	if o.kindToAPIVersions.IsEmpty() {
+		// TODO: embed static apiDocs
+	}
+
+	paths := strings.Split(definitionName, ".")
+	kind := paths[len(paths)-1]
+	versions, ok := o.kindToAPIVersions.Get(kind)
+	if !ok {
+		// kind is the sub-resource of a K8s Kind, i.e. CronJobStatus
+		// such cases are skipped in schema validation
+		return
+	}
+
+	versionsTyped, ok := versions.(apiVersions)
+	if !ok {
+		return "", preferredGVK, fmt.Errorf("type mismatched, expected apiVersions, got %T", versions)
+	}
+
+	if matchGVK(definitionName, versionsTyped.serverPreferredGVK) {
+		preferredGVK = true
+	}
+
+	for _, gvk := range versionsTyped.gvks {
+		if matchGVK(definitionName, gvk) {
+			return gvk, preferredGVK, nil
+		}
+	}
+
+	return "", preferredGVK, fmt.Errorf("gvk not found by the given definition name %s, %v", definitionName, versionsTyped.gvks)
+}
+
+// matchGVK is a helper function that checks if the
+// given GVK matches the definition name
+func matchGVK(definitionName, gvk string) bool {
+	paths := strings.Split(definitionName, ".")
+
+	gvkMap := make(map[string]bool)
+	for _, p := range paths {
+		gvkMap[p] = true
+	}
+
+	gvkList := strings.Split(gvk, "/")
+	// group can be a dot-seperated string
+	// here we allow at most 1 missing element in group elements, except for Ingress
+	// as a specific element could be missing in apiDocs name
+	// io.k8s.api.rbac.v1.Role - rbac.authorization.k8s.io/v1/Role
+	missingMoreThanOneElement := false
+	for i, element := range gvkList {
+		if i == 0 {
+			items := strings.Split(element, ".")
+			for _, item := range items {
+				_, ok := gvkMap[item]
+				if !ok {
+					if gvkList[len(gvkList)-1] == "Ingress" {
+						return false
+					}
+
+					if missingMoreThanOneElement {
+						return false
+					}
+					missingMoreThanOneElement = true
+				}
+			}
+			continue
+		}
+
+		_, ok := gvkMap[element]
+		if !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (c *Controller) updateKindToAPIVersions(discoveryCache discovery.CachedDiscoveryInterface) error {
+	apiResourceLists, err := discoveryCache.ServerResources()
+	if err != nil {
+		return err
+	}
+
+	c.kindToAPIVersions = newConcurrentMap()
+	tempKindToAPIVersions := getAllAPIVersions(apiResourceLists)
+
+	preferredAPIResourcesLists, err := discoveryCache.ServerPreferredResources()
+	if err != nil {
+		return err
+	}
+
+	tempKindToAPIVersions = setPreferredVersions(tempKindToAPIVersions, preferredAPIResourcesLists)
+	for key, value := range tempKindToAPIVersions {
+		c.kindToAPIVersions.Set(key, value)
 	}
 
 	return nil
@@ -312,4 +449,68 @@ func getAnyValue(any *openapiv2.Any) []byte {
 	}
 
 	return nil
+}
+
+// getAllAPIVersions gets all available versions for a kind
+// returns a map which stores all kinds with its versions
+func getAllAPIVersions(apiResourceLists []*metav1.APIResourceList) map[string]apiVersions {
+	tempKindToAPIVersions := make(map[string]apiVersions)
+
+	for _, apiResourceList := range apiResourceLists {
+		lastKind := ""
+		for _, apiResource := range apiResourceList.APIResources {
+			if apiResource.Kind == lastKind {
+				continue
+			}
+
+			version, ok := tempKindToAPIVersions[apiResource.Kind]
+			if !ok {
+				tempKindToAPIVersions[apiResource.Kind] = apiVersions{}
+			}
+
+			gvk := strings.Join([]string{apiResourceList.GroupVersion, apiResource.Kind}, "/")
+			version.gvks = append(version.gvks, gvk)
+			tempKindToAPIVersions[apiResource.Kind] = version
+			lastKind = apiResource.Kind
+		}
+	}
+	return tempKindToAPIVersions
+}
+
+// setPreferredVersions sets the serverPreferredGVK of the given apiVersions map
+func setPreferredVersions(kindToAPIVersions map[string]apiVersions, preferredAPIResourcesLists []*metav1.APIResourceList) map[string]apiVersions {
+	tempKindToAPIVersionsCopied := copyKindToAPIVersions(kindToAPIVersions)
+
+	for kind, versions := range tempKindToAPIVersionsCopied {
+		for _, preferredAPIResourcesList := range preferredAPIResourcesLists {
+			for _, resource := range preferredAPIResourcesList.APIResources {
+				preferredGV := preferredAPIResourcesList.GroupVersion
+				preferredGVK := preferredGV + "/" + resource.Kind
+
+				if utils.ContainsString(versions.gvks, preferredGVK) {
+					v := kindToAPIVersions[kind]
+
+					// if a Kind belongs to multiple groups, the first group/version
+					// returned from discovery docs is used as preferred version
+					// https://github.com/kubernetes/kubernetes/issues/94761#issuecomment-691982480
+					if v.serverPreferredGVK != "" {
+						continue
+					}
+
+					v.serverPreferredGVK = strings.Join([]string{preferredGV, kind}, "/")
+					kindToAPIVersions[kind] = v
+				}
+			}
+		}
+	}
+
+	return kindToAPIVersions
+}
+
+func copyKindToAPIVersions(old map[string]apiVersions) map[string]apiVersions {
+	new := make(map[string]apiVersions, len(old))
+	for key, value := range old {
+		new[key] = value
+	}
+	return new
 }

--- a/pkg/openapi/validation_test.go
+++ b/pkg/openapi/validation_test.go
@@ -131,12 +131,29 @@ func Test_matchGVK(t *testing.T) {
 	}
 }
 
-// definitionName, _ := o.gvkToDefinitionName.Get("Ingress")
-// fmt.Println("====Ingress definitionName", definitionName)
-// definitionName, _ = o.gvkToDefinitionName.Get("networking.k8s.io/v1/Ingress")
-// fmt.Println("====networking.k8s.io/v1/Ingress definitionName", definitionName)
+// this test covers all supported Ingress in 1.20 cluster
+// networking.k8s.io/v1/Ingress
+// networking.k8s.io/v1beta1/Ingress
+// extensions/v1beta1/Ingress
+func Test_Ingress(t *testing.T) {
+	o, err := NewOpenAPIController()
+	assert.NilError(t, err)
 
-// definitionName, _ = o.gvkToDefinitionName.Get("networking.k8s.io/v1beta1/Ingress")
-// fmt.Println("====networking.k8s.io/v1beta1/Ingress definitionName", definitionName)
-// definitionName, _ = o.gvkToDefinitionName.Get("extensions/v1beta1/Ingress")
-// fmt.Println("====extensions/v1beta1/Ingress definitionName", definitionName)
+	versions, ok := o.kindToAPIVersions.Get("Ingress")
+	assert.Equal(t, true, ok)
+	versionsTyped := versions.(apiVersions)
+	assert.Equal(t, versionsTyped.serverPreferredGVK, "networking.k8s.io/v1/Ingress")
+	assert.Equal(t, len(versionsTyped.gvks), 3)
+
+	definitionName, _ := o.gvkToDefinitionName.Get("Ingress")
+	assert.Equal(t, definitionName, "io.k8s.api.networking.v1.Ingress")
+
+	definitionName, _ = o.gvkToDefinitionName.Get("networking.k8s.io/v1/Ingress")
+	assert.Equal(t, definitionName, "io.k8s.api.networking.v1.Ingress")
+
+	definitionName, _ = o.gvkToDefinitionName.Get("networking.k8s.io/v1beta1/Ingress")
+	assert.Equal(t, definitionName, "io.k8s.api.networking.v1beta1.Ingress")
+
+	definitionName, _ = o.gvkToDefinitionName.Get("extensions/v1beta1/Ingress")
+	assert.Equal(t, definitionName, "io.k8s.api.extensions.v1beta1.Ingress")
+}

--- a/pkg/openapi/validation_test.go
+++ b/pkg/openapi/validation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	v1 "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
+	"gotest.tools/assert"
 )
 
 func Test_ValidateMutationPolicy(t *testing.T) {
@@ -70,3 +71,72 @@ func Test_addDefaultFieldsToSchema(t *testing.T) {
 	addingDefaultFieldsToSchema([]byte(`null`))
 	addingDefaultFieldsToSchema(nil)
 }
+
+func Test_matchGVK(t *testing.T) {
+	testCases := []struct {
+		definitionName string
+		gvk            string
+		match          bool
+	}{
+		{
+			"io.k8s.api.networking.v1.Ingress",
+			"networking.k8s.io/v1/Ingress",
+			true,
+		},
+		{
+			"io.wgpolicyk8s.v1alpha1.PolicyReport",
+			"wgpolicyk8s.io/v1alpha1/PolicyReport",
+			true,
+		},
+		{
+			"io.k8s.api.rbac.v1.RoleBinding",
+			"rbac.authorization.k8s.io/v1/RoleBinding",
+			true,
+		},
+		{
+			"io.k8s.api.rbac.v1beta1.ClusterRoleBinding",
+			"rbac.authorization.k8s.io/v1beta1/ClusterRoleBinding",
+			true,
+		},
+		{
+			"io.k8s.api.rbac.v1.Role",
+			"rbac.authorization.k8s.io/v1/Role",
+			true,
+		},
+		{
+			"io.k8s.api.rbac.v1.ClusterRole",
+			"rbac.authorization.k8s.io/v1/ClusterRole",
+			true,
+		},
+		{
+			"io.k8s.api.flowcontrol.v1beta1.FlowSchema",
+			"flowcontrol.apiserver.k8s.io/v1beta1/FlowSchema",
+			true,
+		},
+		{
+			"io.k8s.api.policy.v1beta1.Eviction",
+			"v1/Eviction",
+			true,
+		},
+		{
+			"io.k8s.api.rbac.v1beta1.ClusterRole",
+			"rbac.authorization.k8s.io/v1beta1/ClusterRole",
+			true,
+		},
+	}
+
+	for i, test := range testCases {
+		res := matchGVK(test.definitionName, test.gvk)
+		assert.Equal(t, res, test.match, "test #%d failed", i)
+	}
+}
+
+// definitionName, _ := o.gvkToDefinitionName.Get("Ingress")
+// fmt.Println("====Ingress definitionName", definitionName)
+// definitionName, _ = o.gvkToDefinitionName.Get("networking.k8s.io/v1/Ingress")
+// fmt.Println("====networking.k8s.io/v1/Ingress definitionName", definitionName)
+
+// definitionName, _ = o.gvkToDefinitionName.Get("networking.k8s.io/v1beta1/Ingress")
+// fmt.Println("====networking.k8s.io/v1beta1/Ingress definitionName", definitionName)
+// definitionName, _ = o.gvkToDefinitionName.Get("extensions/v1beta1/Ingress")
+// fmt.Println("====extensions/v1beta1/Ingress definitionName", definitionName)

--- a/pkg/webhooks/checker.go
+++ b/pkg/webhooks/checker.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (ws *WebhookServer) verifyHandler(request *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse {
-	logger := ws.log.WithValues("action", "verify", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation)
+	logger := ws.log.WithValues("action", "verify", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation, "gvk", request.Kind.String())
 	logger.V(4).Info("incoming request")
 	return &v1beta1.AdmissionResponse{
 		Allowed: true,

--- a/pkg/webhooks/generation.go
+++ b/pkg/webhooks/generation.go
@@ -34,7 +34,7 @@ import (
 
 //HandleGenerate handles admission-requests for policies with generate rules
 func (ws *WebhookServer) HandleGenerate(request *v1beta1.AdmissionRequest, policies []*kyverno.ClusterPolicy, ctx *context.Context, userRequestInfo kyverno.RequestInfo, dynamicConfig config.Interface) {
-	logger := ws.log.WithValues("action", "generation", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation)
+	logger := ws.log.WithValues("action", "generation", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation, "gvk", request.Kind.String())
 	logger.V(4).Info("incoming request")
 	var engineResponses []*response.EngineResponse
 	if request.Operation == v1beta1.Create || request.Operation == v1beta1.Update {
@@ -100,7 +100,7 @@ func (ws *WebhookServer) HandleGenerate(request *v1beta1.AdmissionRequest, polic
 
 //handleUpdate handles admission-requests for update
 func (ws *WebhookServer) handleUpdate(request *v1beta1.AdmissionRequest, policies []*kyverno.ClusterPolicy) {
-	logger := ws.log.WithValues("action", "generation", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation)
+	logger := ws.log.WithValues("action", "generation", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation, "gvk", request.Kind.String())
 	resource, err := enginutils.ConvertToUnstructured(request.OldObject.Raw)
 	if err != nil {
 		logger.Error(err, "failed to convert object resource to unstructured format")
@@ -293,7 +293,7 @@ func stripNonPolicyFields(obj, newRes map[string]interface{}, logger logr.Logger
 
 //HandleDelete handles admission-requests for delete
 func (ws *WebhookServer) handleDelete(request *v1beta1.AdmissionRequest) {
-	logger := ws.log.WithValues("action", "generation", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation)
+	logger := ws.log.WithValues("action", "generation", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation, "gvk", request.Kind.String())
 	resource, err := enginutils.ConvertToUnstructured(request.OldObject.Raw)
 	if err != nil {
 		logger.Error(err, "failed to convert object resource to unstructured format")

--- a/pkg/webhooks/mutation.go
+++ b/pkg/webhooks/mutation.go
@@ -35,7 +35,7 @@ func (ws *WebhookServer) HandleMutation(
 		resourceName = request.Namespace + "/" + resourceName
 	}
 
-	logger := ws.log.WithValues("action", "mutate", "resource", resourceName, "operation", request.Operation)
+	logger := ws.log.WithValues("action", "mutate", "resource", resourceName, "operation", request.Operation, "gvk", request.Kind.String())
 
 	var patches [][]byte
 	var engineResponses []*response.EngineResponse
@@ -73,7 +73,7 @@ func (ws *WebhookServer) HandleMutation(
 			continue
 		}
 
-		err := ws.openAPIController.ValidateResource(*engineResponse.PatchedResource.DeepCopy(), engineResponse.PatchedResource.GetKind())
+		err := ws.openAPIController.ValidateResource(*engineResponse.PatchedResource.DeepCopy(), engineResponse.PatchedResource.GetAPIVersion(), engineResponse.PatchedResource.GetKind())
 		if err != nil {
 			logger.V(4).Info("validation error", "policy", policy.Name, "error", err.Error())
 			continue

--- a/pkg/webhooks/policymutation.go
+++ b/pkg/webhooks/policymutation.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (ws *WebhookServer) policyMutation(request *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse {
-	logger := ws.log.WithValues("action", "policy mutation", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation)
+	logger := ws.log.WithValues("action", "policy mutation", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation, "gvk", request.Kind.String())
 	var policy *kyverno.ClusterPolicy
 	raw := request.Object.Raw
 

--- a/pkg/webhooks/policyvalidation.go
+++ b/pkg/webhooks/policyvalidation.go
@@ -13,7 +13,7 @@ import (
 
 //HandlePolicyValidation performs the validation check on policy resource
 func (ws *WebhookServer) policyValidation(request *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse {
-	logger := ws.log.WithValues("action", "policy validation", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation)
+	logger := ws.log.WithValues("action", "policy validation", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation, "gvk", request.Kind.String())
 	var policy *kyverno.ClusterPolicy
 
 	if err := json.Unmarshal(request.Object.Raw, &policy); err != nil {

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -296,7 +296,7 @@ func writeResponse(rw http.ResponseWriter, admissionReview *v1beta1.AdmissionRev
 
 // ResourceMutation mutates resource
 func (ws *WebhookServer) ResourceMutation(request *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse {
-	logger := ws.log.WithName("ResourceMutation").WithValues("uid", request.UID, "kind", request.Kind.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation)
+	logger := ws.log.WithName("ResourceMutation").WithValues("uid", request.UID, "kind", request.Kind.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation, "gvk", request.Kind.String())
 
 	if excludeKyvernoResources(request.Kind.Kind) {
 		return &v1beta1.AdmissionResponse{

--- a/pkg/webhooks/validation.go
+++ b/pkg/webhooks/validation.go
@@ -51,7 +51,7 @@ func HandleValidation(
 		resourceName = request.Namespace + "/" + resourceName
 	}
 
-	logger := log.WithValues("action", "validate", "resource", resourceName, "operation", request.Operation)
+	logger := log.WithValues("action", "validate", "resource", resourceName, "operation", request.Operation, "gvk", request.Kind.String())
 
 	// Get new and old resource
 	newR, oldR, err := utils.ExtractResources(patchedResource, request)

--- a/test/e2e/mutate/config.go
+++ b/test/e2e/mutate/config.go
@@ -20,3 +20,47 @@ var MutateTests = []struct {
 		Data:     configMapMutationWithContextLabelSelectionYaml,
 	},
 }
+
+var ingressTests = struct {
+	testNamesapce string
+	cpol          []byte
+	tests         []struct {
+		testName                          string
+		group, version, rsc, resourceName string
+		resource                          []byte
+	}
+}{
+	testNamesapce: "test-ingress",
+	cpol:          mutateIngressCpol,
+	tests: []struct {
+		testName                          string
+		group, version, rsc, resourceName string
+		resource                          []byte
+	}{
+		{
+			testName:     "test-networking-v1-ingress",
+			group:        "networking.k8s.io",
+			version:      "v1",
+			rsc:          "ingresses",
+			resourceName: "kuard-v1",
+			resource:     ingressNetworkingV1,
+		},
+		// the following two tests can be removed after 1.22 cluster
+		{
+			testName:     "test-networking-v1beta1-ingress",
+			group:        "networking.k8s.io",
+			version:      "v1beta1",
+			rsc:          "ingresses",
+			resourceName: "kuard-v1beta1",
+			resource:     ingressNetworkingV1beta1,
+		},
+		{
+			testName:     "test-extensions-v1beta1-ingress",
+			group:        "extensions",
+			version:      "v1beta1",
+			rsc:          "ingresses",
+			resourceName: "kuard-extensions",
+			resource:     ingressExtensionV1beta1,
+		},
+	},
+}


### PR DESCRIPTION
## Related issue
Closes #1903.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this
/bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Before this change, the openAPISchemas are stored using the Kind only. This PR updates to use gvk to store these schemas.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

Policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: mutate-ingress-host
spec:
  rules:
  - name: mutate-rules-host
    match:
      resources:
        kinds:
        - Ingress
    mutate:
      patchesJson6902: |-
        - op: replace
          path: /spec/rules/0/host
          value: {{request.object.spec.rules[0].host}}.mycompany.com
```

Given `networking.k8s.io/v1` Ingress, it is mutated correctly:
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: kuard2
  # namespace: ingress
  labels:
    app: kuard
spec:
  rules:
  - host: kuard
    http:
      paths:
      - backend:
          service: 
            name: kuard
            port: 
              number: 8080
        path: /
        pathType: ImplementationSpecific
  tls:
  - hosts:
    - kuard
```

```yaml
✗ k get ingress kuard2 -o yaml | k neat
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    policies.kyverno.io/patches: |
      mutate-rules-host.mutate-ingress-host.kyverno.io: replaced /spec/rules/0/host
  labels:
    app: kuard
  name: kuard2
  namespace: default
spec:
  rules:
  - host: kuard.mycompany.com
    http:
      paths:
      - backend:
          service:
            name: kuard
            port:
              number: 8080
        path: /
        pathType: ImplementationSpecific
  tls:
  - hosts:
    - kuard
```

Given `extensions/v1beta1` Ingress, it can be mutated successfully:
```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  labels:
    app: kuard
  name: kuard
spec:
  rules:
  - host: kuard
    http:
      paths:
      - backend:
          serviceName: kuard
          servicePort: 8080
        path: /
        pathType: ImplementationSpecific
  tls:
  - hosts:
    - kuard

```

```yaml
✗ k get ingress kuard -o yaml | k neat
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    policies.kyverno.io/patches: |
      mutate-rules-host.mutate-ingress-host.kyverno.io: replaced /spec/rules/0/host
  labels:
    app: kuard
  name: kuard
  namespace: default
spec:
  rules:
  - host: kuard.mycompany.com
    http:
      paths:
      - backend:
          service:
            name: kuard
            port:
              number: 8080
        path: /
        pathType: ImplementationSpecific
  tls:
  - hosts:
    - kuard
```


<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
