### PR TITLE
Remove runAsUser specification from Security Context

### DIFF
--- a/charts/kyverno/templates/deployment.yaml
+++ b/charts/kyverno/templates/deployment.yaml
@@ -54,7 +54,6 @@ spec:
           resources: {{ tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           securityContext:
-            runAsUser: 1000
             runAsNonRoot: true
             privileged: false
             allowPrivilegeEscalation: false
@@ -82,7 +81,6 @@ spec:
           resources: {{ tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           securityContext:
-            runAsUser: 1000
             runAsNonRoot: true
             privileged: false
             allowPrivilegeEscalation: false


### PR DESCRIPTION
This fails on openshift since we cannot specify users within this range. Also, this template should be as close as possible to the vanilla manifest for deployment https://github.com/kyverno/kyverno/blob/main/definitions/release/install.yaml

Vanilla manifest omits the user specification https://github.com/kyverno/kyverno/blob/main/definitions/release/install.yaml#L2478

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

Signed off: Ahmed Waleed Malik(ahmedwaleedmalik@gmail.com)
