### PR TITLE
Fix : AnyPattern matching on metadata schema element not working

### DIFF
--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -276,7 +276,7 @@ func validatePatterns(log logr.Logger, ctx context.EvalInterface, resource unstr
 			path, err := validate.ValidateResourceWithPattern(logger, resource.Object, pattern)
 			if err != nil {
 				logger.V(4).Info("validation rule failed", "anyPattern[%d]", idx, "path", path)
-				patternErr := fmt.Errorf("rule %s[%d] failed at path %s.", rule.Name, idx, path)
+				patternErr := fmt.Errorf("Rule %s[%d] failed at path %s.", rule.Name, idx, path)
 				failedAnyPatternsErrors = append(failedAnyPatternsErrors, patternErr)
 			}
 

--- a/pkg/engine/validation_test.go
+++ b/pkg/engine/validation_test.go
@@ -2357,7 +2357,7 @@ func TestValidate_metadata_fail_anyPattern(t *testing.T) {
 	er := Validate(&PolicyContext{Policy: policy, NewResource: *resourceUnstructured, JSONContext: context.NewContext()})
 	assert.Assert(t, !er.IsSuccessful())
 
-	msgs := []string{"validation error: Cannot use Flux v1 annotation. rule block-flux-v1[0] failed at path /metadata/annotations/fluxcd.io/foo/."}
+	msgs := []string{"validation error: Cannot use Flux v1 annotation. Rule block-flux-v1[0] failed at path /metadata/annotations/fluxcd.io/foo/."}
 	for index, r := range er.PolicyResponse.Rules {
 		assert.Equal(t, r.Message, msgs[index])
 	}

--- a/pkg/engine/validation_test.go
+++ b/pkg/engine/validation_test.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
@@ -2360,7 +2359,6 @@ func TestValidate_metadata_fail_anyPattern(t *testing.T) {
 
 	msgs := []string{"validation error: Cannot use Flux v1 annotation. rule block-flux-v1[0] failed at path /metadata/annotations/fluxcd.io/foo/."}
 	for index, r := range er.PolicyResponse.Rules {
-		fmt.Println("r.Message", r.Message)
 		assert.Equal(t, r.Message, msgs[index])
 	}
 }

--- a/test/scenarios/other/scenario_validate_volume_whiltelist.yaml
+++ b/test/scenarios/other/scenario_validate_volume_whiltelist.yaml
@@ -17,5 +17,5 @@ expected:
       rules:
         - name: validate-volumes-whitelist
           type: Validation
-          message: "validation error: Volumes white list. Rule validate-volumes-whitelist[0] failed at path /spec/volumes/0/. Rule validate-volumes-whitelist[1] failed at path /spec/volumes/0/"
+          message: "validation error: Volumes white list. Rule validate-volumes-whitelist[0] failed at path /spec/volumes/0/. Rule validate-volumes-whitelist[1] failed at path /spec/volumes/0/,"
           success: true

--- a/test/scenarios/other/scenario_validate_volume_whiltelist.yaml
+++ b/test/scenarios/other/scenario_validate_volume_whiltelist.yaml
@@ -18,4 +18,4 @@ expected:
         - name: validate-volumes-whitelist
           type: Validation
           message: "validation error: Volumes white list. Rule validate-volumes-whitelist[0] failed at path /spec/volumes/0/. Rule validate-volumes-whitelist[1] failed at path /spec/volumes/0/."
-          success: true
+          success: false

--- a/test/scenarios/other/scenario_validate_volume_whiltelist.yaml
+++ b/test/scenarios/other/scenario_validate_volume_whiltelist.yaml
@@ -17,5 +17,5 @@ expected:
       rules:
         - name: validate-volumes-whitelist
           type: Validation
-          message: "validation error: Volumes white list. Rule validate-volumes-whitelist[0] failed at path /spec/volumes/0/. Rule validate-volumes-whitelist[1] failed at path /spec/volumes/0/,"
+          message: "validation error: Volumes white list. Rule validate-volumes-whitelist[0] failed at path /spec/volumes/0/. Rule validate-volumes-whitelist[1] failed at path /spec/volumes/0/."
           success: true

--- a/test/scenarios/other/scenario_validate_volume_whiltelist.yaml
+++ b/test/scenarios/other/scenario_validate_volume_whiltelist.yaml
@@ -17,5 +17,5 @@ expected:
       rules:
         - name: validate-volumes-whitelist
           type: Validation
-          message: "validation rule 'validate-volumes-whitelist' anyPattern[2] passed."
+          message: "validation error: Volumes white list. Rule validate-volumes-whitelist[0] failed at path /spec/volumes/0/. Rule validate-volumes-whitelist[1] failed at path /spec/volumes/0/"
           success: true


### PR DESCRIPTION
Signed-off-by: Vyankatesh <vyankateshkd@gmail.com>

## Related issue

closes https://github.com/kyverno/kyverno/issues/1813

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Deploy `cpol.yaml`
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: restrict-annotations
  annotations:
    policies.kyverno.io/title: Restrict Annotations
    policies.kyverno.io/category: Sample
    policies.kyverno.io/description: >-
      This example policy prevents the use of an annotation beginning with a common
      key name (in this case "fluxcd.io/"). This can be useful to ensure users either
      don't set reserved annotations or to force them to
      use a newer version of an annotation.
    pod-policies.kyverno.io/autogen-controllers: None
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: block-flux-v1
    match:
      resources:
        kinds:
        - Deployment
        - CronJob
        - Job
        - StatefulSet
        - DaemonSet
        - Pod
    validate:
      message: Cannot use Flux v1 annotation.
      anyPattern:
      - metadata:
          =(annotations):
            X(fluxcd.io/*): "*?"
      - metadata:
          =(annotations):
            X(flux.weave.works/*): "*?"
```
2. Create `deploy.yaml`
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: kyvernodeploy
  labels:
    blog: forward
  annotations:
    fluxcd.io/foo: bar
spec:
  replicas: 1
  selector:
    matchLabels:
      blog: forward
  template:
    metadata:
      labels:
        blog: forward
    spec:
      containers: 
      - name: busybox-harbor
        image: busybox:1.28
        command: ["sleep", "9999"]
        resources:
          requests:
            memory: 100Mi
            cpu: 100m
          limits:
            memory: 200Mi
            # cpu: "500m"
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->
Result : 
`validation error: Cannot use Flux v1 annotation. Rule block-flux-v1[0] failed at path /metadata/annotations/fluxcd.io/foo/.`

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [x] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
