### PR TITLE
Add DurationOperator to handle duration comparison operations

### DIFF
--- a/pkg/api/kyverno/v1/policy_types.go
+++ b/pkg/api/kyverno/v1/policy_types.go
@@ -215,6 +215,14 @@ const (
 	LessThanOrEquals ConditionOperator = "LessThanOrEquals"
 	// LessThan evaluates if the key (numeric) is less than the value (numeric).
 	LessThan ConditionOperator = "LessThan"
+	// DurationGreaterThanOrEquals evaluates if the key (duration) is greater than or equal to the value (duration)
+	DurationGreaterThanOrEquals ConditionOperator = "DurationGreaterThanOrEquals"
+	// DurationGreaterThan evaluates if the key (duration) is greater than the value (duration)
+	DurationGreaterThan ConditionOperator = "DurationGreaterThan"
+	// DurationLessThanOrEquals evaluates if the key (duration) is less than or equal to the value (duration)
+	DurationLessThanOrEquals ConditionOperator = "DurationLessThanOrEquals"
+	// DurationLessThan evaluates if the key (duration) is greater than the value (duration)
+	DurationLessThan ConditionOperator = "DurationLessThan"
 )
 
 // MatchResources is used to specify resource and admission review request data for

--- a/pkg/engine/variables/evaluate_test.go
+++ b/pkg/engine/variables/evaluate_test.go
@@ -211,6 +211,150 @@ func Test_Eval_LessThan_Const_string_Fail(t *testing.T) {
 	}
 }
 
+func Test_Eval_DurationGreaterThanOrEquals_Const_string_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1h",
+		Operator: kyverno.DurationGreaterThanOrEquals,
+		Value:    "1h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationGreaterThanOrEquals_Const_string_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "2h",
+		Operator: kyverno.DurationGreaterThanOrEquals,
+		Value:    "1h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationGreaterThanOrEquals_Const_string_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1h",
+		Operator: kyverno.DurationGreaterThanOrEquals,
+		Value:    "2h",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationGreaterThan_Const_string_Equal_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1h",
+		Operator: kyverno.DurationGreaterThan,
+		Value:    "2h",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationGreaterThan_Const_string_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "2h",
+		Operator: kyverno.DurationGreaterThan,
+		Value:    "1h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationGreaterThan_Const_string_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1h",
+		Operator: kyverno.DurationGreaterThan,
+		Value:    "2h",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationLessThanOrEquals_Const_string_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "2h",
+		Operator: kyverno.DurationLessThanOrEquals,
+		Value:    "2h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationLessThanOrEquals_Const_string_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1h",
+		Operator: kyverno.DurationLessThanOrEquals,
+		Value:    "2h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationLessThanOrEquals_Const_string_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "2h",
+		Operator: kyverno.LessThanOrEquals,
+		Value:    "1h",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationLessThan_Const_string_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1h",
+		Operator: kyverno.DurationLessThan,
+		Value:    "1h",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationLessThan_Const_string_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1h",
+		Operator: kyverno.DurationLessThan,
+		Value:    "2h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationLessThan_Const_string_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "2h",
+		Operator: kyverno.DurationLessThan,
+		Value:    "1h",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
 //Bool
 
 func Test_Eval_Equal_Const_Bool_Pass(t *testing.T) {
@@ -470,6 +614,150 @@ func Test_Eval_LessThan_Const_int_Fail(t *testing.T) {
 	}
 }
 
+func Test_Eval_DurationGreaterThanOrEquals_Const_int_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1h",
+		Operator: kyverno.DurationGreaterThanOrEquals,
+		Value:    3600,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationGreaterThanOrEquals_Const_int_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "2h",
+		Operator: kyverno.DurationGreaterThanOrEquals,
+		Value:    3600,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationGreaterThanOrEquals_Const_int_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1h",
+		Operator: kyverno.DurationGreaterThanOrEquals,
+		Value:    7200,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationGreaterThan_Const_int_Equal_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      3600,
+		Operator: kyverno.DurationGreaterThan,
+		Value:    7200,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationGreaterThan_Const_int_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "2h",
+		Operator: kyverno.DurationGreaterThan,
+		Value:    3600,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationGreaterThan_Const_int_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      3600,
+		Operator: kyverno.DurationGreaterThan,
+		Value:    7200,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationLessThanOrEquals_Const_int_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "2h",
+		Operator: kyverno.DurationLessThanOrEquals,
+		Value:    7200,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationLessThanOrEquals_Const_int_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1h",
+		Operator: kyverno.DurationLessThanOrEquals,
+		Value:    7200,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationLessThanOrEquals_Const_int_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      7200,
+		Operator: kyverno.LessThanOrEquals,
+		Value:    3600,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationLessThan_Const_int_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      3600,
+		Operator: kyverno.DurationLessThan,
+		Value:    "1h",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationLessThan_Const_int_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      3600,
+		Operator: kyverno.DurationLessThan,
+		Value:    "2h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationLessThan_Const_int_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      7200,
+		Operator: kyverno.DurationLessThan,
+		Value:    3600,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
 // int64
 func Test_Eval_Equal_Const_int64_Pass(t *testing.T) {
 	ctx := context.NewContext()
@@ -522,6 +810,150 @@ func Test_Eval_NoEqual_Const_int64_Fail(t *testing.T) {
 		Value:    int64(1),
 	}
 
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationGreaterThanOrEquals_Const_int64_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      int64(3600),
+		Operator: kyverno.DurationGreaterThanOrEquals,
+		Value:    "1h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationGreaterThanOrEquals_Const_int64_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      int64(7200),
+		Operator: kyverno.DurationGreaterThanOrEquals,
+		Value:    "1h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationGreaterThanOrEquals_Const_int64_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      int64(3600),
+		Operator: kyverno.DurationGreaterThanOrEquals,
+		Value:    int64(7200),
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationGreaterThan_Const_int64_Equal_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      int64(3600),
+		Operator: kyverno.DurationGreaterThan,
+		Value:    int64(7200),
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationGreaterThan_Const_int64_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      int64(7200),
+		Operator: kyverno.DurationGreaterThan,
+		Value:    int64(3600),
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationGreaterThan_Const_int64_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      int64(3600),
+		Operator: kyverno.DurationGreaterThan,
+		Value:    int64(7200),
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationLessThanOrEquals_Const_int64_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      int64(7200),
+		Operator: kyverno.DurationLessThanOrEquals,
+		Value:    "2h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationLessThanOrEquals_Const_int64_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      int64(3600),
+		Operator: kyverno.DurationLessThanOrEquals,
+		Value:    "2h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationLessThanOrEquals_Const_int64_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      int64(7200),
+		Operator: kyverno.LessThanOrEquals,
+		Value:    int64(3600),
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationLessThan_Const_int64_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      int64(3600),
+		Operator: kyverno.DurationLessThan,
+		Value:    "1h",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationLessThan_Const_int64_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      int64(3600),
+		Operator: kyverno.DurationLessThan,
+		Value:    "2h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationLessThan_Const_int64_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      int64(7200),
+		Operator: kyverno.DurationLessThan,
+		Value:    int64(3600),
+	}
 	if Evaluate(log.Log, ctx, condition) {
 		t.Error("expected to fail")
 	}
@@ -723,6 +1155,150 @@ func Test_Eval_LessThan_Const_float64_Fail(t *testing.T) {
 		Key:      2.5,
 		Operator: kyverno.LessThan,
 		Value:    1.95,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationGreaterThanOrEquals_Const_float64_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      3600.0,
+		Operator: kyverno.DurationGreaterThanOrEquals,
+		Value:    "1h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationGreaterThanOrEquals_Const_float64_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      7200.0,
+		Operator: kyverno.DurationGreaterThanOrEquals,
+		Value:    "1h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationGreaterThanOrEquals_Const_float64_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      3600.0,
+		Operator: kyverno.DurationGreaterThanOrEquals,
+		Value:    7200.0,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationGreaterThan_Const_float64_Equal_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      3600.0,
+		Operator: kyverno.DurationGreaterThan,
+		Value:    7200.0,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationGreaterThan_Const_float64_Greater_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      7200.0,
+		Operator: kyverno.DurationGreaterThan,
+		Value:    "1h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationGreaterThan_Const_float64_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      3600.0,
+		Operator: kyverno.DurationGreaterThan,
+		Value:    7200.0,
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationLessThanOrEquals_Const_float64_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      7200.0,
+		Operator: kyverno.DurationLessThanOrEquals,
+		Value:    "2h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationLessThanOrEquals_Const_float64_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      3600.0,
+		Operator: kyverno.DurationLessThanOrEquals,
+		Value:    "2h",
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationLessThanOrEquals_Const_float64_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      7200.0,
+		Operator: kyverno.LessThanOrEquals,
+		Value:    "1h",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationLessThan_Const_float64_Equal_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      3600.0,
+		Operator: kyverno.DurationLessThan,
+		Value:    "1h",
+	}
+	if Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to fail")
+	}
+}
+
+func Test_Eval_DurationLessThan_Const_float64_Less_Pass(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      "1h",
+		Operator: kyverno.DurationLessThan,
+		Value:    7200.0,
+	}
+	if !Evaluate(log.Log, ctx, condition) {
+		t.Error("expected to pass")
+	}
+}
+
+func Test_Eval_DurationLessThan_Const_float64_Fail(t *testing.T) {
+	ctx := context.NewContext()
+	condition := kyverno.Condition{
+		Key:      7200.0,
+		Operator: kyverno.DurationLessThan,
+		Value:    3600.0,
 	}
 	if Evaluate(log.Log, ctx, condition) {
 		t.Error("expected to fail")

--- a/pkg/engine/variables/operator/duration.go
+++ b/pkg/engine/variables/operator/duration.go
@@ -1,0 +1,139 @@
+package operator
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/engine/context"
+)
+
+//NewDurationOperatorHandler returns handler to manage the provided duration operations (>, >=, <=, <)
+func NewDurationOperatorHandler(log logr.Logger, ctx context.EvalInterface, op kyverno.ConditionOperator) OperatorHandler {
+	return DurationOperatorHandler{
+		ctx:       ctx,
+		log:       log,
+		condition: op,
+	}
+}
+
+//DurationOperatorHandler provides implementation to handle Duration Operations associated with policies
+type DurationOperatorHandler struct {
+	ctx       context.EvalInterface
+	log       logr.Logger
+	condition kyverno.ConditionOperator
+}
+
+// durationCompareByCondition compares a time.Duration key with a time.Duration value on the basis of the provided operator
+func durationCompareByCondition(key time.Duration, value time.Duration, op kyverno.ConditionOperator, log *logr.Logger) bool {
+	switch op {
+	case kyverno.DurationGreaterThanOrEquals:
+		return key >= value
+	case kyverno.DurationGreaterThan:
+		return key > value
+	case kyverno.DurationLessThanOrEquals:
+		return key <= value
+	case kyverno.DurationLessThan:
+		return key < value
+	default:
+		(*log).Info(fmt.Sprintf("Expected operator, one of [DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan], found %s", op))
+		return false
+	}
+}
+
+func (doh DurationOperatorHandler) Evaluate(key, value interface{}) bool {
+	switch typedKey := key.(type) {
+	case int:
+		return doh.validateValueWithIntPattern(int64(typedKey), value)
+	case int64:
+		return doh.validateValueWithIntPattern(typedKey, value)
+	case float64:
+		return doh.validateValueWithFloatPattern(typedKey, value)
+	case string:
+		return doh.validateValueWithStringPattern(typedKey, value)
+	default:
+		doh.log.Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		return false
+	}
+}
+
+func (doh DurationOperatorHandler) validateValueWithIntPattern(key int64, value interface{}) bool {
+	switch typedValue := value.(type) {
+	case int:
+		return durationCompareByCondition(time.Duration(key)*time.Second, time.Duration(typedValue)*time.Second, doh.condition, &doh.log)
+	case int64:
+		return durationCompareByCondition(time.Duration(key)*time.Second, time.Duration(typedValue)*time.Second, doh.condition, &doh.log)
+	case float64:
+		return durationCompareByCondition(time.Duration(key)*time.Second, time.Duration(typedValue)*time.Second, doh.condition, &doh.log)
+	case string:
+		duration, err := time.ParseDuration(typedValue)
+		if err == nil {
+			return durationCompareByCondition(time.Duration(key)*time.Second, duration, doh.condition, &doh.log)
+		}
+		doh.log.Error(fmt.Errorf("Parse Error: "), "Failed to parse time duration from the string value")
+		return false
+	default:
+		doh.log.Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
+		return false
+	}
+}
+
+func (doh DurationOperatorHandler) validateValueWithFloatPattern(key float64, value interface{}) bool {
+	switch typedValue := value.(type) {
+	case int:
+		return durationCompareByCondition(time.Duration(key)*time.Second, time.Duration(typedValue)*time.Second, doh.condition, &doh.log)
+	case int64:
+		return durationCompareByCondition(time.Duration(key)*time.Second, time.Duration(typedValue)*time.Second, doh.condition, &doh.log)
+	case float64:
+		return durationCompareByCondition(time.Duration(key)*time.Second, time.Duration(typedValue)*time.Second, doh.condition, &doh.log)
+	case string:
+		duration, err := time.ParseDuration(typedValue)
+		if err == nil {
+			return durationCompareByCondition(time.Duration(key)*time.Second, duration, doh.condition, &doh.log)
+		}
+		doh.log.Error(fmt.Errorf("Parse Error: "), "Failed to parse time duration from the string value")
+		return false
+	default:
+		doh.log.Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
+		return false
+	}
+}
+
+func (doh DurationOperatorHandler) validateValueWithStringPattern(key string, value interface{}) bool {
+	duration, err := time.ParseDuration(key)
+	if err != nil {
+		doh.log.Error(err, "Failed to parse time duration from the string key")
+		return false
+	}
+	switch typedValue := value.(type) {
+	case int:
+		return durationCompareByCondition(duration, time.Duration(typedValue)*time.Second, doh.condition, &doh.log)
+	case int64:
+		return durationCompareByCondition(duration, time.Duration(typedValue)*time.Second, doh.condition, &doh.log)
+	case float64:
+		return durationCompareByCondition(duration, time.Duration(typedValue)*time.Second, doh.condition, &doh.log)
+	case string:
+		durationValue, err := time.ParseDuration(typedValue)
+		if err == nil {
+			return durationCompareByCondition(duration, durationValue, doh.condition, &doh.log)
+		}
+		doh.log.Error(fmt.Errorf("Parse Error: "), "Failed to parse time duration from the string value")
+		return false
+	default:
+		doh.log.Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
+		return false
+	}
+}
+
+// the following functions are unreachable because the key is strictly supposed to be a duration
+// still the following functions are just created to make DurationOperatorHandler struct implement OperatorHandler interface
+func (doh DurationOperatorHandler) validateValueWithBoolPattern(key bool, value interface{}) bool {
+	return false
+}
+func (doh DurationOperatorHandler) validateValueWithMapPattern(key map[string]interface{}, value interface{}) bool {
+	return false
+}
+func (doh DurationOperatorHandler) validateValueWithSlicePattern(key []interface{}, value interface{}) bool {
+	return false
+}

--- a/pkg/engine/variables/operator/operator.go
+++ b/pkg/engine/variables/operator/operator.go
@@ -51,6 +51,12 @@ func CreateOperatorHandler(log logr.Logger, ctx context.EvalInterface, op kyvern
 		strings.ToLower(string(kyverno.LessThan)):
 		return NewNumericOperatorHandler(log, ctx, op)
 
+	case strings.ToLower(string(kyverno.DurationGreaterThanOrEquals)),
+		strings.ToLower(string(kyverno.DurationGreaterThan)),
+		strings.ToLower(string(kyverno.DurationLessThanOrEquals)),
+		strings.ToLower(string(kyverno.DurationLessThan)):
+		return NewDurationOperatorHandler(log, ctx, op)
+
 	default:
 		log.Info("operator not supported", "operator", str)
 	}


### PR DESCRIPTION
Signed-off-by: Trey Dockendorf <tdockendorf@osc.edu>

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

Fixes #2213

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
-->
> /kind feature

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

Allow deny conditions and preconditions to have the following new operators:

* DurationGreaterThanOrEquals : key >= value?
* DurationGreaterThan : key > value?
* DurationLessThanOrEquals : key <= value?
* DurationLessThan : key < value?

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
The key and value can only be float64, int, int64 or string.  The numeric types are converted to seconds while the string values are expected to be valid Go time durations that can be parsed with `time.ParseDuration`: https://pkg.go.dev/time#ParseDuration

If this kind of change is something that would be accepted, I will open documentation update pull requests.
