### PR TITLE
add check for the forward slash

### DIFF
--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -53,7 +53,7 @@ func validateJSONPatchPathForForwardSlash(patch string) error {
 		val := re.MatchString(path)
 
 		if !val {
-			return fmt.Errorf("Path :%s", path)
+			return fmt.Errorf("%s", path)
 		}
 
 	}
@@ -89,7 +89,7 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 	for i, rule := range p.Spec.Rules {
 		//check for forward slash
 		if err := validateJSONPatchPathForForwardSlash(rule.Mutation.PatchesJSON6902); err != nil {
-			return fmt.Errorf("path: spec.rules[%d]: %s", i, err)
+			return fmt.Errorf("path must begin with a forward slash: spec.rules[%d]: %s", i, err)
 		}
 
 		if jsonPatchOnPod(rule) {

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -27,7 +27,7 @@ import (
 )
 
 //check for forward slash
-func JSONPatchPathHasForwardSlash(patch string) bool {
+func JSONPatchPathHasForwardSlash(patch string) error {
 
 	jsonPatch, err := yaml.ToJSON([]byte(patch))
 	if err != nil {
@@ -45,12 +45,14 @@ func JSONPatchPathHasForwardSlash(patch string) bool {
 			return err
 		}
 
-		out, err := regexp.MatchString(`^/`, path)
+		val, err := regexp.MatchString(`^/`, path)
 		if err != nil {
-			return fmt.Errorf("Path :", err)
+			return err
+		}
+		if val != true {
+			return fmt.Errorf("Path :%s", path)
 		}
 
-		return out
 	}
 	return nil
 }
@@ -83,8 +85,8 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 
 	for i, rule := range p.Spec.Rules {
 		//check for forward slash
-		if JSONPatchPathHasForwardSlash(rule) != true {
-			return fmt.Errorf("path: spec.rules[%d]: %v", i, err)
+		if err := JSONPatchPathHasForwardSlash(rule.Mutation.PatchesJSON6902); err != nil {
+			return fmt.Errorf("path: spec.rules[%d]: %s", i, err)
 		}
 
 		if jsonPatchOnPod(rule) {

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -26,8 +26,8 @@ import (
 	log "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-//check for forward slash
-func JSONPatchPathHasForwardSlash(patch string) error {
+// validateJSONPatchPathForForwardSlash checks for forward slash
+func validateJSONPatchPathForForwardSlash(patch string) error {
 
 	jsonPatch, err := yaml.ToJSON([]byte(patch))
 	if err != nil {
@@ -49,7 +49,7 @@ func JSONPatchPathHasForwardSlash(patch string) error {
 		if err != nil {
 			return err
 		}
-		if val != true {
+		if !val {
 			return fmt.Errorf("Path :%s", path)
 		}
 
@@ -85,7 +85,7 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 
 	for i, rule := range p.Spec.Rules {
 		//check for forward slash
-		if err := JSONPatchPathHasForwardSlash(rule.Mutation.PatchesJSON6902); err != nil {
+		if err := validateJSONPatchPathForForwardSlash(rule.Mutation.PatchesJSON6902); err != nil {
 			return fmt.Errorf("path: spec.rules[%d]: %s", i, err)
 		}
 

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -29,6 +29,11 @@ import (
 // validateJSONPatchPathForForwardSlash checks for forward slash
 func validateJSONPatchPathForForwardSlash(patch string) error {
 
+	re, err := regexp.Compile("^/")
+	if err != nil {
+		return err
+	}
+
 	jsonPatch, err := yaml.ToJSON([]byte(patch))
 	if err != nil {
 		return err
@@ -45,10 +50,8 @@ func validateJSONPatchPathForForwardSlash(patch string) error {
 			return err
 		}
 
-		val, err := regexp.MatchString(`^/`, path)
-		if err != nil {
-			return err
-		}
+		val := re.MatchString(path)
+
 		if !val {
 			return fmt.Errorf("Path :%s", path)
 		}


### PR DESCRIPTION
Signed-off-by: Sachin  sachin.maurya7666@gmail.com

## Related issue
closes #2117
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
>

-->
 /kind feature

## Proposed Changes
I have added the function for the check of the forward slash

PS : I know that the function return type and input is not correct . Please let me know that what are the changes that needs to be done .
 
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Try applying this policy
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: policy-remove-label
spec:
  rules:
    - name: "Remove unwanted label"
      match:
        resources:
          kinds:
          - Secret
      mutate:
        patchesJson6902: |-
          - path: "metadata/labels/purpose"
            op: remove    
```

```
$ kyverno apply policy.yaml
----------------------------------------------------------------------
Policy path is invalid
Error: invalid policy.
Cause: add a forward slash to the path

exit status 1
```


<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
