### PR TITLE
Resolving variables from the resource passed | CLI

### DIFF
--- a/pkg/engine/context/context.go
+++ b/pkg/engine/context/context.go
@@ -143,6 +143,34 @@ func (ctx *Context) AddResource(dataRaw []byte) error {
 	return ctx.AddJSON(objRaw)
 }
 
+//AddResource data at path: request.oldObject
+func (ctx *Context) AddResourceInOldObject(dataRaw []byte) error {
+
+	// unmarshal the resource struct
+	var data interface{}
+	if err := json.Unmarshal(dataRaw, &data); err != nil {
+		ctx.log.Error(err, "failed to unmarshal the resource")
+		return err
+	}
+
+	modifiedResource := struct {
+		Request interface{} `json:"request"`
+	}{
+		Request: struct {
+			OldObject interface{} `json:"oldObject"`
+		}{
+			OldObject: data,
+		},
+	}
+
+	objRaw, err := json.Marshal(modifiedResource)
+	if err != nil {
+		ctx.log.Error(err, "failed to marshal the resource")
+		return err
+	}
+	return ctx.AddJSON(objRaw)
+}
+
 //AddUserInfo adds userInfo at path request.userInfo
 func (ctx *Context) AddUserInfo(userRequestInfo kyverno.RequestInfo) error {
 	modifiedResource := struct {

--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -182,6 +182,7 @@ func substituteVariablesIfAny(log logr.Logger, ctx context.EvalInterface) jsonUt
 					variable = strings.Replace(variable, "@", fmt.Sprintf("request.object.%s", getJMESPath(data.Path)), -1)
 				}
 
+				// TODO: do not change request.object to request.oldObject in case of CLI
 				operation, err := ctx.Query("request.operation")
 				if err == nil && operation == "DELETE" {
 					variable = strings.ReplaceAll(variable, "request.object", "request.oldObject")

--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -182,7 +182,6 @@ func substituteVariablesIfAny(log logr.Logger, ctx context.EvalInterface) jsonUt
 					variable = strings.Replace(variable, "@", fmt.Sprintf("request.object.%s", getJMESPath(data.Path)), -1)
 				}
 
-				// TODO: do not change request.object to request.oldObject in case of CLI
 				operation, err := ctx.Query("request.operation")
 				if err == nil && operation == "DELETE" {
 					variable = strings.ReplaceAll(variable, "request.object", "request.oldObject")

--- a/pkg/kyverno/apply/apply_command.go
+++ b/pkg/kyverno/apply/apply_command.go
@@ -258,7 +258,7 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 		err := policy2.Validate(policy, nil, true, openAPIController)
 		if err != nil {
 			rc.skip += len(resources)
-			log.Log.V(3).Info(fmt.Sprintf("skipping policy %v as it is not valid", policy.Name), "error", err)
+			log.Log.V(3).Info(fmt.Sprintf("1skipping policy %v as it is not valid", policy.Name), "error", err)
 			continue
 		}
 
@@ -267,7 +267,7 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 
 		// TODO: check for request.object variable in variable in value file and warn the user
 
-		if len(matches) > 0 && variablesString == "" && valuesFile == "" {
+		if len(variable) > 0 && variablesString == "" && valuesFile == "" {
 			rc.skip++
 			skipPolicy := SkippedPolicy{
 				Name:     policy.GetName(),
@@ -275,7 +275,7 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 				Variable: variable,
 			}
 			skippedPolicies = append(skippedPolicies, skipPolicy)
-			log.Log.V(3).Info(fmt.Sprintf("skipping policy %s", policy.Name), "error", fmt.Sprintf("policy have variable - %s", variable))
+			log.Log.V(3).Info(fmt.Sprintf("2skipping policy %s", policy.Name), "error", fmt.Sprintf("policy have variable - %s", variable))
 			continue
 		}
 

--- a/pkg/kyverno/apply/apply_command.go
+++ b/pkg/kyverno/apply/apply_command.go
@@ -157,7 +157,7 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 		return validateEngineResponses, rc, resources, skippedPolicies, sanitizederror.NewWithError("pass the values either using set flag or values_file flag", err)
 	}
 
-	variables, valuesMap, namespaceSelectorMap, err := common.GetVariable(variablesString, valuesFile, fs, false, "")
+	variables, valuesMap, namespaceSelectorMap, operationIsDelete, err := common.GetVariable(variablesString, valuesFile, fs, false, "")
 	if err != nil {
 		if !sanitizederror.IsErrorSanitized(err) {
 			return validateEngineResponses, rc, resources, skippedPolicies, sanitizederror.NewWithError("failed to decode yaml", err)
@@ -292,7 +292,7 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 				return validateEngineResponses, rc, resources, skippedPolicies, sanitizederror.NewWithError(fmt.Sprintf("policy %s have variables. pass the values for the variables using set/values_file flag", policy.Name), err)
 			}
 
-			ers, validateErs, responseError, rcErs, err := common.ApplyPolicyOnResource(policy, resource, mutateLogPath, mutateLogPathIsDir, thisPolicyResourceValues, policyReport, namespaceSelectorMap, stdin)
+			ers, validateErs, responseError, rcErs, err := common.ApplyPolicyOnResource(policy, resource, mutateLogPath, mutateLogPathIsDir, thisPolicyResourceValues, policyReport, namespaceSelectorMap, stdin, operationIsDelete)
 			if err != nil {
 				return validateEngineResponses, rc, resources, skippedPolicies, sanitizederror.NewWithError(fmt.Errorf("failed to apply policy %v on resource %v", policy.Name, resource.GetName()).Error(), err)
 			}

--- a/pkg/kyverno/apply/apply_command.go
+++ b/pkg/kyverno/apply/apply_command.go
@@ -263,7 +263,9 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 		}
 
 		matches := common.PolicyHasVariables(*policy)
-		variable := common.RemoveDuplicateVariables(matches)
+		variable := common.RemoveDuplicateAndObjectVariables(matches)
+
+		// TODO: check for request.object variable in variable in value file and warn the user
 
 		if len(matches) > 0 && variablesString == "" && valuesFile == "" {
 			rc.skip++
@@ -288,7 +290,7 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 				thisPolicyResourceValues[k] = v
 			}
 
-			if len(common.PolicyHasVariables(*policy)) > 0 && len(thisPolicyResourceValues) == 0 && len(store.GetContext().Policies) == 0 {
+			if len(variable) > 0 && len(thisPolicyResourceValues) == 0 && len(store.GetContext().Policies) == 0 {
 				return validateEngineResponses, rc, resources, skippedPolicies, sanitizederror.NewWithError(fmt.Sprintf("policy %s have variables. pass the values for the variables using set/values_file flag", policy.Name), err)
 			}
 

--- a/pkg/kyverno/apply/apply_command.go
+++ b/pkg/kyverno/apply/apply_command.go
@@ -258,14 +258,12 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 		err := policy2.Validate(policy, nil, true, openAPIController)
 		if err != nil {
 			rc.skip += len(resources)
-			log.Log.V(3).Info(fmt.Sprintf("1skipping policy %v as it is not valid", policy.Name), "error", err)
+			log.Log.V(3).Info(fmt.Sprintf("skipping policy %v as it is not valid", policy.Name), "error", err)
 			continue
 		}
 
 		matches := common.PolicyHasVariables(*policy)
 		variable := common.RemoveDuplicateAndObjectVariables(matches)
-
-		// TODO: check for request.object variable in variable in value file and warn the user
 
 		if len(variable) > 0 && variablesString == "" && valuesFile == "" {
 			rc.skip++
@@ -275,7 +273,7 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 				Variable: variable,
 			}
 			skippedPolicies = append(skippedPolicies, skipPolicy)
-			log.Log.V(3).Info(fmt.Sprintf("2skipping policy %s", policy.Name), "error", fmt.Sprintf("policy have variable - %s", variable))
+			log.Log.V(3).Info(fmt.Sprintf("skipping policy %s", policy.Name), "error", fmt.Sprintf("policy have variable - %s", variable))
 			continue
 		}
 

--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -394,11 +394,12 @@ func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit 
 		for _, kvpair := range kvpairs {
 			kvs := strings.Split(strings.Trim(kvpair, " "), "=")
 			if strings.Contains(kvs[0], "request.object") {
-				return variables, valuesMapResource, namespaceSelectorMap, sanitizederror.NewWithError("variable request.object.* is handled by kyverno, no need to pass it", err)
+				return variables, valuesMapResource, namespaceSelectorMap, sanitizederror.NewWithError("variable request.object.* is handled by kyverno. please do not pass value for request.object variables ", err)
 			}
 			variables[strings.Trim(kvs[0], " ")] = strings.Trim(kvs[1], " ")
 		}
 	}
+
 	if valuesFile != "" {
 		if isGit {
 			filep, err := fs.Open(filepath.Join(policyResourcePath, valuesFile))
@@ -427,6 +428,11 @@ func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit 
 		for _, p := range values.Policies {
 			resourceMap := make(map[string]Resource)
 			for _, r := range p.Resources {
+				for variableInFile, _ := range r.Values {
+					if strings.Contains(variableInFile, "request.object") {
+						return variables, valuesMapResource, namespaceSelectorMap, sanitizederror.NewWithError("variable request.object.* is handled by kyverno. please do not pass value for request.object variables ", err)
+					}
+				}
 				resourceMap[r.Name] = r
 			}
 			valuesMapResource[p.Name] = resourceMap

--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -428,7 +428,7 @@ func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit 
 		for _, p := range values.Policies {
 			resourceMap := make(map[string]Resource)
 			for _, r := range p.Resources {
-				for variableInFile, _ := range r.Values {
+				for variableInFile := range r.Values {
 					if strings.Contains(variableInFile, "request.object") {
 						return variables, valuesMapResource, namespaceSelectorMap, sanitizederror.NewWithError("variable request.object.* is handled by kyverno. please do not pass value for request.object variables ", err)
 					}

--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -393,6 +393,9 @@ func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit 
 		kvpairs := strings.Split(strings.Trim(variablesString, " "), ",")
 		for _, kvpair := range kvpairs {
 			kvs := strings.Split(strings.Trim(kvpair, " "), "=")
+			if strings.Contains(kvs[0], "request.object") {
+				return variables, valuesMapResource, namespaceSelectorMap, sanitizederror.NewWithError("variable request.object.* is handled by kyverno, no need to pass it", err)
+			}
 			variables[strings.Trim(kvs[0], " ")] = strings.Trim(kvs[1], " ")
 		}
 	}

--- a/pkg/kyverno/common/common_test.go
+++ b/pkg/kyverno/common/common_test.go
@@ -85,7 +85,7 @@ func Test_NamespaceSelector(t *testing.T) {
 	for _, tc := range testcases {
 		policyArray, _ := ut.GetPolicy(tc.policy)
 		resourceArray, _ := GetResource(tc.resource)
-		_, validateErs, _, _, _ := ApplyPolicyOnResource(policyArray[0], resourceArray[0], "", false, nil, false, tc.namespaceSelectorMap, false)
+		_, validateErs, _, _, _ := ApplyPolicyOnResource(policyArray[0], resourceArray[0], "", false, nil, false, tc.namespaceSelectorMap, false, false)
 		assert.Assert(t, tc.success == validateErs.IsSuccessful())
 	}
 }

--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -358,7 +358,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, valuesFile s
 
 		matches := common.PolicyHasVariables(*policy)
 		variable := common.RemoveDuplicateAndObjectVariables(matches)
-		if len(matches) > 0 && variablesString == "" && values.Variables == "" {
+		if len(variable) > 0 && variablesString == "" && values.Variables == "" {
 			skipPolicy := SkippedPolicy{
 				Name:     policy.GetName(),
 				Rules:    policy.Spec.Rules,
@@ -385,7 +385,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, valuesFile s
 			if len(valuesMap[policy.GetName()]) != 0 && !reflect.DeepEqual(valuesMap[policy.GetName()][resource.GetName()], Resource{}) {
 				thisPolicyResourceValues = valuesMap[policy.GetName()][resource.GetName()].Values
 			}
-			if len(common.PolicyHasVariables(*policy)) > 0 && len(thisPolicyResourceValues) == 0 {
+			if len(variable) > 0 && len(thisPolicyResourceValues) == 0 {
 				return sanitizederror.NewWithError(fmt.Sprintf("policy %s have variables. pass the values for the variables using set/values_file flag", policy.Name), err)
 			}
 

--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -305,7 +305,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, valuesFile s
 
 	fmt.Printf("\nExecuting %s...", values.Name)
 
-	_, valuesMap, namespaceSelectorMap, err := common.GetVariable(variablesString, values.Variables, fs, isGit, policyResourcePath)
+	_, valuesMap, namespaceSelectorMap, operationIsDelete, err := common.GetVariable(variablesString, values.Variables, fs, isGit, policyResourcePath)
 	if err != nil {
 		if !sanitizederror.IsErrorSanitized(err) {
 			return sanitizederror.NewWithError("failed to decode yaml", err)
@@ -389,7 +389,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, valuesFile s
 				return sanitizederror.NewWithError(fmt.Sprintf("policy %s have variables. pass the values for the variables using set/values_file flag", policy.Name), err)
 			}
 
-			ers, validateErs, _, _, err := common.ApplyPolicyOnResource(policy, resource, "", false, thisPolicyResourceValues, true, namespaceSelectorMap, false)
+			ers, validateErs, _, _, err := common.ApplyPolicyOnResource(policy, resource, "", false, thisPolicyResourceValues, true, namespaceSelectorMap, false, operationIsDelete)
 			if err != nil {
 				return sanitizederror.NewWithError(fmt.Errorf("failed to apply policy %v on resource %v", policy.Name, resource.GetName()).Error(), err)
 			}

--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -357,7 +357,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, valuesFile s
 		}
 
 		matches := common.PolicyHasVariables(*policy)
-		variable := common.RemoveDuplicateVariables(matches)
+		variable := common.RemoveDuplicateAndObjectVariables(matches)
 		if len(matches) > 0 && variablesString == "" && values.Variables == "" {
 			skipPolicy := SkippedPolicy{
 				Name:     policy.GetName(),


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue
closes https://github.com/kyverno/kyverno/issues/1996
closes https://github.com/kyverno/kyverno/issues/1870

## What type of PR is this
> /kind bug
> /kind feature

## Proposed Changes
- added resource in the context to get `request.object.*` variables
- added check for the variable - user should pass variable other than `request.object.*` variables
- supporting list variable in cli

### Proof Manifests
Example 1:
Apply following policy :
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: mutate-ingress-host
spec:
  rules:
  - name: mutate-rules-host
    match:
      resources:
        kinds:
        - Ingress
    preconditions:
      - key: "{{request.object.spec.rules[0].host}}"
        operator: NotEquals
        value: "*.mycompany.com"
    mutate:
      patchesJson6902: |-
        - op: replace
          path: /spec/rules/0/host
          value: some.mycompany.com
  - name: mutate-tls-hosts
    match:
      resources:
        kinds:
        - Ingress
    preconditions:
      - key: "{{request.object.spec.tls[0].hosts[0]}}"
        operator: NotEquals
        value: "*.mycompany.com"
    mutate:
      patchStrategicMerge:
        spec:
          tls:
          - hosts:
            - "some.mycompany.com"
```
on following resource:
```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: kuard
  labels:
    app: kuard
spec:
  rules:
  - host: kuard
    http:
      paths:
      - backend:
          service: 
            name: kuard
            port: 
              number: 8080
        path: /
        pathType: ImplementationSpecific
  tls:
  - hosts:
     - kuard

```

Command: 
```
kyverno apply policy.yaml -r resource.yaml
```

Result:
```
applying 1 policy to 1 resource... 

mutate policy mutate-ingress-host applied to default/Ingress/kuard:
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    app: kuard
  name: kuard
  namespace: default
spec:
  rules:
  - host: some.mycompany.com
    http:
      paths:
      - backend:
          service:
            name: kuard
            port:
              number: 8080
        path: /
        pathType: ImplementationSpecific
  tls:
  - hosts:
    - some.mycompany.com

---

pass: 1, fail: 0, warn: 0, error: 0, skip: 0 
```

Example 2:
Apply following policy :
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: set-service-labels-env
spec:
  background: false
  rules:
  - name: set-service-env
    match:
      resources:
        kinds:
        - Deployment
        - DeploymentConfig
        - DaemonSet
        - StatefulSet
    exclude:
      resources:
        namespaces:
          - "kube*"
          - "openshift*"
          - "kube-*"
          - "openshift-*"
    preconditions:
      all:
        - key: "{{ request.operation }}"
          operator: Equals
          value: "CREATE"
        - key: "SERVICE"
          operator: NotIn
          value: "{{ request.object.spec.template.spec.containers[].env[].name }}"
    mutate:
      patchesJson6902: |-
       - op: add
         path: /spec/template/spec/containers/0/env/-1
         value: {"name": "SERVICE","value": "something" }

```
on following resource:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-dep2
  namespace: default
  labels:
    app: hello-openshift
spec:
  selector:
    matchLabels:
      app: hello-openshift
  replicas: 1
  template:
    metadata:
      labels:
        app: hello-openshift
        foo: bar
    spec:
      containers:
        - name: hello-openshift
          image: openshift/hello-openshift
          ports:
          - containerPort: 8080
          env:
          - name: test
            value: some-value
```

Command:
```
kyverno apply policy.yaml -r resource.yaml -s request.operation=CREATE  
```

Result:
```
applying 1 policy to 1 resource... 

mutate policy set-service-labels-env applied to default/Deployment/my-dep2:
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: hello-openshift
  name: my-dep2
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: hello-openshift
  template:
    metadata:
      labels:
        app: hello-openshift
        foo: bar
    spec:
      containers:
      - env:
        - name: test
          value: some-value
        - name: SERVICE
          value: something
        image: openshift/hello-openshift
        name: hello-openshift
        ports:
        - containerPort: 8080

---

pass: 1, fail: 0, warn: 0, error: 0, skip: 0 
```

## Checklist


- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [X] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [X] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  https://github.com/kyverno/website/issues/219
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
