### PR TITLE
BugFix - update the annotation lastRequestTimestamp from active instances

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -100,3 +100,11 @@ jobs:
         run: |
           kubectl create namespace kyverno
           ct install --target-branch=main --namespace=kyverno
+
+      - name: Debug failure
+        if: failure()
+        run: |
+          kubectl get mutatingwebhookconfigurations,validatingwebhookconfigurations
+          kubectl -n kyverno get pod
+          kubectl -n kyverno describe pod | grep -i events -A10
+          kubectl -n kyverno logs deploy/kyverno

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -130,4 +130,3 @@ while [[ ${mutatingwebhookconfigurations} -lt 4 || ${validatingwebhookconfigurat
 done
 
 echo "All webhooks are registered."
-echo "kubectl get mutatingwebhookconfigurations,validatingwebhookconfigurations"

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -127,8 +127,7 @@ mutatingwebhookconfigurations=$(kubectl get mutatingwebhookconfigurations | wc -
 validatingwebhookconfigurations=$(kubectl get validatingwebhookconfigurations | wc -l)
 while [[ ${mutatingwebhookconfigurations} -lt 4 || ${validatingwebhookconfigurations} -lt 3 ]]; do
   sleep 5
-  echo "registed webhooks:"
-  kubectl get mutatingwebhookconfigurations,validatingwebhookconfigurations
 done
 
 echo "All webhooks are registered."
+echo "kubectl get mutatingwebhookconfigurations,validatingwebhookconfigurations"

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -122,3 +122,13 @@ while [[ ${updated_replicas} -lt ${specified_replicas} || ${current_replicas} -g
 done
 
 echo "Deployment ${deployment} successful. All ${available_replicas} replicas are ready."
+
+mutatingwebhookconfigurations=$(kubectl get mutatingwebhookconfigurations | wc -l)
+validatingwebhookconfigurations=$(kubectl get validatingwebhookconfigurations | wc -l)
+while [[ ${mutatingwebhookconfigurations} -lt 4 || ${validatingwebhookconfigurations} -lt 3 ]]; do
+  sleep 5
+  echo "registed webhooks:"
+  kubectl get mutatingwebhookconfigurations,validatingwebhookconfigurations
+done
+
+echo "All webhooks are registered."


### PR DESCRIPTION


Signed-off-by: Shuting Zhao <shutting06@gmail.com>

## Related issue
/bug

With HA, each instance will run the webhook monitor to monitor the webhook status. This is because the webhook requests can be forwarded to any Kyverno instance, so the timestamp on the Deployment is to record the last received admission request. However the issue here is that this timestamp is not updated by the active instance (which receives admission requests) correctly. This PR fixes this problem.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
