### PR TITLE
fix: set deployment name env var

### DIFF
--- a/charts/kyverno/templates/deployment.yaml
+++ b/charts/kyverno/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
             protocol: TCP
           - containerPort: 8000
             name: metrics-port
-            protocol: TCP  
+            protocol: TCP
           env:
           - name: INIT_CONFIG
             value: {{ template "kyverno.configMapName" . }}
@@ -103,6 +103,8 @@ spec:
                 fieldPath: metadata.namespace
           - name: KYVERNO_SVC
             value: {{ template "kyverno.serviceName" . }}
+          - name: KYVERNO_DEPLOYMENT
+            value: {{ template "kyverno.fullname" . }}
         {{- with .Values.livenessProbe }}
           livenessProbe: {{ tpl (toYaml .) $ | nindent 12 }}
         {{- end }}


### PR DESCRIPTION
## Related issue

Fixes #2002 and #1819

## What type of PR is this

/kind bug

## Proposed Changes

If instaling the Helm chart with a different release name then the lookup for the OwnerRef fails as it defaults to a deployment name of "kyverno". This change makes sure the `KYVERNO_DEPLOYMENT` environment variable is set to the same name as the deployment to ensure this logic always gets the correct value.

### Proof Manifests

```sh
helm install kyverno-custom --namespace kyverno kyverno/kyverno --create-namespace
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
