### PR TITLE
Patch strategic merge preprocessing: implement anchor handling

### DIFF
--- a/pkg/engine/anchor/common/common.go
+++ b/pkg/engine/anchor/common/common.go
@@ -63,6 +63,12 @@ func IsExistenceAnchor(str string) bool {
 	return (str[:len(left)] == left && str[len(str)-len(right):] == right)
 }
 
+// IsNonAnchor checks that key does not have any anchor
+func IsNonAnchor(str string) bool {
+	key, _ := RemoveAnchor(str)
+	return str == key
+}
+
 // RemoveAnchor remove anchor from the given key. It returns
 // the anchor-free tag value and the prefix of the anchor.
 func RemoveAnchor(key string) (string, string) {

--- a/pkg/engine/forceMutate.go
+++ b/pkg/engine/forceMutate.go
@@ -88,6 +88,14 @@ func ForceMutate(ctx context.EvalInterface, policy kyverno.ClusterPolicy, resour
 			}
 		}
 
+		if rule.Mutation.PatchStrategicMerge != nil {
+			var resp response.RuleResponse
+			resp, resource = mutate.ProcessStrategicMergePatch(rule.Name, rule.Mutation.PatchStrategicMerge, resource, logger.WithValues("rule", rule.Name))
+			if !resp.Success {
+				return unstructured.Unstructured{}, fmt.Errorf(resp.Message)
+			}
+		}
+
 		if rule.Mutation.PatchesJSON6902 != "" {
 			var resp response.RuleResponse
 			jsonPatches, err := yaml.YAMLToJSON([]byte(rule.Mutation.PatchesJSON6902))

--- a/pkg/engine/mutate/patchesUtils_test.go
+++ b/pkg/engine/mutate/patchesUtils_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/mattbaird/jsonpatch"
 	assertnew "github.com/stretchr/testify/assert"
 	"gotest.tools/assert"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func Test_GeneratePatches(t *testing.T) {
 
-	out, err := strategicMergePatch(string(baseBytes), string(overlayBytes))
+	out, err := strategicMergePatch(log.Log, string(baseBytes), string(overlayBytes))
 	assert.NilError(t, err)
 
 	expectedPatches := map[string]bool{

--- a/pkg/engine/mutate/strategicMergePatch.go
+++ b/pkg/engine/mutate/strategicMergePatch.go
@@ -65,7 +65,7 @@ func ProcessStrategicMergePatch(ruleName string, overlay interface{}, resource u
 		resp.Message = fmt.Sprintf("failed to process patchStrategicMerge: %v", err)
 		return resp, resource
 	}
-	patchedBytes, err := strategicMergePatch(string(base), string(overlayBytes))
+	patchedBytes, err := strategicMergePatch(logger, string(base), string(overlayBytes))
 	if err != nil {
 		log.Error(err, "failed to apply patchStrategicMerge")
 		msg := fmt.Sprintf("failed to apply patchStrategicMerge: %v", err)
@@ -103,9 +103,8 @@ func ProcessStrategicMergePatch(ruleName string, overlay interface{}, resource u
 	return resp, patchedResource
 }
 
-func strategicMergePatch(base, overlay string) ([]byte, error) {
-
-	preprocessedYaml, err := preProcessStrategicMergePatch(overlay, base)
+func strategicMergePatch(logger logr.Logger, base, overlay string) ([]byte, error) {
+	preprocessedYaml, err := preProcessStrategicMergePatch(logger, overlay, base)
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to preProcess rule: %+v", err)
 	}
@@ -120,9 +119,9 @@ func strategicMergePatch(base, overlay string) ([]byte, error) {
 	return baseObj.Bytes(), err
 }
 
-func preProcessStrategicMergePatch(pattern, resource string) (*yaml.RNode, error) {
+func preProcessStrategicMergePatch(logger logr.Logger, pattern, resource string) (*yaml.RNode, error) {
 	patternNode := yaml.MustParse(pattern)
 	resourceNode := yaml.MustParse(resource)
-	err := preProcessPattern(patternNode, resourceNode)
+	err := preProcessPattern(logger, patternNode, resourceNode)
 	return patternNode, err
 }

--- a/pkg/engine/mutate/strategicMergePatch.go
+++ b/pkg/engine/mutate/strategicMergePatch.go
@@ -123,10 +123,5 @@ func preProcessStrategicMergePatch(logger logr.Logger, pattern, resource string)
 	patternNode := yaml.MustParse(pattern)
 	resourceNode := yaml.MustParse(resource)
 	err := preProcessPattern(logger, patternNode, resourceNode)
-	fmt.Println("1. --------------- ")
-	fmt.Println(patternNode.String())
-	fmt.Println("2. --------------- ")
-	fmt.Println(resourceNode.String())
-	fmt.Println("3. --------------- ")
 	return patternNode, err
 }

--- a/pkg/engine/mutate/strategicMergePatch.go
+++ b/pkg/engine/mutate/strategicMergePatch.go
@@ -123,5 +123,10 @@ func preProcessStrategicMergePatch(logger logr.Logger, pattern, resource string)
 	patternNode := yaml.MustParse(pattern)
 	resourceNode := yaml.MustParse(resource)
 	err := preProcessPattern(logger, patternNode, resourceNode)
+	fmt.Println("1. --------------- ")
+	fmt.Println(patternNode.String())
+	fmt.Println("2. --------------- ")
+	fmt.Println(resourceNode.String())
+	fmt.Println("3. --------------- ")
 	return patternNode, err
 }

--- a/pkg/engine/mutate/strategicMergePatch_test.go
+++ b/pkg/engine/mutate/strategicMergePatch_test.go
@@ -10,6 +10,7 @@ import (
 	assertnew "github.com/stretchr/testify/assert"
 	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/kustomize/api/filters/patchstrategicmerge"
 	filtersutil "sigs.k8s.io/kustomize/kyaml/filtersutil"
 	yaml "sigs.k8s.io/kustomize/kyaml/yaml"
@@ -43,7 +44,7 @@ func TestMergePatch(t *testing.T) {
 	for i, test := range testCases {
 
 		// out
-		out, err := strategicMergePatch(string(test.rawResource), string(test.rawPolicy))
+		out, err := strategicMergePatch(log.Log, string(test.rawResource), string(test.rawPolicy))
 		assert.NilError(t, err)
 
 		// expect
@@ -136,7 +137,7 @@ func Test_PolicyDeserilize(t *testing.T) {
 	patchString, err := json.Marshal(overlayPatches)
 	assert.NilError(t, err)
 
-	out, err := strategicMergePatch(string(baseBytes), string(patchString))
+	out, err := strategicMergePatch(log.Log, string(baseBytes), string(patchString))
 	assert.NilError(t, err)
 
 	var ep unstructured.Unstructured

--- a/pkg/engine/mutate/strategicMergePatch_test.go
+++ b/pkg/engine/mutate/strategicMergePatch_test.go
@@ -1,6 +1,7 @@
 package mutate
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -9,6 +10,9 @@ import (
 	assertnew "github.com/stretchr/testify/assert"
 	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/kustomize/api/filters/patchstrategicmerge"
+	filtersutil "sigs.k8s.io/kustomize/kyaml/filtersutil"
+	yaml "sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 func TestMergePatch(t *testing.T) {
@@ -145,4 +149,35 @@ func Test_PolicyDeserilize(t *testing.T) {
 	if !assertnew.Equal(t, string(eb), string(out)) {
 		t.FailNow()
 	}
+}
+
+func Test_sample(t *testing.T) {
+	var patch, resource interface{}
+
+	patchRaw := []byte(`{ "key1": "value1", "key2": "value2" }`)
+	resourceRaw := []byte(`{ "key1": "value1" } `)
+
+	var err error
+
+	err = json.Unmarshal(patchRaw, &patch)
+	assert.NilError(t, err)
+
+	err = json.Unmarshal(resourceRaw, &resource)
+	assert.NilError(t, err)
+
+	patchNode := yaml.MustParse(string(patchRaw))
+	//	resourceNode := yaml.MustParse(string(resourceRaw))
+
+	f := patchstrategicmerge.Filter{
+		Patch: patchNode,
+	}
+
+	baseObj := buffer{Buffer: bytes.NewBufferString(string(resourceRaw))}
+	err = filtersutil.ApplyToJSON(f, baseObj)
+	assert.NilError(t, err)
+
+	patchNode.Field("key1").Key.YNode().Value = "key3"
+
+	str := baseObj.String()
+	println(str)
 }

--- a/pkg/engine/mutate/strategicMergePatch_test.go
+++ b/pkg/engine/mutate/strategicMergePatch_test.go
@@ -1,7 +1,6 @@
 package mutate
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -11,9 +10,6 @@ import (
 	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/kustomize/api/filters/patchstrategicmerge"
-	filtersutil "sigs.k8s.io/kustomize/kyaml/filtersutil"
-	yaml "sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 func TestMergePatch(t *testing.T) {
@@ -150,35 +146,4 @@ func Test_PolicyDeserilize(t *testing.T) {
 	if !assertnew.Equal(t, string(eb), string(out)) {
 		t.FailNow()
 	}
-}
-
-func Test_sample(t *testing.T) {
-	var patch, resource interface{}
-
-	patchRaw := []byte(`{ "key1": "value1", "key2": "value2" }`)
-	resourceRaw := []byte(`{ "key1": "value1" } `)
-
-	var err error
-
-	err = json.Unmarshal(patchRaw, &patch)
-	assert.NilError(t, err)
-
-	err = json.Unmarshal(resourceRaw, &resource)
-	assert.NilError(t, err)
-
-	patchNode := yaml.MustParse(string(patchRaw))
-	//	resourceNode := yaml.MustParse(string(resourceRaw))
-
-	f := patchstrategicmerge.Filter{
-		Patch: patchNode,
-	}
-
-	baseObj := buffer{Buffer: bytes.NewBufferString(string(resourceRaw))}
-	err = filtersutil.ApplyToJSON(f, baseObj)
-	assert.NilError(t, err)
-
-	patchNode.Field("key1").Key.YNode().Value = "key3"
-
-	str := baseObj.String()
-	println(str)
 }

--- a/pkg/engine/mutate/strategicPreprocessing.go
+++ b/pkg/engine/mutate/strategicPreprocessing.go
@@ -57,12 +57,12 @@ func walkMap(logger logr.Logger, pattern, resource *yaml.RNode) error {
 
 	err = validateConditions(logger, pattern, resource)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	err = handleAddings(logger, pattern, resource)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	fields, err := pattern.Fields()
@@ -200,7 +200,7 @@ func validateConditions(logger logr.Logger, pattern, resource *yaml.RNode) error
 func handleAddings(logger logr.Logger, pattern, resource *yaml.RNode) error {
 	addings, err := filterKeys(pattern, anchor.IsAddingAnchor)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	for _, adding := range addings {

--- a/pkg/engine/mutate/strategicPreprocessing.go
+++ b/pkg/engine/mutate/strategicPreprocessing.go
@@ -45,7 +45,7 @@ func preProcessRecursive(logger logr.Logger, pattern, resource *yaml.RNode) erro
 	case yaml.MappingNode:
 		return walkMap(logger, pattern, resource)
 	case yaml.SequenceNode:
-		return walkArray(logger, pattern, resource)
+		return walkList(logger, pattern, resource)
 	}
 
 	return nil
@@ -91,8 +91,8 @@ func walkMap(logger logr.Logger, pattern, resource *yaml.RNode) error {
 	return nil
 }
 
-// walkArray - walk through array elements
-func walkArray(logger logr.Logger, pattern, resource *yaml.RNode) error {
+// walkList - walk through array elements
+func walkList(logger logr.Logger, pattern, resource *yaml.RNode) error {
 	elements, err := pattern.Elements()
 	if err != nil {
 		return err

--- a/pkg/engine/mutate/strategicPreprocessing.go
+++ b/pkg/engine/mutate/strategicPreprocessing.go
@@ -370,6 +370,26 @@ func deleteConditionElements(pattern *yaml.RNode) error {
 			return err
 		}
 
+		// In this case we have no resource elements that matched the condition.
+		// Just create dummy element with empty name so list must not be deleted.
+		if len(elements) == 1 {
+			element := elements[0]
+			if hasAnchors(element) {
+				deleteListElement(pattern, 0)
+				dummy, err := yaml.Parse(`{ "name": "" }`)
+				if err != nil {
+					return err
+				}
+
+				err = pattern.PipeE(yaml.Append(dummy.YNode()))
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}
+
 		for i, element := range elements {
 			if hasAnchors(element) {
 				deleteListElement(pattern, i)

--- a/pkg/engine/mutate/strategicPreprocessing.go
+++ b/pkg/engine/mutate/strategicPreprocessing.go
@@ -394,7 +394,10 @@ func deleteConditionElements(pattern *yaml.RNode) error {
 			if hasAnchors(element) {
 				deleteListElement(pattern, i)
 			} else {
-				deleteConditionElements(element)
+				err = deleteConditionElements(element)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/engine/mutate/strategicPreprocessing_test.go
+++ b/pkg/engine/mutate/strategicPreprocessing_test.go
@@ -615,6 +615,58 @@ func Test_preProcessStrategicMergePatch_multipleAnchors(t *testing.T) {
 				}
 			  }`),
 		},
+		{
+			rawPolicy: []byte(`{
+				"metadata": {
+					"labels": {
+						"(key1)": "value1",
+					}
+				},
+				"spec": {
+				  "containers": [
+					{
+					  "name": "busybox",
+					  "image": "gcr.io/google-containers/busybox:latest"
+					}
+				  ],
+				  "imagePullSecrets": [
+					{
+					  "name": "regcred"
+					}
+				  ]
+				}
+			  }`),
+			rawResource: []byte(`{
+				"apiVersion": "v1",
+				"kind": "Pod",
+				"metadata": {
+				  "name": "hello"
+				},
+				"spec": {
+				  "containers": [
+					{
+					  "name": "hello",
+					  "image": "busybox"
+					}
+				  ]
+				}
+			  }`),
+			expectedPatch: []byte(`{
+				"spec": {
+				  "containers": [
+					{
+						"name": "hello",
+						"image": "gcr.io/google-containers/busybox:latest"
+					}
+				  ],
+				  "imagePullSecrets": [
+					{
+					  "name": "regcred"
+					}
+				  ]
+				}
+			  }`),
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/engine/mutate/strategicPreprocessing_test.go
+++ b/pkg/engine/mutate/strategicPreprocessing_test.go
@@ -3,189 +3,33 @@ package mutate
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
-	"regexp"
-	"strings"
 	"testing"
 
 	anchor "github.com/kyverno/kyverno/pkg/engine/anchor/common"
-	assertnew "github.com/stretchr/testify/assert"
 	"gotest.tools/assert"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	yaml "sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-func areEqualJSONs(s1, s2 []byte) (bool, error) {
+func areEqualJSONs(t *testing.T, s1, s2 []byte) {
 	var o1 interface{}
 	var o2 interface{}
 
 	var err error
 	err = json.Unmarshal(s1, &o1)
-	if err != nil {
-		return false, err
-	}
+	assert.NilError(t, err)
+
 	err = json.Unmarshal(s2, &o2)
-	if err != nil {
-		return false, err
-	}
-
-	return reflect.DeepEqual(o1, o2), nil
-}
-
-func Test_preProcessStrategicMergePatch(t *testing.T) {
-	rawPolicy := []byte(`{"metadata":{"annotations":{"+(annotation1)":"atest1", "+(annotation2)":"atest2"},"labels":{"+(label1)":"test1"}},"spec":{"(volumes)":[{"(hostPath)":{"path":"/var/run/docker.sock"}}],"containers":[{"(image)":"*:latest","command":["ls"],"imagePullPolicy":"Always"}]}}`)
-
-	rawResource := []byte(`{"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{"annotation1":"atest2"},"labels":{"label1":"test2","label2":"test2"},"name":"check-root-user"},"spec":{"containers":[{"command":["ll"],"image":"nginx:latest","imagePullPolicy":"Never","name":"nginx"},{"image":"busybox:latest","imagePullPolicy":"Never","name":"busybox"}],"volumes":[{"hostPath":{"path":"/var/run/docker.sock"},"name":"test-volume"}]}}`)
-
-	expected := `{"metadata": {"annotations": {"annotation2":"atest2"}, "labels": {}},"spec": {"containers": [{"command": ["ls", "ll"], "imagePullPolicy": "Always", "name": "nginx"},{"command": ["ls"], "imagePullPolicy": "Always", "name": "busybox"}]}}`
-
-	preProcessedPolicy, err := preProcessStrategicMergePatch(log.Log, string(rawPolicy), string(rawResource))
-	assert.NilError(t, err)
-	output, err := preProcessedPolicy.String()
-	assert.NilError(t, err)
-	re := regexp.MustCompile("\\n")
-	if !assertnew.Equal(t, strings.ReplaceAll(expected, " ", ""), strings.ReplaceAll(re.ReplaceAllString(output, ""), " ", "")) {
-		t.FailNow()
-	}
-}
-
-func Test_preProcessStrategicMergePatch_Deployment(t *testing.T) {
-	rawPolicy := []byte(`"spec": {
-						  "template": {
-							 "spec": {
-								"containers": [
-								   {
-									  "(name)": "*",
-									  "resources": {
-										 "limits": {
-											"+(memory)": "300Mi",
-											"+(cpu)": "100"
-										 }
-									  }
-								   }
-								]
-							 }
-						  }
-					   }`)
-
-	rawResource := []byte(`{
-		"apiVersion": "apps/v1",
-		"kind": "Deployment",
-		"metadata": {
-		   "name": "qos-demo",
-		   "labels": {
-			  "test": "qos"
-		   }
-		},
-		"spec": {
-		   "replicas": 1,
-		   "selector": {
-			  "matchLabels": {
-				 "app": "nginx"
-			  }
-		   },
-		   "template": {
-			  "metadata": {
-				 "labels": {
-					"app": "nginx"
-				 }
-			  },
-			  "spec": {
-				 "containers": [
-					{
-					   "name": "nginx",
-					   "image": "nginx:latest",
-					   "resources": {
-						  "limits": {
-							 "cpu": "50m"
-						  }
-					   }
-					}
-				 ]
-			  }
-		   }
-		}
-	 }`)
-
-	expected := `"spec":{"template":{"spec":{"containers":[{"resources":{"limits":{"memory":"300Mi"}},"name":"nginx"}]}}}`
-
-	preProcessedPolicy, err := preProcessStrategicMergePatch(log.Log, string(rawPolicy), string(rawResource))
-	assert.NilError(t, err)
-	output, err := preProcessedPolicy.String()
-	assert.NilError(t, err)
-	re := regexp.MustCompile("\\n")
-	if !assertnew.Equal(t, strings.ReplaceAll(expected, " ", ""), strings.ReplaceAll(re.ReplaceAllString(output, ""), " ", "")) {
-		t.FailNow()
-	}
-}
-
-func Test_preProcessStrategicMergePatch_AnnotationMap(t *testing.T) {
-	rawPolicy := []byte(`{
-		"metadata": {
-			"annotations": {
-				"+(alb.ingress.kubernetes.io/backend-protocol)": "HTTPS",
-				"+(alb.ingress.kubernetes.io/healthcheck-protocol)": "HTTPS",
-				"+(alb.ingress.kubernetes.io/scheme)": "internal",
-				"+(alb.ingress.kubernetes.io/target-type)": "ip",
-				"+(kubernetes.io/ingress.class)": "alb"
-			}
-		}
-	}`)
-
-	rawResource := []byte(`{"apiVersion": "extensions/v1beta1","kind": "Ingress","metadata": {"annotations": {"alb.ingress.kubernetes.io/backend-protocol": "HTTPS","alb.ingress.kubernetes.io/healthcheck-protocol": "HTTPS","alb.ingress.kubernetes.io/scheme": "internal","alb.ingress.kubernetes.io/target-type": "ip","external-dns.alpha.kubernetes.io/hostname": "argo","kubernetes.io/ingress.class": "test"},"labels": {"app": "argocd-server","app.kubernetes.io/name": "argocd-server"},"name": "argocd","namespace": "default"}}`)
-
-	expected := `{"metadata":{"annotations":{}}}`
-
-	preProcessedPolicy, err := preProcessStrategicMergePatch(log.Log, string(rawPolicy), string(rawResource))
-	assert.NilError(t, err)
-	output, err := preProcessedPolicy.String()
 	assert.NilError(t, err)
 
-	re := regexp.MustCompile("\\n")
-	if !assertnew.Equal(t, strings.ReplaceAll(expected, " ", ""), strings.ReplaceAll(re.ReplaceAllString(output, ""), " ", "")) {
-		t.FailNow()
-	}
-}
-
-func Test_preProcessStrategicMergePatch_Annotation(t *testing.T) {
-	rawPolicy := []byte(`{"metadata":{"annotations":{"+(cluster-autoscaler.kubernetes.io/safe-to-evict)":true}},"spec":{"volumes":[{"(hostPath)":{"path":"*"}}]}}`)
-
-	rawResource := []byte(`{"kind":"Pod","apiVersion":"v1","metadata":{"name":"nginx","annotations":{"cluster-autoscaler.kubernetes.io/safe-to-evict":"false"}},"spec":{"containers":[{"name":"nginx","image":"nginx:latest","imagePullPolicy":"Never","volumeMounts":[{"mountPath":"/cache","name":"cache-volume"}]}],"volumes":[{"name":"cache-volume","hostPath":{"path":"/data","type":"Directory"}}]}}`)
-
-	expected := `{"metadata":{"annotations":{}},"spec":{"volumes":[{"name":"cache-volume"}]}}`
-
-	preProcessedPolicy, err := preProcessStrategicMergePatch(log.Log, string(rawPolicy), string(rawResource))
-	assert.NilError(t, err)
-	output, err := preProcessedPolicy.String()
-	assert.NilError(t, err)
-	re := regexp.MustCompile("\\n")
-	if !assertnew.Equal(t, strings.ReplaceAll(expected, " ", ""), strings.ReplaceAll(re.ReplaceAllString(output, ""), " ", "")) {
-		t.FailNow()
-	}
-}
-
-func Test_preProcessStrategicMergePatch_BlankAnnotation(t *testing.T) {
-	rawPolicy := []byte(`{"metadata":{"annotations":{"+(cluster-autoscaler.kubernetes.io/safe-to-evict)":true},"labels":{"+(add-labels)":"add"}},"spec":{"volumes":[{"(hostPath)":{"path":"*"}}]}}`)
-
-	rawResource := []byte(`{"kind":"Pod","apiVersion":"v1","metadata":{"name":"nginx"},"spec":{"containers":[{"name":"nginx","image":"nginx:latest","imagePullPolicy":"Never","volumeMounts":[{"mountPath":"/cache","name":"cache-volume"}]}],"volumes":[{"name":"cache-volume","hostPath":{"path":"/data","type":"Directory"}}]}}`)
-
-	expected := `{"metadata":{"annotations":{"cluster-autoscaler.kubernetes.io/safe-to-evict":true},"labels":{"add-labels":"add"}},"spec":{"volumes":[{"name":"cache-volume"}]}}`
-
-	preProcessedPolicy, err := preProcessStrategicMergePatch(log.Log, string(rawPolicy), string(rawResource))
-	assert.NilError(t, err)
-	output, err := preProcessedPolicy.String()
-	assert.NilError(t, err)
-	re := regexp.MustCompile("\\n")
-	if !assertnew.Equal(t, strings.ReplaceAll(expected, " ", ""), strings.ReplaceAll(re.ReplaceAllString(output, ""), " ", "")) {
-		t.FailNow()
-	}
+	assert.DeepEqual(t, o1, o2)
 }
 
 func Test_preProcessStrategicMergePatch_multipleAnchors(t *testing.T) {
 	testCases := []struct {
-		rawPolicy   []byte
-		rawResource []byte
-		expected    []byte
+		rawPolicy     []byte
+		rawResource   []byte
+		expectedPatch []byte
 	}{
 		{
 			rawPolicy: []byte(`{
@@ -218,7 +62,7 @@ func Test_preProcessStrategicMergePatch_multipleAnchors(t *testing.T) {
 				  ]
 				}
 			  }`),
-			expected: []byte(`{
+			expectedPatch: []byte(`{
 				"spec": {
 				  "containers": [
 					{
@@ -235,40 +79,554 @@ func Test_preProcessStrategicMergePatch_multipleAnchors(t *testing.T) {
 			  }`),
 		},
 		{
-			rawPolicy:   []byte(`{"spec": {"containers": [{"(name)": "*","(image)": "gcr.io/google-containers/busybox:*"}],"imagePullSecrets": [{"name": "regcred"}]}}`),
-			rawResource: []byte(`{"apiVersion": "v1","kind": "Pod","metadata": {"name": "hello2"},"spec": {"containers": [{"name": "hello","image": "gcr.io/google-containers/busybox:latest"}]}}`),
-			expected:    []byte(`{"spec":{"containers":[],"imagePullSecrets":[{"name":"regcred"}]}}`),
+			rawPolicy: []byte(`{
+				"spec": {
+				  "containers": [
+					{
+					  "(name)": "*",
+					  "(image)": "gcr.io/google-containers/busybox:*",
+					  "new_filed": "must be inserted"
+					}
+				  ],
+				  "imagePullSecrets": [
+					{
+					  "name": "regcred"
+					}
+				  ]
+				}
+			  }`),
+			rawResource: []byte(`{
+				"apiVersion": "v1",
+				"kind": "Pod",
+				"metadata": {
+				  "name": "hello2"
+				},
+				"spec": {
+				  "containers": [
+					{
+					  "name": "hello",
+					  "image": "gcr.io/google-containers/busybox:latest"
+					}
+				  ]
+				}
+			  }`),
+			expectedPatch: []byte(`{
+				"spec": {
+				  "containers": [{
+					"name": "hello",
+					"new_filed": "must be inserted"
+				  }],
+				  "imagePullSecrets": [
+					{
+					  "name": "regcred"
+					}
+				  ]
+				}
+			  }`),
 		},
 		{
-			rawPolicy:   []byte(`{"spec": {"containers": [{"(image)": "gcr.io/google-containers/busybox:latest"}],"imagePullSecrets": [{"name": "regcred"}]}}`),
-			rawResource: []byte(`{"apiVersion": "v1","kind": "Pod","metadata": {"name": "hello2"},"spec": {"containers": [{"name": "hello","image": "gcr.io/google-containers/busybox:latest"}]}}`),
-			expected:    []byte(`{"spec":{"containers":[{"name":"hello"}],"imagePullSecrets":[{"name":"regcred"}]}}`),
+			rawPolicy: []byte(`{
+				"spec": {
+				  "containers": [
+					{
+					  "(image)": "gcr.io/google-containers/busybox:latest"
+					}
+				  ],
+				  "imagePullSecrets": [
+					{
+					  "name": "regcred"
+					}
+				  ]
+				}
+			  }`),
+			rawResource: []byte(`{
+				"apiVersion": "v1",
+				"kind": "Pod",
+				"metadata": {
+				  "name": "hello2"
+				},
+				"spec": {
+				  "containers": [
+					{
+					  "name": "hello",
+					  "image": "gcr.io/google-containers/busybox:latest"
+					}
+				  ]
+				}
+			  }`),
+			expectedPatch: []byte(`{
+				"spec": {
+				  "containers": [
+					{
+					  "name": "hello"
+					}
+				  ],
+				  "imagePullSecrets": [
+					{
+					  "name": "regcred"
+					}
+				  ]
+				}
+			  }`),
 		},
 		{
-			rawPolicy:   []byte(`{"spec": {"containers": [{"(image)": "gcr.io/google-containers/busybox:*"}],"imagePullSecrets": [{"name": "regcred"}]}}`),
-			rawResource: []byte(`{"apiVersion": "v1","kind": "Pod","metadata": {"name": "hello2"},"spec": {"containers": [{"name": "hello","image": "gcr.io/google-containers/busybox:latest"}]}}`),
-			expected:    []byte(`{"spec":{"containers":[{"name":"hello"}],"imagePullSecrets":[{"name":"regcred"}]}}`),
+			rawPolicy: []byte(`{
+				"spec": {
+				  "containers": [
+					{
+					  "(image)": "gcr.io/google-containers/busybox:*"
+					}
+				  ],
+				  "imagePullSecrets": [
+					{
+					  "name": "regcred"
+					}
+				  ]
+				}
+			  }`),
+			rawResource: []byte(`{
+				"apiVersion": "v1",
+				"kind": "Pod",
+				"metadata": {
+				  "name": "hello2"
+				},
+				"spec": {
+				  "containers": [
+					{
+					  "name": "hello",
+					  "image": "gcr.io/google-containers/busybox:latest"
+					}
+				  ]
+				}
+			  }`),
+			expectedPatch: []byte(`{
+				"spec": {
+				  "containers": [
+					{
+					  "name": "hello"
+					}
+				  ],
+				  "imagePullSecrets": [
+					{
+					  "name": "regcred"
+					}
+				  ]
+				}
+			  }`),
 		},
 		{
-			// only the third container matches the given condition
-			rawPolicy:   []byte(`{"spec": {"containers": [{"(image)": "gcr.io/google-containers/busybox:*"}],"imagePullSecrets": [{"name": "regcred"}]}}`),
-			rawResource: []byte(`{"apiVersion": "v1","kind": "Pod","metadata": {"name": "hello"},"spec": {"containers": [{"name": "hello","image": "gcr.io/google-containers/busybox:latest"},{"name": "hello2","image": "gcr.io/google-containers/busybox:latest"},{"name": "hello3","image": "gcr.io/google-containers/nginx:latest"}]}}`),
-			expected:    []byte(`{"spec":{"containers":[{"name":"hello"},{"name":"hello2"}],"imagePullSecrets":[{"name":"regcred"}]}}`),
+			// only the third container does not match the given condition
+			rawPolicy: []byte(`{
+				"spec": {
+				  "containers": [
+					{
+					  "(image)": "gcr.io/google-containers/busybox:*"
+					}
+				  ],
+				  "imagePullSecrets": [
+					{
+					  "name": "regcred"
+					}
+				  ]
+				}
+			  }`),
+			rawResource: []byte(`{
+				"apiVersion": "v1",
+				"kind": "Pod",
+				"metadata": {
+				  "name": "hello"
+				},
+				"spec": {
+				  "containers": [
+					{
+					  "name": "hello",
+					  "image": "gcr.io/google-containers/busybox:latest"
+					},
+					{
+					  "name": "hello2",
+					  "image": "gcr.io/google-containers/busybox:latest"
+					},
+					{
+					  "name": "hello3",
+					  "image": "gcr.io/google-containers/nginx:latest"
+					}
+				  ]
+				}
+			  }`),
+			expectedPatch: []byte(`{
+				"spec": {
+				  "containers": [
+					{
+					  "name": "hello"
+					},
+					{
+					  "name": "hello2"
+					}
+				  ],
+				  "imagePullSecrets": [
+					{
+					  "name": "regcred"
+					}
+				  ]
+				}
+			  }`),
+		},
+		{
+			rawPolicy: []byte(`{
+				"metadata": {
+				  "annotations": {
+					"+(cluster-autoscaler.kubernetes.io/safe-to-evict)": true
+				  },
+				  "labels": {
+					"+(add-labels)": "add"
+				  }
+				},
+				"spec": {
+				  "volumes": [
+					{
+					  "(hostPath)": {
+						"path": "*"
+					  }
+					}
+				  ]
+				}
+			  }`),
+			rawResource: []byte(`{
+				"kind": "Pod",
+				"apiVersion": "v1",
+				"metadata": {
+				  "name": "nginx"
+				},
+				"spec": {
+				  "containers": [
+					{
+					  "name": "nginx",
+					  "image": "nginx:latest",
+					  "imagePullPolicy": "Never",
+					  "volumeMounts": [
+						{
+						  "mountPath": "/cache",
+						  "name": "cache-volume"
+						}
+					  ]
+					}
+				  ],
+				  "volumes": [
+					{
+					  "name": "cache-volume",
+					  "hostPath": {
+						"path": "/data",
+						"type": "Directory"
+					  }
+					}
+				  ]
+				}
+			  }`),
+			expectedPatch: []byte(`{
+				"metadata": {
+				  "annotations": {
+					"cluster-autoscaler.kubernetes.io/safe-to-evict": true
+				  },
+				  "labels": {
+					"add-labels": "add"
+				  }
+				},
+				"spec": {
+				  "volumes": [
+					{
+					  "name": "cache-volume"
+					}
+				  ]
+				}
+			  }`),
+		},
+		{
+			rawPolicy: []byte(`{
+				"metadata": {
+				  "annotations": {
+					"+(cluster-autoscaler.kubernetes.io/safe-to-evict)": true
+				  }
+				},
+				"spec": {
+				  "volumes": [
+					{
+					  "(hostPath)": {
+						"path": "*"
+					  }
+					}
+				  ]
+				}
+			  }`),
+			rawResource: []byte(`{
+				"kind": "Pod",
+				"apiVersion": "v1",
+				"metadata": {
+				  "name": "nginx",
+				  "annotations": {
+					"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+				  }
+				},
+				"spec": {
+				  "containers": [
+					{
+					  "name": "nginx",
+					  "image": "nginx:latest",
+					  "imagePullPolicy": "Never",
+					  "volumeMounts": [
+						{
+						  "mountPath": "/cache",
+						  "name": "cache-volume"
+						}
+					  ]
+					}
+				  ],
+				  "volumes": [
+					{
+					  "name": "cache-volume",
+					  "hostPath": {
+						"path": "/data",
+						"type": "Directory"
+					  }
+					}
+				  ]
+				}
+			  }`),
+			expectedPatch: []byte(`{
+				"metadata": {
+				  "annotations": {}
+				},
+				"spec": {
+				  "volumes": [
+					{
+					  "name": "cache-volume"
+					}
+				  ]
+				}
+			  }`),
+		},
+		{
+			rawPolicy: []byte(`{
+				"metadata": {
+					"annotations": {
+						"+(alb.ingress.kubernetes.io/backend-protocol)": "HTTPS",
+						"+(alb.ingress.kubernetes.io/healthcheck-protocol)": "HTTPS",
+						"+(alb.ingress.kubernetes.io/scheme)": "internal",
+						"+(alb.ingress.kubernetes.io/target-type)": "ip",
+						"+(kubernetes.io/ingress.class)": "alb"
+					}
+				}
+			}`),
+			rawResource: []byte(`{
+				"apiVersion": "extensions/v1beta1",
+				"kind": "Ingress",
+				"metadata": {
+				  "annotations": {
+					"alb.ingress.kubernetes.io/backend-protocol": "HTTPS",
+					"alb.ingress.kubernetes.io/healthcheck-protocol": "HTTPS",
+					"alb.ingress.kubernetes.io/scheme": "internal",
+					"alb.ingress.kubernetes.io/target-type": "ip",
+					"external-dns.alpha.kubernetes.io/hostname": "argo",
+					"kubernetes.io/ingress.class": "test"
+				  },
+				  "labels": {
+					"app": "argocd-server",
+					"app.kubernetes.io/name": "argocd-server"
+				  },
+				  "name": "argocd",
+				  "namespace": "default"
+				}
+			  }`),
+			expectedPatch: []byte(`{
+				"metadata": {
+				  "annotations": {}
+				}
+			  }`),
+		},
+		{
+			rawPolicy: []byte(`{
+			"spec": {
+				"template": {
+				   "spec": {
+					  "containers": [
+						 {
+							"(name)": "*",
+							"resources": {
+							   "limits": {
+								  "+(memory)": "300Mi",
+								  "+(cpu)": "100"
+							   }
+							}
+						 }
+					  ]
+				   }
+				}
+			 }
+			}`),
+			rawResource: []byte(`{
+				"apiVersion": "apps/v1",
+				"kind": "Deployment",
+				"metadata": {
+				   "name": "qos-demo",
+				   "labels": {
+					  "test": "qos"
+				   }
+				},
+				"spec": {
+				   "replicas": 1,
+				   "selector": {
+					  "matchLabels": {
+						 "app": "nginx"
+					  }
+				   },
+				   "template": {
+					  "metadata": {
+						 "labels": {
+							"app": "nginx"
+						 }
+					  },
+					  "spec": {
+						 "containers": [
+							{
+							   "name": "nginx",
+							   "image": "nginx:latest",
+							   "resources": {
+								  "limits": {
+									 "cpu": "50m"
+								  }
+							   }
+							}
+						 ]
+					  }
+				   }
+				}
+			 }`),
+			expectedPatch: []byte(`{
+				"spec": {
+				  "template": {
+					"spec": {
+					  "containers": [
+						{
+						  "resources": {
+							"limits": {
+							  "memory": "300Mi"
+							}
+						  },
+						  "name": "nginx"
+						}
+					  ]
+					}
+				  }
+				}
+			  }`),
+		},
+		{
+			rawPolicy: []byte(`{
+				"metadata": {
+				  "annotations": {
+					"+(annotation1)": "atest1",
+					"+(annotation2)": "atest2"
+				  },
+				  "labels": {
+					"+(label1)": "test1"
+				  }
+				},
+				"spec": {
+				  "(volumes)": [
+					{
+					  "(hostPath)": {
+						"path": "/var/run/docker.sock"
+					  }
+					}
+				  ],
+				  "containers": [
+					{
+					  "(image)": "*:latest",
+					  "command": [
+						"ls"
+					  ],
+					  "imagePullPolicy": "Always"
+					}
+				  ]
+				}
+			  }`),
+			rawResource: []byte(`{
+				"apiVersion": "v1",
+				"kind": "Pod",
+				"metadata": {
+				  "annotations": {
+					"annotation1": "atest2"
+				  },
+				  "labels": {
+					"label1": "test2",
+					"label2": "test2"
+				  },
+				  "name": "check-root-user"
+				},
+				"spec": {
+				  "containers": [
+					{
+					  "command": [
+						"ll"
+					  ],
+					  "image": "nginx:latest",
+					  "imagePullPolicy": "Never",
+					  "name": "nginx"
+					},
+					{
+					  "image": "busybox:latest",
+					  "imagePullPolicy": "Never",
+					  "name": "busybox"
+					}
+				  ],
+				  "volumes": [
+					{
+					  "hostPath": {
+						"path": "/var/run/docker.sock"
+					  },
+					  "name": "test-volume"
+					}
+				  ]
+				}
+			  }`),
+			expectedPatch: []byte(`{
+				"metadata": {
+				  "annotations": {
+					"annotation2": "atest2"
+				  },
+				  "labels": {}
+				},
+				"spec": {
+				  "containers": [
+					{
+					  "command": [
+						"ls"
+					  ],
+					  "imagePullPolicy": "Always",
+					  "name": "nginx"
+					},
+					{
+					  "command": [
+						"ls"
+					  ],
+					  "imagePullPolicy": "Always",
+					  "name": "busybox"
+					}
+				  ]
+				}
+			  }`),
 		},
 	}
 
-	//for i, test := range testCases {
-	test := testCases[0]
+	for _, test := range testCases {
+		preProcessedPolicy, err := preProcessStrategicMergePatch(log.Log, string(test.rawPolicy), string(test.rawResource))
+		assert.NilError(t, err)
 
-	preProcessedPolicy, err := preProcessStrategicMergePatch(log.Log, string(test.rawPolicy), string(test.rawResource))
-	assert.NilError(t, err)
+		output, err := preProcessedPolicy.MarshalJSON()
+		assert.NilError(t, err)
 
-	output, err := preProcessedPolicy.MarshalJSON()
-	assert.NilError(t, err)
-
-	areEqual, err := areEqualJSONs(test.expected, output)
-	assert.NilError(t, err)
-	assert.Assert(t, areEqual)
+		// has assertions inside
+		areEqualJSONs(t, test.expectedPatch, output)
+	}
 }
 
 func Test_FilterKeys_NoConditions(t *testing.T) {
@@ -468,4 +826,42 @@ func Test_DeleteConditions(t *testing.T) {
 
 	name := containers[0].Field("name").Value.YNode().Value
 	assert.Equal(t, name, "hello")
+}
+
+func Test_ConditionCheck_SeveralElementsMatchExceptOne(t *testing.T) {
+	patternRaw := []byte(`{
+		"containers": [
+			{
+			  "(image)": "gcr.io/google-containers/busybox:*"
+			}
+		]
+	}`)
+
+	containersRaw := []byte(`{
+		"containers": [
+			{
+			  "name": "hello",
+			  "image": "gcr.io/google-containers/busybox:latest"
+			},
+			{
+			  "name": "hello2",
+			  "image": "gcr.io/google-containers/busybox:latest"
+			},
+			{
+			  "name": "hello3",
+			  "image": "gcr.io/google-containers/nginx:latest"
+			}
+		  ]
+	}`)
+
+	pattern := yaml.MustParse(string(patternRaw))
+	containers := yaml.MustParse(string(containersRaw))
+
+	err := preProcessPattern(log.Log, pattern, containers)
+	assert.NilError(t, err)
+
+	containersElements, err := pattern.Field("containers").Value.Elements()
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(containersElements), 2)
 }

--- a/pkg/engine/mutate/strategicPreprocessing_test.go
+++ b/pkg/engine/mutate/strategicPreprocessing_test.go
@@ -8,6 +8,7 @@ import (
 
 	assertnew "github.com/stretchr/testify/assert"
 	"gotest.tools/assert"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func Test_preProcessStrategicMergePatch(t *testing.T) {
@@ -17,7 +18,7 @@ func Test_preProcessStrategicMergePatch(t *testing.T) {
 
 	expected := `{"metadata": {"annotations": {"annotation2":"atest2"}, "labels": {}},"spec": {"containers": [{"command": ["ls", "ll"], "imagePullPolicy": "Always", "name": "nginx"},{"command": ["ls"], "imagePullPolicy": "Always", "name": "busybox"}]}}`
 
-	preProcessedPolicy, err := preProcessStrategicMergePatch(string(rawPolicy), string(rawResource))
+	preProcessedPolicy, err := preProcessStrategicMergePatch(log.Log, string(rawPolicy), string(rawResource))
 	assert.NilError(t, err)
 	output, err := preProcessedPolicy.String()
 	assert.NilError(t, err)
@@ -87,7 +88,7 @@ func Test_preProcessStrategicMergePatch_Deployment(t *testing.T) {
 
 	expected := `"spec":{"template":{"spec":{"containers":[{"resources":{"limits":{"memory":"300Mi"}},"name":"nginx"}]}}}`
 
-	preProcessedPolicy, err := preProcessStrategicMergePatch(string(rawPolicy), string(rawResource))
+	preProcessedPolicy, err := preProcessStrategicMergePatch(log.Log, string(rawPolicy), string(rawResource))
 	assert.NilError(t, err)
 	output, err := preProcessedPolicy.String()
 	assert.NilError(t, err)
@@ -114,7 +115,7 @@ func Test_preProcessStrategicMergePatch_AnnotationMap(t *testing.T) {
 
 	expected := `{"metadata":{"annotations":{}}}`
 
-	preProcessedPolicy, err := preProcessStrategicMergePatch(string(rawPolicy), string(rawResource))
+	preProcessedPolicy, err := preProcessStrategicMergePatch(log.Log, string(rawPolicy), string(rawResource))
 	assert.NilError(t, err)
 	output, err := preProcessedPolicy.String()
 	assert.NilError(t, err)
@@ -132,7 +133,7 @@ func Test_preProcessStrategicMergePatch_Annotation(t *testing.T) {
 
 	expected := `{"metadata":{"annotations":{}},"spec":{"volumes":[{"name":"cache-volume"}]}}`
 
-	preProcessedPolicy, err := preProcessStrategicMergePatch(string(rawPolicy), string(rawResource))
+	preProcessedPolicy, err := preProcessStrategicMergePatch(log.Log, string(rawPolicy), string(rawResource))
 	assert.NilError(t, err)
 	output, err := preProcessedPolicy.String()
 	assert.NilError(t, err)
@@ -149,7 +150,7 @@ func Test_preProcessStrategicMergePatch_BlankAnnotation(t *testing.T) {
 
 	expected := `{"metadata":{"annotations":{"cluster-autoscaler.kubernetes.io/safe-to-evict":true},"labels":{"add-labels":"add"}},"spec":{"volumes":[{"name":"cache-volume"}]}}`
 
-	preProcessedPolicy, err := preProcessStrategicMergePatch(string(rawPolicy), string(rawResource))
+	preProcessedPolicy, err := preProcessStrategicMergePatch(log.Log, string(rawPolicy), string(rawResource))
 	assert.NilError(t, err)
 	output, err := preProcessedPolicy.String()
 	assert.NilError(t, err)
@@ -194,7 +195,7 @@ func Test_preProcessStrategicMergePatch_multipleAnchors(t *testing.T) {
 	}
 
 	for i, test := range testCases {
-		preProcessedPolicy, err := preProcessStrategicMergePatch(string(test.rawPolicy), string(test.rawResource))
+		preProcessedPolicy, err := preProcessStrategicMergePatch(log.Log, string(test.rawPolicy), string(test.rawResource))
 		assert.NilError(t, err)
 
 		output, err := preProcessedPolicy.String()

--- a/pkg/engine/validate/validate.go
+++ b/pkg/engine/validate/validate.go
@@ -15,10 +15,10 @@ import (
 
 // ValidateResourceWithPattern is a start of element-by-element validation process
 // It assumes that validation is started from root, so "/" is passed
-func ValidateResourceWithPattern(log logr.Logger, resource, pattern interface{}) (string, error) {
+func ValidateResourceWithPattern(logger logr.Logger, resource, pattern interface{}) (string, error) {
 	// newAnchorMap - to check anchor key has values
 	ac := common.NewAnchorMap()
-	elemPath, err := validateResourceElement(log, resource, pattern, pattern, "/", ac)
+	elemPath, err := validateResourceElement(logger, resource, pattern, pattern, "/", ac)
 	if err != nil {
 		if common.IsConditionalAnchorError(err.Error()) {
 			return "", nil


### PR DESCRIPTION
## Related issue
Closes #1658 
Closes #1915 
Fixes #1896 

## What type of PR is this
/kind bug

## Proposed Changes
I have totally refactored patchStrategicMerge. Now condition anchors should work properly for lists: impact only list element that it was specified in. I have fixed panic during creation by adding stub element to list that does nothing. It prevents list from being deleted, if it cointains only condition and nothing more. Condition is needed to be deleted during preProcessing, so we have an empty list that will delete the same list in the resource. To workaround this moment, I have added stub element `{ "name": "" } to the patch`. It won't mutate anything, it is needed for list to not be empty.
Also I have added new tests.
### Proof Manifests
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata: 
  name: add-safe-to-evict
  annotations:
    policies.kyverno.io/title: Add safe-to-evict 
    policies.kyverno.io/category: Best Practices
    policies.kyverno.io/subject: Pod
    policies.kyverno.io/description: >-
      The Kubernetes cluster autoscaler does not evict pods that use hostPath 
      or emptyDir volumes. To allow eviction of these pods, the annotation 
      cluster-autoscaler.kubernetes.io/safe-to-evict=true must be added to pods. 
spec: 
  rules: 
  - name: annotate-empty-dir
    match: 
      resources: 
        kinds: 
        - Pod
    mutate: 
      patchStrategicMerge:
        metadata:
          annotations:
            +(cluster-autoscaler.kubernetes.io/safe-to-evict): "true"
        spec:          
          volumes: 
          - (emptyDir): {}
  - name: annotate-host-path
    match: 
      resources: 
        kinds: 
        - Pod
    mutate: 
      patchStrategicMerge:
        metadata:
          annotations:
            +(cluster-autoscaler.kubernetes.io/safe-to-evict): "true"
        spec:          
          volumes: 
          - (hostPath):
              path: "*"
```

```yaml
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  name: mycronjob
  namespace: default
spec:
  concurrencyPolicy: Forbid
  jobTemplate:
    spec:
      template:
        spec:
          containers:
          - envFrom:
            - configMapRef:
                name: myconfigmap
            image: myimage:latest
            imagePullPolicy: Always
            name: myjob
          restartPolicy: OnFailure
  schedule: 0 0 * * *
```
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [x] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->kyverno/website/issues/208
  - [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.