### PR TITLE
fix: add templating variable for Datasource field

### DIFF
--- a/dashboard/grafana/dashboard.json
+++ b/dashboard/grafana/dashboard.json
@@ -2212,7 +2212,18 @@
     "style": "dark",
     "tags": [],
     "templating": {
-      "list": []
+      "list": [
+        {
+          "hide": 0,
+          "label": "datasource",
+          "name": "DS_PROMETHEUS_KYVERNO",
+          "options": [],
+          "query": "prometheus",
+          "refresh": 1,
+          "regex": "",
+          "type": "datasource"
+        }
+      ]
     },
     "time": {
       "from": "now-30m",


### PR DESCRIPTION
## Related issue

https://github.com/kyverno/kyverno/issues/2188

## What type of PR is this

/kind feature

## Proposed Changes

Add a templating value for the variable DS_PROMETHEUS_KYVERNO to make it use the default Prometheus datasource by default.

### Proof Manifests
N/A

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments
