### PR TITLE
CLI result varies if multiple resources are passed for a policy with `request.operation`

### DIFF
--- a/pkg/kyverno/apply/apply_command.go
+++ b/pkg/kyverno/apply/apply_command.go
@@ -157,7 +157,8 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 		return validateEngineResponses, rc, resources, skippedPolicies, sanitizederror.NewWithError("pass the values either using set flag or values_file flag", err)
 	}
 
-	variables, valuesMap, namespaceSelectorMap, operationIsDelete, err := common.GetVariable(variablesString, valuesFile, fs, false, "")
+	variables, valuesMap, namespaceSelectorMap, err := common.GetVariable(variablesString, valuesFile, fs, false, "")
+
 	if err != nil {
 		if !sanitizederror.IsErrorSanitized(err) {
 			return validateEngineResponses, rc, resources, skippedPolicies, sanitizederror.NewWithError("failed to decode yaml", err)
@@ -292,7 +293,7 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 				return validateEngineResponses, rc, resources, skippedPolicies, sanitizederror.NewWithError(fmt.Sprintf("policy %s have variables. pass the values for the variables using set/values_file flag", policy.Name), err)
 			}
 
-			ers, validateErs, responseError, rcErs, err := common.ApplyPolicyOnResource(policy, resource, mutateLogPath, mutateLogPathIsDir, thisPolicyResourceValues, policyReport, namespaceSelectorMap, stdin, operationIsDelete)
+			ers, validateErs, responseError, rcErs, err := common.ApplyPolicyOnResource(policy, resource, mutateLogPath, mutateLogPathIsDir, thisPolicyResourceValues, policyReport, namespaceSelectorMap, stdin)
 			if err != nil {
 				return validateEngineResponses, rc, resources, skippedPolicies, sanitizederror.NewWithError(fmt.Errorf("failed to apply policy %v on resource %v", policy.Name, resource.GetName()).Error(), err)
 			}

--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -382,12 +382,12 @@ func RemoveDuplicateAndObjectVariables(matches [][]string) string {
 	return variableStr
 }
 
-func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit bool, policyResourcePath string) (map[string]string, map[string]map[string]Resource, map[string]map[string]string, bool, error) {
+func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit bool, policyResourcePath string) (map[string]string, map[string]map[string]Resource, map[string]map[string]string, error) {
 	valuesMapResource := make(map[string]map[string]Resource)
 	valuesMapRule := make(map[string]map[string]Rule)
 	namespaceSelectorMap := make(map[string]map[string]string)
 	variables := make(map[string]string)
-	operationIsDelete := false
+
 	var yamlFile []byte
 	var err error
 	if variablesString != "" {
@@ -395,11 +395,9 @@ func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit 
 		for _, kvpair := range kvpairs {
 			kvs := strings.Split(strings.Trim(kvpair, " "), "=")
 			if strings.Contains(kvs[0], "request.object") {
-				return variables, valuesMapResource, namespaceSelectorMap, operationIsDelete, sanitizederror.NewWithError("variable request.object.* is handled by kyverno. please do not pass value for request.object variables ", err)
+				return variables, valuesMapResource, namespaceSelectorMap, sanitizederror.NewWithError("variable request.object.* is handled by kyverno. please do not pass value for request.object variables ", err)
 			}
-			if strings.Contains(kvs[0], "request.operation") && strings.Contains(kvs[1], "DELETE") {
-				operationIsDelete = true
-			}
+
 			variables[strings.Trim(kvs[0], " ")] = strings.Trim(kvs[1], " ")
 		}
 	}
@@ -416,28 +414,25 @@ func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit 
 		}
 
 		if err != nil {
-			return variables, valuesMapResource, namespaceSelectorMap, operationIsDelete, sanitizederror.NewWithError("unable to read yaml", err)
+			return variables, valuesMapResource, namespaceSelectorMap, sanitizederror.NewWithError("unable to read yaml", err)
 		}
 
 		valuesBytes, err := yaml.ToJSON(yamlFile)
 		if err != nil {
-			return variables, valuesMapResource, namespaceSelectorMap, operationIsDelete, sanitizederror.NewWithError("failed to convert json", err)
+			return variables, valuesMapResource, namespaceSelectorMap, sanitizederror.NewWithError("failed to convert json", err)
 		}
 
 		values := &Values{}
 		if err := json.Unmarshal(valuesBytes, values); err != nil {
-			return variables, valuesMapResource, namespaceSelectorMap, operationIsDelete, sanitizederror.NewWithError("failed to decode yaml", err)
+			return variables, valuesMapResource, namespaceSelectorMap, sanitizederror.NewWithError("failed to decode yaml", err)
 		}
 
 		for _, p := range values.Policies {
 			resourceMap := make(map[string]Resource)
 			for _, r := range p.Resources {
-				for variableInFile, valueInFile := range r.Values {
+				for variableInFile := range r.Values {
 					if strings.Contains(variableInFile, "request.object") {
-						return variables, valuesMapResource, namespaceSelectorMap, operationIsDelete, sanitizederror.NewWithError("variable request.object.* is handled by kyverno. please do not pass value for request.object variables ", err)
-					}
-					if strings.Contains(variableInFile, "request.operation") && strings.Contains(valueInFile, "DELETE") {
-						operationIsDelete = true
+						return variables, valuesMapResource, namespaceSelectorMap, sanitizederror.NewWithError("variable request.object.* is handled by kyverno. please do not pass value for request.object variables ", err)
 					}
 				}
 				resourceMap[r.Name] = r
@@ -477,7 +472,7 @@ func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit 
 		Policies: storePolices,
 	})
 
-	return variables, valuesMapResource, namespaceSelectorMap, operationIsDelete, nil
+	return variables, valuesMapResource, namespaceSelectorMap, nil
 }
 
 // MutatePolices - function to apply mutation on policies
@@ -500,7 +495,13 @@ func MutatePolices(policies []*v1.ClusterPolicy) ([]*v1.ClusterPolicy, error) {
 
 // ApplyPolicyOnResource - function to apply policy on resource
 func ApplyPolicyOnResource(policy *v1.ClusterPolicy, resource *unstructured.Unstructured,
-	mutateLogPath string, mutateLogPathIsDir bool, variables map[string]string, policyReport bool, namespaceSelectorMap map[string]map[string]string, stdin bool, operationIsDelete bool) ([]*response.EngineResponse, *response.EngineResponse, bool, bool, error) {
+	mutateLogPath string, mutateLogPathIsDir bool, variables map[string]string, policyReport bool, namespaceSelectorMap map[string]map[string]string, stdin bool) ([]*response.EngineResponse, *response.EngineResponse, bool, bool, error) {
+
+	operationIsDelete := false
+
+	if variables["request.operation"] == "DELETE" {
+		operationIsDelete = true
+	}
 
 	responseError := false
 	rcError := false

--- a/pkg/kyverno/common/common_test.go
+++ b/pkg/kyverno/common/common_test.go
@@ -85,7 +85,7 @@ func Test_NamespaceSelector(t *testing.T) {
 	for _, tc := range testcases {
 		policyArray, _ := ut.GetPolicy(tc.policy)
 		resourceArray, _ := GetResource(tc.resource)
-		_, validateErs, _, _, _ := ApplyPolicyOnResource(policyArray[0], resourceArray[0], "", false, nil, false, tc.namespaceSelectorMap, false, false)
+		_, validateErs, _, _, _ := ApplyPolicyOnResource(policyArray[0], resourceArray[0], "", false, nil, false, tc.namespaceSelectorMap, false)
 		assert.Assert(t, tc.success == validateErs.IsSuccessful())
 	}
 }

--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -305,7 +305,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, valuesFile s
 
 	fmt.Printf("\nExecuting %s...", values.Name)
 
-	_, valuesMap, namespaceSelectorMap, operationIsDelete, err := common.GetVariable(variablesString, values.Variables, fs, isGit, policyResourcePath)
+	_, valuesMap, namespaceSelectorMap, err := common.GetVariable(variablesString, values.Variables, fs, isGit, policyResourcePath)
 	if err != nil {
 		if !sanitizederror.IsErrorSanitized(err) {
 			return sanitizederror.NewWithError("failed to decode yaml", err)
@@ -389,7 +389,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, valuesFile s
 				return sanitizederror.NewWithError(fmt.Sprintf("policy %s have variables. pass the values for the variables using set/values_file flag", policy.Name), err)
 			}
 
-			ers, validateErs, _, _, err := common.ApplyPolicyOnResource(policy, resource, "", false, thisPolicyResourceValues, true, namespaceSelectorMap, false, operationIsDelete)
+			ers, validateErs, _, _, err := common.ApplyPolicyOnResource(policy, resource, "", false, thisPolicyResourceValues, true, namespaceSelectorMap, false)
 			if err != nil {
 				return sanitizederror.NewWithError(fmt.Errorf("failed to apply policy %v on resource %v", policy.Name, resource.GetName()).Error(), err)
 			}

--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -428,7 +428,7 @@ func printTestResult(resps map[string]report.PolicyReportResult, testResults []T
 		}
 		if testRes.Status == v.Status {
 			if testRes.Status == report.StatusSkip {
-				res.Result = boldGreen.Sprintf("Skip")
+				res.Result = boldGreen.Sprintf("Pass")
 				rc.skip++
 			} else {
 				res.Result = boldGreen.Sprintf("Pass")


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue
closes https://github.com/kyverno/kyverno/issues/2197

## What type of PR is this
> /kind bug

## Proposed Changes
moving position of logic to check operation is delete or not

### Proof Manifests

Using following files:
policy.yaml
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: pod-account-validation
  namespace: kyverno
spec:
  background: false
  validationFailureAction: enforce
  rules:
  - name: pods-user-authorized-for-account
    match:
      resources:
        kinds:
        - Pod
        namespaces:
        - "user-?*"
    preconditions:
    - key: "{{ request.operation }}"
      operator: In
      value: ["CREATE","UPDATE"]
    context:
    - name: userGroupMap
      configMap:
        name: user-groups-map
        namespace: k8-ldap-configmap
    validate:
      message: "{{ request.object.metadata.namespace }} not authorized to charge against account {{ request.object.metadata.labels.account }}"
      deny:
        conditions:
        - key: "{{ request.object.metadata.labels.account }}"
          operator: NotIn
          value: "{{ userGroupMap.data.\"{{ request.object.metadata.namespace }}\" }}"
```

resources.yaml
```
apiVersion: v1
kind: Pod
metadata:
  name: test-pass
  namespace: user-test
  labels:
    account: PZS0001
spec: 
  containers:
  - name: nginx
    image: nginx:1.12
---
apiVersion: v1
kind: Pod
metadata:
  name: test-fail
  namespace: user-test
  labels:
    account: PZS0002
spec: 
  containers:
  - name: nginx
    image: nginx:1.12
```

value.yaml
```
policies:
  - name: pod-account-validation
    rules:
      - name: pods-user-authorized-for-account
        values:
          userGroupMap.data.user-test: '["PZS0001","PZS0003"]'
    resources:
      - name: test-pass
        values:
          request.operation: CREATE
      - name: test-fail
        values:
          request.operation: CREATE
```

test.yaml
```
name: pod-account-validation
policies:
  - policy.yaml
resources:
  - resources.yaml
variables: value.yaml
results:
  - policy: pod-account-validation
    rule: pods-user-authorized-for-account
    resource: test-pass
    status: pass
  - policy: pod-account-validation
    rule: pods-user-authorized-for-account
    resource: test-fail
    status: fail
```

command: 
`kyverno test <foldername>`

Result:
```
Executing pod-account-validation...
applying 1 policy to 2 resources... 
│───│───────────────────────────────────────────────────────────────────────────│────────│
│ # │ TEST                                                                      │ RESULT │
│───│───────────────────────────────────────────────────────────────────────────│────────│
│ 1 │ test-pass with pod-account-validation/pods-user-authorized-for-account    │ Pass   │
│ 2 │ test-fail with pod-account-validation/pods-user-authorized-for-account    │ Pass   │
│───│───────────────────────────────────────────────────────────────────────────│────────│

```

command:
`kyverno apply policy.yaml -r resources.yaml -f value.yaml`

Result:
```
applying 1 policy to 2 resources... 

policy pod-account-validation -> resource user-test/Pod/test-fail failed: 
1. pods-user-authorized-for-account: user-test not authorized to charge against account PZS0002 

pass: 1, fail: 1, warn: 0, error: 0, skip: 0 
exit status 1
```

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
