### PR TITLE
Fix Helm chart metrics service to allow NodePort

### DIFF
--- a/charts/kyverno/templates/service.yaml
+++ b/charts/kyverno/templates/service.yaml
@@ -38,7 +38,7 @@ spec:
     protocol: TCP
     name: metrics-port
     {{- if and (eq .Values.metricsService.type "NodePort") (not (empty .Values.metricsService.nodePort)) }}
-    nodePort: {{ .Values.metricsService.metricsNodePort }}
+    nodePort: {{ .Values.metricsService.nodePort }}
     {{- end }}
   selector: {{ include "kyverno.matchLabels" . | nindent 4 }}
     app: kyverno


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

This fixes issue introduced with #1987 

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
> /kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->
Fix typo from #1987

