### PR TITLE
Fix `{{@}}` behavior

### DIFF
--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -186,8 +186,7 @@ func substituteVariablesIfAny(log logr.Logger, ctx context.EvalInterface) jsonUt
 				variable := replaceBracesAndTrimSpaces(v)
 
 				if variable == "@" {
-					currentPath := getJMESPath(data.Path)
-					variable = strings.Replace(variable, "@", fmt.Sprintf("request.object%s", currentPath), -1)
+					variable = strings.Replace(variable, "@", fmt.Sprintf("request.object.%s", getJMESPath(data.Path)), -1)
 				}
 
 				operation, err := ctx.Query("request.operation")
@@ -235,7 +234,8 @@ func substituteVariablesIfAny(log logr.Logger, ctx context.EvalInterface) jsonUt
 
 // getJMESPath converts path to JMES format
 func getJMESPath(rawPath string) string {
-	path := strings.ReplaceAll(rawPath, "/", ".")
+	tokens := strings.Split(rawPath, "/")[3:] // skip empty element and two non-resource (like mutate.overlay)
+	path := strings.Join(tokens, ".")
 	regex := regexp.MustCompile(`\.([\d])\.`)
 	return string(regex.ReplaceAll([]byte(path), []byte("[$1].")))
 }

--- a/pkg/engine/variables/vars_test.go
+++ b/pkg/engine/variables/vars_test.go
@@ -300,7 +300,6 @@ func Test_subVars_withRegexReplaceAll(t *testing.T) {
 				}
 			}
 		}
-			
 	}`)
 
 	resourceRaw := []byte(`{

--- a/pkg/kyverno/common/regex.go
+++ b/pkg/kyverno/common/regex.go
@@ -7,5 +7,5 @@ import (
 // RegexVariables represents regex for '{{}}'
 var RegexVariables = regexp.MustCompile(`\{\{[^{}]*\}\}`)
 
-// AllowedVariables represents regex for {{request.}} {{serviceAccountName}} and {{serviceAccountNamespace}}
-var AllowedVariables = regexp.MustCompile(`\{\{\s*[request\.|serviceAccountName|serviceAccountNamespace][^{}]*\}\}`)
+// AllowedVariables represents regex for {{request.}}, {{serviceAccountName}}, {{serviceAccountNamespace}} and {{@}}
+var AllowedVariables = regexp.MustCompile(`\{\{\s*[request\.|serviceAccountName|serviceAccountNamespace|@][^{}]*\}\}`)


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

/kind bug

## Proposed Changes
- Added @ to allowed variables
- Fixed @ substitution

### Proof Manifests
Policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: replace-image-registry
spec:
  background: false
  rules:
    - name: replace-image-registry
      match:
        resources:
          kinds:
          - Pod
      mutate:
        patchStrategicMerge:
          spec:
            containers:
              - (name): "*"
                image: "{{ replace_all('{{@}}', 'ghcr.io/linuxserver', 'index.docker.io') }}"
```

Resource:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-dep2
  namespace: default
  labels:
    app: hello-nginx
spec:
  selector:
    matchLabels:
      app: hello-nginx
  replicas: 1
  template:
    metadata:
      labels:
        app: hello-nginx
        foo: bar
    spec:
      containers:
        - name: hello-nginx
          image: ghcr.io/linuxserver/nginx
          ports:
          - containerPort: 8080
        - name: hello-nginx2
          image: ghcr.io/linuxserver/nginx
          ports:
          - containerPort: 9090
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
