### PR TITLE
Updated cli comment for skipping `request.object.*` variables

### DIFF
--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -462,7 +462,7 @@ func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit 
 	}
 
 	if reqObjVars != "" {
-		fmt.Printf(("\nvariable request.object.* is handled by kyverno. ignoring value of variables: `%v` passed by the user.\n"), reqObjVars)
+		fmt.Printf(("\nNOTICE: request.object.* variables are automatically parsed from the supplied resource. Ignoring value of variables `%v`.\n"), reqObjVars)
 	}
 
 	storePolices := make([]store.Policy, 0)


### PR DESCRIPTION
Related discussion:- https://kubernetes.slack.com/archives/CLGR9BJU9/p1628261152173800?thread_ts=1628188238.149400&cid=CLGR9BJU9