### PR TITLE
Fix precondition logic for mutating policies

### DIFF
--- a/pkg/engine/mutation.go
+++ b/pkg/engine/mutation.go
@@ -101,7 +101,7 @@ func Mutate(policyContext *PolicyContext) (resp *response.EngineResponse) {
 		}
 
 		// operate on the copy of the conditions, as we perform variable substitution
-		copyConditions, err := transformConditions(rule.AnyAllConditions)
+		copyConditions, err := transformConditions(ruleCopy.AnyAllConditions)
 		if err != nil {
 			logger.V(2).Info("failed to load context", "reason", err.Error())
 			continue

--- a/pkg/engine/mutation_test.go
+++ b/pkg/engine/mutation_test.go
@@ -361,7 +361,7 @@ func Test_precondition(t *testing.T) {
   }
 }`)
 
-	expectedPatch := []byte(`{"op":"add","path":"/metadata/labels","value":{"my-added-label":"test"}}`)
+	expectedPatch := []byte(`{"op":"add","path":"/metadata/labels/my-added-label","value":"test"}`)
 
 	store.SetMock(true)
 	var policy kyverno.ClusterPolicy

--- a/pkg/engine/mutation_test.go
+++ b/pkg/engine/mutation_test.go
@@ -302,3 +302,88 @@ func Test_chained_rules(t *testing.T) {
 	assert.Equal(t, string(er.PolicyResponse.Rules[0].Patches[0]), `{"op":"replace","path":"/spec/containers/0/image","value":"myregistry.corp.com/foo/bash:5.0"}`)
 	assert.Equal(t, string(er.PolicyResponse.Rules[1].Patches[0]), `{"op":"replace","path":"/spec/containers/0/image","value":"otherregistry.corp.com/foo/bash:5.0"}`)
 }
+
+func Test_precondition(t *testing.T) {
+	resourceRaw := []byte(`{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "nginx-config-test",
+    "labels": {
+      "app.kubernetes.io/managed-by": "Helm"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "image": "nginx:latest",
+        "name": "test-nginx"
+      }
+    ]
+  }
+}`)
+
+	policyraw := []byte(`{
+  "apiVersion": "kyverno.io/v1",
+  "kind": "ClusterPolicy",
+  "metadata": {
+    "name": "cm-variable-example"
+  },
+  "spec": {
+    "rules": [
+      {
+        "name": "example-configmap-lookup",
+        "match": {
+          "resources": {
+            "kinds": [
+              "Pod"
+            ]
+          }
+        },
+        "preconditions": [
+          {
+            "key": "{{ request.object.metadata.labels.\"app.kubernetes.io/managed-by\"}}",
+            "operator": "Equals",
+            "value": "Helm"
+          }
+        ],
+        "mutate": {
+          "patchStrategicMerge": {
+            "metadata": {
+              "labels": {
+                "my-added-label": "test"
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}`)
+
+	expectedPatch := []byte(`{"op":"add","path":"/metadata/labels","value":{"my-added-label":"test"}}`)
+
+	store.SetMock(true)
+	var policy kyverno.ClusterPolicy
+	err := json.Unmarshal(policyraw, &policy)
+	assert.NilError(t, err)
+	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	assert.NilError(t, err)
+
+	ctx := context.NewContext()
+	err = ctx.AddResource(resourceRaw)
+	assert.NilError(t, err)
+
+	policyContext := &PolicyContext{
+		Policy:      policy,
+		JSONContext: ctx,
+		NewResource: *resourceUnstructured,
+	}
+
+	er := Mutate(policyContext)
+	t.Log(string(expectedPatch))
+	t.Log(string(er.PolicyResponse.Rules[0].Patches[0]))
+	if !reflect.DeepEqual(expectedPatch, er.PolicyResponse.Rules[0].Patches[0]) {
+		t.Error("patches don't match")
+	}
+}


### PR DESCRIPTION
## Related issue

No issue - just a regression I noticed.

## What type of PR is this

/kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

Fixes a mistake where some templating was done on the original object instead of the copy which is used for condition validation.

### Proof Manifests

To test this easily with `kubectl apply -f`:

```json
{
  "apiVersion": "v1",
  "kind": "Pod",
  "metadata": {
    "name": "nginx-config-test",
    "labels": {
      "app.kubernetes.io/managed-by": "Helm"
    }
  },
  "spec": {
    "containers": [
      {
        "image": "nginx:latest",
        "name": "test-nginx"
      }
    ]
  }
}
```
```json
{
  "apiVersion": "kyverno.io/v1",
  "kind": "ClusterPolicy",
  "metadata": {
    "name": "cm-variable-example"
  },
  "spec": {
    "rules": [
      {
        "name": "example-configmap-lookup",
        "match": {
          "resources": {
            "kinds": [
              "Pod"
            ]
          }
        },
        "preconditions": [
          {
            "key": "{{ request.object.metadata.labels.\"app.kubernetes.io/managed-by\"}}",
            "operator": "Equals",
            "value": "Helm"
          }
        ],
        "mutate": {
          "patchStrategicMerge": {
            "metadata": {
              "labels": {
                "my-added-label": "test"
              }
            }
          }
        }
      }
    ]
  }
}
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

This PR is currently only showing a test case which I have verified to be working in `kyverno` `1.4.1` but does not longer pass in Kyverno following `1.4.2`.
