### PR TITLE
Added condition for resource sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ kyverno: fmt vet
 docker-publish-kyverno: docker-build-kyverno docker-push-kyverno
 
 docker-build-kyverno:
-	@docker buildx build --file $(PWD)/$(KYVERNO_PATH)/Dockerfile --progress plane --platform linux/arm64,linux/amd64 --tag $(REPO)/$(KYVERNO_IMAGE):$(IMAGE_TAG) . --build-arg LD_FLAGS=$(LD_FLAGS) --build-arg TAGS=$(TAGS)
+	@docker build --file $(PWD)/$(KYVERNO_PATH)/Dockerfile --tag $(REPO)/$(KYVERNO_IMAGE):$(IMAGE_TAG) . --build-arg LD_FLAGS=$(LD_FLAGS)
 
 docker-build-kyverno-local:
 	CGO_ENABLED=0 GOOS=linux go build -o $(PWD)/$(KYVERNO_PATH)/kyverno -tags $(TAGS) -ldflags=$(LD_FLAGS) $(PWD)/$(KYVERNO_PATH)/main.go

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ kyverno: fmt vet
 docker-publish-kyverno: docker-build-kyverno docker-push-kyverno
 
 docker-build-kyverno:
-	@docker build --file $(PWD)/$(KYVERNO_PATH)/Dockerfile --tag $(REPO)/$(KYVERNO_IMAGE):$(IMAGE_TAG) . --build-arg LD_FLAGS=$(LD_FLAGS)
+	@docker buildx build --file $(PWD)/$(KYVERNO_PATH)/Dockerfile --progress plane --platform linux/arm64,linux/amd64 --tag $(REPO)/$(KYVERNO_IMAGE):$(IMAGE_TAG) . --build-arg LD_FLAGS=$(LD_FLAGS) --build-arg TAGS=$(TAGS)
 
 docker-build-kyverno-local:
 	CGO_ENABLED=0 GOOS=linux go build -o $(PWD)/$(KYVERNO_PATH)/kyverno -tags $(TAGS) -ldflags=$(LD_FLAGS) $(PWD)/$(KYVERNO_PATH)/main.go

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -321,7 +321,6 @@ func applyRule(log logr.Logger, client *dclient.Client, rule kyverno.Rule, resou
 
 	// build the resource template
 	newResource := &unstructured.Unstructured{}
-	newResourceOnlyLabel := &unstructured.Unstructured{}
 	newResource.SetUnstructuredContent(rdata)
 	newResource.SetName(genName)
 	newResource.SetNamespace(genNamespace)
@@ -360,14 +359,10 @@ func applyRule(log logr.Logger, client *dclient.Client, rule kyverno.Rule, resou
 		logger.V(2).Info("created generate target resource")
 
 	} else if mode == Update {
-		if rule.Generation.Synchronize {
-			label["policy.kyverno.io/synchronize"] = "enable"
-		} else {
-			label["policy.kyverno.io/synchronize"] = "disable"
-		}
-
+		// if synchronize is true - update the label and generated resource with generate policy data
 		if rule.Generation.Synchronize {
 			logger.V(4).Info("updating existing resource")
+			label["policy.kyverno.io/synchronize"] = "enable"
 			newResource.SetLabels(label)
 			_, err := client.UpdateResource(genAPIVersion, genKind, genNamespace, newResource, false)
 			if err != nil {
@@ -375,14 +370,33 @@ func applyRule(log logr.Logger, client *dclient.Client, rule kyverno.Rule, resou
 				return noGenResource, err
 			}
 		} else {
-			logger.V(4).Info("updating label in existing resource")
-			newResourceOnlyLabel.SetLabels(label)
-			_, err := client.UpdateResource(genAPIVersion, genKind, genNamespace, newResource, false)
+			// if synchronize is false - update the label in already generated resource,
+			// without comparing it with the generate policy data
+			generatedObj, err := client.GetResource(genAPIVersion, genKind, genNamespace, genName)
 			if err != nil {
-				logger.Error(err, "failed to update label in existing resource")
-				return noGenResource, err
+				logger.Error(err, fmt.Sprintf("generated resource not found  name:%v namespace:%v kind:%v", genName, genNamespace, genKind))
+				return newGenResource, err
 			}
+
+			currentGeneratedResourcelabel := generatedObj.GetLabels()
+			currentSynclabel := currentGeneratedResourcelabel["policy.kyverno.io/synchronize"]
+
+			// update only if the labels mismatches
+			if (!rule.Generation.Synchronize && currentSynclabel == "enable") ||
+				(rule.Generation.Synchronize && currentSynclabel == "disable") {
+				logger.V(4).Info("updating label in existing resource")
+				currentGeneratedResourcelabel["policy.kyverno.io/synchronize"] = "disable"
+				generatedObj.SetLabels(currentGeneratedResourcelabel)
+
+				_, err = client.UpdateResource(genAPIVersion, genKind, genNamespace, generatedObj, false)
+				if err != nil {
+					logger.Error(err, "failed to update label in existing resource")
+					return noGenResource, err
+				}
+			}
+
 		}
+
 		logger.V(2).Info("updated generate target resource")
 	}
 


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue
closes https://github.com/kyverno/kyverno/issues/2181

## What type of PR is this
> /kind bug

## Proposed Changes
Added logic to update the label and generated resource according to the `synchronize` flag in generate policy.

**Logic:**
In case `synchronize` is true - update the resource label and generated resource according to the data available in generate policy.
In case `synchronize` is false - update the resource label only if it does not match with the generate policy label and do not update the old generated resource.

### Proof Manifests
1. Apply the following policy:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  annotations:
    policies.kyverno.io/category: Workload Isolation
    policies.kyverno.io/description: To limit the number of objects, as well as the total amount of compute that may be consumed by a single namespace, create a default resource quota for each namespace.
  labels:
    app.kubernetes.io/version: v1.4.1
  name: add-ns-quota
spec:
  background: false
  rules:
    - generate:
        data:
          spec:
            hard:
              limits.cpu: 1600m
              limits.memory: 8Gi
              pods: 8
        kind: ResourceQuota
        name: default-resourcequota
        namespace: '{{request.object.metadata.name}}'
        synchronize: false
      match:
        resources:
          kinds:
            - Namespace
      name: generate-resourcequota
      preconditions:
        all:
          - key: '{{request.object.metadata.labels.businessunit}}'
            operator: NotEquals
            value: ""
```
2. Apply following resource :
```
apiVersion: v1
kind: Namespace
metadata:
  labels:
    businessunit: supplychain
    dataclassification: nonpci
    env: dev3
    networkzone: internal
  name: supplychainontario-wsigateway-dev3
```
3. Edit the generated resource:
```
kubectl edit ResourceQuota -n supplychainontario-wsigateway-dev3 
```
4. Wait for the next time trigger (approx 15min ) - the resource should not get updated by the kyverno. The changes should be still present in the generated resource.

## Checklist
- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
