### PR TITLE
moving to error info log for external.metrics.k8s.io/v1beta1 

### DIFF
--- a/pkg/dclient/client.go
+++ b/pkg/dclient/client.go
@@ -357,7 +357,7 @@ func (c ServerPreferredResources) findResource(apiVersion string, kind string) (
 func logDiscoveryErrors(err error, c ServerPreferredResources) {
 	discoveryError := err.(*discovery.ErrGroupDiscoveryFailed)
 	for gv, e := range discoveryError.Groups {
-		if gv.Group == "custom.metrics.k8s.io" || gv.Group == "metrics.k8s.io" {
+		if gv.Group == "custom.metrics.k8s.io" || gv.Group == "metrics.k8s.io" || gv.Group == "external.metrics.k8s.io" {
 			// These error occur when Prometheus is installed as an external metrics server
 			// See: https://github.com/kyverno/kyverno/issues/1490
 			c.log.V(3).Info("failed to retrieve metrics API group", "gv", gv)


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue
closes https://github.com/kyverno/kyverno/issues/2126

## What type of PR is this
> /kind bug
> /kind cleanup

## Proposed Changes
Moved error log to info log for group `external.metrics.k8s.i`
 
### Proof Manifests
1. install keda using `kubectl apply -f https://github.com/kedacore/keda/releases/download/v2.3.0/keda-2.3.0.yaml`
2. install kyverno
3. check kyverno logs - should not get any error in logs. 

Prior to code changes, we were getting the following error log:
```
E0719 11:59:10.973641       1 memcache.go:196] couldn't get resource list for external.metrics.k8s.io/v1beta1: Got empty response for: external.metrics.k8s.io/v1beta1
E0719 11:59:10.974143       1 client.go:367] dclient "msg"="failed to retrieve API group" "error"="Got empty response for: external.metrics.k8s.io/v1beta1"  "gv"={"Group":"external.metrics.k8s.io","Version":"v1beta1"}
E0719 11:59:40.951394       1 client.go:367] dclient "msg"="failed to retrieve API group" "error"="Got empty response for: external.metrics.k8s.io/v1beta1"  "gv"={"Group":"external.metrics.k8s.io","Version":"v1beta1"}
E0719 12:00:11.349533       1 client.go:367] dclient "msg"="failed to retrieve API group" "error"="Got empty response for: external.metrics.k8s.io/v1beta1"  "gv"={"Group":"external.metrics.k8s.io","Version":"v1beta1"}
```

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
