### PR TITLE
adding support for policies.kyverno.io/scored annotation

### DIFF
--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -133,6 +133,7 @@ func (builder *requestBuilder) build(info Info) (req *unstructured.Unstructured,
 
 func (builder *requestBuilder) buildRCRResult(policy string, resource response.ResourceSpec, rule kyverno.ViolatedRule) *report.PolicyReportResult {
 	av := builder.fetchAnnotationValues(policy, resource.Namespace)
+
 	result := &report.PolicyReportResult{
 		Policy: policy,
 		Resources: []*v1.ObjectReference{

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -155,6 +155,9 @@ func (builder *requestBuilder) buildRCRResult(policy string, resource response.R
 	result.Rule = rule.Name
 	result.Message = rule.Message
 	result.Status = report.PolicyStatus(rule.Check)
+	if result.Status == "fail" && !av.scored {
+		result.Status = "warn"
+	}
 	return result
 }
 
@@ -290,10 +293,10 @@ func (builder *requestBuilder) fetchAnnotationValues(policy, ns string) annotati
 		av.setSeverityFromString(severity)
 	}
 	if scored, ok := ann[scoredLabel]; ok {
-		if scored == "true" {
-			av.scored = true
-		} else {
+		if scored == "false" {
 			av.scored = false
+		} else {
+			av.scored = true
 		}
 	}
 

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -133,7 +133,9 @@ func (builder *requestBuilder) build(info Info) (req *unstructured.Unstructured,
 
 func (builder *requestBuilder) buildRCRResult(policy string, resource response.ResourceSpec, rule kyverno.ViolatedRule) *report.PolicyReportResult {
 	av := builder.fetchAnnotationValues(policy, resource.Namespace)
-
+	fmt.Println("$$$")
+	fmt.Println(av.scored)
+	fmt.Println("$$$")
 	result := &report.PolicyReportResult{
 		Policy: policy,
 		Resources: []*v1.ObjectReference{

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -296,6 +296,8 @@ func (builder *requestBuilder) fetchAnnotationValues(policy, ns string) annotati
 		} else {
 			av.scored = true
 		}
+	} else {
+		av.scored = true
 	}
 
 	return av

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -145,7 +145,7 @@ func (builder *requestBuilder) buildRCRResult(policy string, resource response.R
 				UID:        types.UID(resource.UID),
 			},
 		},
-		Scored:   true,
+		Scored:   av.scored,
 		Category: av.category,
 		Severity: av.severity,
 	}
@@ -258,10 +258,12 @@ func buildViolatedRules(er *response.EngineResponse) []kyverno.ViolatedRule {
 
 const categoryLabel string = "policies.kyverno.io/category"
 const severityLabel string = "policies.kyverno.io/severity"
+const scoredLabel string = "policies.kyverno.io/scored"
 
 type annotationValues struct {
 	category string
 	severity report.PolicySeverity
+	scored   bool
 }
 
 func (av *annotationValues) setSeverityFromString(severity string) {
@@ -284,6 +286,13 @@ func (builder *requestBuilder) fetchAnnotationValues(policy, ns string) annotati
 	}
 	if severity, ok := ann[severityLabel]; ok {
 		av.setSeverityFromString(severity)
+	}
+	if scored, ok := ann[scoredLabel]; ok {
+		if scored == "true" {
+			av.scored = true
+		} else {
+			av.scored = false
+		}
 	}
 
 	return av

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -133,9 +133,6 @@ func (builder *requestBuilder) build(info Info) (req *unstructured.Unstructured,
 
 func (builder *requestBuilder) buildRCRResult(policy string, resource response.ResourceSpec, rule kyverno.ViolatedRule) *report.PolicyReportResult {
 	av := builder.fetchAnnotationValues(policy, resource.Namespace)
-	fmt.Println("$$$")
-	fmt.Println(av.scored)
-	fmt.Println("$$$")
 	result := &report.PolicyReportResult{
 		Policy: policy,
 		Resources: []*v1.ObjectReference{


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

## Related issue
Fixes #1961 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
-->
> /kind feature

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->
Create the following policy:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
  annotations:
    policies.kyverno.io/scored: "false"
spec:
  validationFailureAction: audit
  rules:
  - name: no-labels
    match:
      resources:
        kinds:
        - Pod
    validate:
      message: "label 'app.kubernetes.io/name' is required"
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"
```

Create a pod which violates this policy:
```
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  containers:
    - name: web
      image: nginx
```

Run `kubectl get polr -o wide` and you'll see that it is reported under `warn` and not `fail`.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments
Will make the documentation change once we can confirm if the fix is correct.
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
