### PR TITLE
support for disallow pod exec operation

### DIFF
--- a/pkg/webhookconfig/resource.go
+++ b/pkg/webhookconfig/resource.go
@@ -111,7 +111,7 @@ func (wrc *Register) constructDefaultDebugValidatingWebhookConfig(caData []byte)
 				[]string{"*/*"},
 				"*",
 				"*",
-				[]admregapi.OperationType{admregapi.Create, admregapi.Update, admregapi.Delete},
+				[]admregapi.OperationType{admregapi.Create, admregapi.Update, admregapi.Delete, admregapi.Connect},
 			),
 		},
 	}
@@ -135,7 +135,7 @@ func (wrc *Register) constructDefaultValidatingWebhookConfig(caData []byte) *adm
 				[]string{"*/*"},
 				"*",
 				"*",
-				[]admregapi.OperationType{admregapi.Create, admregapi.Update, admregapi.Delete},
+				[]admregapi.OperationType{admregapi.Create, admregapi.Update, admregapi.Delete, admregapi.Connect},
 			),
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Vyankatesh <vyankateshkd@gmail.com>

## Related issue

closes https://github.com/kyverno/kyverno/issues/2044

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Resource :
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: myapp-maintenance
  namespace: myapp
  labels:
    app: nginx
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
```
Scenario : 
1.  Block pod Exec depend on Pod name
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: pod-exec-allowed
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: myapp-maintenance-allowed
    match:
      resources:
        kinds:
        - PodExecOptions
    preconditions:
    - key: "{{ request.operation }}"
      operator: Equals
      value: "CONNECT"
    validate:
      deny:
          conditions:
            - key: "{{ request.name }}"
              operator: Equals
              value: "myapp-maintenance-*"
```

2. Block all pod Exec in particular Namespace
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: pod-exec-allowed
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: myapp-maintenance-allowed
    match:
      resources:
        kinds:
        - PodExecOptions
    preconditions:
    - key: "{{ request.operation }}"
      operator: Equals
      value: "CONNECT"
    validate:
      deny:
          conditions:
            - key: "{{ request.namespace }}"
              operator: Equals
              value: "test"
```
3 Block pod exec in namespace with particular name

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: pod-exec-allowed
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: myapp-maintenance-allowed
    match:
      resources:
        kinds:
        - PodExecOptions
    preconditions:
      all:
      - key: "{{ request.operation }}"
        operator: Equals
        value: "CONNECT"
      - key: "{{ request.namespace }}"
        operator: Equals
        value: test
    validate:
      deny:
          conditions:
            - key: "{{ request.name }}"
              operator: Equals
              value: "myapp-maintenance-*"
```
4. Namespace Policy to restrict pod exec
```yaml

apiVersion: kyverno.io/v1
kind: Policy
metadata:
  name: pod-exec-allowed
  namespace: myapp
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: myapp-maintenance-allowed
    match:
      resources:
        kinds:
        - PodExecOptions
    preconditions:
    - key: "{{ request.operation }}"
      operator: Equals
      value: "CONNECT"
    validate:
      deny:
          conditions:
            - key: "{{ request.name }}"
              operator: Equals
              value: "myapp-maintenance-*"
```
5. Block pod exec depend on Container name
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: pod-exec-allowed
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: myapp-maintenance-allowed
    match:
      resources:
        kinds:
        - PodExecOptions
    preconditions:
      all:
      - key: "{{ request.operation }}"
        operator: Equals
        value: "CONNECT"
      - key: "{{ request.name }}"
        operator: Equals
        value: "multi-continer"
    validate:
      deny:
          conditions:
            - key: "{{ request.object.container }}"
              operator: Equals
              value: "nginx"
```



<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
