### PR TITLE
Validate that negation anchor is null

### DIFF
--- a/pkg/policy/common/validate_pattern.go
+++ b/pkg/policy/common/validate_pattern.go
@@ -31,16 +31,20 @@ func validateMap(patternMap map[string]interface{}, path string, supportedAnchor
 		// single char ()
 		re, err := regexp.Compile(`^.?\(.+\)$`)
 		if err != nil {
-			return path + "/" + key, fmt.Errorf("Unable to parse the field %s: %v", key, err)
+			return path + "/" + key, fmt.Errorf("unable to parse the field %s: %v", key, err)
 		}
-
 		matched := re.MatchString(key)
 		// check the type of anchor
 		if matched {
 			// some type of anchor
 			// check if valid anchor
 			if !checkAnchors(key, supportedAnchors) {
-				return path + "/" + key, fmt.Errorf("Unsupported anchor %s", key)
+				return path + "/" + key, fmt.Errorf("unsupported anchor %s", key)
+			}
+			if commonAnchors.IsNegationAnchor(key) {
+				if value != "null" {
+					return path + "/" + key, fmt.Errorf("negation anchor should have value null")
+				}
 			}
 
 			// addition check for existence anchor


### PR DESCRIPTION
Signed-off-by: Vyankatesh vyankateshkd@gmail.com

Related issue
closes #1820

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this
Block installation of policy if negation anchor is not null 
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
I have check Most of  the policy defined for negation, they all set to null.
https://kyverno.io/policies/pod-security/restricted/restrict-volume-types/restrict-volume-types/?policytypes
https://kyverno.io/policies/pod-security/baseline/disallow-adding-capabilities/disallow-adding-capabilities/?policytypes=validate


<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. 
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: restrict-controlplane-scheduling
  annotations:
    policies.kyverno.io/title: Restrict control plane scheduling
    policies.kyverno.io/category: Sample
    policies.kyverno.io/description: >-
      This policy prevents users from setting a toleration
      in a Pod spec which allows running on control plane nodes
      with the taint key "node-role.kubernetes.io/master".         
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: restrict-controlplane-scheduling
    match:
      resources:
        kinds:
        - Pod
    validate:
      message: Pods may not use tolerations which schedule on control plane nodes.
      pattern:
        spec:
          =(tolerations):
            - X(key): "node-role.kubernetes.io/master"
```
Error while Installing policy:
`Error from server: error when creating ".\\yamls\\policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: path: spec.rulee request: path: spec.rules[0].validate.pattern.//spec/=(securityContext)/X(seLinuxOptions).: negation anchor should have value null`


2.
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-add-capabilities
  annotations:
    policies.kyverno.io/category: Pod Security Standards (Baseline)
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod
    policies.kyverno.io/description: >-
      Capabilities permit privileged actions without giving full root access.
      Adding capabilities beyond the default set must not be allowed.      
spec:
  validationFailureAction: audit
  background: true
  rules:
    - name: capabilities
      match:
        resources:
          kinds:
            - Pod
      validate:
        message: >-
          Adding of additional capabilities beyond the default set is not allowed.
          The fields spec.containers[*].securityContext.capabilities.add and 
          spec.initContainers[*].securityContext.capabilities.add must be empty.          
        pattern:
          spec:
            containers:
              - =(securityContext):
                  =(capabilities):
                    X(add): "not.null"
            =(initContainers):
              - =(securityContext):
                  =(capabilities):
                    X(add): "null"
```
Result:
`Error from server: error when creating ".\\yamls\\policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: path: spec.rules[0].validate.pattern.//spec/=(initContainers)0//=(securityContext)/=(capabilities)/X(add).: negation anchor should have value null`.

3. Working example

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-add-capabilities
  annotations:
    policies.kyverno.io/category: Pod Security Standards (Baseline)
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod
    policies.kyverno.io/description: >-
      Capabilities permit privileged actions without giving full root access.
      Adding capabilities beyond the default set must not be allowed.      
spec:
  validationFailureAction: audit
  background: true
  rules:
    - name: capabilities
      match:
        resources:
          kinds:
            - Pod
      validate:
        message: >-
          Adding of additional capabilities beyond the default set is not allowed.
          The fields spec.containers[*].securityContext.capabilities.add and 
          spec.initContainers[*].securityContext.capabilities.add must be empty.          
        pattern:
          spec:
            containers:
              - =(securityContext):
                  =(capabilities):
                    X(add): "null"
            =(initContainers):
              - =(securityContext):
                  =(capabilities):
                    X(add): "null"
```
Result :
`clusterpolicy.kyverno.io/disallow-add-capabilities created`
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [x] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
