### PR TITLE
Added 2241 test case

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/sigstore/cosign v1.0.0
 	github.com/sigstore/rekor v0.3.0 // indirect
 	github.com/sigstore/sigstore v0.0.0-20210726180807-7e34e36ecda1
-	github.com/sigstore/fulcio v0.1.1
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -53,7 +53,7 @@ func newPreconditionsVariableResolver(log logr.Logger) VariableResolver {
 	return func(ctx context.EvalInterface, variable string) (interface{}, error) {
 		value, err := DefaultVariableResolver(ctx, variable)
 		if err != nil {
-			log.Info(fmt.Sprintf("Variable \"%s\" is not resolved in preconditions. Considering it as an empty string", variable))
+			log.V(4).Info(fmt.Sprintf("Variable \"%s\" is not resolved in preconditions. Considering it as an empty string", variable))
 			return "", nil
 		}
 

--- a/test/e2e/validate/config.go
+++ b/test/e2e/validate/config.go
@@ -4,14 +4,27 @@ package validate
 var ValidateTests = []struct {
 	//TestName - Name of the Test
 	TestName string
-	// Data - The Yaml file of the ClusterPolicy
-	Data []byte
+	// PolicyRaw - The Yaml file of the ClusterPolicy
+	PolicyRaw []byte
+	// ResourceRaw - The Yaml file of the ClusterPolicy
+	ResourceRaw []byte
 	// ResourceNamespace - Namespace of the Resource
 	ResourceNamespace string
+	// MustSucceed declares if test case must fail on validation
+	MustSucceed bool
 }{
 	{
-		TestName:          "test-validate-with-flux-and-variable-substitution",
-		Data:              kyverno_2043_policy,
+		TestName:          "test-validate-with-flux-and-variable-substitution-2043",
+		PolicyRaw:         kyverno_2043_policy,
+		ResourceRaw:       kyverno_2043_FluxKustomization,
 		ResourceNamespace: "test-validate",
+		MustSucceed:       false,
+	},
+	{
+		TestName:          "test-validate-with-flux-and-variable-substitution-2241",
+		PolicyRaw:         kyverno_2241_policy,
+		ResourceRaw:       kyverno_2241_FluxKustomization,
+		ResourceNamespace: "test-validate",
+		MustSucceed:       true,
 	},
 }

--- a/test/e2e/validate/validate_test.go
+++ b/test/e2e/validate/validate_test.go
@@ -69,7 +69,7 @@ func Test_Validate_Sets(t *testing.T) {
 
 		// Create policy
 		By(fmt.Sprintf("Creating policy in \"%s\"", clPolNS))
-		_, err = e2eClient.CreateNamespacedResourceYaml(clPolGVR, clPolNS, test.Data)
+		_, err = e2eClient.CreateNamespacedResourceYaml(clPolGVR, clPolNS, test.PolicyRaw)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Create Flux CRD
@@ -92,8 +92,13 @@ func Test_Validate_Sets(t *testing.T) {
 		// Create Kustomize resource
 		kustomizeGVR := e2e.GetGVR("kustomize.toolkit.fluxcd.io", "v1beta1", "kustomizations")
 		By(fmt.Sprintf("Creating Kustomize resource in \"%s\"", nspace))
-		_, err = e2eClient.CreateNamespacedResourceYaml(kustomizeGVR, nspace, kyverno_2043_FluxKustomization)
-		Expect(err).NotTo(HaveOccurred())
+		_, err = e2eClient.CreateNamespacedResourceYaml(kustomizeGVR, nspace, test.ResourceRaw)
+
+		if test.MustSucceed {
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
 
 		//CleanUp Resources
 		e2eClient.CleanClusterPolicies(clPolGVR)


### PR DESCRIPTION
Signed-off-by: Maxim Goncharenko <goncharenko.maxim@apriorit.com>

## Related issue
Closes #2241

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

/kind failing-test

## Proposed Changes
Added test case from #2241 using new variant of [this policy](https://github.com/fluxcd/flux2-multi-tenancy/blob/985b484959707bbe291340f3020b4c2d4144d15d/infrastructure/kyverno-policies/flux-multi-tenancy.yaml) with preconditions.

### Proof Manifests
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: flux-multi-tenancy
spec:
  validationFailureAction: enforce
  rules:
    - name: serviceAccountName
      exclude:
        resources:
          namespaces:
            - flux-system
      match:
        resources:
          kinds:
            - Kustomization
            - HelmRelease
      validate:
        message: ".spec.serviceAccountName is required"
        pattern:
          spec:
            serviceAccountName: "?*"
    - name: sourceRefNamespace
      exclude:
        resources:
          namespaces:
            - flux-system
      match:
        resources:
          kinds:
            - Kustomization
            - HelmRelease
      preconditions:
        any:
        - key: "{{request.object.spec.sourceRef.namespace}}"
          operator: NotEquals
          value: ""
      validate:
        message: "spec.sourceRef.namespace must be the same as metadata.namespace"
        deny:
          conditions:
            - key: "{{request.object.spec.sourceRef.namespace}}"
              operator: NotEquals
              value:  "{{request.object.metadata.namespace}}"
```

```yaml
apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
kind: Kustomization
metadata:
  name: tenants
  namespace: flux-system
spec:
  interval: 5m
  sourceRef:
    kind: GitRepository
    name: flux-system
  path: ./tenants/production
  prune: true
  validation: client
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
