### PR TITLE
Changed error to info for NotFoundError in jsonContext

### DIFF
--- a/pkg/engine/jsonContext.go
+++ b/pkg/engine/jsonContext.go
@@ -86,7 +86,7 @@ func loadAPIData(logger logr.Logger, entry kyverno.ContextEntry, ctx *PolicyCont
 
 	results, err := applyJMESPath(path.(string), jsonData)
 	if err != nil {
-		return fmt.Errorf("failed to apply JMESPath for context entry %v: %v", entry, err)
+		return err
 	}
 
 	contextNamedData := make(map[string]interface{})

--- a/pkg/engine/mutation.go
+++ b/pkg/engine/mutation.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	gojmespath "github.com/jmespath/go-jmespath"
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/engine/mutate"
 	"github.com/kyverno/kyverno/pkg/engine/response"
@@ -71,7 +72,11 @@ func Mutate(policyContext *PolicyContext) (resp *response.EngineResponse) {
 
 		policyContext.JSONContext.Restore()
 		if err := LoadContext(logger, rule.Context, resCache, policyContext, rule.Name); err != nil {
-			logger.Error(err, "failed to load context")
+			if _, ok := err.(gojmespath.NotFoundError); ok {
+				logger.Info("failed to load context", "reason", err.Error())
+			} else {
+				logger.Error(err, "failed to load context")
+			}
 			continue
 		}
 

--- a/pkg/engine/mutation.go
+++ b/pkg/engine/mutation.go
@@ -73,7 +73,7 @@ func Mutate(policyContext *PolicyContext) (resp *response.EngineResponse) {
 		policyContext.JSONContext.Restore()
 		if err := LoadContext(logger, rule.Context, resCache, policyContext, rule.Name); err != nil {
 			if _, ok := err.(gojmespath.NotFoundError); ok {
-				logger.Info("failed to load context", "reason", err.Error())
+				logger.V(3).Info("failed to load context", "reason", err.Error())
 			} else {
 				logger.Error(err, "failed to load context")
 			}

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -102,7 +102,7 @@ func validateResource(log logr.Logger, ctx *PolicyContext) *response.EngineRespo
 		ctx.JSONContext.Restore()
 		if err := LoadContext(log, rule.Context, ctx.ResourceCache, ctx, rule.Name); err != nil {
 			if _, ok := err.(gojmespath.NotFoundError); ok {
-				log.V(2).Info("failed to load context", "reason", err.Error())
+				log.V(3).Info("failed to load context", "reason", err.Error())
 			} else {
 				log.Error(err, "failed to load context")
 			}

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -101,7 +101,11 @@ func validateResource(log logr.Logger, ctx *PolicyContext) *response.EngineRespo
 
 		ctx.JSONContext.Restore()
 		if err := LoadContext(log, rule.Context, ctx.ResourceCache, ctx, rule.Name); err != nil {
-			log.Error(err, "failed to load context")
+			if _, ok := err.(gojmespath.NotFoundError); ok {
+				log.V(2).Info("failed to load context", "reason", err.Error())
+			} else {
+				log.Error(err, "failed to load context")
+			}
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: Maxim Goncharenko <goncharenko.maxim@apriorit.com>

## What type of PR is this
/kind cleanup

## Proposed Changes
I have added exception for NotFoundError in mutation and validation handling logic when context is resolved.
Now it is logged at Info level.

### Proof Manifests
Policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: select-secrets
spec:
  background: false
  validationFailureAction: enforce
  rules:
  - name: select-secrets-from-volumes
    match:
      resources:
        kinds:
        - Pod
    context:
    - name: volsecret
      apiCall:
        urlPath: "/api/v1/namespaces/{{request.object.metadata.namespace}}/secrets/{{request.object.spec.volumes[0].secret.secretName}}"
        jmesPath: "metadata.labels.foo"
    preconditions:
    - key: "{{ request.operation }}"
      operator: Equals
      value: "CREATE"
    validate:
      message: "The Secret named {{request.object.spec.volumes[0].secret.secretName}} is restricted and may not be used."
      pattern:
        spec:
          containers:
          - image: "registry.domain.com/*"
```
Resource:
`kubectl run pod --image=nginx`

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
