### PR TITLE
Validation for generate loops and support ClusterPolicy/Policy in match block

### DIFF
--- a/pkg/policy/actions.go
+++ b/pkg/policy/actions.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/policy/generate"
 	"github.com/kyverno/kyverno/pkg/policy/mutate"
 	"github.com/kyverno/kyverno/pkg/policy/validate"
+	"github.com/kyverno/kyverno/pkg/utils"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -54,6 +55,10 @@ func validateActions(idx int, rule kyverno.Rule, client *dclient.Client, mock bo
 			if path, err := checker.Validate(); err != nil {
 				return fmt.Errorf("path: spec.rules[%d].generate.%s.: %v", idx, path, err)
 			}
+		}
+
+		if utils.ContainsString(rule.MatchResources.Kinds, rule.Generation.Kind) {
+			return fmt.Errorf("genration kind and match resource kind should not be same")
 		}
 	}
 

--- a/pkg/policy/actions.go
+++ b/pkg/policy/actions.go
@@ -58,7 +58,7 @@ func validateActions(idx int, rule kyverno.Rule, client *dclient.Client, mock bo
 		}
 
 		if utils.ContainsString(rule.MatchResources.Kinds, rule.Generation.Kind) {
-			return fmt.Errorf("genration kind and match resource kind should not be same")
+			return fmt.Errorf("generation kind and match resource kind should not be the same.")
 		}
 	}
 

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -134,11 +134,11 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 			return fmt.Errorf("wildcards (*) are currently not supported in the match.resources.kinds field. at least one resource kind must be specified in a kind block.")
 		}
 
-		// Validate Kind with match resource kind's
+		// Validate Kind with match resource kinds
 		for _, kind := range rule.MatchResources.Kinds {
 			_, k := c.GetKindFromGVK(kind)
 			if k == p.Kind {
-				return fmt.Errorf(" kind and match resource kind should not be same")
+				return fmt.Errorf("kind and match resource kind should not be the same.")
 			}
 		}
 

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/jmespath/go-jmespath"
+	c "github.com/kyverno/kyverno/pkg/common"
 	"github.com/kyverno/kyverno/pkg/engine"
 	"github.com/kyverno/kyverno/pkg/engine/variables"
 	"github.com/kyverno/kyverno/pkg/kyverno/common"
@@ -131,6 +132,14 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 
 		if utils.ContainsString(rule.MatchResources.Kinds, "*") || utils.ContainsString(rule.ExcludeResources.Kinds, "*") {
 			return fmt.Errorf("wildcards (*) are currently not supported in the match.resources.kinds field. at least one resource kind must be specified in a kind block.")
+		}
+
+		// Validate Kind with match resource kind's
+		for _, kind := range rule.MatchResources.Kinds {
+			_, k := c.GetKindFromGVK(kind)
+			if k == p.Kind {
+				return fmt.Errorf(" kind and match resource kind should not be same")
+			}
 		}
 
 		// Validate string values in labels

--- a/pkg/webhooks/common.go
+++ b/pkg/webhooks/common.go
@@ -170,10 +170,6 @@ func convertResource(raw []byte, group, version, kind, namespace string) (unstru
 
 func excludeKyvernoResources(kind string) bool {
 	switch kind {
-	case "ClusterPolicy":
-		return true
-	case "Policy":
-		return true
 	case "ClusterPolicyReport":
 		return true
 	case "PolicyReport":


### PR DESCRIPTION
Signed-off-by: Vyankatesh <vyankateshkd@gmail.com>

## Related issue

closes https://github.com/kyverno/kyverno/issues/2149
closes https://github.com/kyverno/kyverno/issues/1941


<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.5.0



<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->


### Proof Manifests

Policy with same generate kind get block while installation
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: add-networkpolicy
  annotations:
    policies.kyverno.io/title: Add Network Policy
    policies.kyverno.io/category: Multi-Tenancy
    policies.kyverno.io/subject: NetworkPolicy
    policies.kyverno.io/description: >-
      By default, Kubernetes allows communications across all Pods within a cluster. 
      The NetworkPolicy resource and a CNI plug-in that supports NetworkPolicy must be used to restrict 
      communications. A default NetworkPolicy should be configured for each Namespace to 
      default deny all ingress and egress traffic to the Pods in the Namespace. Application 
      teams can then configure additional NetworkPolicy resources to allow desired traffic 
      to application Pods from select sources. This policy will create a new NetworkPolicy resource
      named `default-deny` which will deny all traffic anytime a new Namespace is created.      
spec:
  validationFailureAction: audit
  rules:
  - name: default-deny
    match:
      resources: 
        kinds:
        - NetworkPolicy
    generate:
      kind: NetworkPolicy
      name: default-deny
      namespace: "{{request.object.metadata.name}}"
      synchronize: true
      data:
        spec:
          # select all pods in the namespace
          podSelector: {}
          # deny all traffic
          policyTypes: 
          - Ingress
          - Egress
```
```
Error from server: error when creating ".\\Yamls\\policy-label.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: generation kind and match resource kind should not be the same.
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [x] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
