### PR TITLE
Ignoring preconditions while processing generate request

### DIFF
--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -99,6 +99,12 @@ func (c *Controller) applyGenerate(resource unstructured.Unstructured, gr kyvern
 		return nil, err
 	}
 
+	// ignorning pre conditions because they were taken care
+	// while adding generate request
+	for idx := range policyObj.Spec.Rules {
+		policyObj.Spec.Rules[idx].AnyAllConditions = nil
+	}
+
 	resourceRaw, err := resource.MarshalJSON()
 	if err != nil {
 		logger.Error(err, "failed to marshal resource")


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue

closes https://github.com/kyverno/kyverno/issues/2095
closes https://github.com/kyverno/kyverno/issues/2226

## What type of PR is this
> /kind bug

## Proposed Changes
Ignoring preconditions while processing the generate request because they were taken care of when adding/enque the generate request.

### Proof Manifests
1. Apply the following policy:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: policy-k13.06.3-cdi-upload-server
spec:
  background: false
  rules:
  - name: generate-networkpolicy
    match:
      resources:
        kinds:
        - Pod
        selector:
          matchLabels:
            acme.cert-manager.io/http01-solver: "true"
    preconditions:
      - key: "{{ request.operation }}"
        operator: Equals
        value: "CREATE"
    generate:
      kind: NetworkPolicy
      name: letsencrypt-http-solver-policy
      synchronize: true
      namespace: "{{request.object.metadata.namespace}}"
      data:
        spec:
          podSelector:
            matchLabels:
              acme.cert-manager.io/http01-solver: "true"
          ingress:
          - {}
```
2. Create a namespace `test`. Apply the following pod manifest:
```
apiVersion: v1
kind: Pod
metadata:
  name: nginx-pod
  namespace: test
  labels:
    acme.cert-manager.io/http01-solver: "true"
spec:
  containers:
  - name: nginx
    image: nginx
```
3. Check the network policy will be generated under `test` namespace.
```
$ kubectl get netpol -A -n test                                         
NAMESPACE   NAME                             POD-SELECTOR                              AGE
test        letsencrypt-http-solver-policy   acme.cert-manager.io/http01-solver=true   30s
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
