### PR TITLE
Update JSON context with patched resource for chained mutate rules

### DIFF
--- a/pkg/engine/context/context.go
+++ b/pkg/engine/context/context.go
@@ -143,6 +143,25 @@ func (ctx *Context) AddResource(dataRaw []byte) error {
 	return ctx.AddJSON(objRaw)
 }
 
+func (ctx *Context) AddResourceAsObject(data interface{}) error {
+	modifiedResource := struct {
+		Request interface{} `json:"request"`
+	}{
+		Request: struct {
+			Object interface{} `json:"object"`
+		}{
+			Object: data,
+		},
+	}
+
+	objRaw, err := json.Marshal(modifiedResource)
+	if err != nil {
+		ctx.log.Error(err, "failed to marshal the resource")
+		return err
+	}
+	return ctx.AddJSON(objRaw)
+}
+
 //AddUserInfo adds userInfo at path request.userInfo
 func (ctx *Context) AddUserInfo(userRequestInfo kyverno.RequestInfo) error {
 	modifiedResource := struct {

--- a/pkg/engine/mutation.go
+++ b/pkg/engine/mutation.go
@@ -131,7 +131,10 @@ func Mutate(policyContext *PolicyContext) (resp *response.EngineResponse) {
 			logger.V(4).Info("mutate rule applied successfully", "ruleName", rule.Name)
 		}
 
-		ctx.AddResourceAsObject(patchedResource.Object)
+		if err := ctx.AddResourceAsObject(patchedResource.Object); err != nil {
+			logger.Error(err, "failed to update resource in the JSON context")
+		}
+
 		resp.PolicyResponse.Rules = append(resp.PolicyResponse.Rules, ruleResponse)
 		incrementAppliedRuleCount(resp)
 	}


### PR DESCRIPTION
Signed-off-by: Shuting Zhao <shutting06@gmail.com>

## Related issue
Closes https://github.com/kyverno/kyverno/issues/2022.
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this
/bug
/enhancement
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
The JSON context for resource object in the mutate policy is not updated with the patched resource, thus the chained mutate rules fail. This PR updates the JSON context with the updated patched resource.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Given this chained mutate policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: replace-image-registry
  annotations:
    policies.kyverno.io/minversion: 1.4.2   
spec:
  background: false
  rules:
    - name: replace-image-registry
      match:
        resources:
          kinds:
          - Pod
      mutate:
        patchStrategicMerge:
          spec:
            containers:
            - (name): "*"
              image: |-
                {{ regex_replace_all('^[^/]+', '{{@}}', 'myregistry.corp.com') }}
    - name: replace-image-registry-chained
      match:
        resources:
          kinds:
          - Pod
      mutate:
        patchStrategicMerge:
          spec:
            containers:
            - (name): "*"
              image: |-
                {{ regex_replace_all('\b(myregistry.corp.com)\b', '{{@}}', 'otherregistry.corp.com') }}
```

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  containers:
  - name: test
    image: foo/bash:5.0
```
The registry is replaced successfully by the second rule:
```
 ✗ k get pod test -o yaml | k neat
apiVersion: v1
kind: Pod
metadata:
  annotations:
    policies.kyverno.io/patches: |
      replace-image-registry-chained.replace-image-registry.kyverno.io: replaced /spec/containers/0/image
      replace-image-registry.replace-image-registry.kyverno.io: replaced /spec/containers/0/image
  name: test
  namespace: default
spec:
  containers:
  - image: otherregistry.corp.com/foo/bash:5.0
    name: test
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  serviceAccountName: default
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
