### PR TITLE
Added backward compatibility | Resolving variables from the resource passed | CLI 

### DIFF
--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -387,6 +387,7 @@ func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit 
 	valuesMapRule := make(map[string]map[string]Rule)
 	namespaceSelectorMap := make(map[string]map[string]string)
 	variables := make(map[string]string)
+	reqObjVars := ""
 
 	var yamlFile []byte
 	var err error
@@ -395,7 +396,10 @@ func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit 
 		for _, kvpair := range kvpairs {
 			kvs := strings.Split(strings.Trim(kvpair, " "), "=")
 			if strings.Contains(kvs[0], "request.object") {
-				return variables, valuesMapResource, namespaceSelectorMap, sanitizederror.NewWithError("variable request.object.* is handled by kyverno. please do not pass value for request.object variables ", err)
+				if !strings.Contains(reqObjVars, kvs[0]) {
+					reqObjVars = reqObjVars + "," + kvs[0]
+				}
+				continue
 			}
 
 			variables[strings.Trim(kvs[0], " ")] = strings.Trim(kvs[1], " ")
@@ -432,7 +436,11 @@ func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit 
 			for _, r := range p.Resources {
 				for variableInFile := range r.Values {
 					if strings.Contains(variableInFile, "request.object") {
-						return variables, valuesMapResource, namespaceSelectorMap, sanitizederror.NewWithError("variable request.object.* is handled by kyverno. please do not pass value for request.object variables ", err)
+						if !strings.Contains(reqObjVars, variableInFile) {
+							reqObjVars = reqObjVars + "," + variableInFile
+						}
+						delete(r.Values, variableInFile)
+						continue
 					}
 				}
 				resourceMap[r.Name] = r
@@ -451,6 +459,10 @@ func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit 
 		for _, n := range values.NamespaceSelectors {
 			namespaceSelectorMap[n.Name] = n.Labels
 		}
+	}
+
+	if reqObjVars != "" {
+		fmt.Printf(("\nvariable request.object.* is handled by kyverno. ignoring value of variables: `%v` passed by the user.\n"), reqObjVars)
 	}
 
 	storePolices := make([]store.Policy, 0)


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue
Supporting backward compatibility for PR - https://github.com/kyverno/kyverno/pull/2180.

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Ignoring `request.object*` variables passed by the user will be ignored by Kyverno CLI.

### Proof Manifests
policy.yaml:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: pod-account-validation
  namespace: kyverno
spec:
  background: false
  validationFailureAction: enforce
  rules:
  - name: pods-user-authorized-for-account
    match:
      resources:
        kinds:
        - Pod
        namespaces:
        - "user-?*"
    preconditions:
    - key: "{{ request.operation }}"
      operator: In
      value: ["CREATE","UPDATE"]
    context:
    - name: userGroupMap
      configMap:
        name: user-groups-map
        namespace: k8-ldap-configmap
    validate:
      message: "{{ request.object.metadata.namespace }} not authorized to charge against account {{ request.object.metadata.labels.account }}"
      deny:
        conditions:
        - key: "{{ request.object.metadata.labels.account }}"
          operator: NotIn
          value: "{{ userGroupMap.data.\"{{ request.object.metadata.namespace }}\" }}"
```

resource.yaml:
```
apiVersion: v1
kind: Pod
metadata:
  name: test-fail
  namespace: user-test
  labels:
    account: PZS0002
spec: 
  containers:
  - name: nginx
    image: nginx:1.12
```

value.yaml
```
policies:
  - name: pod-account-validation
    rules:
      - name: pods-user-authorized-for-account
        values:
          userGroupMap.data.user-test: '["PZS0001","PZS0003"]'
    resources:
      - name: test-fail
        values:
          request.operation: CREATE
          request.object.metadata.namespace: someuser
          request.object.metadata.labels.account: someaccount
```

command:
`kyverno apply policy.yaml -r resource.yaml -f value.yaml`

Result:
```
variable request.object.* is handled by kyverno. ignoring value of variables: `,request.object.metadata.labels.account,request.object.metadata.namespace` passed by the user.

applying 1 policy to 1 resource... 

policy pod-account-validation -> resource user-test/Pod/test-fail failed: 
1. pods-user-authorized-for-account: user-test not authorized to charge against account PZS0002 

pass: 0, fail: 1, warn: 0, error: 0, skip: 0 
exit status 1
```


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

