### PR TITLE
Fix prometheus panics

### DIFF
--- a/pkg/metrics/parsers.go
+++ b/pkg/metrics/parsers.go
@@ -2,8 +2,9 @@ package metrics
 
 import (
 	"fmt"
-	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"reflect"
+
+	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 )
 
 func ParsePolicyValidationMode(validationFailureAction string) (PolicyValidationMode, error) {
@@ -17,10 +18,11 @@ func ParsePolicyValidationMode(validationFailureAction string) (PolicyValidation
 	}
 }
 
-func ParsePolicyBackgroundMode(backgroundMode bool) PolicyBackgroundMode {
-	if backgroundMode {
+func ParsePolicyBackgroundMode(backgroundMode *bool) PolicyBackgroundMode {
+	if backgroundMode == nil || *backgroundMode {
 		return BackgroundTrue
 	}
+
 	return BackgroundFalse
 }
 

--- a/pkg/metrics/policychanges/policyChanges.go
+++ b/pkg/metrics/policychanges/policyChanges.go
@@ -2,10 +2,11 @@ package policychanges
 
 import (
 	"fmt"
+	"time"
+
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	prom "github.com/prometheus/client_golang/prometheus"
-	"time"
 )
 
 func (pm PromMetrics) registerPolicyChangesMetric(
@@ -38,7 +39,7 @@ func (pm PromMetrics) RegisterPolicy(policy interface{}, policyChangeType Policy
 		if err != nil {
 			return err
 		}
-		policyBackgroundMode := metrics.ParsePolicyBackgroundMode(*inputPolicy.Spec.Background)
+		policyBackgroundMode := metrics.ParsePolicyBackgroundMode(inputPolicy.Spec.Background)
 		policyType := metrics.Cluster
 		policyNamespace := "" // doesn't matter for cluster policy
 		policyName := inputPolicy.ObjectMeta.Name
@@ -51,7 +52,7 @@ func (pm PromMetrics) RegisterPolicy(policy interface{}, policyChangeType Policy
 		if err != nil {
 			return err
 		}
-		policyBackgroundMode := metrics.ParsePolicyBackgroundMode(*inputPolicy.Spec.Background)
+		policyBackgroundMode := metrics.ParsePolicyBackgroundMode(inputPolicy.Spec.Background)
 		policyType := metrics.Namespaced
 		policyNamespace := inputPolicy.ObjectMeta.Namespace
 		policyName := inputPolicy.ObjectMeta.Name

--- a/pkg/metrics/policyruleexecutionlatency/policyRuleExecutionLatency.go
+++ b/pkg/metrics/policyruleexecutionlatency/policyRuleExecutionLatency.go
@@ -64,7 +64,7 @@ func (pm PromMetrics) ProcessEngineResponse(policy kyverno.ClusterPolicy, engine
 		return err
 	}
 	policyType := metrics.Namespaced
-	policyBackgroundMode := metrics.ParsePolicyBackgroundMode(*policy.Spec.Background)
+	policyBackgroundMode := metrics.ParsePolicyBackgroundMode(policy.Spec.Background)
 	policyNamespace := policy.ObjectMeta.Namespace
 	if policyNamespace == "" {
 		policyNamespace = "-"

--- a/pkg/metrics/policyruleinfo/policyRuleInfo.go
+++ b/pkg/metrics/policyruleinfo/policyRuleInfo.go
@@ -50,7 +50,7 @@ func (pm PromMetrics) AddPolicy(policy interface{}) error {
 		if err != nil {
 			return err
 		}
-		policyBackgroundMode := metrics.ParsePolicyBackgroundMode(*inputPolicy.Spec.Background)
+		policyBackgroundMode := metrics.ParsePolicyBackgroundMode(inputPolicy.Spec.Background)
 		policyType := metrics.Cluster
 		policyNamespace := "" // doesn't matter for cluster policy
 		policyName := inputPolicy.ObjectMeta.Name
@@ -69,7 +69,7 @@ func (pm PromMetrics) AddPolicy(policy interface{}) error {
 		if err != nil {
 			return err
 		}
-		policyBackgroundMode := metrics.ParsePolicyBackgroundMode(*inputPolicy.Spec.Background)
+		policyBackgroundMode := metrics.ParsePolicyBackgroundMode(inputPolicy.Spec.Background)
 		policyType := metrics.Namespaced
 		policyNamespace := inputPolicy.ObjectMeta.Namespace
 		policyName := inputPolicy.ObjectMeta.Name
@@ -96,7 +96,7 @@ func (pm PromMetrics) RemovePolicy(policy interface{}) error {
 			if err != nil {
 				return err
 			}
-			policyBackgroundMode := metrics.ParsePolicyBackgroundMode(*inputPolicy.Spec.Background)
+			policyBackgroundMode := metrics.ParsePolicyBackgroundMode(inputPolicy.Spec.Background)
 			policyType := metrics.Cluster
 			policyNamespace := "" // doesn't matter for cluster policy
 			policyName := inputPolicy.ObjectMeta.Name
@@ -114,7 +114,7 @@ func (pm PromMetrics) RemovePolicy(policy interface{}) error {
 			if err != nil {
 				return err
 			}
-			policyBackgroundMode := metrics.ParsePolicyBackgroundMode(*inputPolicy.Spec.Background)
+			policyBackgroundMode := metrics.ParsePolicyBackgroundMode(inputPolicy.Spec.Background)
 			policyType := metrics.Namespaced
 			policyNamespace := inputPolicy.ObjectMeta.Namespace
 			policyName := inputPolicy.ObjectMeta.Name

--- a/pkg/metrics/policyruleresults/policyRuleResults.go
+++ b/pkg/metrics/policyruleresults/policyRuleResults.go
@@ -2,11 +2,12 @@ package policyruleresults
 
 import (
 	"fmt"
+	"time"
+
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/engine/response"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	prom "github.com/prometheus/client_golang/prometheus"
-	"time"
 )
 
 func (pm PromMetrics) registerPolicyRuleResultsMetric(
@@ -57,7 +58,7 @@ func (pm PromMetrics) ProcessEngineResponse(policy kyverno.ClusterPolicy, engine
 		return err
 	}
 	policyType := metrics.Namespaced
-	policyBackgroundMode := metrics.ParsePolicyBackgroundMode(*policy.Spec.Background)
+	policyBackgroundMode := metrics.ParsePolicyBackgroundMode(policy.Spec.Background)
 	policyNamespace := policy.ObjectMeta.Namespace
 	if policyNamespace == "" {
 		policyNamespace = "-"


### PR DESCRIPTION
Signed-off-by: Shuting Zhao <shutting06@gmail.com>

## Related issue

Fixes #1989.
/bug
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

As[ cpol.spec.background](https://github.com/kyverno/kyverno/blob/6f07ea407fce4d2f9677298c7c1f9579beddd660/pkg/api/kyverno/v1/policy_types.go#L55) takes a pointer to boolean, we need to check nil before access its value. This PR fixes the panics when referencing a nil pointer.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
cc @yashvardhan-kukreja 