### PR TITLE
Fix for - CLI panics when variables are passed using `set` flag

### DIFF
--- a/pkg/kyverno/apply/apply_command.go
+++ b/pkg/kyverno/apply/apply_command.go
@@ -138,6 +138,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&resourcePaths, "resource", "r", []string{}, "Path to resource files")
 	cmd.Flags().BoolVarP(&cluster, "cluster", "c", false, "Checks if policies should be applied to cluster in the current context")
 	cmd.Flags().StringVarP(&mutateLogPath, "output", "o", "", "Prints the mutated resources in provided file/directory")
+	// currently `set` flag supports variable for single policy applied on single resource
 	cmd.Flags().StringVarP(&variablesString, "set", "s", "", "Variables that are required")
 	cmd.Flags().StringVarP(&valuesFile, "values-file", "f", "", "File containing values for policy variables")
 	cmd.Flags().BoolVarP(&policyReport, "policy-report", "", false, "Generates policy report when passed (default policyviolation r")
@@ -232,6 +233,14 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 	if err != nil {
 		fmt.Printf("Error: failed to load resources\nCause: %s\n", err)
 		os.Exit(1)
+	}
+
+	if (len(resources) > 1 || len(mutatedPolicies) > 1) && variablesString != "" {
+		return validateEngineResponses, rc, resources, skippedPolicies, sanitizederror.NewWithError("currently `set` flag supports variable for single policy applied on single resource ", nil)
+	}
+
+	if variablesString != "" {
+		setInStoreContext(mutatedPolicies, variables)
 	}
 
 	msgPolicies := "1 policy"
@@ -410,4 +419,36 @@ func createFileOrFolder(mutateLogPath string, mutateLogPathIsDir bool) error {
 	}
 
 	return nil
+}
+
+func setInStoreContext(mutatedPolicies []*v1.ClusterPolicy, variables map[string]string) {
+	storePolices := make([]store.Policy, 0)
+	for _, policy := range mutatedPolicies {
+		storeRules := make([]store.Rule, 0)
+		for _, rule := range policy.Spec.Rules {
+			contextVal := make(map[string]string)
+			if len(rule.Context) != 0 {
+				for _, contextVar := range rule.Context {
+					for k, v := range variables {
+						if strings.HasPrefix(k, contextVar.Name) {
+							contextVal[k] = v
+						}
+					}
+				}
+				storeRules = append(storeRules, store.Rule{
+					Name:   rule.Name,
+					Values: contextVal,
+				})
+
+			}
+		}
+		storePolices = append(storePolices, store.Policy{
+			Name:  policy.Name,
+			Rules: storeRules,
+		})
+	}
+
+	store.SetContext(store.Context{
+		Policies: storePolices,
+	})
 }

--- a/pkg/kyverno/apply/apply_command.go
+++ b/pkg/kyverno/apply/apply_command.go
@@ -240,7 +240,7 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 	}
 
 	if variablesString != "" {
-		setInStoreContext(mutatedPolicies, variables)
+		variables = setInStoreContext(mutatedPolicies, variables)
 	}
 
 	msgPolicies := "1 policy"
@@ -421,7 +421,7 @@ func createFileOrFolder(mutateLogPath string, mutateLogPathIsDir bool) error {
 	return nil
 }
 
-func setInStoreContext(mutatedPolicies []*v1.ClusterPolicy, variables map[string]string) {
+func setInStoreContext(mutatedPolicies []*v1.ClusterPolicy, variables map[string]string) map[string]string {
 	storePolices := make([]store.Policy, 0)
 	for _, policy := range mutatedPolicies {
 		storeRules := make([]store.Rule, 0)
@@ -432,6 +432,7 @@ func setInStoreContext(mutatedPolicies []*v1.ClusterPolicy, variables map[string
 					for k, v := range variables {
 						if strings.HasPrefix(k, contextVar.Name) {
 							contextVal[k] = v
+							delete(variables, k)
 						}
 					}
 				}
@@ -439,7 +440,6 @@ func setInStoreContext(mutatedPolicies []*v1.ClusterPolicy, variables map[string
 					Name:   rule.Name,
 					Values: contextVal,
 				})
-
 			}
 		}
 		storePolices = append(storePolices, store.Policy{
@@ -451,4 +451,6 @@ func setInStoreContext(mutatedPolicies []*v1.ClusterPolicy, variables map[string
 	store.SetContext(store.Context{
 		Policies: storePolices,
 	})
+
+	return variables
 }


### PR DESCRIPTION
## Related issue

closes https://github.com/kyverno/kyverno/issues/2223

## What type of PR is this

> /kind bug

## Proposed Changes

Adding context variable in `store.Context `.

### Proof Manifests
policy.yaml:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: pod-account-validation
  namespace: kyverno
spec:
  background: false
  validationFailureAction: enforce
  rules:
  - name: pods-user-authorized-for-account
    match:
      resources:
        kinds:
        - Pod
        namespaces:
        - "user-?*"
    preconditions:
    - key: "{{ request.operation }}"
      operator: In
      value: ["CREATE","UPDATE"]
    context:
    - name: userGroupMap
      configMap:
        name: user-groups-map
        namespace: k8-ldap-configmap
    validate:
      message: "{{ request.object.metadata.namespace }} not authorized to charge against account {{ request.object.metadata.labels.account }}"
      deny:
        conditions:
        - key: "{{ request.object.metadata.labels.account }}"
          operator: NotIn
          value: "{{ userGroupMap.data.\"{{ request.object.metadata.namespace }}\" }}"
```

resource.yaml
```
apiVersion: v1
kind: Pod
metadata:
  name: test-fail
  namespace: user-test
  labels:
    account: PZS0002
spec: 
  containers:
  - name: nginx
    image: nginx:1.12
```

Command:
```
kyverno apply policy.yaml -r resource.yaml -s request.operation=CREATE,userGroupMap.data.user-test='["PZS0001"]'
```

Result:
```
applying 1 policy to 1 resource... 

policy pod-account-validation -> resource user-test/Pod/test-fail failed: 
1. pods-user-authorized-for-account: user-test not authorized to charge against account PZS0002 

pass: 0, fail: 1, warn: 0, error: 0, skip: 0 
exit status 1
```

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
