### PR TITLE
add platform to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,7 @@ assignees: ''
 State the version numbers of applications involved in the bug.
 
 * Kubernetes version:
+* Kubernetes platform (if applicable; ex., EKS, GKE, OpenShift):
 * Kyverno version:
 
 **Describe the bug**


### PR DESCRIPTION
Just adds a field in the bug template to ask for the Kubernetes platform in use.