### PR TITLE
HA | Fixed generate policy flow

### DIFF
--- a/pkg/webhooks/generation.go
+++ b/pkg/webhooks/generation.go
@@ -40,10 +40,7 @@ func (ws *WebhookServer) HandleGenerate(request *v1beta1.AdmissionRequest, polic
 	logger := ws.log.WithValues("action", "generation", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation, "gvk", request.Kind.String())
 	logger.V(4).Info("incoming request")
 	var engineResponses []*response.EngineResponse
-	if request.Operation == v1beta1.Create || request.Operation == v1beta1.Update {
-		if len(policies) == 0 {
-			return
-		}
+	if (request.Operation == v1beta1.Create || request.Operation == v1beta1.Update) && len(policies) != 0 {
 		// convert RAW to unstructured
 		new, old, err := kyvernoutils.ExtractResources(nil, request)
 		if err != nil {
@@ -162,8 +159,24 @@ func (ws *WebhookServer) handleUpdateCloneSourceResource(resLabels map[string]st
 			return
 		}
 		for _, gr := range grList {
-			ws.grController.EnqueueGenerateRequestFromWebhook(gr)
+			ws.updateAnnotationInGR(gr, logger)
 		}
+	}
+}
+
+// updateAnnotationInGR - function used to update GR annotation
+// updating GR will trigger reprocessing of GR and recreation/updation of generated resource
+func (ws *WebhookServer) updateAnnotationInGR(gr *v1.GenerateRequest, logger logr.Logger) {
+	grAnnotations := gr.Annotations
+	if len(grAnnotations) == 0 {
+		grAnnotations = make(map[string]string)
+	}
+	grAnnotations["generate.kyverno.io/updation-time"] = time.Now().String()
+	gr.SetAnnotations(grAnnotations)
+	_, err := ws.kyvernoClient.KyvernoV1().GenerateRequests(config.KyvernoNamespace).Update(contextdefault.TODO(), gr, metav1.UpdateOptions{})
+	if err != nil {
+		logger.Error(err, "failed to update generate request for the resource", "generate request", gr.Name)
+		return
 	}
 }
 
@@ -179,37 +192,38 @@ func (ws *WebhookServer) handleUpdateTargetResource(request *v1beta1.AdmissionRe
 	targetSourceName := newRes.GetName()
 	targetSourceKind := newRes.GetKind()
 
-	for _, policy := range policies {
-		if policy.GetName() == policyName {
-			for _, rule := range policy.Spec.Rules {
-				if rule.Generation.Kind == targetSourceKind && rule.Generation.Name == targetSourceName {
-					updatedRule, err := getGeneratedByResource(newRes, resLabels, ws.client, rule, logger)
+	policy, err := ws.kyvernoClient.KyvernoV1().ClusterPolicies().Get(contextdefault.TODO(), policyName, metav1.GetOptions{})
+	if err != nil {
+		logger.Error(err, "failed to get policy from kyverno client.", "policy name", policyName)
+		return
+	}
+	for _, rule := range policy.Spec.Rules {
+		if rule.Generation.Kind == targetSourceKind && rule.Generation.Name == targetSourceName {
+			updatedRule, err := getGeneratedByResource(newRes, resLabels, ws.client, rule, logger)
+			if err != nil {
+				logger.V(4).Info("skipping generate policy and resource pattern validaton", "error", err)
+			} else {
+				data := updatedRule.Generation.DeepCopy().Data
+				if data != nil {
+					if _, err := gen.ValidateResourceWithPattern(logger, newRes.Object, data); err != nil {
+						enqueueBool = true
+						break
+					}
+				}
+
+				cloneName := updatedRule.Generation.Clone.Name
+				if cloneName != "" {
+					obj, err := ws.client.GetResource("", rule.Generation.Kind, rule.Generation.Clone.Namespace, rule.Generation.Clone.Name)
 					if err != nil {
-						logger.V(4).Info("skipping generate policy and resource pattern validaton", "error", err)
-					} else {
-						data := updatedRule.Generation.DeepCopy().Data
-						if data != nil {
-							if _, err := gen.ValidateResourceWithPattern(logger, newRes.Object, data); err != nil {
-								enqueueBool = true
-								break
-							}
-						}
+						logger.Error(err, fmt.Sprintf("source resource %s/%s/%s not found.", rule.Generation.Kind, rule.Generation.Clone.Namespace, rule.Generation.Clone.Name))
+						continue
+					}
 
-						cloneName := updatedRule.Generation.Clone.Name
-						if cloneName != "" {
-							obj, err := ws.client.GetResource("", rule.Generation.Kind, rule.Generation.Clone.Namespace, rule.Generation.Clone.Name)
-							if err != nil {
-								logger.Error(err, fmt.Sprintf("source resource %s/%s/%s not found.", rule.Generation.Kind, rule.Generation.Clone.Namespace, rule.Generation.Clone.Name))
-								continue
-							}
+					sourceObj, newResObj := stripNonPolicyFields(obj.Object, newRes.Object, logger)
 
-							sourceObj, newResObj := stripNonPolicyFields(obj.Object, newRes.Object, logger)
-
-							if _, err := gen.ValidateResourceWithPattern(logger, newResObj, sourceObj); err != nil {
-								enqueueBool = true
-								break
-							}
-						}
+					if _, err := gen.ValidateResourceWithPattern(logger, newResObj, sourceObj); err != nil {
+						enqueueBool = true
+						break
 					}
 				}
 			}
@@ -223,7 +237,7 @@ func (ws *WebhookServer) handleUpdateTargetResource(request *v1beta1.AdmissionRe
 			logger.Error(err, "failed to get generate request", "name", grName)
 			return
 		}
-		ws.grController.EnqueueGenerateRequestFromWebhook(gr)
+		ws.updateAnnotationInGR(gr, logger)
 	}
 }
 
@@ -339,7 +353,7 @@ func (ws *WebhookServer) handleDelete(request *v1beta1.AdmissionRequest) {
 			logger.Error(err, "failed to get generate request", "name", grName)
 			return
 		}
-		ws.grController.EnqueueGenerateRequestFromWebhook(gr)
+		ws.updateAnnotationInGR(gr, logger)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue
closes https://github.com/kyverno/kyverno/issues/1932

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
PR for HA - fixing generate policy flow.
Fixing 3 generate policy flows:
-  **Case 1:** When changes are made in clone source resource, the same should be replicated in generated resources.
-  **Case 2:** When generated resource is deleted, kyverno should immediately  recreate the deleted resource
-  **Case 3:** When any changes are made in generated resource and the changes conflict with the generate policy data, Kyverno should replace the updated generated resource.

### Proof Manifests
**Case 1:**
1. Create the following config map:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: config-template
data:
  player_initial_lives: "5"
  ui_properties_file_name: "user-interface.properties"
```
2. Apply following policy:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: basic-policy
spec:
  rules:
  - name: Clone ConfigMap
    match:
      resources:
        kinds:
        - Namespace
    exclude:
      resources:
        namespaces:
        - kube-system
        - default
        - kube-public
        - kyverno
    generate:
      kind: ConfigMap
      name: default-config
      namespace: "{{request.object.metadata.name}}"
      synchronize : true
      clone:
        namespace: default
        name: config-template
```
3. Create a new namespace `test1`
4. Check configmap under the new namespace. (configmap name - default-config)
5. Now edit the configmap in default namespace (config-template), i.e.,clone source resource.
6. Check the configmap in the created namespace(test1), same changes should be replicated in the generated configmap(default-config).

**Case 2:**
7. Delete the generated configmap (default-config) from the created namespace (test1).
8. Check the configmap(default-config) in the namespace(test1), the resource should be regenerated.

**Case 3:**
1. Apply following policy:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: add-networkpolicy
spec:
  background: true
  rules:
  - name: allow-dns
    match:
      resources:
        kinds:
        - Namespace
        selector:
            matchLabels:
              security: standard
    exclude:
      resources:
        namespaces:
          - "kube-system"
          - "default"
          - "kube-public"
          - "nova-kyverno"
    generate:
      synchronize: true
      kind: NetworkPolicy
      name: allow-dns
      namespace: "{{request.object.metadata.name}}"
      data:
        spec:
          egress:
          - ports:
            - protocol: TCP
              port: 5353    
          podSelector: {}
          policyTypes:
          - Egress   
```
2. Apply the following namespace:
```
apiVersion: v1
kind: Namespace
metadata:
  name: test2
  labels:
    security: standard
```
3. Check network policy under namespace `test2`
4. Now edit ports (say protocol: TCP to protocol: UDP ) in the generated network policy and save it.
5. Again check the changes in generated network policy, even after editing the port(protocol: TCP to protocol: UDP ), the changes will be replaced by the data mention in the generate policy (i.e, protocol: TCP).

## Checklist

- [] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
