### PR TITLE
added: admission_request_timestamp for kyverno_admission_review_latency_milliseconds

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -76,6 +76,7 @@ func NewPromConfig() *PromConfig {
 		"cluster_policies_count", "namespaced_policies_count",
 		"validate_rules_count", "mutate_rules_count", "generate_rules_count",
 		"resource_name", "resource_kind", "resource_namespace", "resource_request_operation",
+		"admission_request_timestamp",
 	}
 	admissionReviewLatencyMetric := prom.NewGaugeVec(
 		prom.GaugeOpts{

--- a/pkg/webhooks/generation.go
+++ b/pkg/webhooks/generation.go
@@ -36,10 +36,12 @@ import (
 )
 
 //HandleGenerate handles admission-requests for policies with generate rules
-func (ws *WebhookServer) HandleGenerate(request *v1beta1.AdmissionRequest, policies []*kyverno.ClusterPolicy, ctx *context.Context, userRequestInfo kyverno.RequestInfo, dynamicConfig config.Interface, admissionRequestTimestamp int64, latencySender *chan int64) {
+func (ws *WebhookServer) HandleGenerate(request *v1beta1.AdmissionRequest, policies []*kyverno.ClusterPolicy, ctx *context.Context, userRequestInfo kyverno.RequestInfo, dynamicConfig config.Interface, admissionRequestTimestamp int64, latencySender *chan int64, triggeredGeneratePoliciesSender *chan []kyverno.ClusterPolicy, generateEngineResponsesSender *chan []*response.EngineResponse) {
 	logger := ws.log.WithValues("action", "generation", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation, "gvk", request.Kind.String())
 	logger.V(4).Info("incoming request")
+
 	var engineResponses []*response.EngineResponse
+	var triggeredGeneratePolicies []kyverno.ClusterPolicy
 	if (request.Operation == v1beta1.Create || request.Operation == v1beta1.Update) && len(policies) != 0 {
 		// convert RAW to unstructured
 		new, old, err := kyvernoutils.ExtractResources(nil, request)
@@ -77,6 +79,7 @@ func (ws *WebhookServer) HandleGenerate(request *v1beta1.AdmissionRequest, polic
 				engineResponse.PolicyResponse.Rules = rules
 				// some generate rules do apply to the resource
 				engineResponses = append(engineResponses, engineResponse)
+				triggeredGeneratePolicies = append(triggeredGeneratePolicies, *policy)
 				ws.statusListener.Update(generateStats{
 					resp: engineResponse,
 				})
@@ -105,6 +108,8 @@ func (ws *WebhookServer) HandleGenerate(request *v1beta1.AdmissionRequest, polic
 	// sending the admission request latency to other goroutine (reporting the metrics) over the channel
 	admissionReviewLatencyDuration := int64(time.Since(time.Unix(admissionRequestTimestamp, 0)))
 	*latencySender <- admissionReviewLatencyDuration
+	*triggeredGeneratePoliciesSender <- triggeredGeneratePolicies
+	*generateEngineResponsesSender <- engineResponses
 }
 
 func (ws *WebhookServer) registerPolicyRuleResultsMetricGeneration(logger logr.Logger, resourceRequestOperation string, policy kyverno.ClusterPolicy, engineResponse response.EngineResponse, admissionRequestTimestamp int64) {

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -375,7 +375,7 @@ func (ws *WebhookServer) ResourceMutation(request *v1beta1.AdmissionRequest) *v1
 	logger.V(6).Info("", "patchedResource", string(patchedResource))
 	admissionReviewLatencyDuration := int64(time.Since(time.Unix(admissionRequestTimestamp, 0)))
 	// registering the kyverno_admission_review_latency_milliseconds metric concurrently
-	go registerAdmissionReviewLatencyMetricMutate(logger, *ws.promConfig.Metrics, string(request.Operation), mutateEngineResponses, triggeredMutatePolicies, admissionReviewLatencyDuration)
+	go registerAdmissionReviewLatencyMetricMutate(logger, *ws.promConfig.Metrics, string(request.Operation), mutateEngineResponses, triggeredMutatePolicies, admissionReviewLatencyDuration, admissionRequestTimestamp)
 
 	// GENERATE
 	newRequest := request.DeepCopy()
@@ -383,11 +383,12 @@ func (ws *WebhookServer) ResourceMutation(request *v1beta1.AdmissionRequest) *v1
 
 	// this channel will be used to transmit the admissionReviewLatency from ws.HandleGenerate(..,) goroutine to registeGeneraterPolicyAdmissionReviewLatencyMetric(...) goroutine
 	admissionReviewCompletionLatencyChannel := make(chan int64, 1)
+	triggeredGeneratePoliciesChannel := make(chan []v1.ClusterPolicy, 1)
+	generateEngineResponsesChannel := make(chan []*response.EngineResponse, 1)
 
-	go ws.HandleGenerate(newRequest, generatePolicies, ctx, userRequestInfo, ws.configHandler, admissionRequestTimestamp, &admissionReviewCompletionLatencyChannel)
-
+	go ws.HandleGenerate(newRequest, generatePolicies, ctx, userRequestInfo, ws.configHandler, admissionRequestTimestamp, &admissionReviewCompletionLatencyChannel, &triggeredGeneratePoliciesChannel, &generateEngineResponsesChannel)
 	// registering the kyverno_admission_review_latency_milliseconds metric concurrently
-	go registerAdmissionReviewLatencyMetricGenerate(logger, *ws.promConfig.Metrics, string(request.Operation), mutateEngineResponses, triggeredMutatePolicies, &admissionReviewCompletionLatencyChannel)
+	go registerAdmissionReviewLatencyMetricGenerate(logger, *ws.promConfig.Metrics, string(newRequest.Operation), admissionRequestTimestamp, &admissionReviewCompletionLatencyChannel, &triggeredGeneratePoliciesChannel, &generateEngineResponsesChannel)
 	patchType := v1beta1.PatchTypeJSONPatch
 	return &v1beta1.AdmissionResponse{
 		Allowed: true,
@@ -399,25 +400,31 @@ func (ws *WebhookServer) ResourceMutation(request *v1beta1.AdmissionRequest) *v1
 	}
 }
 
-func registerAdmissionReviewLatencyMetricMutate(logger logr.Logger, promMetrics metrics.PromMetrics, requestOperation string, engineResponses []*response.EngineResponse, triggeredPolicies []v1.ClusterPolicy, admissionReviewLatencyDuration int64) {
+func registerAdmissionReviewLatencyMetricMutate(logger logr.Logger, promMetrics metrics.PromMetrics, requestOperation string, engineResponses []*response.EngineResponse, triggeredPolicies []v1.ClusterPolicy, admissionReviewLatencyDuration int64, admissionRequestTimestamp int64) {
 	resourceRequestOperationPromAlias, err := admissionReviewLatency.ParseResourceRequestOperation(requestOperation)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_review_latency_milliseconds metrics")
 	}
-	if err := admissionReviewLatency.ParsePromMetrics(promMetrics).ProcessEngineResponses(engineResponses, triggeredPolicies, admissionReviewLatencyDuration, resourceRequestOperationPromAlias); err != nil {
+	if err := admissionReviewLatency.ParsePromMetrics(promMetrics).ProcessEngineResponses(engineResponses, triggeredPolicies, admissionReviewLatencyDuration, resourceRequestOperationPromAlias, admissionRequestTimestamp); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_review_latency_milliseconds metrics")
 	}
 }
 
-func registerAdmissionReviewLatencyMetricGenerate(logger logr.Logger, promMetrics metrics.PromMetrics, requestOperation string, engineResponses []*response.EngineResponse, triggeredPolicies []v1.ClusterPolicy, latencyReceiver *chan int64) {
+func registerAdmissionReviewLatencyMetricGenerate(logger logr.Logger, promMetrics metrics.PromMetrics, requestOperation string, admissionRequestTimestamp int64, latencyReceiver *chan int64, triggeredGeneratePoliciesReceiver *chan []v1.ClusterPolicy, engineResponsesReceiver *chan []*response.EngineResponse) {
 	defer close(*latencyReceiver)
+	defer close(*triggeredGeneratePoliciesReceiver)
+	defer close(*engineResponsesReceiver)
+
+	triggeredPolicies := <-(*triggeredGeneratePoliciesReceiver)
+	engineResponses := <-(*engineResponsesReceiver)
+
 	resourceRequestOperationPromAlias, err := admissionReviewLatency.ParseResourceRequestOperation(requestOperation)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_review_latency_milliseconds metrics")
 	}
 	// this goroutine will keep on waiting here till it doesn't receive the admission review latency int64 from the other goroutine i.e. ws.HandleGenerate
 	admissionReviewLatencyDuration := <-(*latencyReceiver)
-	if err := admissionReviewLatency.ParsePromMetrics(promMetrics).ProcessEngineResponses(engineResponses, triggeredPolicies, admissionReviewLatencyDuration, resourceRequestOperationPromAlias); err != nil {
+	if err := admissionReviewLatency.ParsePromMetrics(promMetrics).ProcessEngineResponses(engineResponses, triggeredPolicies, admissionReviewLatencyDuration, resourceRequestOperationPromAlias, admissionRequestTimestamp); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_review_latency_milliseconds metrics")
 	}
 }

--- a/pkg/webhooks/validation.go
+++ b/pkg/webhooks/validation.go
@@ -147,7 +147,7 @@ func HandleValidation(
 		logger.V(4).Info("resource blocked")
 		//registering the kyverno_admission_review_latency_milliseconds metric concurrently
 		admissionReviewLatencyDuration := int64(time.Since(time.Unix(admissionRequestTimestamp, 0)))
-		go registerAdmissionReviewLatencyMetricValidate(promConfig, logger, string(request.Operation), engineResponses, triggeredPolicies, admissionReviewLatencyDuration)
+		go registerAdmissionReviewLatencyMetricValidate(promConfig, logger, string(request.Operation), engineResponses, triggeredPolicies, admissionReviewLatencyDuration, admissionRequestTimestamp)
 		return false, getEnforceFailureErrorMsg(engineResponses)
 	}
 
@@ -161,7 +161,7 @@ func HandleValidation(
 
 	//registering the kyverno_admission_review_latency_milliseconds metric concurrently
 	admissionReviewLatencyDuration := int64(time.Since(time.Unix(admissionRequestTimestamp, 0)))
-	go registerAdmissionReviewLatencyMetricValidate(promConfig, logger, string(request.Operation), engineResponses, triggeredPolicies, admissionReviewLatencyDuration)
+	go registerAdmissionReviewLatencyMetricValidate(promConfig, logger, string(request.Operation), engineResponses, triggeredPolicies, admissionReviewLatencyDuration, admissionRequestTimestamp)
 
 	return true, ""
 }
@@ -186,12 +186,12 @@ func registerPolicyRuleExecutionLatencyMetricValidate(promConfig *metrics.PromCo
 	}
 }
 
-func registerAdmissionReviewLatencyMetricValidate(promConfig *metrics.PromConfig, logger logr.Logger, requestOperation string, engineResponses []*response.EngineResponse, triggeredPolicies []kyverno.ClusterPolicy, admissionReviewLatencyDuration int64) {
+func registerAdmissionReviewLatencyMetricValidate(promConfig *metrics.PromConfig, logger logr.Logger, requestOperation string, engineResponses []*response.EngineResponse, triggeredPolicies []kyverno.ClusterPolicy, admissionReviewLatencyDuration int64, admissionRequestTimestamp int64) {
 	resourceRequestOperationPromAlias, err := admissionReviewLatency.ParseResourceRequestOperation(requestOperation)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_review_latency_milliseconds metrics")
 	}
-	if err := admissionReviewLatency.ParsePromMetrics(*promConfig.Metrics).ProcessEngineResponses(engineResponses, triggeredPolicies, admissionReviewLatencyDuration, resourceRequestOperationPromAlias); err != nil {
+	if err := admissionReviewLatency.ParsePromMetrics(*promConfig.Metrics).ProcessEngineResponses(engineResponses, triggeredPolicies, admissionReviewLatencyDuration, resourceRequestOperationPromAlias, admissionRequestTimestamp); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_review_latency_milliseconds metrics")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yash.kukreja.98@gmail.com>

## Related issue
closes #1969 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this
> /kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
From now on, even `admission_request_timestamp` will be registered as a part of the `kyverno_admission_review_latency_milliseconds` metric.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Output
Same resource being re-applied again and again yet still kyverno_admission_review_latency_milliseconds is successfully able to register a new metric for each of them

```

kyverno_admission_review_latency_milliseconds{admission_request_timestamp="2021-06-07 02:02:15 +0000 UTC", cluster_policies_count="1", generate_rules_count="1", instance="localhost:8000", job="kyverno", mutate_rules_count="0", namespaced_policies_count="0", resource_kind="Namespace", resource_name="something", resource_request_operation="create", validate_rules_count="0"}  851.0625
kyverno_admission_review_latency_milliseconds{admission_request_timestamp="2021-06-07 02:02:48 +0000 UTC", cluster_policies_count="1", generate_rules_count="1", instance="localhost:8000", job="kyverno", mutate_rules_count="0", namespaced_policies_count="0", resource_kind="Namespace", resource_name="something", resource_request_operation="update", validate_rules_count="0"} 460.4672
kyverno_admission_review_latency_milliseconds{admission_request_timestamp="2021-06-07 02:21:29 +0000 UTC", cluster_policies_count="1", generate_rules_count="1", instance="localhost:8000", job="kyverno", mutate_rules_count="0", namespaced_policies_count="0", resource_kind="Namespace", resource_name="something", resource_request_operation="create", validate_rules_count="0"}  95.8793
kyverno_admission_review_latency_milliseconds{admission_request_timestamp="2021-06-07 02:21:38 +0000 UTC", cluster_policies_count="1", generate_rules_count="1", instance="localhost:8000", job="kyverno", mutate_rules_count="0", namespaced_policies_count="0", resource_kind="Namespace", resource_name="something", resource_request_operation="update", validate_rules_count="0"}   684.5059
kyverno_admission_review_latency_milliseconds{admission_request_timestamp="2021-06-07 02:21:41 +0000 UTC", cluster_policies_count="1", generate_rules_count="1", instance="localhost:8000", job="kyverno", mutate_rules_count="0", namespaced_policies_count="0", resource_kind="Namespace", resource_name="something", resource_request_operation="create", validate_rules_count="0"}.  181.4544
``` 

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments
Also, strengthened the inter-channel communication of the registration of generate rule metric so as to avoid flakiness around its registration in the future.
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
