### PR TITLE
added: support for metrics configuration, periodic metrics cleanup and selective namespace whitelisting and blacklisting with respect to metrics registration

### DIFF
--- a/charts/kyverno-crds/templates/crds.yaml
+++ b/charts/kyverno-crds/templates/crds.yaml
@@ -34,18 +34,13 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: ClusterPolicy declares validation, mutation, and generation behaviors
-          for matching resources.
+        description: ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -53,49 +48,26 @@ spec:
             description: Spec declares policy behaviors.
             properties:
               background:
-                description: Background controls if rules are applied to existing
-                  resources during a background scan. Optional. Default value is "true".
-                  The value must be set to "false" if the policy rule uses variables
-                  that are only available in the admission review request (e.g. user
-                  name).
+                description: Background controls if rules are applied to existing resources during a background scan. Optional. Default value is "true". The value must be set to "false" if the policy rule uses variables that are only available in the admission review request (e.g. user name).
                 type: boolean
               rules:
-                description: Rules is a list of Rule instances. A Policy contains
-                  multiple rules and each rule can validate, mutate, or generate resources.
+                description: Rules is a list of Rule instances. A Policy contains multiple rules and each rule can validate, mutate, or generate resources.
                 items:
-                  description: Rule defines a validation, mutation, or generation
-                    control for matching resources. Each rules contains a match declaration
-                    to select resources, and an optional exclude declaration to specify
-                    which resources to exclude.
+                  description: Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.
                   properties:
                     context:
-                      description: Context defines variables and data sources that
-                        can be used during rule execution.
+                      description: Context defines variables and data sources that can be used during rule execution.
                       items:
-                        description: ContextEntry adds variables and data sources
-                          to a rule Context. Either a ConfigMap reference or a APILookup
-                          must be provided.
+                        description: ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.
                         properties:
                           apiCall:
-                            description: APICall defines an HTTP request to the Kubernetes
-                              API server. The JSON data retrieved is stored in the
-                              context.
+                            description: APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.
                             properties:
                               jmesPath:
-                                description: JMESPath is an optional JSON Match Expression
-                                  that can be used to transform the JSON response
-                                  returned from the API server. For example a JMESPath
-                                  of "items | length(@)" applied to the API server
-                                  response to the URLPath "/apis/apps/v1/deployments"
-                                  will return the total count of deployments across
-                                  all namespaces.
+                                description: JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of "items | length(@)" applied to the API server response to the URLPath "/apis/apps/v1/deployments" will return the total count of deployments across all namespaces.
                                 type: string
                               urlPath:
-                                description: URLPath is the URL path to be used in
-                                  the HTTP GET request to the Kubernetes API server
-                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
-                                  The format required is the same format used by the
-                                  `kubectl get --raw` command.
+                                description: URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments"). The format required is the same format used by the `kubectl get --raw` command.
                                 type: string
                             required:
                             - urlPath
@@ -118,36 +90,25 @@ spec:
                         type: object
                       type: array
                     exclude:
-                      description: ExcludeResources defines when this policy rule
-                        should not be applied. The exclude criteria can include resource
-                        information (e.g. kind, name, namespace, labels) and admission
-                        review request information like the name or role.
+                      description: ExcludeResources defines when this policy rule should not be applied. The exclude criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the name or role.
                       properties:
                         all:
-                          description: All allows specifying resources which will
-                            be ANDed
+                          description: All allows specifying resources which will be ANDed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR"
-                              between resources
+                            description: ResourceFilters allow users to "AND" or "OR" between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide
-                                  role names for the user.
+                                description: ClusterRoles is the list of cluster-wide role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information
-                                  about the resource being created or modified.
+                                description: ResourceDescription contains information about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations
-                                      (key-value pairs of type string). Annotation
-                                      keys and values support the wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (matches at least one character).
+                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -155,59 +116,29 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource.
-                                      The name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character).
+                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources.
-                                      Each name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character). NOTE: "Name" is being deprecated
-                                      in favor of "Names".'
+                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector
-                                      for the resource namespace. Label keys and values
-                                      in `matchLabels` support the wildcard characters
-                                      `*` (matches zero or many characters) and `?`
-                                      (matches one character).Wildcards allows writing
-                                      label selectors like ["storage.k8s.io/*": "*"].
-                                      Note that using ["*" : "*"] matches any key
-                                      and value but does not match an empty label
-                                      set.'
+                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -219,60 +150,30 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces
-                                      names. Each name supports wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (at least one character).
+                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label
-                                      keys and values in `matchLabels` support the
-                                      wildcard characters `*` (matches zero or many
-                                      characters) and `?` (matches one character).
-                                      Wildcards allows writing label selectors like
-                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                      : "*"] matches any key and value but does not
-                                      match an empty label set.'
+                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -284,52 +185,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role
-                                  names for the user.
+                                description: Roles is the list of namespaced role names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names
-                                  like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the
-                                    object or user identities a role binding applies
-                                    to.  This can either hold a direct API object
-                                    reference, or a value for non-objects such as
-                                    user and group names.
+                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of
-                                        the referenced subject. Defaults to "" for
-                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
-                                        for User and Group subjects.
+                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced.
-                                        Values defined by this API group are "User",
-                                        "Group", and "ServiceAccount". If the Authorizer
-                                        does not recognized the kind value, the Authorizer
-                                        should report an error.
+                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If
-                                        the object kind is non-namespace, such as
-                                        "User" or "Group", and this value is not empty
-                                        the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -339,30 +219,22 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will
-                            be ORed
+                          description: Any allows specifying resources which will be ORed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR"
-                              between resources
+                            description: ResourceFilters allow users to "AND" or "OR" between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide
-                                  role names for the user.
+                                description: ClusterRoles is the list of cluster-wide role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information
-                                  about the resource being created or modified.
+                                description: ResourceDescription contains information about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations
-                                      (key-value pairs of type string). Annotation
-                                      keys and values support the wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (matches at least one character).
+                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -370,59 +242,29 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource.
-                                      The name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character).
+                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources.
-                                      Each name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character). NOTE: "Name" is being deprecated
-                                      in favor of "Names".'
+                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector
-                                      for the resource namespace. Label keys and values
-                                      in `matchLabels` support the wildcard characters
-                                      `*` (matches zero or many characters) and `?`
-                                      (matches one character).Wildcards allows writing
-                                      label selectors like ["storage.k8s.io/*": "*"].
-                                      Note that using ["*" : "*"] matches any key
-                                      and value but does not match an empty label
-                                      set.'
+                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -434,60 +276,30 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces
-                                      names. Each name supports wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (at least one character).
+                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label
-                                      keys and values in `matchLabels` support the
-                                      wildcard characters `*` (matches zero or many
-                                      characters) and `?` (matches one character).
-                                      Wildcards allows writing label selectors like
-                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                      : "*"] matches any key and value but does not
-                                      match an empty label set.'
+                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -499,52 +311,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role
-                                  names for the user.
+                                description: Roles is the list of namespaced role names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names
-                                  like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the
-                                    object or user identities a role binding applies
-                                    to.  This can either hold a direct API object
-                                    reference, or a value for non-objects such as
-                                    user and group names.
+                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of
-                                        the referenced subject. Defaults to "" for
-                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
-                                        for User and Group subjects.
+                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced.
-                                        Values defined by this API group are "User",
-                                        "Group", and "ServiceAccount". If the Authorizer
-                                        does not recognized the kind value, the Authorizer
-                                        should report an error.
+                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If
-                                        the object kind is non-namespace, such as
-                                        "User" or "Group", and this value is not empty
-                                        the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -554,23 +345,17 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role
-                            names for the user.
+                          description: ClusterRoles is the list of cluster-wide role names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about
-                            the resource being created or modified.
+                          description: ResourceDescription contains information about the resource being created or modified.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value
-                                pairs of type string). Annotation keys and values
-                                support the wildcard characters "*" (matches zero
-                                or many characters) and "?" (matches at least one
-                                character).
+                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -578,52 +363,29 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name
-                                supports wildcard characters "*" (matches zero or
-                                many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources.
-                                Each name supports wildcard characters "*" (matches
-                                zero or many characters) and "?" (at least one character).
-                                NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector
-                                for the resource namespace. Label keys and values
-                                in `matchLabels` support the wildcard characters `*`
-                                (matches zero or many characters) and `?` (matches
-                                one character).Wildcards allows writing label selectors
-                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                : "*"] matches any key and value but does not match
-                                an empty label set.'
+                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
+                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -635,54 +397,30 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names.
-                                Each name supports wildcard characters "*" (matches
-                                zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys
-                                and values in `matchLabels` support the wildcard characters
-                                `*` (matches zero or many characters) and `?` (matches
-                                one character). Wildcards allows writing label selectors
-                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                : "*"] matches any key and value but does not match
-                                an empty label set.'
+                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
+                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -694,51 +432,31 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names
-                            for the user.
+                          description: Roles is the list of namespaced role names for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like
-                            users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object
-                              or user identities a role binding applies to.  This
-                              can either hold a direct API object reference, or a
-                              value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced
-                                  subject. Defaults to "" for ServiceAccount subjects.
-                                  Defaults to "rbac.authorization.k8s.io" for User
-                                  and Group subjects.
+                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values
-                                  defined by this API group are "User", "Group", and
-                                  "ServiceAccount". If the Authorizer does not recognized
-                                  the kind value, the Authorizer should report an
-                                  error.
+                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If
-                                  the object kind is non-namespace, such as "User"
-                                  or "Group", and this value is not empty the Authorizer
-                                  should report an error.
+                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
                                 type: string
                             required:
                             - kind
@@ -753,10 +471,7 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specifies the source resource used to
-                            populate each generated resource. At most one of Data
-                            or Clone can be specified. If neither are provided, the
-                            generated resource will be created with default data only.
+                          description: Clone specifies the source resource used to populate each generated resource. At most one of Data or Clone can be specified. If neither are provided, the generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -766,10 +481,7 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource declaration used
-                            to populate each generated resource. At most one of Data
-                            or Clone must be specified. If neither are provided, the
-                            generated resource will be created with default data only.
+                          description: Data provides the resource declaration used to populate each generated resource. At most one of Data or Clone must be specified. If neither are provided, the generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -781,46 +493,29 @@ spec:
                           description: Namespace specifies resource namespace.
                           type: string
                         synchronize:
-                          description: Synchronize controls if generated resources
-                            should be kept in-sync with their source resource. If
-                            Synchronize is set to "true" changes to generated resources
-                            will be overwritten with resource data from Data or the
-                            resource specified in the Clone declaration. Optional.
-                            Defaults to "false" if not specified.
+                          description: Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to "true" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to "false" if not specified.
                           type: boolean
                       type: object
                     match:
-                      description: MatchResources defines when this policy rule should
-                        be applied. The match criteria can include resource information
-                        (e.g. kind, name, namespace, labels) and admission review
-                        request information like the user name or role. At least one
-                        kind is required.
+                      description: MatchResources defines when this policy rule should be applied. The match criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the user name or role. At least one kind is required.
                       properties:
                         all:
-                          description: All allows specifying resources which will
-                            be ANDed
+                          description: All allows specifying resources which will be ANDed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR"
-                              between resources
+                            description: ResourceFilters allow users to "AND" or "OR" between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide
-                                  role names for the user.
+                                description: ClusterRoles is the list of cluster-wide role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information
-                                  about the resource being created or modified.
+                                description: ResourceDescription contains information about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations
-                                      (key-value pairs of type string). Annotation
-                                      keys and values support the wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (matches at least one character).
+                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -828,59 +523,29 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource.
-                                      The name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character).
+                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources.
-                                      Each name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character). NOTE: "Name" is being deprecated
-                                      in favor of "Names".'
+                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector
-                                      for the resource namespace. Label keys and values
-                                      in `matchLabels` support the wildcard characters
-                                      `*` (matches zero or many characters) and `?`
-                                      (matches one character).Wildcards allows writing
-                                      label selectors like ["storage.k8s.io/*": "*"].
-                                      Note that using ["*" : "*"] matches any key
-                                      and value but does not match an empty label
-                                      set.'
+                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -892,60 +557,30 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces
-                                      names. Each name supports wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (at least one character).
+                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label
-                                      keys and values in `matchLabels` support the
-                                      wildcard characters `*` (matches zero or many
-                                      characters) and `?` (matches one character).
-                                      Wildcards allows writing label selectors like
-                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                      : "*"] matches any key and value but does not
-                                      match an empty label set.'
+                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -957,52 +592,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role
-                                  names for the user.
+                                description: Roles is the list of namespaced role names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names
-                                  like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the
-                                    object or user identities a role binding applies
-                                    to.  This can either hold a direct API object
-                                    reference, or a value for non-objects such as
-                                    user and group names.
+                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of
-                                        the referenced subject. Defaults to "" for
-                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
-                                        for User and Group subjects.
+                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced.
-                                        Values defined by this API group are "User",
-                                        "Group", and "ServiceAccount". If the Authorizer
-                                        does not recognized the kind value, the Authorizer
-                                        should report an error.
+                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If
-                                        the object kind is non-namespace, such as
-                                        "User" or "Group", and this value is not empty
-                                        the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -1012,30 +626,22 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will
-                            be ORed
+                          description: Any allows specifying resources which will be ORed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR"
-                              between resources
+                            description: ResourceFilters allow users to "AND" or "OR" between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide
-                                  role names for the user.
+                                description: ClusterRoles is the list of cluster-wide role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information
-                                  about the resource being created or modified.
+                                description: ResourceDescription contains information about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations
-                                      (key-value pairs of type string). Annotation
-                                      keys and values support the wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (matches at least one character).
+                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -1043,59 +649,29 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource.
-                                      The name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character).
+                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources.
-                                      Each name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character). NOTE: "Name" is being deprecated
-                                      in favor of "Names".'
+                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector
-                                      for the resource namespace. Label keys and values
-                                      in `matchLabels` support the wildcard characters
-                                      `*` (matches zero or many characters) and `?`
-                                      (matches one character).Wildcards allows writing
-                                      label selectors like ["storage.k8s.io/*": "*"].
-                                      Note that using ["*" : "*"] matches any key
-                                      and value but does not match an empty label
-                                      set.'
+                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1107,60 +683,30 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces
-                                      names. Each name supports wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (at least one character).
+                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label
-                                      keys and values in `matchLabels` support the
-                                      wildcard characters `*` (matches zero or many
-                                      characters) and `?` (matches one character).
-                                      Wildcards allows writing label selectors like
-                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                      : "*"] matches any key and value but does not
-                                      match an empty label set.'
+                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1172,52 +718,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role
-                                  names for the user.
+                                description: Roles is the list of namespaced role names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names
-                                  like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the
-                                    object or user identities a role binding applies
-                                    to.  This can either hold a direct API object
-                                    reference, or a value for non-objects such as
-                                    user and group names.
+                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of
-                                        the referenced subject. Defaults to "" for
-                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
-                                        for User and Group subjects.
+                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced.
-                                        Values defined by this API group are "User",
-                                        "Group", and "ServiceAccount". If the Authorizer
-                                        does not recognized the kind value, the Authorizer
-                                        should report an error.
+                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If
-                                        the object kind is non-namespace, such as
-                                        "User" or "Group", and this value is not empty
-                                        the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -1227,24 +752,17 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role
-                            names for the user.
+                          description: ClusterRoles is the list of cluster-wide role names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about
-                            the resource being created or modified. Requires at least
-                            one tag to be specified when under MatchResources.
+                          description: ResourceDescription contains information about the resource being created or modified. Requires at least one tag to be specified when under MatchResources.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value
-                                pairs of type string). Annotation keys and values
-                                support the wildcard characters "*" (matches zero
-                                or many characters) and "?" (matches at least one
-                                character).
+                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -1252,52 +770,29 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name
-                                supports wildcard characters "*" (matches zero or
-                                many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources.
-                                Each name supports wildcard characters "*" (matches
-                                zero or many characters) and "?" (at least one character).
-                                NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector
-                                for the resource namespace. Label keys and values
-                                in `matchLabels` support the wildcard characters `*`
-                                (matches zero or many characters) and `?` (matches
-                                one character).Wildcards allows writing label selectors
-                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                : "*"] matches any key and value but does not match
-                                an empty label set.'
+                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
+                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -1309,54 +804,30 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names.
-                                Each name supports wildcard characters "*" (matches
-                                zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys
-                                and values in `matchLabels` support the wildcard characters
-                                `*` (matches zero or many characters) and `?` (matches
-                                one character). Wildcards allows writing label selectors
-                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                : "*"] matches any key and value but does not match
-                                an empty label set.'
+                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
+                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -1368,51 +839,31 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names
-                            for the user.
+                          description: Roles is the list of namespaced role names for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like
-                            users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object
-                              or user identities a role binding applies to.  This
-                              can either hold a direct API object reference, or a
-                              value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced
-                                  subject. Defaults to "" for ServiceAccount subjects.
-                                  Defaults to "rbac.authorization.k8s.io" for User
-                                  and Group subjects.
+                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values
-                                  defined by this API group are "User", "Group", and
-                                  "ServiceAccount". If the Authorizer does not recognized
-                                  the kind value, the Authorizer should report an
-                                  error.
+                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If
-                                  the object kind is non-namespace, such as "User"
-                                  or "Group", and this value is not empty the Authorizer
-                                  should report an error.
+                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
                                 type: string
                             required:
                             - kind
@@ -1424,25 +875,18 @@ spec:
                       description: Mutation is used to modify matching resources.
                       properties:
                         overlay:
-                          description: Overlay specifies an overlay pattern to modify
-                            resources. DEPRECATED. Use PatchStrategicMerge instead.
-                            Scheduled for removal in release 1.5+.
+                          description: Overlay specifies an overlay pattern to modify resources. DEPRECATED. Use PatchStrategicMerge instead. Scheduled for removal in release 1.5+.
                           x-kubernetes-preserve-unknown-fields: true
                         patchStrategicMerge:
-                          description: PatchStrategicMerge is a strategic merge patch
-                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
-                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          description: PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
                           x-kubernetes-preserve-unknown-fields: true
                         patches:
-                          description: Patches specifies a RFC 6902 JSON Patch to
-                            modify resources. DEPRECATED. Use PatchesJSON6902 instead.
-                            Scheduled for removal in release 1.5+.
+                          description: Patches specifies a RFC 6902 JSON Patch to modify resources. DEPRECATED. Use PatchesJSON6902 instead. Scheduled for removal in release 1.5+.
                           items:
                             description: 'Patch is a RFC 6902 JSON Patch. See: https://tools.ietf.org/html/rfc6902'
                             properties:
                               op:
-                                description: Operation specifies operations supported
-                                  by JSON Patch. i.e:- add, replace and delete.
+                                description: Operation specifies operations supported by JSON Patch. i.e:- add, replace and delete.
                                 type: string
                               path:
                                 description: Path specifies path of the resource.
@@ -1455,159 +899,114 @@ spec:
                           type: array
                           x-kubernetes-preserve-unknown-fields: true
                         patchesJson6902:
-                          description: PatchesJSON6902 is a list of RFC 6902 JSON
-                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
-                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
                           type: string
                       type: object
                     name:
-                      description: Name is a label to identify the rule, It must be
-                        unique within the policy.
+                      description: Name is a label to identify the rule, It must be unique within the policy.
                       maxLength: 63
                       type: string
                     preconditions:
-                      description: 'Preconditions are used to determine if a policy
-                        rule should be applied by evaluating a set of conditions.
-                        The declaration can contain nested `any` or `all` statements.
-                        A direct list of conditions (without `any` or `all` statements
-                        is supported for backwards compatibility but will be deprecated
-                        in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      description: 'Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
                       x-kubernetes-preserve-unknown-fields: true
                     validate:
                       description: Validation is used to validate matching resources.
                       properties:
                         anyPattern:
-                          description: AnyPattern specifies list of validation patterns.
-                            At least one of the patterns must be satisfied for the
-                            validation rule to succeed.
+                          description: AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.
                           x-kubernetes-preserve-unknown-fields: true
                         deny:
-                          description: Deny defines conditions used to pass or fail
-                            a validation rule.
+                          description: Deny defines conditions used to pass or fail a validation rule.
                           properties:
                             conditions:
-                              description: 'Multiple conditions can be declared under
-                                an `any` or `all` statement. A direct list of conditions
-                                (without `any` or `all` statements) is also supported
-                                for backwards compatibility but will be deprecated
-                                in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              description: 'Multiple conditions can be declared under an `any` or `all` statement. A direct list of conditions (without `any` or `all` statements) is also supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
                               x-kubernetes-preserve-unknown-fields: true
                           type: object
                         message:
-                          description: Message specifies a custom message to be displayed
-                            on failure.
+                          description: Message specifies a custom message to be displayed on failure.
                           type: string
                         pattern:
-                          description: Pattern specifies an overlay-style pattern
-                            used to check resources.
+                          description: Pattern specifies an overlay-style pattern used to check resources.
                           x-kubernetes-preserve-unknown-fields: true
                       type: object
                     verifyImages:
-                      description: VerifyImages is used to verify image signatures
-                        and mutate them to add a digest
+                      description: VerifyImages is used to verify image signatures and mutate them to add a digest
                       items:
-                        description: ImageVerification validates that images that
-                          match the specified pattern are signed with the supplied
-                          public key. Once the image is verified it is mutated to
-                          include the SHA digest retrieved during the registration.
+                        description: ImageVerification validates that images that match the specified pattern are signed with the supplied public key. Once the image is verified it is mutated to include the SHA digest retrieved during the registration.
                         properties:
                           image:
-                            description: 'Image is the image name consisting of the
-                              registry address, repository, image, and tag. Wildcards
-                              (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                            description: 'Image is the image name consisting of the registry address, repository, image, and tag. Wildcards (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
                             type: string
                           key:
-                            description: Key is the PEM encoded public key that the
-                              image is signed with.
+                            description: Key is the PEM encoded public key that the image is signed with.
                             type: string
                         type: object
                       type: array
                   type: object
                 type: array
               schemaValidation:
-                description: SchemaValidation skips policy validation checks. Optional.
-                  The default value is set to "true", it must be set to "false" to
-                  disable the validation checks.
+                description: SchemaValidation skips policy validation checks. Optional. The default value is set to "true", it must be set to "false" to disable the validation checks.
                 type: boolean
               validationFailureAction:
-                description: ValidationFailureAction controls if a validation policy
-                  rule failure should disallow the admission review request (enforce),
-                  or allow (audit) the admission review request and report an error
-                  in a policy report. Optional. The default value is "audit".
+                description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
                 type: string
             type: object
           status:
             description: Status contains policy runtime data.
             properties:
               averageExecutionTime:
-                description: AvgExecutionTime is the average time taken to process
-                  the policy rules on a resource.
+                description: AvgExecutionTime is the average time taken to process the policy rules on a resource.
                 type: string
               resourcesBlockedCount:
-                description: ResourcesBlockedCount is the total count of admission
-                  review requests that were blocked by this policy.
+                description: ResourcesBlockedCount is the total count of admission review requests that were blocked by this policy.
                 type: integer
               resourcesGeneratedCount:
-                description: ResourcesGeneratedCount is the total count of resources
-                  that were generated by this policy.
+                description: ResourcesGeneratedCount is the total count of resources that were generated by this policy.
                 type: integer
               resourcesMutatedCount:
-                description: ResourcesMutatedCount is the total count of resources
-                  that were mutated by this policy.
+                description: ResourcesMutatedCount is the total count of resources that were mutated by this policy.
                 type: integer
               ruleStatus:
                 description: Rules provides per rule statistics
                 items:
-                  description: 'RuleStats provides statistics for an individual rule
-                    within a policy. Deprecated. Policy metrics are now available
-                    via the "/metrics" endpoint. See: https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/'
+                  description: 'RuleStats provides statistics for an individual rule within a policy. Deprecated. Policy metrics are now available via the "/metrics" endpoint. See: https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/'
                   properties:
                     appliedCount:
-                      description: AppliedCount is the total number of times this
-                        rule was applied.
+                      description: AppliedCount is the total number of times this rule was applied.
                       type: integer
                     averageExecutionTime:
-                      description: ExecutionTime is the average time taken to execute
-                        this rule.
+                      description: ExecutionTime is the average time taken to execute this rule.
                       type: string
                     failedCount:
-                      description: FailedCount is the total count of policy error
-                        results for this rule.
+                      description: FailedCount is the total count of policy error results for this rule.
                       type: integer
                     resourcesBlockedCount:
-                      description: ResourcesBlockedCount is the total count of admission
-                        review requests that were blocked by this rule.
+                      description: ResourcesBlockedCount is the total count of admission review requests that were blocked by this rule.
                       type: integer
                     resourcesGeneratedCount:
-                      description: ResourcesGeneratedCount is the total count of resources
-                        that were generated by this rule.
+                      description: ResourcesGeneratedCount is the total count of resources that were generated by this rule.
                       type: integer
                     resourcesMutatedCount:
-                      description: ResourcesMutatedCount is the total count of resources
-                        that were mutated by this rule.
+                      description: ResourcesMutatedCount is the total count of resources that were mutated by this rule.
                       type: integer
                     ruleName:
                       description: Name is the rule name.
                       type: string
                     violationCount:
-                      description: ViolationCount is the total count of policy failure
-                        results for this rule.
+                      description: ViolationCount is the total count of policy failure results for this rule.
                       type: integer
                   required:
                   - ruleName
                   type: object
                 type: array
               rulesAppliedCount:
-                description: RulesAppliedCount is the total number of times this policy
-                  was applied.
+                description: RulesAppliedCount is the total number of times this policy was applied.
                 type: integer
               rulesFailedCount:
-                description: RulesFailedCount is the total count of policy execution
-                  errors for this policy.
+                description: RulesFailedCount is the total count of policy execution errors for this policy.
                 type: integer
               violationCount:
-                description: ViolationCount is the total count of policy failure results
-                  for this policy.
+                description: ViolationCount is the total count of policy failure results for this policy.
                 type: integer
             type: object
         required:
@@ -1680,26 +1079,20 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterPolicyReport is the Schema for the clusterpolicyreports
-          API
+        description: ClusterPolicyReport is the Schema for the clusterpolicyreports API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual
-                policy
+              description: PolicyReportResult provides the result for an individual policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -1707,46 +1100,30 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy
-                    rule
+                  description: Data provides additional information for the policy rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the
-                    policy rule
+                  description: Message is a short user friendly description of the policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy
-                    results that apply to multiple resources. For example, a policy
-                    result may apply to all pods that match a label. Either a Resource
-                    or a ResourceSelector can be specified. If neither are provided,
-                    the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies
-                              to.
+                            description: key is the label key that the selector applies to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -1758,58 +1135,19 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource
-                    checked by the policy and rule
+                  description: Resources is an optional reference to the resource checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
+                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1821,8 +1159,7 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -1856,23 +1193,13 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g.
-              a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire
-                  object, this string should contain a valid JSON/Go field access
-                  statement, such as desiredState.manifest.containers[2]. For example,
-                  if the object reference is to a container within a pod, this would
-                  take on a value like: "spec.containers{name}" (where "name" refers
-                  to the name of the container that triggered the event) or if no
-                  container name is specified "spec.containers[2]" (container with
-                  index 2 in this pod). This syntax is chosen only to have some well-defined
-                  way of referencing a part of an object. TODO: this design is not
-                  final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1884,39 +1211,28 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is
-                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes
-              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
-              should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements.
-                  The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains
-                    values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies
-                        to.
+                      description: key is the label key that the selector applies to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set
-                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator
-                        is In or NotIn, the values array must be non-empty. If the
-                        operator is Exists or DoesNotExist, the values array must
-                        be empty. This array is replaced during a strategic merge
-                        patch.
+                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                       items:
                         type: string
                       type: array
@@ -1928,34 +1244,26 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value}
-                  in the matchLabels map is equivalent to an element of matchExpressions,
-                  whose key field is "key", the operator is "In", and the values array
-                  contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be
-                  evaluated
+                description: Error provides the count of policies that could not be evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements
-                  were not met
+                description: Fail provides the count of policies whose requirements were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements
-                  were met
+                description: Pass provides the count of policies whose requirements were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected
-                  for evaluation
+                description: Skip indicates the count of policies that were not selected for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements
-                  were not met
+                description: Warn provides the count of unscored policies whose requirements were not met
                 type: integer
             type: object
         type: object
@@ -1992,33 +1300,26 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: ClusterPolicyReport is the Schema for the clusterpolicyreports
-          API
+        description: ClusterPolicyReport is the Schema for the clusterpolicyreports API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual
-                policy
+              description: PolicyReportResult provides the result for an individual policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the
-                    policy rule
+                  description: Message is a short user friendly description of the policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -2026,39 +1327,24 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the
-                    policy rule
+                  description: Properties provides additional information for the policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy
-                    results that apply to multiple resources. For example, a policy
-                    result may apply to all pods that match a label. Either a Resource
-                    or a ResourceSelector can be specified. If neither are provided,
-                    the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies
-                              to.
+                            description: key is the label key that the selector applies to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -2070,58 +1356,19 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource
-                    checked by the policy and rule
+                  description: Resources is an optional reference to the resource checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
+                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -2133,8 +1380,7 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -2164,24 +1410,17 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that
-                    manages this report
+                  description: Source is an identifier for the policy engine that manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond
-                        resolution. Negative second values with fractions must still
-                        have non-negative nanos values that count forward in time.
-                        Must be from 0 to 999,999,999 inclusive. This field may be
-                        limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch
-                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-                        9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -2193,23 +1432,13 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g.
-              a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire
-                  object, this string should contain a valid JSON/Go field access
-                  statement, such as desiredState.manifest.containers[2]. For example,
-                  if the object reference is to a container within a pod, this would
-                  take on a value like: "spec.containers{name}" (where "name" refers
-                  to the name of the container that triggered the event) or if no
-                  container name is specified "spec.containers[2]" (container with
-                  index 2 in this pod). This syntax is chosen only to have some well-defined
-                  way of referencing a part of an object. TODO: this design is not
-                  final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -2221,39 +1450,28 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is
-                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes
-              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
-              should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements.
-                  The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains
-                    values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies
-                        to.
+                      description: key is the label key that the selector applies to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set
-                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator
-                        is In or NotIn, the values array must be non-empty. If the
-                        operator is Exists or DoesNotExist, the values array must
-                        be empty. This array is replaced during a strategic merge
-                        patch.
+                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                       items:
                         type: string
                       type: array
@@ -2265,34 +1483,26 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value}
-                  in the matchLabels map is equivalent to an element of matchExpressions,
-                  whose key field is "key", the operator is "In", and the values array
-                  contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be
-                  evaluated
+                description: Error provides the count of policies that could not be evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements
-                  were not met
+                description: Fail provides the count of policies whose requirements were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements
-                  were met
+                description: Pass provides the count of policies whose requirements were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected
-                  for evaluation
+                description: Skip indicates the count of policies that were not selected for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements
-                  were not met
+                description: Warn provides the count of unscored policies whose requirements were not met
                 type: integer
             type: object
         type: object
@@ -2362,26 +1572,20 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests
-          API
+        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual
-                policy
+              description: PolicyReportResult provides the result for an individual policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -2389,46 +1593,30 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy
-                    rule
+                  description: Data provides additional information for the policy rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the
-                    policy rule
+                  description: Message is a short user friendly description of the policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy
-                    results that apply to multiple resources. For example, a policy
-                    result may apply to all pods that match a label. Either a Resource
-                    or a ResourceSelector can be specified. If neither are provided,
-                    the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies
-                              to.
+                            description: key is the label key that the selector applies to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -2440,58 +1628,19 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource
-                    checked by the policy and rule
+                  description: Resources is an optional reference to the resource checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
+                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -2503,8 +1652,7 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -2538,23 +1686,13 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g.
-              a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire
-                  object, this string should contain a valid JSON/Go field access
-                  statement, such as desiredState.manifest.containers[2]. For example,
-                  if the object reference is to a container within a pod, this would
-                  take on a value like: "spec.containers{name}" (where "name" refers
-                  to the name of the container that triggered the event) or if no
-                  container name is specified "spec.containers[2]" (container with
-                  index 2 in this pod). This syntax is chosen only to have some well-defined
-                  way of referencing a part of an object. TODO: this design is not
-                  final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -2566,39 +1704,28 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is
-                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes
-              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
-              should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements.
-                  The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains
-                    values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies
-                        to.
+                      description: key is the label key that the selector applies to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set
-                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator
-                        is In or NotIn, the values array must be non-empty. If the
-                        operator is Exists or DoesNotExist, the values array must
-                        be empty. This array is replaced during a strategic merge
-                        patch.
+                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                       items:
                         type: string
                       type: array
@@ -2610,34 +1737,26 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value}
-                  in the matchLabels map is equivalent to an element of matchExpressions,
-                  whose key field is "key", the operator is "In", and the values array
-                  contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be
-                  evaluated
+                description: Error provides the count of policies that could not be evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements
-                  were not met
+                description: Fail provides the count of policies whose requirements were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements
-                  were met
+                description: Pass provides the count of policies whose requirements were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected
-                  for evaluation
+                description: Skip indicates the count of policies that were not selected for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements
-                  were not met
+                description: Warn provides the count of unscored policies whose requirements were not met
                 type: integer
             type: object
         type: object
@@ -2674,33 +1793,26 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests
-          API
+        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual
-                policy
+              description: PolicyReportResult provides the result for an individual policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the
-                    policy rule
+                  description: Message is a short user friendly description of the policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -2708,39 +1820,24 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the
-                    policy rule
+                  description: Properties provides additional information for the policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy
-                    results that apply to multiple resources. For example, a policy
-                    result may apply to all pods that match a label. Either a Resource
-                    or a ResourceSelector can be specified. If neither are provided,
-                    the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies
-                              to.
+                            description: key is the label key that the selector applies to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -2752,58 +1849,19 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource
-                    checked by the policy and rule
+                  description: Resources is an optional reference to the resource checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
+                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -2815,8 +1873,7 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -2846,24 +1903,17 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that
-                    manages this report
+                  description: Source is an identifier for the policy engine that manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond
-                        resolution. Negative second values with fractions must still
-                        have non-negative nanos values that count forward in time.
-                        Must be from 0 to 999,999,999 inclusive. This field may be
-                        limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch
-                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-                        9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -2875,23 +1925,13 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g.
-              a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire
-                  object, this string should contain a valid JSON/Go field access
-                  statement, such as desiredState.manifest.containers[2]. For example,
-                  if the object reference is to a container within a pod, this would
-                  take on a value like: "spec.containers{name}" (where "name" refers
-                  to the name of the container that triggered the event) or if no
-                  container name is specified "spec.containers[2]" (container with
-                  index 2 in this pod). This syntax is chosen only to have some well-defined
-                  way of referencing a part of an object. TODO: this design is not
-                  final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -2903,39 +1943,28 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is
-                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes
-              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
-              should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements.
-                  The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains
-                    values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies
-                        to.
+                      description: key is the label key that the selector applies to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set
-                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator
-                        is In or NotIn, the values array must be non-empty. If the
-                        operator is Exists or DoesNotExist, the values array must
-                        be empty. This array is replaced during a strategic merge
-                        patch.
+                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                       items:
                         type: string
                       type: array
@@ -2947,34 +1976,26 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value}
-                  in the matchLabels map is equivalent to an element of matchExpressions,
-                  whose key field is "key", the operator is "In", and the values array
-                  contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be
-                  evaluated
+                description: Error provides the count of policies that could not be evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements
-                  were not met
+                description: Fail provides the count of policies whose requirements were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements
-                  were met
+                description: Pass provides the count of policies whose requirements were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected
-                  for evaluation
+                description: Skip indicates the count of policies that were not selected for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements
-                  were not met
+                description: Warn provides the count of unscored policies whose requirements were not met
                 type: integer
             type: object
         type: object
@@ -3039,14 +2060,10 @@ spec:
         description: GenerateRequest is a request to process generate rule.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -3057,12 +2074,10 @@ spec:
                 description: Context ...
                 properties:
                   userInfo:
-                    description: RequestInfo contains permission info carried in an
-                      admission request.
+                    description: RequestInfo contains permission info carried in an admission request.
                     properties:
                       clusterRoles:
-                        description: ClusterRoles is a list of possible clusterRoles
-                          send the request.
+                        description: ClusterRoles is a list of possible clusterRoles send the request.
                         items:
                           type: string
                         nullable: true
@@ -3074,18 +2089,15 @@ spec:
                         nullable: true
                         type: array
                       userInfo:
-                        description: UserInfo is the userInfo carried in the admission
-                          request.
+                        description: UserInfo is the userInfo carried in the admission request.
                         properties:
                           extra:
                             additionalProperties:
-                              description: ExtraValue masks the value so protobuf
-                                can generate
+                              description: ExtraValue masks the value so protobuf can generate
                               items:
                                 type: string
                               type: array
-                            description: Any additional information provided by the
-                              authenticator.
+                            description: Any additional information provided by the authenticator.
                             type: object
                           groups:
                             description: The names of groups this user is a part of.
@@ -3093,14 +2105,10 @@ spec:
                               type: string
                             type: array
                           uid:
-                            description: A unique value that identifies this user
-                              across time. If this user is deleted and another user
-                              by the same name is added, they will have different
-                              UIDs.
+                            description: A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs.
                             type: string
                           username:
-                            description: The name that uniquely identifies this user
-                              among all active users.
+                            description: The name that uniquely identifies this user among all active users.
                             type: string
                         type: object
                     type: object
@@ -3109,8 +2117,7 @@ spec:
                 description: Specifies the name of the policy.
                 type: string
               resource:
-                description: ResourceSpec is the information to identify the generate
-                  request.
+                description: ResourceSpec is the information to identify the generate request.
                 properties:
                   apiVersion:
                     description: APIVersion specifies resource apiVersion.
@@ -3134,8 +2141,7 @@ spec:
             description: Status contains statistics related to generate request.
             properties:
               generatedResources:
-                description: This will track the resources that are generated by the
-                  generate Policy. Will be used during clean up resources.
+                description: This will track the resources that are generated by the generate Policy. Will be used during clean up resources.
                 items:
                   description: ResourceSpec contains information to identify a resource.
                   properties:
@@ -3212,19 +2218,13 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: 'Policy declares validation, mutation, and generation behaviors
-          for matching resources. See: https://kyverno.io/docs/writing-policies/ for
-          more information.'
+        description: 'Policy declares validation, mutation, and generation behaviors for matching resources. See: https://kyverno.io/docs/writing-policies/ for more information.'
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -3232,49 +2232,26 @@ spec:
             description: Spec defines policy behaviors and contains one or more rules.
             properties:
               background:
-                description: Background controls if rules are applied to existing
-                  resources during a background scan. Optional. Default value is "true".
-                  The value must be set to "false" if the policy rule uses variables
-                  that are only available in the admission review request (e.g. user
-                  name).
+                description: Background controls if rules are applied to existing resources during a background scan. Optional. Default value is "true". The value must be set to "false" if the policy rule uses variables that are only available in the admission review request (e.g. user name).
                 type: boolean
               rules:
-                description: Rules is a list of Rule instances. A Policy contains
-                  multiple rules and each rule can validate, mutate, or generate resources.
+                description: Rules is a list of Rule instances. A Policy contains multiple rules and each rule can validate, mutate, or generate resources.
                 items:
-                  description: Rule defines a validation, mutation, or generation
-                    control for matching resources. Each rules contains a match declaration
-                    to select resources, and an optional exclude declaration to specify
-                    which resources to exclude.
+                  description: Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.
                   properties:
                     context:
-                      description: Context defines variables and data sources that
-                        can be used during rule execution.
+                      description: Context defines variables and data sources that can be used during rule execution.
                       items:
-                        description: ContextEntry adds variables and data sources
-                          to a rule Context. Either a ConfigMap reference or a APILookup
-                          must be provided.
+                        description: ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.
                         properties:
                           apiCall:
-                            description: APICall defines an HTTP request to the Kubernetes
-                              API server. The JSON data retrieved is stored in the
-                              context.
+                            description: APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.
                             properties:
                               jmesPath:
-                                description: JMESPath is an optional JSON Match Expression
-                                  that can be used to transform the JSON response
-                                  returned from the API server. For example a JMESPath
-                                  of "items | length(@)" applied to the API server
-                                  response to the URLPath "/apis/apps/v1/deployments"
-                                  will return the total count of deployments across
-                                  all namespaces.
+                                description: JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of "items | length(@)" applied to the API server response to the URLPath "/apis/apps/v1/deployments" will return the total count of deployments across all namespaces.
                                 type: string
                               urlPath:
-                                description: URLPath is the URL path to be used in
-                                  the HTTP GET request to the Kubernetes API server
-                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
-                                  The format required is the same format used by the
-                                  `kubectl get --raw` command.
+                                description: URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments"). The format required is the same format used by the `kubectl get --raw` command.
                                 type: string
                             required:
                             - urlPath
@@ -3297,36 +2274,25 @@ spec:
                         type: object
                       type: array
                     exclude:
-                      description: ExcludeResources defines when this policy rule
-                        should not be applied. The exclude criteria can include resource
-                        information (e.g. kind, name, namespace, labels) and admission
-                        review request information like the name or role.
+                      description: ExcludeResources defines when this policy rule should not be applied. The exclude criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the name or role.
                       properties:
                         all:
-                          description: All allows specifying resources which will
-                            be ANDed
+                          description: All allows specifying resources which will be ANDed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR"
-                              between resources
+                            description: ResourceFilters allow users to "AND" or "OR" between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide
-                                  role names for the user.
+                                description: ClusterRoles is the list of cluster-wide role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information
-                                  about the resource being created or modified.
+                                description: ResourceDescription contains information about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations
-                                      (key-value pairs of type string). Annotation
-                                      keys and values support the wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (matches at least one character).
+                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -3334,59 +2300,29 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource.
-                                      The name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character).
+                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources.
-                                      Each name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character). NOTE: "Name" is being deprecated
-                                      in favor of "Names".'
+                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector
-                                      for the resource namespace. Label keys and values
-                                      in `matchLabels` support the wildcard characters
-                                      `*` (matches zero or many characters) and `?`
-                                      (matches one character).Wildcards allows writing
-                                      label selectors like ["storage.k8s.io/*": "*"].
-                                      Note that using ["*" : "*"] matches any key
-                                      and value but does not match an empty label
-                                      set.'
+                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3398,60 +2334,30 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces
-                                      names. Each name supports wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (at least one character).
+                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label
-                                      keys and values in `matchLabels` support the
-                                      wildcard characters `*` (matches zero or many
-                                      characters) and `?` (matches one character).
-                                      Wildcards allows writing label selectors like
-                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                      : "*"] matches any key and value but does not
-                                      match an empty label set.'
+                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3463,52 +2369,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role
-                                  names for the user.
+                                description: Roles is the list of namespaced role names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names
-                                  like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the
-                                    object or user identities a role binding applies
-                                    to.  This can either hold a direct API object
-                                    reference, or a value for non-objects such as
-                                    user and group names.
+                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of
-                                        the referenced subject. Defaults to "" for
-                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
-                                        for User and Group subjects.
+                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced.
-                                        Values defined by this API group are "User",
-                                        "Group", and "ServiceAccount". If the Authorizer
-                                        does not recognized the kind value, the Authorizer
-                                        should report an error.
+                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If
-                                        the object kind is non-namespace, such as
-                                        "User" or "Group", and this value is not empty
-                                        the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -3518,30 +2403,22 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will
-                            be ORed
+                          description: Any allows specifying resources which will be ORed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR"
-                              between resources
+                            description: ResourceFilters allow users to "AND" or "OR" between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide
-                                  role names for the user.
+                                description: ClusterRoles is the list of cluster-wide role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information
-                                  about the resource being created or modified.
+                                description: ResourceDescription contains information about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations
-                                      (key-value pairs of type string). Annotation
-                                      keys and values support the wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (matches at least one character).
+                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -3549,59 +2426,29 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource.
-                                      The name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character).
+                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources.
-                                      Each name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character). NOTE: "Name" is being deprecated
-                                      in favor of "Names".'
+                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector
-                                      for the resource namespace. Label keys and values
-                                      in `matchLabels` support the wildcard characters
-                                      `*` (matches zero or many characters) and `?`
-                                      (matches one character).Wildcards allows writing
-                                      label selectors like ["storage.k8s.io/*": "*"].
-                                      Note that using ["*" : "*"] matches any key
-                                      and value but does not match an empty label
-                                      set.'
+                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3613,60 +2460,30 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces
-                                      names. Each name supports wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (at least one character).
+                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label
-                                      keys and values in `matchLabels` support the
-                                      wildcard characters `*` (matches zero or many
-                                      characters) and `?` (matches one character).
-                                      Wildcards allows writing label selectors like
-                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                      : "*"] matches any key and value but does not
-                                      match an empty label set.'
+                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3678,52 +2495,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role
-                                  names for the user.
+                                description: Roles is the list of namespaced role names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names
-                                  like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the
-                                    object or user identities a role binding applies
-                                    to.  This can either hold a direct API object
-                                    reference, or a value for non-objects such as
-                                    user and group names.
+                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of
-                                        the referenced subject. Defaults to "" for
-                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
-                                        for User and Group subjects.
+                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced.
-                                        Values defined by this API group are "User",
-                                        "Group", and "ServiceAccount". If the Authorizer
-                                        does not recognized the kind value, the Authorizer
-                                        should report an error.
+                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If
-                                        the object kind is non-namespace, such as
-                                        "User" or "Group", and this value is not empty
-                                        the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -3733,23 +2529,17 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role
-                            names for the user.
+                          description: ClusterRoles is the list of cluster-wide role names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about
-                            the resource being created or modified.
+                          description: ResourceDescription contains information about the resource being created or modified.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value
-                                pairs of type string). Annotation keys and values
-                                support the wildcard characters "*" (matches zero
-                                or many characters) and "?" (matches at least one
-                                character).
+                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -3757,52 +2547,29 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name
-                                supports wildcard characters "*" (matches zero or
-                                many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources.
-                                Each name supports wildcard characters "*" (matches
-                                zero or many characters) and "?" (at least one character).
-                                NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector
-                                for the resource namespace. Label keys and values
-                                in `matchLabels` support the wildcard characters `*`
-                                (matches zero or many characters) and `?` (matches
-                                one character).Wildcards allows writing label selectors
-                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                : "*"] matches any key and value but does not match
-                                an empty label set.'
+                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
+                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -3814,54 +2581,30 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names.
-                                Each name supports wildcard characters "*" (matches
-                                zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys
-                                and values in `matchLabels` support the wildcard characters
-                                `*` (matches zero or many characters) and `?` (matches
-                                one character). Wildcards allows writing label selectors
-                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                : "*"] matches any key and value but does not match
-                                an empty label set.'
+                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
+                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -3873,51 +2616,31 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names
-                            for the user.
+                          description: Roles is the list of namespaced role names for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like
-                            users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object
-                              or user identities a role binding applies to.  This
-                              can either hold a direct API object reference, or a
-                              value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced
-                                  subject. Defaults to "" for ServiceAccount subjects.
-                                  Defaults to "rbac.authorization.k8s.io" for User
-                                  and Group subjects.
+                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values
-                                  defined by this API group are "User", "Group", and
-                                  "ServiceAccount". If the Authorizer does not recognized
-                                  the kind value, the Authorizer should report an
-                                  error.
+                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If
-                                  the object kind is non-namespace, such as "User"
-                                  or "Group", and this value is not empty the Authorizer
-                                  should report an error.
+                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
                                 type: string
                             required:
                             - kind
@@ -3932,10 +2655,7 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specifies the source resource used to
-                            populate each generated resource. At most one of Data
-                            or Clone can be specified. If neither are provided, the
-                            generated resource will be created with default data only.
+                          description: Clone specifies the source resource used to populate each generated resource. At most one of Data or Clone can be specified. If neither are provided, the generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -3945,10 +2665,7 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource declaration used
-                            to populate each generated resource. At most one of Data
-                            or Clone must be specified. If neither are provided, the
-                            generated resource will be created with default data only.
+                          description: Data provides the resource declaration used to populate each generated resource. At most one of Data or Clone must be specified. If neither are provided, the generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -3960,46 +2677,29 @@ spec:
                           description: Namespace specifies resource namespace.
                           type: string
                         synchronize:
-                          description: Synchronize controls if generated resources
-                            should be kept in-sync with their source resource. If
-                            Synchronize is set to "true" changes to generated resources
-                            will be overwritten with resource data from Data or the
-                            resource specified in the Clone declaration. Optional.
-                            Defaults to "false" if not specified.
+                          description: Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to "true" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to "false" if not specified.
                           type: boolean
                       type: object
                     match:
-                      description: MatchResources defines when this policy rule should
-                        be applied. The match criteria can include resource information
-                        (e.g. kind, name, namespace, labels) and admission review
-                        request information like the user name or role. At least one
-                        kind is required.
+                      description: MatchResources defines when this policy rule should be applied. The match criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the user name or role. At least one kind is required.
                       properties:
                         all:
-                          description: All allows specifying resources which will
-                            be ANDed
+                          description: All allows specifying resources which will be ANDed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR"
-                              between resources
+                            description: ResourceFilters allow users to "AND" or "OR" between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide
-                                  role names for the user.
+                                description: ClusterRoles is the list of cluster-wide role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information
-                                  about the resource being created or modified.
+                                description: ResourceDescription contains information about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations
-                                      (key-value pairs of type string). Annotation
-                                      keys and values support the wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (matches at least one character).
+                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -4007,59 +2707,29 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource.
-                                      The name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character).
+                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources.
-                                      Each name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character). NOTE: "Name" is being deprecated
-                                      in favor of "Names".'
+                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector
-                                      for the resource namespace. Label keys and values
-                                      in `matchLabels` support the wildcard characters
-                                      `*` (matches zero or many characters) and `?`
-                                      (matches one character).Wildcards allows writing
-                                      label selectors like ["storage.k8s.io/*": "*"].
-                                      Note that using ["*" : "*"] matches any key
-                                      and value but does not match an empty label
-                                      set.'
+                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4071,60 +2741,30 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces
-                                      names. Each name supports wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (at least one character).
+                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label
-                                      keys and values in `matchLabels` support the
-                                      wildcard characters `*` (matches zero or many
-                                      characters) and `?` (matches one character).
-                                      Wildcards allows writing label selectors like
-                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                      : "*"] matches any key and value but does not
-                                      match an empty label set.'
+                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4136,52 +2776,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role
-                                  names for the user.
+                                description: Roles is the list of namespaced role names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names
-                                  like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the
-                                    object or user identities a role binding applies
-                                    to.  This can either hold a direct API object
-                                    reference, or a value for non-objects such as
-                                    user and group names.
+                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of
-                                        the referenced subject. Defaults to "" for
-                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
-                                        for User and Group subjects.
+                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced.
-                                        Values defined by this API group are "User",
-                                        "Group", and "ServiceAccount". If the Authorizer
-                                        does not recognized the kind value, the Authorizer
-                                        should report an error.
+                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If
-                                        the object kind is non-namespace, such as
-                                        "User" or "Group", and this value is not empty
-                                        the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -4191,30 +2810,22 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will
-                            be ORed
+                          description: Any allows specifying resources which will be ORed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR"
-                              between resources
+                            description: ResourceFilters allow users to "AND" or "OR" between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide
-                                  role names for the user.
+                                description: ClusterRoles is the list of cluster-wide role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information
-                                  about the resource being created or modified.
+                                description: ResourceDescription contains information about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations
-                                      (key-value pairs of type string). Annotation
-                                      keys and values support the wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (matches at least one character).
+                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -4222,59 +2833,29 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource.
-                                      The name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character).
+                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources.
-                                      Each name supports wildcard characters "*" (matches
-                                      zero or many characters) and "?" (at least one
-                                      character). NOTE: "Name" is being deprecated
-                                      in favor of "Names".'
+                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector
-                                      for the resource namespace. Label keys and values
-                                      in `matchLabels` support the wildcard characters
-                                      `*` (matches zero or many characters) and `?`
-                                      (matches one character).Wildcards allows writing
-                                      label selectors like ["storage.k8s.io/*": "*"].
-                                      Note that using ["*" : "*"] matches any key
-                                      and value but does not match an empty label
-                                      set.'
+                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4286,60 +2867,30 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces
-                                      names. Each name supports wildcard characters
-                                      "*" (matches zero or many characters) and "?"
-                                      (at least one character).
+                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label
-                                      keys and values in `matchLabels` support the
-                                      wildcard characters `*` (matches zero or many
-                                      characters) and `?` (matches one character).
-                                      Wildcards allows writing label selectors like
-                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                      : "*"] matches any key and value but does not
-                                      match an empty label set.'
+                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4351,52 +2902,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role
-                                  names for the user.
+                                description: Roles is the list of namespaced role names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names
-                                  like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the
-                                    object or user identities a role binding applies
-                                    to.  This can either hold a direct API object
-                                    reference, or a value for non-objects such as
-                                    user and group names.
+                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of
-                                        the referenced subject. Defaults to "" for
-                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
-                                        for User and Group subjects.
+                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced.
-                                        Values defined by this API group are "User",
-                                        "Group", and "ServiceAccount". If the Authorizer
-                                        does not recognized the kind value, the Authorizer
-                                        should report an error.
+                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If
-                                        the object kind is non-namespace, such as
-                                        "User" or "Group", and this value is not empty
-                                        the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -4406,24 +2936,17 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role
-                            names for the user.
+                          description: ClusterRoles is the list of cluster-wide role names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about
-                            the resource being created or modified. Requires at least
-                            one tag to be specified when under MatchResources.
+                          description: ResourceDescription contains information about the resource being created or modified. Requires at least one tag to be specified when under MatchResources.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value
-                                pairs of type string). Annotation keys and values
-                                support the wildcard characters "*" (matches zero
-                                or many characters) and "?" (matches at least one
-                                character).
+                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -4431,52 +2954,29 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name
-                                supports wildcard characters "*" (matches zero or
-                                many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources.
-                                Each name supports wildcard characters "*" (matches
-                                zero or many characters) and "?" (at least one character).
-                                NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector
-                                for the resource namespace. Label keys and values
-                                in `matchLabels` support the wildcard characters `*`
-                                (matches zero or many characters) and `?` (matches
-                                one character).Wildcards allows writing label selectors
-                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                : "*"] matches any key and value but does not match
-                                an empty label set.'
+                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
+                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -4488,54 +2988,30 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names.
-                                Each name supports wildcard characters "*" (matches
-                                zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys
-                                and values in `matchLabels` support the wildcard characters
-                                `*` (matches zero or many characters) and `?` (matches
-                                one character). Wildcards allows writing label selectors
-                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
-                                : "*"] matches any key and value but does not match
-                                an empty label set.'
+                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
+                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -4547,51 +3023,31 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names
-                            for the user.
+                          description: Roles is the list of namespaced role names for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like
-                            users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object
-                              or user identities a role binding applies to.  This
-                              can either hold a direct API object reference, or a
-                              value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced
-                                  subject. Defaults to "" for ServiceAccount subjects.
-                                  Defaults to "rbac.authorization.k8s.io" for User
-                                  and Group subjects.
+                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values
-                                  defined by this API group are "User", "Group", and
-                                  "ServiceAccount". If the Authorizer does not recognized
-                                  the kind value, the Authorizer should report an
-                                  error.
+                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If
-                                  the object kind is non-namespace, such as "User"
-                                  or "Group", and this value is not empty the Authorizer
-                                  should report an error.
+                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
                                 type: string
                             required:
                             - kind
@@ -4603,25 +3059,18 @@ spec:
                       description: Mutation is used to modify matching resources.
                       properties:
                         overlay:
-                          description: Overlay specifies an overlay pattern to modify
-                            resources. DEPRECATED. Use PatchStrategicMerge instead.
-                            Scheduled for removal in release 1.5+.
+                          description: Overlay specifies an overlay pattern to modify resources. DEPRECATED. Use PatchStrategicMerge instead. Scheduled for removal in release 1.5+.
                           x-kubernetes-preserve-unknown-fields: true
                         patchStrategicMerge:
-                          description: PatchStrategicMerge is a strategic merge patch
-                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
-                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          description: PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
                           x-kubernetes-preserve-unknown-fields: true
                         patches:
-                          description: Patches specifies a RFC 6902 JSON Patch to
-                            modify resources. DEPRECATED. Use PatchesJSON6902 instead.
-                            Scheduled for removal in release 1.5+.
+                          description: Patches specifies a RFC 6902 JSON Patch to modify resources. DEPRECATED. Use PatchesJSON6902 instead. Scheduled for removal in release 1.5+.
                           items:
                             description: 'Patch is a RFC 6902 JSON Patch. See: https://tools.ietf.org/html/rfc6902'
                             properties:
                               op:
-                                description: Operation specifies operations supported
-                                  by JSON Patch. i.e:- add, replace and delete.
+                                description: Operation specifies operations supported by JSON Patch. i.e:- add, replace and delete.
                                 type: string
                               path:
                                 description: Path specifies path of the resource.
@@ -4634,160 +3083,114 @@ spec:
                           type: array
                           x-kubernetes-preserve-unknown-fields: true
                         patchesJson6902:
-                          description: PatchesJSON6902 is a list of RFC 6902 JSON
-                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
-                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
                           type: string
                       type: object
                     name:
-                      description: Name is a label to identify the rule, It must be
-                        unique within the policy.
+                      description: Name is a label to identify the rule, It must be unique within the policy.
                       maxLength: 63
                       type: string
                     preconditions:
-                      description: 'Preconditions are used to determine if a policy
-                        rule should be applied by evaluating a set of conditions.
-                        The declaration can contain nested `any` or `all` statements.
-                        A direct list of conditions (without `any` or `all` statements
-                        is supported for backwards compatibility but will be deprecated
-                        in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      description: 'Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
                       x-kubernetes-preserve-unknown-fields: true
                     validate:
                       description: Validation is used to validate matching resources.
                       properties:
                         anyPattern:
-                          description: AnyPattern specifies list of validation patterns.
-                            At least one of the patterns must be satisfied for the
-                            validation rule to succeed.
+                          description: AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.
                           x-kubernetes-preserve-unknown-fields: true
                         deny:
-                          description: Deny defines conditions used to pass or fail
-                            a validation rule.
+                          description: Deny defines conditions used to pass or fail a validation rule.
                           properties:
                             conditions:
-                              description: 'Multiple conditions can be declared under
-                                an `any` or `all` statement. A direct list of conditions
-                                (without `any` or `all` statements) is also supported
-                                for backwards compatibility but will be deprecated
-                                in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              description: 'Multiple conditions can be declared under an `any` or `all` statement. A direct list of conditions (without `any` or `all` statements) is also supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
                               x-kubernetes-preserve-unknown-fields: true
                           type: object
                         message:
-                          description: Message specifies a custom message to be displayed
-                            on failure.
+                          description: Message specifies a custom message to be displayed on failure.
                           type: string
                         pattern:
-                          description: Pattern specifies an overlay-style pattern
-                            used to check resources.
+                          description: Pattern specifies an overlay-style pattern used to check resources.
                           x-kubernetes-preserve-unknown-fields: true
                       type: object
                     verifyImages:
-                      description: VerifyImages is used to verify image signatures
-                        and mutate them to add a digest
+                      description: VerifyImages is used to verify image signatures and mutate them to add a digest
                       items:
-                        description: ImageVerification validates that images that
-                          match the specified pattern are signed with the supplied
-                          public key. Once the image is verified it is mutated to
-                          include the SHA digest retrieved during the registration.
+                        description: ImageVerification validates that images that match the specified pattern are signed with the supplied public key. Once the image is verified it is mutated to include the SHA digest retrieved during the registration.
                         properties:
                           image:
-                            description: 'Image is the image name consisting of the
-                              registry address, repository, image, and tag. Wildcards
-                              (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                            description: 'Image is the image name consisting of the registry address, repository, image, and tag. Wildcards (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
                             type: string
                           key:
-                            description: Key is the PEM encoded public key that the
-                              image is signed with.
+                            description: Key is the PEM encoded public key that the image is signed with.
                             type: string
                         type: object
                       type: array
                   type: object
                 type: array
               schemaValidation:
-                description: SchemaValidation skips policy validation checks. Optional.
-                  The default value is set to "true", it must be set to "false" to
-                  disable the validation checks.
+                description: SchemaValidation skips policy validation checks. Optional. The default value is set to "true", it must be set to "false" to disable the validation checks.
                 type: boolean
               validationFailureAction:
-                description: ValidationFailureAction controls if a validation policy
-                  rule failure should disallow the admission review request (enforce),
-                  or allow (audit) the admission review request and report an error
-                  in a policy report. Optional. The default value is "audit".
+                description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
                 type: string
             type: object
           status:
-            description: Status contains policy runtime information. Deprecated. Policy
-              metrics are available via the metrics endpoint
+            description: Status contains policy runtime information. Deprecated. Policy metrics are available via the metrics endpoint
             properties:
               averageExecutionTime:
-                description: AvgExecutionTime is the average time taken to process
-                  the policy rules on a resource.
+                description: AvgExecutionTime is the average time taken to process the policy rules on a resource.
                 type: string
               resourcesBlockedCount:
-                description: ResourcesBlockedCount is the total count of admission
-                  review requests that were blocked by this policy.
+                description: ResourcesBlockedCount is the total count of admission review requests that were blocked by this policy.
                 type: integer
               resourcesGeneratedCount:
-                description: ResourcesGeneratedCount is the total count of resources
-                  that were generated by this policy.
+                description: ResourcesGeneratedCount is the total count of resources that were generated by this policy.
                 type: integer
               resourcesMutatedCount:
-                description: ResourcesMutatedCount is the total count of resources
-                  that were mutated by this policy.
+                description: ResourcesMutatedCount is the total count of resources that were mutated by this policy.
                 type: integer
               ruleStatus:
                 description: Rules provides per rule statistics
                 items:
-                  description: 'RuleStats provides statistics for an individual rule
-                    within a policy. Deprecated. Policy metrics are now available
-                    via the "/metrics" endpoint. See: https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/'
+                  description: 'RuleStats provides statistics for an individual rule within a policy. Deprecated. Policy metrics are now available via the "/metrics" endpoint. See: https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/'
                   properties:
                     appliedCount:
-                      description: AppliedCount is the total number of times this
-                        rule was applied.
+                      description: AppliedCount is the total number of times this rule was applied.
                       type: integer
                     averageExecutionTime:
-                      description: ExecutionTime is the average time taken to execute
-                        this rule.
+                      description: ExecutionTime is the average time taken to execute this rule.
                       type: string
                     failedCount:
-                      description: FailedCount is the total count of policy error
-                        results for this rule.
+                      description: FailedCount is the total count of policy error results for this rule.
                       type: integer
                     resourcesBlockedCount:
-                      description: ResourcesBlockedCount is the total count of admission
-                        review requests that were blocked by this rule.
+                      description: ResourcesBlockedCount is the total count of admission review requests that were blocked by this rule.
                       type: integer
                     resourcesGeneratedCount:
-                      description: ResourcesGeneratedCount is the total count of resources
-                        that were generated by this rule.
+                      description: ResourcesGeneratedCount is the total count of resources that were generated by this rule.
                       type: integer
                     resourcesMutatedCount:
-                      description: ResourcesMutatedCount is the total count of resources
-                        that were mutated by this rule.
+                      description: ResourcesMutatedCount is the total count of resources that were mutated by this rule.
                       type: integer
                     ruleName:
                       description: Name is the rule name.
                       type: string
                     violationCount:
-                      description: ViolationCount is the total count of policy failure
-                        results for this rule.
+                      description: ViolationCount is the total count of policy failure results for this rule.
                       type: integer
                   required:
                   - ruleName
                   type: object
                 type: array
               rulesAppliedCount:
-                description: RulesAppliedCount is the total number of times this policy
-                  was applied.
+                description: RulesAppliedCount is the total number of times this policy was applied.
                 type: integer
               rulesFailedCount:
-                description: RulesFailedCount is the total count of policy execution
-                  errors for this policy.
+                description: RulesFailedCount is the total count of policy execution errors for this policy.
                 type: integer
               violationCount:
-                description: ViolationCount is the total count of policy failure results
-                  for this policy.
+                description: ViolationCount is the total count of policy failure results for this policy.
                 type: integer
             type: object
         required:
@@ -4863,22 +3266,17 @@ spec:
         description: PolicyReport is the Schema for the policyreports API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual
-                policy
+              description: PolicyReportResult provides the result for an individual policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -4886,46 +3284,30 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy
-                    rule
+                  description: Data provides additional information for the policy rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the
-                    policy rule
+                  description: Message is a short user friendly description of the policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy
-                    results that apply to multiple resources. For example, a policy
-                    result may apply to all pods that match a label. Either a Resource
-                    or a ResourceSelector can be specified. If neither are provided,
-                    the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies
-                              to.
+                            description: key is the label key that the selector applies to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -4937,58 +3319,19 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource
-                    checked by the policy and rule
+                  description: Resources is an optional reference to the resource checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
+                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -5000,8 +3343,7 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -5035,23 +3377,13 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g.
-              a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire
-                  object, this string should contain a valid JSON/Go field access
-                  statement, such as desiredState.manifest.containers[2]. For example,
-                  if the object reference is to a container within a pod, this would
-                  take on a value like: "spec.containers{name}" (where "name" refers
-                  to the name of the container that triggered the event) or if no
-                  container name is specified "spec.containers[2]" (container with
-                  index 2 in this pod). This syntax is chosen only to have some well-defined
-                  way of referencing a part of an object. TODO: this design is not
-                  final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -5063,39 +3395,28 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is
-                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes
-              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
-              should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements.
-                  The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains
-                    values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies
-                        to.
+                      description: key is the label key that the selector applies to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set
-                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator
-                        is In or NotIn, the values array must be non-empty. If the
-                        operator is Exists or DoesNotExist, the values array must
-                        be empty. This array is replaced during a strategic merge
-                        patch.
+                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                       items:
                         type: string
                       type: array
@@ -5107,34 +3428,26 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value}
-                  in the matchLabels map is equivalent to an element of matchExpressions,
-                  whose key field is "key", the operator is "In", and the values array
-                  contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be
-                  evaluated
+                description: Error provides the count of policies that could not be evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements
-                  were not met
+                description: Fail provides the count of policies whose requirements were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements
-                  were met
+                description: Pass provides the count of policies whose requirements were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected
-                  for evaluation
+                description: Skip indicates the count of policies that were not selected for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements
-                  were not met
+                description: Warn provides the count of unscored policies whose requirements were not met
                 type: integer
             type: object
         type: object
@@ -5174,29 +3487,23 @@ spec:
         description: PolicyReport is the Schema for the policyreports API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual
-                policy
+              description: PolicyReportResult provides the result for an individual policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the
-                    policy rule
+                  description: Message is a short user friendly description of the policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -5204,39 +3511,24 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the
-                    policy rule
+                  description: Properties provides additional information for the policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy
-                    results that apply to multiple resources. For example, a policy
-                    result may apply to all pods that match a label. Either a Resource
-                    or a ResourceSelector can be specified. If neither are provided,
-                    the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies
-                              to.
+                            description: key is the label key that the selector applies to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -5248,58 +3540,19 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource
-                    checked by the policy and rule
+                  description: Resources is an optional reference to the resource checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
+                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -5311,8 +3564,7 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -5342,24 +3594,17 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that
-                    manages this report
+                  description: Source is an identifier for the policy engine that manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond
-                        resolution. Negative second values with fractions must still
-                        have non-negative nanos values that count forward in time.
-                        Must be from 0 to 999,999,999 inclusive. This field may be
-                        limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch
-                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-                        9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -5371,23 +3616,13 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g.
-              a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire
-                  object, this string should contain a valid JSON/Go field access
-                  statement, such as desiredState.manifest.containers[2]. For example,
-                  if the object reference is to a container within a pod, this would
-                  take on a value like: "spec.containers{name}" (where "name" refers
-                  to the name of the container that triggered the event) or if no
-                  container name is specified "spec.containers[2]" (container with
-                  index 2 in this pod). This syntax is chosen only to have some well-defined
-                  way of referencing a part of an object. TODO: this design is not
-                  final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -5399,39 +3634,28 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is
-                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes
-              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
-              should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements.
-                  The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains
-                    values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies
-                        to.
+                      description: key is the label key that the selector applies to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set
-                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator
-                        is In or NotIn, the values array must be non-empty. If the
-                        operator is Exists or DoesNotExist, the values array must
-                        be empty. This array is replaced during a strategic merge
-                        patch.
+                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                       items:
                         type: string
                       type: array
@@ -5443,34 +3667,26 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value}
-                  in the matchLabels map is equivalent to an element of matchExpressions,
-                  whose key field is "key", the operator is "In", and the values array
-                  contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be
-                  evaluated
+                description: Error provides the count of policies that could not be evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements
-                  were not met
+                description: Fail provides the count of policies whose requirements were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements
-                  were met
+                description: Pass provides the count of policies whose requirements were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected
-                  for evaluation
+                description: Skip indicates the count of policies that were not selected for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements
-                  were not met
+                description: Warn provides the count of unscored policies whose requirements were not met
                 type: integer
             type: object
         type: object
@@ -5540,26 +3756,20 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ReportChangeRequest is the Schema for the ReportChangeRequests
-          API
+        description: ReportChangeRequest is the Schema for the ReportChangeRequests API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual
-                policy
+              description: PolicyReportResult provides the result for an individual policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -5567,46 +3777,30 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy
-                    rule
+                  description: Data provides additional information for the policy rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the
-                    policy rule
+                  description: Message is a short user friendly description of the policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy
-                    results that apply to multiple resources. For example, a policy
-                    result may apply to all pods that match a label. Either a Resource
-                    or a ResourceSelector can be specified. If neither are provided,
-                    the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies
-                              to.
+                            description: key is the label key that the selector applies to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -5618,58 +3812,19 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource
-                    checked by the policy and rule
+                  description: Resources is an optional reference to the resource checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
+                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -5681,8 +3836,7 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -5716,23 +3870,13 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g.
-              a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire
-                  object, this string should contain a valid JSON/Go field access
-                  statement, such as desiredState.manifest.containers[2]. For example,
-                  if the object reference is to a container within a pod, this would
-                  take on a value like: "spec.containers{name}" (where "name" refers
-                  to the name of the container that triggered the event) or if no
-                  container name is specified "spec.containers[2]" (container with
-                  index 2 in this pod). This syntax is chosen only to have some well-defined
-                  way of referencing a part of an object. TODO: this design is not
-                  final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -5744,39 +3888,28 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is
-                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes
-              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
-              should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements.
-                  The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains
-                    values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies
-                        to.
+                      description: key is the label key that the selector applies to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set
-                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator
-                        is In or NotIn, the values array must be non-empty. If the
-                        operator is Exists or DoesNotExist, the values array must
-                        be empty. This array is replaced during a strategic merge
-                        patch.
+                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                       items:
                         type: string
                       type: array
@@ -5788,34 +3921,26 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value}
-                  in the matchLabels map is equivalent to an element of matchExpressions,
-                  whose key field is "key", the operator is "In", and the values array
-                  contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be
-                  evaluated
+                description: Error provides the count of policies that could not be evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements
-                  were not met
+                description: Fail provides the count of policies whose requirements were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements
-                  were met
+                description: Pass provides the count of policies whose requirements were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected
-                  for evaluation
+                description: Skip indicates the count of policies that were not selected for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements
-                  were not met
+                description: Warn provides the count of unscored policies whose requirements were not met
                 type: integer
             type: object
         type: object
@@ -5852,33 +3977,26 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: ReportChangeRequest is the Schema for the ReportChangeRequests
-          API
+        description: ReportChangeRequest is the Schema for the ReportChangeRequests API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual
-                policy
+              description: PolicyReportResult provides the result for an individual policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the
-                    policy rule
+                  description: Message is a short user friendly description of the policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -5886,39 +4004,24 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the
-                    policy rule
+                  description: Properties provides additional information for the policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy
-                    results that apply to multiple resources. For example, a policy
-                    result may apply to all pods that match a label. Either a Resource
-                    or a ResourceSelector can be specified. If neither are provided,
-                    the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies
-                              to.
+                            description: key is the label key that the selector applies to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -5930,58 +4033,19 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource
-                    checked by the policy and rule
+                  description: Resources is an optional reference to the resource checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
+                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -5993,8 +4057,7 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -6024,24 +4087,17 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that
-                    manages this report
+                  description: Source is an identifier for the policy engine that manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond
-                        resolution. Negative second values with fractions must still
-                        have non-negative nanos values that count forward in time.
-                        Must be from 0 to 999,999,999 inclusive. This field may be
-                        limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch
-                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-                        9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -6053,23 +4109,13 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g.
-              a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire
-                  object, this string should contain a valid JSON/Go field access
-                  statement, such as desiredState.manifest.containers[2]. For example,
-                  if the object reference is to a container within a pod, this would
-                  take on a value like: "spec.containers{name}" (where "name" refers
-                  to the name of the container that triggered the event) or if no
-                  container name is specified "spec.containers[2]" (container with
-                  index 2 in this pod). This syntax is chosen only to have some well-defined
-                  way of referencing a part of an object. TODO: this design is not
-                  final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -6081,39 +4127,28 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is
-                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes
-              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
-              should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements.
-                  The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains
-                    values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies
-                        to.
+                      description: key is the label key that the selector applies to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set
-                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator
-                        is In or NotIn, the values array must be non-empty. If the
-                        operator is Exists or DoesNotExist, the values array must
-                        be empty. This array is replaced during a strategic merge
-                        patch.
+                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                       items:
                         type: string
                       type: array
@@ -6125,34 +4160,26 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value}
-                  in the matchLabels map is equivalent to an element of matchExpressions,
-                  whose key field is "key", the operator is "In", and the values array
-                  contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be
-                  evaluated
+                description: Error provides the count of policies that could not be evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements
-                  were not met
+                description: Fail provides the count of policies whose requirements were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements
-                  were met
+                description: Pass provides the count of policies whose requirements were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected
-                  for evaluation
+                description: Skip indicates the count of policies that were not selected for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements
-                  were not met
+                description: Warn provides the count of unscored policies whose requirements were not met
                 type: integer
             type: object
         type: object

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -53,6 +53,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s" (default (include "kyverno.fullname" .) .Values.config.existingConfig) -}}
 {{- end -}}
 
+{{/* Get the metrics config map name. */}}
+{{- define "kyverno.metricsConfigMapName" -}}
+{{- printf "%s" (default (printf "%s-metrics" (include "kyverno.fullname" .)) .Values.config.existingMetricsConfig) -}}
+{{- end -}}
 
 {{/* Get the namespace name. */}}
 {{- define "kyverno.namespace" -}}

--- a/charts/kyverno/templates/deployment.yaml
+++ b/charts/kyverno/templates/deployment.yaml
@@ -68,6 +68,8 @@ spec:
               drop:
                 - all
           env:
+          - name: METRICS_CONFIG
+            value: {{ template "kyverno.metricsConfigMapName" . }}
           - name: KYVERNO_NAMESPACE
             valueFrom:
               fieldRef:
@@ -103,6 +105,8 @@ spec:
           env:
           - name: INIT_CONFIG
             value: {{ template "kyverno.configMapName" . }}
+          - name: METRICS_CONFIG
+            value: {{ template "kyverno.metricsConfigMapName" . }}
           - name: KYVERNO_NAMESPACE
             valueFrom:
               fieldRef:

--- a/charts/kyverno/templates/metricsconfigmap.yaml
+++ b/charts/kyverno/templates/metricsconfigmap.yaml
@@ -1,0 +1,22 @@
+{{- if (not .Values.config.existingMetricsConfig) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels: {{ include "kyverno.labels" . | nindent 4 }}
+    app: kyverno
+  name: {{ template "kyverno.metricsConfigMapName" . }}
+  namespace: {{ template "kyverno.namespace" . }}
+{{- if .Values.config.metricsConfig }}
+data:
+  {{- if .Values.config.metricsConfig.namespaces }}
+  namespaces: {{ .Values.config.metricsConfig.namespaces | toJson | quote }}
+  {{- end -}}
+  {{- if .Values.config.metricsConfig.metricsRefreshInterval }}
+  metricsRefreshInterval: {{ .Values.config.metricsConfig.metricsRefreshInterval }}
+  {{- end -}}
+{{- else }}
+data:
+  namespaces: '{"include": [], "exclude": []}'
+  metricsRefreshInterval: 0s
+{{- end }}
+{{- end -}}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -94,7 +94,7 @@ livenessProbe:
     path: /health/liveness
     port: 9443
     scheme: HTTPS
-  initialDelaySeconds: 10
+  initialDelaySeconds: 15
   periodSeconds: 30
   timeoutSeconds: 5
   failureThreshold: 2
@@ -152,6 +152,19 @@ config:
   # webhooks: [{"namespaceSelector":{"matchExpressions":[{"key":"environment","operator":"In","values":["prod"]}]}}]
   generateSuccessEvents: 'false'
   # existingConfig: init-config
+  metricsConfig:
+    namespaces: {
+      "include": [],
+      "exclude": []
+    }
+    # 'namespaces.include': list of namespaces to capture metrics for. Default: metrics being captured for all namespaces except excludeNamespaces.
+    # 'namespaces.exclude': list of namespaces to NOT capture metrics for. Default: []
+
+    # metricsRefreshInterval: 24h
+    # rate at which metrics should reset so as to clean up the memory footprint of kyverno metrics, if you might be expecting high memory footprint of Kyverno's metrics. Default: 0, no refresh of metrics
+
+  # Or provide an existing metrics config-map by uncommenting the below line
+  # existingMetricsConfig: sample-metrics-configmap. Refer to the ./templates/metricsconfigmap.yaml for the structure of metrics configmap.
 
 ## Deployment update strategy
 ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -113,20 +113,6 @@ func main() {
 		}()
 	}
 
-	if !disableMetricsExport {
-		promConfig = metrics.NewPromConfig()
-		metricsServerMux = http.NewServeMux()
-		metricsServerMux.Handle("/metrics", promhttp.HandlerFor(promConfig.MetricsRegistry, promhttp.HandlerOpts{Timeout: 10 * time.Second}))
-		metricsAddr := ":" + metricsPort
-		go func() {
-			setupLog.Info("enabling metrics service", "address", metricsAddr)
-			if err := http.ListenAndServe(metricsAddr, metricsServerMux); err != nil {
-				setupLog.Error(err, "failed to enable metrics service", "address", metricsAddr)
-				os.Exit(1)
-			}
-		}()
-	}
-
 	// KYVERNO CRD CLIENT
 	// access CRD resources
 	//		- ClusterPolicy, Policy
@@ -252,6 +238,33 @@ func main() {
 		webhookCfg.UpdateWebhookChan,
 		log.Log.WithName("ConfigData"),
 	)
+
+	metricsConfigData, err := config.NewMetricsConfigData(
+		kubeClient,
+		log.Log.WithName("MetricsConfigData"),
+	)
+	if err != nil {
+		setupLog.Error(err, "failed to fetch metrics config")
+		os.Exit(1)
+	}
+
+	if !disableMetricsExport {
+		promConfig, err = metrics.NewPromConfig(metricsConfigData, log.Log.WithName("MetricsConfig"))
+		if err != nil {
+			setupLog.Error(err, "failed to setup Prometheus metric configuration")
+			os.Exit(1)
+		}
+		metricsServerMux = http.NewServeMux()
+		metricsServerMux.Handle("/metrics", promhttp.HandlerFor(promConfig.MetricsRegistry, promhttp.HandlerOpts{Timeout: 10 * time.Second}))
+		metricsAddr := ":" + metricsPort
+		go func() {
+			setupLog.Info("enabling metrics service", "address", metricsAddr)
+			if err := http.ListenAndServe(metricsAddr, metricsServerMux); err != nil {
+				setupLog.Error(err, "failed to enable metrics service", "address", metricsAddr)
+				os.Exit(1)
+			}
+		}()
+	}
 
 	// POLICY CONTROLLER
 	// - reconciliation policy and policy violation

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -46,13 +46,18 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.
+        description: ClusterPolicy declares validation, mutation, and generation behaviors
+          for matching resources.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -60,26 +65,49 @@ spec:
             description: Spec declares policy behaviors.
             properties:
               background:
-                description: Background controls if rules are applied to existing resources during a background scan. Optional. Default value is "true". The value must be set to "false" if the policy rule uses variables that are only available in the admission review request (e.g. user name).
+                description: Background controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
                 type: boolean
               rules:
-                description: Rules is a list of Rule instances. A Policy contains multiple rules and each rule can validate, mutate, or generate resources.
+                description: Rules is a list of Rule instances. A Policy contains
+                  multiple rules and each rule can validate, mutate, or generate resources.
                 items:
-                  description: Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.
+                  description: Rule defines a validation, mutation, or generation
+                    control for matching resources. Each rules contains a match declaration
+                    to select resources, and an optional exclude declaration to specify
+                    which resources to exclude.
                   properties:
                     context:
-                      description: Context defines variables and data sources that can be used during rule execution.
+                      description: Context defines variables and data sources that
+                        can be used during rule execution.
                       items:
-                        description: ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.
+                        description: ContextEntry adds variables and data sources
+                          to a rule Context. Either a ConfigMap reference or a APILookup
+                          must be provided.
                         properties:
                           apiCall:
-                            description: APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.
+                            description: APICall defines an HTTP request to the Kubernetes
+                              API server. The JSON data retrieved is stored in the
+                              context.
                             properties:
                               jmesPath:
-                                description: JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of "items | length(@)" applied to the API server response to the URLPath "/apis/apps/v1/deployments" will return the total count of deployments across all namespaces.
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the JSON response
+                                  returned from the API server. For example a JMESPath
+                                  of "items | length(@)" applied to the API server
+                                  response to the URLPath "/apis/apps/v1/deployments"
+                                  will return the total count of deployments across
+                                  all namespaces.
                                 type: string
                               urlPath:
-                                description: URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments"). The format required is the same format used by the `kubectl get --raw` command.
+                                description: URLPath is the URL path to be used in
+                                  the HTTP GET request to the Kubernetes API server
+                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                  The format required is the same format used by the
+                                  `kubectl get --raw` command.
                                 type: string
                             required:
                             - urlPath
@@ -102,25 +130,36 @@ spec:
                         type: object
                       type: array
                     exclude:
-                      description: ExcludeResources defines when this policy rule should not be applied. The exclude criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the name or role.
+                      description: ExcludeResources defines when this policy rule
+                        should not be applied. The exclude criteria can include resource
+                        information (e.g. kind, name, namespace, labels) and admission
+                        review request information like the name or role.
                       properties:
                         all:
-                          description: All allows specifying resources which will be ANDed
+                          description: All allows specifying resources which will
+                            be ANDed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -128,29 +167,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -162,30 +231,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -197,31 +296,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -231,22 +351,30 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will be ORed
+                          description: Any allows specifying resources which will
+                            be ORed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -254,29 +382,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -288,30 +446,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -323,31 +511,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -357,17 +566,23 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role names for the user.
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about the resource being created or modified.
+                          description: ResourceDescription contains information about
+                            the resource being created or modified.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -375,29 +590,52 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -409,30 +647,54 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -444,31 +706,51 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names for the user.
+                          description: Roles is the list of namespaced role names
+                            for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
                                 type: string
                             required:
                             - kind
@@ -483,7 +765,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specifies the source resource used to populate each generated resource. At most one of Data or Clone can be specified. If neither are provided, the generated resource will be created with default data only.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -493,7 +778,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource declaration used to populate each generated resource. At most one of Data or Clone must be specified. If neither are provided, the generated resource will be created with default data only.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -505,29 +793,46 @@ spec:
                           description: Namespace specifies resource namespace.
                           type: string
                         synchronize:
-                          description: Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to "true" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to "false" if not specified.
+                          description: Synchronize controls if generated resources
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
+                            Defaults to "false" if not specified.
                           type: boolean
                       type: object
                     match:
-                      description: MatchResources defines when this policy rule should be applied. The match criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the user name or role. At least one kind is required.
+                      description: MatchResources defines when this policy rule should
+                        be applied. The match criteria can include resource information
+                        (e.g. kind, name, namespace, labels) and admission review
+                        request information like the user name or role. At least one
+                        kind is required.
                       properties:
                         all:
-                          description: All allows specifying resources which will be ANDed
+                          description: All allows specifying resources which will
+                            be ANDed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -535,29 +840,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -569,30 +904,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -604,31 +969,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -638,22 +1024,30 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will be ORed
+                          description: Any allows specifying resources which will
+                            be ORed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -661,29 +1055,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -695,30 +1119,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -730,31 +1184,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -764,17 +1239,24 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role names for the user.
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about the resource being created or modified. Requires at least one tag to be specified when under MatchResources.
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Requires at least
+                            one tag to be specified when under MatchResources.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -782,29 +1264,52 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -816,30 +1321,54 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -851,31 +1380,51 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names for the user.
+                          description: Roles is the list of namespaced role names
+                            for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
                                 type: string
                             required:
                             - kind
@@ -887,18 +1436,25 @@ spec:
                       description: Mutation is used to modify matching resources.
                       properties:
                         overlay:
-                          description: Overlay specifies an overlay pattern to modify resources. DEPRECATED. Use PatchStrategicMerge instead. Scheduled for removal in release 1.5+.
+                          description: Overlay specifies an overlay pattern to modify
+                            resources. DEPRECATED. Use PatchStrategicMerge instead.
+                            Scheduled for removal in release 1.5+.
                           x-kubernetes-preserve-unknown-fields: true
                         patchStrategicMerge:
-                          description: PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          description: PatchStrategicMerge is a strategic merge patch
+                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
                           x-kubernetes-preserve-unknown-fields: true
                         patches:
-                          description: Patches specifies a RFC 6902 JSON Patch to modify resources. DEPRECATED. Use PatchesJSON6902 instead. Scheduled for removal in release 1.5+.
+                          description: Patches specifies a RFC 6902 JSON Patch to
+                            modify resources. DEPRECATED. Use PatchesJSON6902 instead.
+                            Scheduled for removal in release 1.5+.
                           items:
                             description: 'Patch is a RFC 6902 JSON Patch. See: https://tools.ietf.org/html/rfc6902'
                             properties:
                               op:
-                                description: Operation specifies operations supported by JSON Patch. i.e:- add, replace and delete.
+                                description: Operation specifies operations supported
+                                  by JSON Patch. i.e:- add, replace and delete.
                                 type: string
                               path:
                                 description: Path specifies path of the resource.
@@ -911,114 +1467,159 @@ spec:
                           type: array
                           x-kubernetes-preserve-unknown-fields: true
                         patchesJson6902:
-                          description: PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON
+                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
                           type: string
                       type: object
                     name:
-                      description: Name is a label to identify the rule, It must be unique within the policy.
+                      description: Name is a label to identify the rule, It must be
+                        unique within the policy.
                       maxLength: 63
                       type: string
                     preconditions:
-                      description: 'Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      description: 'Preconditions are used to determine if a policy
+                        rule should be applied by evaluating a set of conditions.
+                        The declaration can contain nested `any` or `all` statements.
+                        A direct list of conditions (without `any` or `all` statements
+                        is supported for backwards compatibility but will be deprecated
+                        in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
                       x-kubernetes-preserve-unknown-fields: true
                     validate:
                       description: Validation is used to validate matching resources.
                       properties:
                         anyPattern:
-                          description: AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.
+                          description: AnyPattern specifies list of validation patterns.
+                            At least one of the patterns must be satisfied for the
+                            validation rule to succeed.
                           x-kubernetes-preserve-unknown-fields: true
                         deny:
-                          description: Deny defines conditions used to pass or fail a validation rule.
+                          description: Deny defines conditions used to pass or fail
+                            a validation rule.
                           properties:
                             conditions:
-                              description: 'Multiple conditions can be declared under an `any` or `all` statement. A direct list of conditions (without `any` or `all` statements) is also supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              description: 'Multiple conditions can be declared under
+                                an `any` or `all` statement. A direct list of conditions
+                                (without `any` or `all` statements) is also supported
+                                for backwards compatibility but will be deprecated
+                                in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
                               x-kubernetes-preserve-unknown-fields: true
                           type: object
                         message:
-                          description: Message specifies a custom message to be displayed on failure.
+                          description: Message specifies a custom message to be displayed
+                            on failure.
                           type: string
                         pattern:
-                          description: Pattern specifies an overlay-style pattern used to check resources.
+                          description: Pattern specifies an overlay-style pattern
+                            used to check resources.
                           x-kubernetes-preserve-unknown-fields: true
                       type: object
                     verifyImages:
-                      description: VerifyImages is used to verify image signatures and mutate them to add a digest
+                      description: VerifyImages is used to verify image signatures
+                        and mutate them to add a digest
                       items:
-                        description: ImageVerification validates that images that match the specified pattern are signed with the supplied public key. Once the image is verified it is mutated to include the SHA digest retrieved during the registration.
+                        description: ImageVerification validates that images that
+                          match the specified pattern are signed with the supplied
+                          public key. Once the image is verified it is mutated to
+                          include the SHA digest retrieved during the registration.
                         properties:
                           image:
-                            description: 'Image is the image name consisting of the registry address, repository, image, and tag. Wildcards (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                            description: 'Image is the image name consisting of the
+                              registry address, repository, image, and tag. Wildcards
+                              (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
                             type: string
                           key:
-                            description: Key is the PEM encoded public key that the image is signed with.
+                            description: Key is the PEM encoded public key that the
+                              image is signed with.
                             type: string
                         type: object
                       type: array
                   type: object
                 type: array
               schemaValidation:
-                description: SchemaValidation skips policy validation checks. Optional. The default value is set to "true", it must be set to "false" to disable the validation checks.
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
                 type: boolean
               validationFailureAction:
-                description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
+                description: ValidationFailureAction controls if a validation policy
+                  rule failure should disallow the admission review request (enforce),
+                  or allow (audit) the admission review request and report an error
+                  in a policy report. Optional. The default value is "audit".
                 type: string
             type: object
           status:
             description: Status contains policy runtime data.
             properties:
               averageExecutionTime:
-                description: AvgExecutionTime is the average time taken to process the policy rules on a resource.
+                description: AvgExecutionTime is the average time taken to process
+                  the policy rules on a resource.
                 type: string
               resourcesBlockedCount:
-                description: ResourcesBlockedCount is the total count of admission review requests that were blocked by this policy.
+                description: ResourcesBlockedCount is the total count of admission
+                  review requests that were blocked by this policy.
                 type: integer
               resourcesGeneratedCount:
-                description: ResourcesGeneratedCount is the total count of resources that were generated by this policy.
+                description: ResourcesGeneratedCount is the total count of resources
+                  that were generated by this policy.
                 type: integer
               resourcesMutatedCount:
-                description: ResourcesMutatedCount is the total count of resources that were mutated by this policy.
+                description: ResourcesMutatedCount is the total count of resources
+                  that were mutated by this policy.
                 type: integer
               ruleStatus:
                 description: Rules provides per rule statistics
                 items:
-                  description: 'RuleStats provides statistics for an individual rule within a policy. Deprecated. Policy metrics are now available via the "/metrics" endpoint. See: https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/'
+                  description: 'RuleStats provides statistics for an individual rule
+                    within a policy. Deprecated. Policy metrics are now available
+                    via the "/metrics" endpoint. See: https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/'
                   properties:
                     appliedCount:
-                      description: AppliedCount is the total number of times this rule was applied.
+                      description: AppliedCount is the total number of times this
+                        rule was applied.
                       type: integer
                     averageExecutionTime:
-                      description: ExecutionTime is the average time taken to execute this rule.
+                      description: ExecutionTime is the average time taken to execute
+                        this rule.
                       type: string
                     failedCount:
-                      description: FailedCount is the total count of policy error results for this rule.
+                      description: FailedCount is the total count of policy error
+                        results for this rule.
                       type: integer
                     resourcesBlockedCount:
-                      description: ResourcesBlockedCount is the total count of admission review requests that were blocked by this rule.
+                      description: ResourcesBlockedCount is the total count of admission
+                        review requests that were blocked by this rule.
                       type: integer
                     resourcesGeneratedCount:
-                      description: ResourcesGeneratedCount is the total count of resources that were generated by this rule.
+                      description: ResourcesGeneratedCount is the total count of resources
+                        that were generated by this rule.
                       type: integer
                     resourcesMutatedCount:
-                      description: ResourcesMutatedCount is the total count of resources that were mutated by this rule.
+                      description: ResourcesMutatedCount is the total count of resources
+                        that were mutated by this rule.
                       type: integer
                     ruleName:
                       description: Name is the rule name.
                       type: string
                     violationCount:
-                      description: ViolationCount is the total count of policy failure results for this rule.
+                      description: ViolationCount is the total count of policy failure
+                        results for this rule.
                       type: integer
                   required:
                   - ruleName
                   type: object
                 type: array
               rulesAppliedCount:
-                description: RulesAppliedCount is the total number of times this policy was applied.
+                description: RulesAppliedCount is the total number of times this policy
+                  was applied.
                 type: integer
               rulesFailedCount:
-                description: RulesFailedCount is the total count of policy execution errors for this policy.
+                description: RulesFailedCount is the total count of policy execution
+                  errors for this policy.
                 type: integer
               violationCount:
-                description: ViolationCount is the total count of policy failure results for this policy.
+                description: ViolationCount is the total count of policy failure results
+                  for this policy.
                 type: integer
             type: object
         required:
@@ -1090,20 +1691,26 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterPolicyReport is the Schema for the clusterpolicyreports API
+        description: ClusterPolicyReport is the Schema for the clusterpolicyreports
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -1111,30 +1718,46 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy rule
+                  description: Data provides additional information for the policy
+                    rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -1146,19 +1769,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1170,7 +1832,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -1204,13 +1867,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1222,28 +1895,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -1255,26 +1939,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -1311,26 +2003,33 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: ClusterPolicyReport is the Schema for the clusterpolicyreports API
+        description: ClusterPolicyReport is the Schema for the clusterpolicyreports
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -1338,24 +2037,39 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the policy rule
+                  description: Properties provides additional information for the
+                    policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -1367,19 +2081,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1391,7 +2144,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -1421,17 +2175,24 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that manages this report
+                  description: Source is an identifier for the policy engine that
+                    manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -1443,13 +2204,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1461,28 +2232,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -1494,26 +2276,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -1582,20 +2372,26 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests API
+        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -1603,30 +2399,46 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy rule
+                  description: Data provides additional information for the policy
+                    rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -1638,19 +2450,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1662,7 +2513,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -1696,13 +2548,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1714,28 +2576,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -1747,26 +2620,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -1803,26 +2684,33 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests API
+        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -1830,24 +2718,39 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the policy rule
+                  description: Properties provides additional information for the
+                    policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -1859,19 +2762,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1883,7 +2825,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -1913,17 +2856,24 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that manages this report
+                  description: Source is an identifier for the policy engine that
+                    manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -1935,13 +2885,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1953,28 +2913,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -1986,26 +2957,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -2069,10 +3048,14 @@ spec:
         description: GenerateRequest is a request to process generate rule.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2083,10 +3066,12 @@ spec:
                 description: Context ...
                 properties:
                   userInfo:
-                    description: RequestInfo contains permission info carried in an admission request.
+                    description: RequestInfo contains permission info carried in an
+                      admission request.
                     properties:
                       clusterRoles:
-                        description: ClusterRoles is a list of possible clusterRoles send the request.
+                        description: ClusterRoles is a list of possible clusterRoles
+                          send the request.
                         items:
                           type: string
                         nullable: true
@@ -2098,15 +3083,18 @@ spec:
                         nullable: true
                         type: array
                       userInfo:
-                        description: UserInfo is the userInfo carried in the admission request.
+                        description: UserInfo is the userInfo carried in the admission
+                          request.
                         properties:
                           extra:
                             additionalProperties:
-                              description: ExtraValue masks the value so protobuf can generate
+                              description: ExtraValue masks the value so protobuf
+                                can generate
                               items:
                                 type: string
                               type: array
-                            description: Any additional information provided by the authenticator.
+                            description: Any additional information provided by the
+                              authenticator.
                             type: object
                           groups:
                             description: The names of groups this user is a part of.
@@ -2114,10 +3102,14 @@ spec:
                               type: string
                             type: array
                           uid:
-                            description: A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs.
+                            description: A unique value that identifies this user
+                              across time. If this user is deleted and another user
+                              by the same name is added, they will have different
+                              UIDs.
                             type: string
                           username:
-                            description: The name that uniquely identifies this user among all active users.
+                            description: The name that uniquely identifies this user
+                              among all active users.
                             type: string
                         type: object
                     type: object
@@ -2126,7 +3118,8 @@ spec:
                 description: Specifies the name of the policy.
                 type: string
               resource:
-                description: ResourceSpec is the information to identify the generate request.
+                description: ResourceSpec is the information to identify the generate
+                  request.
                 properties:
                   apiVersion:
                     description: APIVersion specifies resource apiVersion.
@@ -2150,7 +3143,8 @@ spec:
             description: Status contains statistics related to generate request.
             properties:
               generatedResources:
-                description: This will track the resources that are generated by the generate Policy. Will be used during clean up resources.
+                description: This will track the resources that are generated by the
+                  generate Policy. Will be used during clean up resources.
                 items:
                   description: ResourceSpec contains information to identify a resource.
                   properties:
@@ -2226,13 +3220,19 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: 'Policy declares validation, mutation, and generation behaviors for matching resources. See: https://kyverno.io/docs/writing-policies/ for more information.'
+        description: 'Policy declares validation, mutation, and generation behaviors
+          for matching resources. See: https://kyverno.io/docs/writing-policies/ for
+          more information.'
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2240,26 +3240,49 @@ spec:
             description: Spec defines policy behaviors and contains one or more rules.
             properties:
               background:
-                description: Background controls if rules are applied to existing resources during a background scan. Optional. Default value is "true". The value must be set to "false" if the policy rule uses variables that are only available in the admission review request (e.g. user name).
+                description: Background controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
                 type: boolean
               rules:
-                description: Rules is a list of Rule instances. A Policy contains multiple rules and each rule can validate, mutate, or generate resources.
+                description: Rules is a list of Rule instances. A Policy contains
+                  multiple rules and each rule can validate, mutate, or generate resources.
                 items:
-                  description: Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.
+                  description: Rule defines a validation, mutation, or generation
+                    control for matching resources. Each rules contains a match declaration
+                    to select resources, and an optional exclude declaration to specify
+                    which resources to exclude.
                   properties:
                     context:
-                      description: Context defines variables and data sources that can be used during rule execution.
+                      description: Context defines variables and data sources that
+                        can be used during rule execution.
                       items:
-                        description: ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.
+                        description: ContextEntry adds variables and data sources
+                          to a rule Context. Either a ConfigMap reference or a APILookup
+                          must be provided.
                         properties:
                           apiCall:
-                            description: APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.
+                            description: APICall defines an HTTP request to the Kubernetes
+                              API server. The JSON data retrieved is stored in the
+                              context.
                             properties:
                               jmesPath:
-                                description: JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of "items | length(@)" applied to the API server response to the URLPath "/apis/apps/v1/deployments" will return the total count of deployments across all namespaces.
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the JSON response
+                                  returned from the API server. For example a JMESPath
+                                  of "items | length(@)" applied to the API server
+                                  response to the URLPath "/apis/apps/v1/deployments"
+                                  will return the total count of deployments across
+                                  all namespaces.
                                 type: string
                               urlPath:
-                                description: URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments"). The format required is the same format used by the `kubectl get --raw` command.
+                                description: URLPath is the URL path to be used in
+                                  the HTTP GET request to the Kubernetes API server
+                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                  The format required is the same format used by the
+                                  `kubectl get --raw` command.
                                 type: string
                             required:
                             - urlPath
@@ -2282,25 +3305,36 @@ spec:
                         type: object
                       type: array
                     exclude:
-                      description: ExcludeResources defines when this policy rule should not be applied. The exclude criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the name or role.
+                      description: ExcludeResources defines when this policy rule
+                        should not be applied. The exclude criteria can include resource
+                        information (e.g. kind, name, namespace, labels) and admission
+                        review request information like the name or role.
                       properties:
                         all:
-                          description: All allows specifying resources which will be ANDed
+                          description: All allows specifying resources which will
+                            be ANDed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -2308,29 +3342,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2342,30 +3406,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2377,31 +3471,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -2411,22 +3526,30 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will be ORed
+                          description: Any allows specifying resources which will
+                            be ORed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -2434,29 +3557,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2468,30 +3621,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2503,31 +3686,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -2537,17 +3741,23 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role names for the user.
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about the resource being created or modified.
+                          description: ResourceDescription contains information about
+                            the resource being created or modified.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -2555,29 +3765,52 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -2589,30 +3822,54 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -2624,31 +3881,51 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names for the user.
+                          description: Roles is the list of namespaced role names
+                            for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
                                 type: string
                             required:
                             - kind
@@ -2663,7 +3940,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specifies the source resource used to populate each generated resource. At most one of Data or Clone can be specified. If neither are provided, the generated resource will be created with default data only.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -2673,7 +3953,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource declaration used to populate each generated resource. At most one of Data or Clone must be specified. If neither are provided, the generated resource will be created with default data only.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -2685,29 +3968,46 @@ spec:
                           description: Namespace specifies resource namespace.
                           type: string
                         synchronize:
-                          description: Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to "true" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to "false" if not specified.
+                          description: Synchronize controls if generated resources
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
+                            Defaults to "false" if not specified.
                           type: boolean
                       type: object
                     match:
-                      description: MatchResources defines when this policy rule should be applied. The match criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the user name or role. At least one kind is required.
+                      description: MatchResources defines when this policy rule should
+                        be applied. The match criteria can include resource information
+                        (e.g. kind, name, namespace, labels) and admission review
+                        request information like the user name or role. At least one
+                        kind is required.
                       properties:
                         all:
-                          description: All allows specifying resources which will be ANDed
+                          description: All allows specifying resources which will
+                            be ANDed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -2715,29 +4015,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2749,30 +4079,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2784,31 +4144,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -2818,22 +4199,30 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will be ORed
+                          description: Any allows specifying resources which will
+                            be ORed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -2841,29 +4230,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2875,30 +4294,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2910,31 +4359,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -2944,17 +4414,24 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role names for the user.
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about the resource being created or modified. Requires at least one tag to be specified when under MatchResources.
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Requires at least
+                            one tag to be specified when under MatchResources.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -2962,29 +4439,52 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -2996,30 +4496,54 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -3031,31 +4555,51 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names for the user.
+                          description: Roles is the list of namespaced role names
+                            for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
                                 type: string
                             required:
                             - kind
@@ -3067,18 +4611,25 @@ spec:
                       description: Mutation is used to modify matching resources.
                       properties:
                         overlay:
-                          description: Overlay specifies an overlay pattern to modify resources. DEPRECATED. Use PatchStrategicMerge instead. Scheduled for removal in release 1.5+.
+                          description: Overlay specifies an overlay pattern to modify
+                            resources. DEPRECATED. Use PatchStrategicMerge instead.
+                            Scheduled for removal in release 1.5+.
                           x-kubernetes-preserve-unknown-fields: true
                         patchStrategicMerge:
-                          description: PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          description: PatchStrategicMerge is a strategic merge patch
+                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
                           x-kubernetes-preserve-unknown-fields: true
                         patches:
-                          description: Patches specifies a RFC 6902 JSON Patch to modify resources. DEPRECATED. Use PatchesJSON6902 instead. Scheduled for removal in release 1.5+.
+                          description: Patches specifies a RFC 6902 JSON Patch to
+                            modify resources. DEPRECATED. Use PatchesJSON6902 instead.
+                            Scheduled for removal in release 1.5+.
                           items:
                             description: 'Patch is a RFC 6902 JSON Patch. See: https://tools.ietf.org/html/rfc6902'
                             properties:
                               op:
-                                description: Operation specifies operations supported by JSON Patch. i.e:- add, replace and delete.
+                                description: Operation specifies operations supported
+                                  by JSON Patch. i.e:- add, replace and delete.
                                 type: string
                               path:
                                 description: Path specifies path of the resource.
@@ -3091,114 +4642,160 @@ spec:
                           type: array
                           x-kubernetes-preserve-unknown-fields: true
                         patchesJson6902:
-                          description: PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON
+                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
                           type: string
                       type: object
                     name:
-                      description: Name is a label to identify the rule, It must be unique within the policy.
+                      description: Name is a label to identify the rule, It must be
+                        unique within the policy.
                       maxLength: 63
                       type: string
                     preconditions:
-                      description: 'Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      description: 'Preconditions are used to determine if a policy
+                        rule should be applied by evaluating a set of conditions.
+                        The declaration can contain nested `any` or `all` statements.
+                        A direct list of conditions (without `any` or `all` statements
+                        is supported for backwards compatibility but will be deprecated
+                        in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
                       x-kubernetes-preserve-unknown-fields: true
                     validate:
                       description: Validation is used to validate matching resources.
                       properties:
                         anyPattern:
-                          description: AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.
+                          description: AnyPattern specifies list of validation patterns.
+                            At least one of the patterns must be satisfied for the
+                            validation rule to succeed.
                           x-kubernetes-preserve-unknown-fields: true
                         deny:
-                          description: Deny defines conditions used to pass or fail a validation rule.
+                          description: Deny defines conditions used to pass or fail
+                            a validation rule.
                           properties:
                             conditions:
-                              description: 'Multiple conditions can be declared under an `any` or `all` statement. A direct list of conditions (without `any` or `all` statements) is also supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              description: 'Multiple conditions can be declared under
+                                an `any` or `all` statement. A direct list of conditions
+                                (without `any` or `all` statements) is also supported
+                                for backwards compatibility but will be deprecated
+                                in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
                               x-kubernetes-preserve-unknown-fields: true
                           type: object
                         message:
-                          description: Message specifies a custom message to be displayed on failure.
+                          description: Message specifies a custom message to be displayed
+                            on failure.
                           type: string
                         pattern:
-                          description: Pattern specifies an overlay-style pattern used to check resources.
+                          description: Pattern specifies an overlay-style pattern
+                            used to check resources.
                           x-kubernetes-preserve-unknown-fields: true
                       type: object
                     verifyImages:
-                      description: VerifyImages is used to verify image signatures and mutate them to add a digest
+                      description: VerifyImages is used to verify image signatures
+                        and mutate them to add a digest
                       items:
-                        description: ImageVerification validates that images that match the specified pattern are signed with the supplied public key. Once the image is verified it is mutated to include the SHA digest retrieved during the registration.
+                        description: ImageVerification validates that images that
+                          match the specified pattern are signed with the supplied
+                          public key. Once the image is verified it is mutated to
+                          include the SHA digest retrieved during the registration.
                         properties:
                           image:
-                            description: 'Image is the image name consisting of the registry address, repository, image, and tag. Wildcards (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                            description: 'Image is the image name consisting of the
+                              registry address, repository, image, and tag. Wildcards
+                              (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
                             type: string
                           key:
-                            description: Key is the PEM encoded public key that the image is signed with.
+                            description: Key is the PEM encoded public key that the
+                              image is signed with.
                             type: string
                         type: object
                       type: array
                   type: object
                 type: array
               schemaValidation:
-                description: SchemaValidation skips policy validation checks. Optional. The default value is set to "true", it must be set to "false" to disable the validation checks.
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
                 type: boolean
               validationFailureAction:
-                description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
+                description: ValidationFailureAction controls if a validation policy
+                  rule failure should disallow the admission review request (enforce),
+                  or allow (audit) the admission review request and report an error
+                  in a policy report. Optional. The default value is "audit".
                 type: string
             type: object
           status:
-            description: Status contains policy runtime information. Deprecated. Policy metrics are available via the metrics endpoint
+            description: Status contains policy runtime information. Deprecated. Policy
+              metrics are available via the metrics endpoint
             properties:
               averageExecutionTime:
-                description: AvgExecutionTime is the average time taken to process the policy rules on a resource.
+                description: AvgExecutionTime is the average time taken to process
+                  the policy rules on a resource.
                 type: string
               resourcesBlockedCount:
-                description: ResourcesBlockedCount is the total count of admission review requests that were blocked by this policy.
+                description: ResourcesBlockedCount is the total count of admission
+                  review requests that were blocked by this policy.
                 type: integer
               resourcesGeneratedCount:
-                description: ResourcesGeneratedCount is the total count of resources that were generated by this policy.
+                description: ResourcesGeneratedCount is the total count of resources
+                  that were generated by this policy.
                 type: integer
               resourcesMutatedCount:
-                description: ResourcesMutatedCount is the total count of resources that were mutated by this policy.
+                description: ResourcesMutatedCount is the total count of resources
+                  that were mutated by this policy.
                 type: integer
               ruleStatus:
                 description: Rules provides per rule statistics
                 items:
-                  description: 'RuleStats provides statistics for an individual rule within a policy. Deprecated. Policy metrics are now available via the "/metrics" endpoint. See: https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/'
+                  description: 'RuleStats provides statistics for an individual rule
+                    within a policy. Deprecated. Policy metrics are now available
+                    via the "/metrics" endpoint. See: https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/'
                   properties:
                     appliedCount:
-                      description: AppliedCount is the total number of times this rule was applied.
+                      description: AppliedCount is the total number of times this
+                        rule was applied.
                       type: integer
                     averageExecutionTime:
-                      description: ExecutionTime is the average time taken to execute this rule.
+                      description: ExecutionTime is the average time taken to execute
+                        this rule.
                       type: string
                     failedCount:
-                      description: FailedCount is the total count of policy error results for this rule.
+                      description: FailedCount is the total count of policy error
+                        results for this rule.
                       type: integer
                     resourcesBlockedCount:
-                      description: ResourcesBlockedCount is the total count of admission review requests that were blocked by this rule.
+                      description: ResourcesBlockedCount is the total count of admission
+                        review requests that were blocked by this rule.
                       type: integer
                     resourcesGeneratedCount:
-                      description: ResourcesGeneratedCount is the total count of resources that were generated by this rule.
+                      description: ResourcesGeneratedCount is the total count of resources
+                        that were generated by this rule.
                       type: integer
                     resourcesMutatedCount:
-                      description: ResourcesMutatedCount is the total count of resources that were mutated by this rule.
+                      description: ResourcesMutatedCount is the total count of resources
+                        that were mutated by this rule.
                       type: integer
                     ruleName:
                       description: Name is the rule name.
                       type: string
                     violationCount:
-                      description: ViolationCount is the total count of policy failure results for this rule.
+                      description: ViolationCount is the total count of policy failure
+                        results for this rule.
                       type: integer
                   required:
                   - ruleName
                   type: object
                 type: array
               rulesAppliedCount:
-                description: RulesAppliedCount is the total number of times this policy was applied.
+                description: RulesAppliedCount is the total number of times this policy
+                  was applied.
                 type: integer
               rulesFailedCount:
-                description: RulesFailedCount is the total count of policy execution errors for this policy.
+                description: RulesFailedCount is the total count of policy execution
+                  errors for this policy.
                 type: integer
               violationCount:
-                description: ViolationCount is the total count of policy failure results for this policy.
+                description: ViolationCount is the total count of policy failure results
+                  for this policy.
                 type: integer
             type: object
         required:
@@ -3273,17 +4870,22 @@ spec:
         description: PolicyReport is the Schema for the policyreports API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -3291,30 +4893,46 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy rule
+                  description: Data provides additional information for the policy
+                    rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -3326,19 +4944,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -3350,7 +5007,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -3384,13 +5042,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -3402,28 +5070,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -3435,26 +5114,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -3494,23 +5181,29 @@ spec:
         description: PolicyReport is the Schema for the policyreports API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -3518,24 +5211,39 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the policy rule
+                  description: Properties provides additional information for the
+                    policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -3547,19 +5255,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -3571,7 +5318,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -3601,17 +5349,24 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that manages this report
+                  description: Source is an identifier for the policy engine that
+                    manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -3623,13 +5378,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -3641,28 +5406,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -3674,26 +5450,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -3762,20 +5546,26 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ReportChangeRequest is the Schema for the ReportChangeRequests API
+        description: ReportChangeRequest is the Schema for the ReportChangeRequests
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -3783,30 +5573,46 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy rule
+                  description: Data provides additional information for the policy
+                    rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -3818,19 +5624,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -3842,7 +5687,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -3876,13 +5722,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -3894,28 +5750,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -3927,26 +5794,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -3983,26 +5858,33 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: ReportChangeRequest is the Schema for the ReportChangeRequests API
+        description: ReportChangeRequest is the Schema for the ReportChangeRequests
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -4010,24 +5892,39 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the policy rule
+                  description: Properties provides additional information for the
+                    policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -4039,19 +5936,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -4063,7 +5999,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -4093,17 +6030,24 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that manages this report
+                  description: Source is an identifier for the policy engine that
+                    manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -4115,13 +6059,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -4133,28 +6087,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -4166,26 +6131,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -4630,6 +6603,23 @@ metadata:
   namespace: kyverno
 ---
 apiVersion: v1
+data:
+  metricsRefreshInterval: 24h
+  namespaces: '{"exclude":[],"include":[]}'
+kind: ConfigMap
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: Kustomize
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.4.2
+  name: kyverno-metrics
+  namespace: kyverno
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -4715,6 +6705,8 @@ spec:
         env:
         - name: INIT_CONFIG
           value: init-config
+        - name: METRICS_CONFIG
+          value: kyverno-metrics
         - name: KYVERNO_NAMESPACE
           valueFrom:
             fieldRef:
@@ -4729,7 +6721,7 @@ spec:
             path: /health/liveness
             port: 9443
             scheme: HTTPS
-          initialDelaySeconds: 10
+          initialDelaySeconds: 15
           periodSeconds: 30
           successThreshold: 1
           timeoutSeconds: 5
@@ -4766,7 +6758,10 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
       initContainers:
-      - image: ghcr.io/kyverno/kyvernopre:v1.4.2
+      - env:
+        - name: METRICS_CONFIG
+          value: kyverno-metrics
+        image: ghcr.io/kyverno/kyvernopre:v1.4.2
         imagePullPolicy: IfNotPresent
         name: kyverno-pre
         resources:

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -33,13 +33,18 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.
+        description: ClusterPolicy declares validation, mutation, and generation behaviors
+          for matching resources.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -47,26 +52,49 @@ spec:
             description: Spec declares policy behaviors.
             properties:
               background:
-                description: Background controls if rules are applied to existing resources during a background scan. Optional. Default value is "true". The value must be set to "false" if the policy rule uses variables that are only available in the admission review request (e.g. user name).
+                description: Background controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
                 type: boolean
               rules:
-                description: Rules is a list of Rule instances. A Policy contains multiple rules and each rule can validate, mutate, or generate resources.
+                description: Rules is a list of Rule instances. A Policy contains
+                  multiple rules and each rule can validate, mutate, or generate resources.
                 items:
-                  description: Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.
+                  description: Rule defines a validation, mutation, or generation
+                    control for matching resources. Each rules contains a match declaration
+                    to select resources, and an optional exclude declaration to specify
+                    which resources to exclude.
                   properties:
                     context:
-                      description: Context defines variables and data sources that can be used during rule execution.
+                      description: Context defines variables and data sources that
+                        can be used during rule execution.
                       items:
-                        description: ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.
+                        description: ContextEntry adds variables and data sources
+                          to a rule Context. Either a ConfigMap reference or a APILookup
+                          must be provided.
                         properties:
                           apiCall:
-                            description: APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.
+                            description: APICall defines an HTTP request to the Kubernetes
+                              API server. The JSON data retrieved is stored in the
+                              context.
                             properties:
                               jmesPath:
-                                description: JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of "items | length(@)" applied to the API server response to the URLPath "/apis/apps/v1/deployments" will return the total count of deployments across all namespaces.
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the JSON response
+                                  returned from the API server. For example a JMESPath
+                                  of "items | length(@)" applied to the API server
+                                  response to the URLPath "/apis/apps/v1/deployments"
+                                  will return the total count of deployments across
+                                  all namespaces.
                                 type: string
                               urlPath:
-                                description: URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments"). The format required is the same format used by the `kubectl get --raw` command.
+                                description: URLPath is the URL path to be used in
+                                  the HTTP GET request to the Kubernetes API server
+                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                  The format required is the same format used by the
+                                  `kubectl get --raw` command.
                                 type: string
                             required:
                             - urlPath
@@ -89,25 +117,36 @@ spec:
                         type: object
                       type: array
                     exclude:
-                      description: ExcludeResources defines when this policy rule should not be applied. The exclude criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the name or role.
+                      description: ExcludeResources defines when this policy rule
+                        should not be applied. The exclude criteria can include resource
+                        information (e.g. kind, name, namespace, labels) and admission
+                        review request information like the name or role.
                       properties:
                         all:
-                          description: All allows specifying resources which will be ANDed
+                          description: All allows specifying resources which will
+                            be ANDed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -115,29 +154,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -149,30 +218,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -184,31 +283,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -218,22 +338,30 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will be ORed
+                          description: Any allows specifying resources which will
+                            be ORed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -241,29 +369,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -275,30 +433,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -310,31 +498,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -344,17 +553,23 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role names for the user.
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about the resource being created or modified.
+                          description: ResourceDescription contains information about
+                            the resource being created or modified.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -362,29 +577,52 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -396,30 +634,54 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -431,31 +693,51 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names for the user.
+                          description: Roles is the list of namespaced role names
+                            for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
                                 type: string
                             required:
                             - kind
@@ -470,7 +752,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specifies the source resource used to populate each generated resource. At most one of Data or Clone can be specified. If neither are provided, the generated resource will be created with default data only.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -480,7 +765,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource declaration used to populate each generated resource. At most one of Data or Clone must be specified. If neither are provided, the generated resource will be created with default data only.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -492,29 +780,46 @@ spec:
                           description: Namespace specifies resource namespace.
                           type: string
                         synchronize:
-                          description: Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to "true" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to "false" if not specified.
+                          description: Synchronize controls if generated resources
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
+                            Defaults to "false" if not specified.
                           type: boolean
                       type: object
                     match:
-                      description: MatchResources defines when this policy rule should be applied. The match criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the user name or role. At least one kind is required.
+                      description: MatchResources defines when this policy rule should
+                        be applied. The match criteria can include resource information
+                        (e.g. kind, name, namespace, labels) and admission review
+                        request information like the user name or role. At least one
+                        kind is required.
                       properties:
                         all:
-                          description: All allows specifying resources which will be ANDed
+                          description: All allows specifying resources which will
+                            be ANDed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -522,29 +827,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -556,30 +891,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -591,31 +956,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -625,22 +1011,30 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will be ORed
+                          description: Any allows specifying resources which will
+                            be ORed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -648,29 +1042,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -682,30 +1106,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -717,31 +1171,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -751,17 +1226,24 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role names for the user.
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about the resource being created or modified. Requires at least one tag to be specified when under MatchResources.
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Requires at least
+                            one tag to be specified when under MatchResources.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -769,29 +1251,52 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -803,30 +1308,54 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -838,31 +1367,51 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names for the user.
+                          description: Roles is the list of namespaced role names
+                            for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
                                 type: string
                             required:
                             - kind
@@ -874,18 +1423,25 @@ spec:
                       description: Mutation is used to modify matching resources.
                       properties:
                         overlay:
-                          description: Overlay specifies an overlay pattern to modify resources. DEPRECATED. Use PatchStrategicMerge instead. Scheduled for removal in release 1.5+.
+                          description: Overlay specifies an overlay pattern to modify
+                            resources. DEPRECATED. Use PatchStrategicMerge instead.
+                            Scheduled for removal in release 1.5+.
                           x-kubernetes-preserve-unknown-fields: true
                         patchStrategicMerge:
-                          description: PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          description: PatchStrategicMerge is a strategic merge patch
+                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
                           x-kubernetes-preserve-unknown-fields: true
                         patches:
-                          description: Patches specifies a RFC 6902 JSON Patch to modify resources. DEPRECATED. Use PatchesJSON6902 instead. Scheduled for removal in release 1.5+.
+                          description: Patches specifies a RFC 6902 JSON Patch to
+                            modify resources. DEPRECATED. Use PatchesJSON6902 instead.
+                            Scheduled for removal in release 1.5+.
                           items:
                             description: 'Patch is a RFC 6902 JSON Patch. See: https://tools.ietf.org/html/rfc6902'
                             properties:
                               op:
-                                description: Operation specifies operations supported by JSON Patch. i.e:- add, replace and delete.
+                                description: Operation specifies operations supported
+                                  by JSON Patch. i.e:- add, replace and delete.
                                 type: string
                               path:
                                 description: Path specifies path of the resource.
@@ -898,114 +1454,159 @@ spec:
                           type: array
                           x-kubernetes-preserve-unknown-fields: true
                         patchesJson6902:
-                          description: PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON
+                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
                           type: string
                       type: object
                     name:
-                      description: Name is a label to identify the rule, It must be unique within the policy.
+                      description: Name is a label to identify the rule, It must be
+                        unique within the policy.
                       maxLength: 63
                       type: string
                     preconditions:
-                      description: 'Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      description: 'Preconditions are used to determine if a policy
+                        rule should be applied by evaluating a set of conditions.
+                        The declaration can contain nested `any` or `all` statements.
+                        A direct list of conditions (without `any` or `all` statements
+                        is supported for backwards compatibility but will be deprecated
+                        in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
                       x-kubernetes-preserve-unknown-fields: true
                     validate:
                       description: Validation is used to validate matching resources.
                       properties:
                         anyPattern:
-                          description: AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.
+                          description: AnyPattern specifies list of validation patterns.
+                            At least one of the patterns must be satisfied for the
+                            validation rule to succeed.
                           x-kubernetes-preserve-unknown-fields: true
                         deny:
-                          description: Deny defines conditions used to pass or fail a validation rule.
+                          description: Deny defines conditions used to pass or fail
+                            a validation rule.
                           properties:
                             conditions:
-                              description: 'Multiple conditions can be declared under an `any` or `all` statement. A direct list of conditions (without `any` or `all` statements) is also supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              description: 'Multiple conditions can be declared under
+                                an `any` or `all` statement. A direct list of conditions
+                                (without `any` or `all` statements) is also supported
+                                for backwards compatibility but will be deprecated
+                                in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
                               x-kubernetes-preserve-unknown-fields: true
                           type: object
                         message:
-                          description: Message specifies a custom message to be displayed on failure.
+                          description: Message specifies a custom message to be displayed
+                            on failure.
                           type: string
                         pattern:
-                          description: Pattern specifies an overlay-style pattern used to check resources.
+                          description: Pattern specifies an overlay-style pattern
+                            used to check resources.
                           x-kubernetes-preserve-unknown-fields: true
                       type: object
                     verifyImages:
-                      description: VerifyImages is used to verify image signatures and mutate them to add a digest
+                      description: VerifyImages is used to verify image signatures
+                        and mutate them to add a digest
                       items:
-                        description: ImageVerification validates that images that match the specified pattern are signed with the supplied public key. Once the image is verified it is mutated to include the SHA digest retrieved during the registration.
+                        description: ImageVerification validates that images that
+                          match the specified pattern are signed with the supplied
+                          public key. Once the image is verified it is mutated to
+                          include the SHA digest retrieved during the registration.
                         properties:
                           image:
-                            description: 'Image is the image name consisting of the registry address, repository, image, and tag. Wildcards (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                            description: 'Image is the image name consisting of the
+                              registry address, repository, image, and tag. Wildcards
+                              (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
                             type: string
                           key:
-                            description: Key is the PEM encoded public key that the image is signed with.
+                            description: Key is the PEM encoded public key that the
+                              image is signed with.
                             type: string
                         type: object
                       type: array
                   type: object
                 type: array
               schemaValidation:
-                description: SchemaValidation skips policy validation checks. Optional. The default value is set to "true", it must be set to "false" to disable the validation checks.
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
                 type: boolean
               validationFailureAction:
-                description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
+                description: ValidationFailureAction controls if a validation policy
+                  rule failure should disallow the admission review request (enforce),
+                  or allow (audit) the admission review request and report an error
+                  in a policy report. Optional. The default value is "audit".
                 type: string
             type: object
           status:
             description: Status contains policy runtime data.
             properties:
               averageExecutionTime:
-                description: AvgExecutionTime is the average time taken to process the policy rules on a resource.
+                description: AvgExecutionTime is the average time taken to process
+                  the policy rules on a resource.
                 type: string
               resourcesBlockedCount:
-                description: ResourcesBlockedCount is the total count of admission review requests that were blocked by this policy.
+                description: ResourcesBlockedCount is the total count of admission
+                  review requests that were blocked by this policy.
                 type: integer
               resourcesGeneratedCount:
-                description: ResourcesGeneratedCount is the total count of resources that were generated by this policy.
+                description: ResourcesGeneratedCount is the total count of resources
+                  that were generated by this policy.
                 type: integer
               resourcesMutatedCount:
-                description: ResourcesMutatedCount is the total count of resources that were mutated by this policy.
+                description: ResourcesMutatedCount is the total count of resources
+                  that were mutated by this policy.
                 type: integer
               ruleStatus:
                 description: Rules provides per rule statistics
                 items:
-                  description: 'RuleStats provides statistics for an individual rule within a policy. Deprecated. Policy metrics are now available via the "/metrics" endpoint. See: https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/'
+                  description: 'RuleStats provides statistics for an individual rule
+                    within a policy. Deprecated. Policy metrics are now available
+                    via the "/metrics" endpoint. See: https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/'
                   properties:
                     appliedCount:
-                      description: AppliedCount is the total number of times this rule was applied.
+                      description: AppliedCount is the total number of times this
+                        rule was applied.
                       type: integer
                     averageExecutionTime:
-                      description: ExecutionTime is the average time taken to execute this rule.
+                      description: ExecutionTime is the average time taken to execute
+                        this rule.
                       type: string
                     failedCount:
-                      description: FailedCount is the total count of policy error results for this rule.
+                      description: FailedCount is the total count of policy error
+                        results for this rule.
                       type: integer
                     resourcesBlockedCount:
-                      description: ResourcesBlockedCount is the total count of admission review requests that were blocked by this rule.
+                      description: ResourcesBlockedCount is the total count of admission
+                        review requests that were blocked by this rule.
                       type: integer
                     resourcesGeneratedCount:
-                      description: ResourcesGeneratedCount is the total count of resources that were generated by this rule.
+                      description: ResourcesGeneratedCount is the total count of resources
+                        that were generated by this rule.
                       type: integer
                     resourcesMutatedCount:
-                      description: ResourcesMutatedCount is the total count of resources that were mutated by this rule.
+                      description: ResourcesMutatedCount is the total count of resources
+                        that were mutated by this rule.
                       type: integer
                     ruleName:
                       description: Name is the rule name.
                       type: string
                     violationCount:
-                      description: ViolationCount is the total count of policy failure results for this rule.
+                      description: ViolationCount is the total count of policy failure
+                        results for this rule.
                       type: integer
                   required:
                   - ruleName
                   type: object
                 type: array
               rulesAppliedCount:
-                description: RulesAppliedCount is the total number of times this policy was applied.
+                description: RulesAppliedCount is the total number of times this policy
+                  was applied.
                 type: integer
               rulesFailedCount:
-                description: RulesFailedCount is the total count of policy execution errors for this policy.
+                description: RulesFailedCount is the total count of policy execution
+                  errors for this policy.
                 type: integer
               violationCount:
-                description: ViolationCount is the total count of policy failure results for this policy.
+                description: ViolationCount is the total count of policy failure results
+                  for this policy.
                 type: integer
             type: object
         required:
@@ -1070,20 +1671,26 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterPolicyReport is the Schema for the clusterpolicyreports API
+        description: ClusterPolicyReport is the Schema for the clusterpolicyreports
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -1091,30 +1698,46 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy rule
+                  description: Data provides additional information for the policy
+                    rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -1126,19 +1749,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1150,7 +1812,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -1184,13 +1847,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1202,28 +1875,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -1235,26 +1919,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -1291,26 +1983,33 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: ClusterPolicyReport is the Schema for the clusterpolicyreports API
+        description: ClusterPolicyReport is the Schema for the clusterpolicyreports
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -1318,24 +2017,39 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the policy rule
+                  description: Properties provides additional information for the
+                    policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -1347,19 +2061,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1371,7 +2124,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -1401,17 +2155,24 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that manages this report
+                  description: Source is an identifier for the policy engine that
+                    manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -1423,13 +2184,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1441,28 +2212,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -1474,26 +2256,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -1555,20 +2345,26 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests API
+        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -1576,30 +2372,46 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy rule
+                  description: Data provides additional information for the policy
+                    rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -1611,19 +2423,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1635,7 +2486,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -1669,13 +2521,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1687,28 +2549,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -1720,26 +2593,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -1776,26 +2657,33 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests API
+        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -1803,24 +2691,39 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the policy rule
+                  description: Properties provides additional information for the
+                    policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -1832,19 +2735,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1856,7 +2798,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -1886,17 +2829,24 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that manages this report
+                  description: Source is an identifier for the policy engine that
+                    manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -1908,13 +2858,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -1926,28 +2886,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -1959,26 +2930,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -2035,10 +3014,14 @@ spec:
         description: GenerateRequest is a request to process generate rule.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2049,10 +3032,12 @@ spec:
                 description: Context ...
                 properties:
                   userInfo:
-                    description: RequestInfo contains permission info carried in an admission request.
+                    description: RequestInfo contains permission info carried in an
+                      admission request.
                     properties:
                       clusterRoles:
-                        description: ClusterRoles is a list of possible clusterRoles send the request.
+                        description: ClusterRoles is a list of possible clusterRoles
+                          send the request.
                         items:
                           type: string
                         nullable: true
@@ -2064,15 +3049,18 @@ spec:
                         nullable: true
                         type: array
                       userInfo:
-                        description: UserInfo is the userInfo carried in the admission request.
+                        description: UserInfo is the userInfo carried in the admission
+                          request.
                         properties:
                           extra:
                             additionalProperties:
-                              description: ExtraValue masks the value so protobuf can generate
+                              description: ExtraValue masks the value so protobuf
+                                can generate
                               items:
                                 type: string
                               type: array
-                            description: Any additional information provided by the authenticator.
+                            description: Any additional information provided by the
+                              authenticator.
                             type: object
                           groups:
                             description: The names of groups this user is a part of.
@@ -2080,10 +3068,14 @@ spec:
                               type: string
                             type: array
                           uid:
-                            description: A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs.
+                            description: A unique value that identifies this user
+                              across time. If this user is deleted and another user
+                              by the same name is added, they will have different
+                              UIDs.
                             type: string
                           username:
-                            description: The name that uniquely identifies this user among all active users.
+                            description: The name that uniquely identifies this user
+                              among all active users.
                             type: string
                         type: object
                     type: object
@@ -2092,7 +3084,8 @@ spec:
                 description: Specifies the name of the policy.
                 type: string
               resource:
-                description: ResourceSpec is the information to identify the generate request.
+                description: ResourceSpec is the information to identify the generate
+                  request.
                 properties:
                   apiVersion:
                     description: APIVersion specifies resource apiVersion.
@@ -2116,7 +3109,8 @@ spec:
             description: Status contains statistics related to generate request.
             properties:
               generatedResources:
-                description: This will track the resources that are generated by the generate Policy. Will be used during clean up resources.
+                description: This will track the resources that are generated by the
+                  generate Policy. Will be used during clean up resources.
                 items:
                   description: ResourceSpec contains information to identify a resource.
                   properties:
@@ -2185,13 +3179,19 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: 'Policy declares validation, mutation, and generation behaviors for matching resources. See: https://kyverno.io/docs/writing-policies/ for more information.'
+        description: 'Policy declares validation, mutation, and generation behaviors
+          for matching resources. See: https://kyverno.io/docs/writing-policies/ for
+          more information.'
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2199,26 +3199,49 @@ spec:
             description: Spec defines policy behaviors and contains one or more rules.
             properties:
               background:
-                description: Background controls if rules are applied to existing resources during a background scan. Optional. Default value is "true". The value must be set to "false" if the policy rule uses variables that are only available in the admission review request (e.g. user name).
+                description: Background controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
                 type: boolean
               rules:
-                description: Rules is a list of Rule instances. A Policy contains multiple rules and each rule can validate, mutate, or generate resources.
+                description: Rules is a list of Rule instances. A Policy contains
+                  multiple rules and each rule can validate, mutate, or generate resources.
                 items:
-                  description: Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.
+                  description: Rule defines a validation, mutation, or generation
+                    control for matching resources. Each rules contains a match declaration
+                    to select resources, and an optional exclude declaration to specify
+                    which resources to exclude.
                   properties:
                     context:
-                      description: Context defines variables and data sources that can be used during rule execution.
+                      description: Context defines variables and data sources that
+                        can be used during rule execution.
                       items:
-                        description: ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.
+                        description: ContextEntry adds variables and data sources
+                          to a rule Context. Either a ConfigMap reference or a APILookup
+                          must be provided.
                         properties:
                           apiCall:
-                            description: APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.
+                            description: APICall defines an HTTP request to the Kubernetes
+                              API server. The JSON data retrieved is stored in the
+                              context.
                             properties:
                               jmesPath:
-                                description: JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of "items | length(@)" applied to the API server response to the URLPath "/apis/apps/v1/deployments" will return the total count of deployments across all namespaces.
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the JSON response
+                                  returned from the API server. For example a JMESPath
+                                  of "items | length(@)" applied to the API server
+                                  response to the URLPath "/apis/apps/v1/deployments"
+                                  will return the total count of deployments across
+                                  all namespaces.
                                 type: string
                               urlPath:
-                                description: URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments"). The format required is the same format used by the `kubectl get --raw` command.
+                                description: URLPath is the URL path to be used in
+                                  the HTTP GET request to the Kubernetes API server
+                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                  The format required is the same format used by the
+                                  `kubectl get --raw` command.
                                 type: string
                             required:
                             - urlPath
@@ -2241,25 +3264,36 @@ spec:
                         type: object
                       type: array
                     exclude:
-                      description: ExcludeResources defines when this policy rule should not be applied. The exclude criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the name or role.
+                      description: ExcludeResources defines when this policy rule
+                        should not be applied. The exclude criteria can include resource
+                        information (e.g. kind, name, namespace, labels) and admission
+                        review request information like the name or role.
                       properties:
                         all:
-                          description: All allows specifying resources which will be ANDed
+                          description: All allows specifying resources which will
+                            be ANDed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -2267,29 +3301,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2301,30 +3365,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2336,31 +3430,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -2370,22 +3485,30 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will be ORed
+                          description: Any allows specifying resources which will
+                            be ORed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -2393,29 +3516,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2427,30 +3580,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2462,31 +3645,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -2496,17 +3700,23 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role names for the user.
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about the resource being created or modified.
+                          description: ResourceDescription contains information about
+                            the resource being created or modified.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -2514,29 +3724,52 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -2548,30 +3781,54 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -2583,31 +3840,51 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names for the user.
+                          description: Roles is the list of namespaced role names
+                            for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
                                 type: string
                             required:
                             - kind
@@ -2622,7 +3899,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specifies the source resource used to populate each generated resource. At most one of Data or Clone can be specified. If neither are provided, the generated resource will be created with default data only.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -2632,7 +3912,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource declaration used to populate each generated resource. At most one of Data or Clone must be specified. If neither are provided, the generated resource will be created with default data only.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -2644,29 +3927,46 @@ spec:
                           description: Namespace specifies resource namespace.
                           type: string
                         synchronize:
-                          description: Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to "true" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to "false" if not specified.
+                          description: Synchronize controls if generated resources
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
+                            Defaults to "false" if not specified.
                           type: boolean
                       type: object
                     match:
-                      description: MatchResources defines when this policy rule should be applied. The match criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the user name or role. At least one kind is required.
+                      description: MatchResources defines when this policy rule should
+                        be applied. The match criteria can include resource information
+                        (e.g. kind, name, namespace, labels) and admission review
+                        request information like the user name or role. At least one
+                        kind is required.
                       properties:
                         all:
-                          description: All allows specifying resources which will be ANDed
+                          description: All allows specifying resources which will
+                            be ANDed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -2674,29 +3974,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2708,30 +4038,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2743,31 +4103,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -2777,22 +4158,30 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will be ORed
+                          description: Any allows specifying resources which will
+                            be ORed
                           items:
-                            description: ResourceFilters allow users to "AND" or "OR" between resources
+                            description: ResourceFilters allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -2800,29 +4189,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2834,30 +4253,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2869,31 +4318,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -2903,17 +4373,24 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role names for the user.
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about the resource being created or modified. Requires at least one tag to be specified when under MatchResources.
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Requires at least
+                            one tag to be specified when under MatchResources.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -2921,29 +4398,52 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -2955,30 +4455,54 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -2990,31 +4514,51 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names for the user.
+                          description: Roles is the list of namespaced role names
+                            for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
                                 type: string
                             required:
                             - kind
@@ -3026,18 +4570,25 @@ spec:
                       description: Mutation is used to modify matching resources.
                       properties:
                         overlay:
-                          description: Overlay specifies an overlay pattern to modify resources. DEPRECATED. Use PatchStrategicMerge instead. Scheduled for removal in release 1.5+.
+                          description: Overlay specifies an overlay pattern to modify
+                            resources. DEPRECATED. Use PatchStrategicMerge instead.
+                            Scheduled for removal in release 1.5+.
                           x-kubernetes-preserve-unknown-fields: true
                         patchStrategicMerge:
-                          description: PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          description: PatchStrategicMerge is a strategic merge patch
+                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
                           x-kubernetes-preserve-unknown-fields: true
                         patches:
-                          description: Patches specifies a RFC 6902 JSON Patch to modify resources. DEPRECATED. Use PatchesJSON6902 instead. Scheduled for removal in release 1.5+.
+                          description: Patches specifies a RFC 6902 JSON Patch to
+                            modify resources. DEPRECATED. Use PatchesJSON6902 instead.
+                            Scheduled for removal in release 1.5+.
                           items:
                             description: 'Patch is a RFC 6902 JSON Patch. See: https://tools.ietf.org/html/rfc6902'
                             properties:
                               op:
-                                description: Operation specifies operations supported by JSON Patch. i.e:- add, replace and delete.
+                                description: Operation specifies operations supported
+                                  by JSON Patch. i.e:- add, replace and delete.
                                 type: string
                               path:
                                 description: Path specifies path of the resource.
@@ -3050,114 +4601,160 @@ spec:
                           type: array
                           x-kubernetes-preserve-unknown-fields: true
                         patchesJson6902:
-                          description: PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON
+                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
                           type: string
                       type: object
                     name:
-                      description: Name is a label to identify the rule, It must be unique within the policy.
+                      description: Name is a label to identify the rule, It must be
+                        unique within the policy.
                       maxLength: 63
                       type: string
                     preconditions:
-                      description: 'Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      description: 'Preconditions are used to determine if a policy
+                        rule should be applied by evaluating a set of conditions.
+                        The declaration can contain nested `any` or `all` statements.
+                        A direct list of conditions (without `any` or `all` statements
+                        is supported for backwards compatibility but will be deprecated
+                        in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
                       x-kubernetes-preserve-unknown-fields: true
                     validate:
                       description: Validation is used to validate matching resources.
                       properties:
                         anyPattern:
-                          description: AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.
+                          description: AnyPattern specifies list of validation patterns.
+                            At least one of the patterns must be satisfied for the
+                            validation rule to succeed.
                           x-kubernetes-preserve-unknown-fields: true
                         deny:
-                          description: Deny defines conditions used to pass or fail a validation rule.
+                          description: Deny defines conditions used to pass or fail
+                            a validation rule.
                           properties:
                             conditions:
-                              description: 'Multiple conditions can be declared under an `any` or `all` statement. A direct list of conditions (without `any` or `all` statements) is also supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              description: 'Multiple conditions can be declared under
+                                an `any` or `all` statement. A direct list of conditions
+                                (without `any` or `all` statements) is also supported
+                                for backwards compatibility but will be deprecated
+                                in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
                               x-kubernetes-preserve-unknown-fields: true
                           type: object
                         message:
-                          description: Message specifies a custom message to be displayed on failure.
+                          description: Message specifies a custom message to be displayed
+                            on failure.
                           type: string
                         pattern:
-                          description: Pattern specifies an overlay-style pattern used to check resources.
+                          description: Pattern specifies an overlay-style pattern
+                            used to check resources.
                           x-kubernetes-preserve-unknown-fields: true
                       type: object
                     verifyImages:
-                      description: VerifyImages is used to verify image signatures and mutate them to add a digest
+                      description: VerifyImages is used to verify image signatures
+                        and mutate them to add a digest
                       items:
-                        description: ImageVerification validates that images that match the specified pattern are signed with the supplied public key. Once the image is verified it is mutated to include the SHA digest retrieved during the registration.
+                        description: ImageVerification validates that images that
+                          match the specified pattern are signed with the supplied
+                          public key. Once the image is verified it is mutated to
+                          include the SHA digest retrieved during the registration.
                         properties:
                           image:
-                            description: 'Image is the image name consisting of the registry address, repository, image, and tag. Wildcards (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                            description: 'Image is the image name consisting of the
+                              registry address, repository, image, and tag. Wildcards
+                              (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
                             type: string
                           key:
-                            description: Key is the PEM encoded public key that the image is signed with.
+                            description: Key is the PEM encoded public key that the
+                              image is signed with.
                             type: string
                         type: object
                       type: array
                   type: object
                 type: array
               schemaValidation:
-                description: SchemaValidation skips policy validation checks. Optional. The default value is set to "true", it must be set to "false" to disable the validation checks.
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
                 type: boolean
               validationFailureAction:
-                description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
+                description: ValidationFailureAction controls if a validation policy
+                  rule failure should disallow the admission review request (enforce),
+                  or allow (audit) the admission review request and report an error
+                  in a policy report. Optional. The default value is "audit".
                 type: string
             type: object
           status:
-            description: Status contains policy runtime information. Deprecated. Policy metrics are available via the metrics endpoint
+            description: Status contains policy runtime information. Deprecated. Policy
+              metrics are available via the metrics endpoint
             properties:
               averageExecutionTime:
-                description: AvgExecutionTime is the average time taken to process the policy rules on a resource.
+                description: AvgExecutionTime is the average time taken to process
+                  the policy rules on a resource.
                 type: string
               resourcesBlockedCount:
-                description: ResourcesBlockedCount is the total count of admission review requests that were blocked by this policy.
+                description: ResourcesBlockedCount is the total count of admission
+                  review requests that were blocked by this policy.
                 type: integer
               resourcesGeneratedCount:
-                description: ResourcesGeneratedCount is the total count of resources that were generated by this policy.
+                description: ResourcesGeneratedCount is the total count of resources
+                  that were generated by this policy.
                 type: integer
               resourcesMutatedCount:
-                description: ResourcesMutatedCount is the total count of resources that were mutated by this policy.
+                description: ResourcesMutatedCount is the total count of resources
+                  that were mutated by this policy.
                 type: integer
               ruleStatus:
                 description: Rules provides per rule statistics
                 items:
-                  description: 'RuleStats provides statistics for an individual rule within a policy. Deprecated. Policy metrics are now available via the "/metrics" endpoint. See: https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/'
+                  description: 'RuleStats provides statistics for an individual rule
+                    within a policy. Deprecated. Policy metrics are now available
+                    via the "/metrics" endpoint. See: https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/'
                   properties:
                     appliedCount:
-                      description: AppliedCount is the total number of times this rule was applied.
+                      description: AppliedCount is the total number of times this
+                        rule was applied.
                       type: integer
                     averageExecutionTime:
-                      description: ExecutionTime is the average time taken to execute this rule.
+                      description: ExecutionTime is the average time taken to execute
+                        this rule.
                       type: string
                     failedCount:
-                      description: FailedCount is the total count of policy error results for this rule.
+                      description: FailedCount is the total count of policy error
+                        results for this rule.
                       type: integer
                     resourcesBlockedCount:
-                      description: ResourcesBlockedCount is the total count of admission review requests that were blocked by this rule.
+                      description: ResourcesBlockedCount is the total count of admission
+                        review requests that were blocked by this rule.
                       type: integer
                     resourcesGeneratedCount:
-                      description: ResourcesGeneratedCount is the total count of resources that were generated by this rule.
+                      description: ResourcesGeneratedCount is the total count of resources
+                        that were generated by this rule.
                       type: integer
                     resourcesMutatedCount:
-                      description: ResourcesMutatedCount is the total count of resources that were mutated by this rule.
+                      description: ResourcesMutatedCount is the total count of resources
+                        that were mutated by this rule.
                       type: integer
                     ruleName:
                       description: Name is the rule name.
                       type: string
                     violationCount:
-                      description: ViolationCount is the total count of policy failure results for this rule.
+                      description: ViolationCount is the total count of policy failure
+                        results for this rule.
                       type: integer
                   required:
                   - ruleName
                   type: object
                 type: array
               rulesAppliedCount:
-                description: RulesAppliedCount is the total number of times this policy was applied.
+                description: RulesAppliedCount is the total number of times this policy
+                  was applied.
                 type: integer
               rulesFailedCount:
-                description: RulesFailedCount is the total count of policy execution errors for this policy.
+                description: RulesFailedCount is the total count of policy execution
+                  errors for this policy.
                 type: integer
               violationCount:
-                description: ViolationCount is the total count of policy failure results for this policy.
+                description: ViolationCount is the total count of policy failure results
+                  for this policy.
                 type: integer
             type: object
         required:
@@ -3225,17 +4822,22 @@ spec:
         description: PolicyReport is the Schema for the policyreports API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -3243,30 +4845,46 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy rule
+                  description: Data provides additional information for the policy
+                    rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -3278,19 +4896,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -3302,7 +4959,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -3336,13 +4994,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -3354,28 +5022,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -3387,26 +5066,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -3446,23 +5133,29 @@ spec:
         description: PolicyReport is the Schema for the policyreports API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -3470,24 +5163,39 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the policy rule
+                  description: Properties provides additional information for the
+                    policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -3499,19 +5207,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -3523,7 +5270,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -3553,17 +5301,24 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that manages this report
+                  description: Source is an identifier for the policy engine that
+                    manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -3575,13 +5330,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -3593,28 +5358,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -3626,26 +5402,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -3707,20 +5491,26 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ReportChangeRequest is the Schema for the ReportChangeRequests API
+        description: ReportChangeRequest is the Schema for the ReportChangeRequests
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -3728,30 +5518,46 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy rule
+                  description: Data provides additional information for the policy
+                    rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -3763,19 +5569,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -3787,7 +5632,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -3821,13 +5667,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -3839,28 +5695,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -3872,26 +5739,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -3928,26 +5803,33 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: ReportChangeRequest is the Schema for the ReportChangeRequests API
+        description: ReportChangeRequest is the Schema for the ReportChangeRequests
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -3955,24 +5837,39 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the policy rule
+                  description: Properties provides additional information for the
+                    policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -3984,19 +5881,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -4008,7 +5944,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -4038,17 +5975,24 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that manages this report
+                  description: Source is an identifier for the policy engine that
+                    manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -4060,13 +6004,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -4078,28 +6032,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -4111,26 +6076,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -4470,6 +6443,17 @@ metadata:
   labels:
     app: kyverno
   name: init-config
+  namespace: kyverno
+---
+apiVersion: v1
+data:
+  metricsRefreshInterval: 24h
+  namespaces: '{"exclude":[],"include":[]}'
+kind: ConfigMap
+metadata:
+  labels:
+    app: kyverno
+  name: kyverno-metrics
   namespace: kyverno
 ---
 apiVersion: v1

--- a/definitions/k8s-resource/kustomization.yaml
+++ b/definitions/k8s-resource/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
 - ./clusterroles.yaml
 - ./clusterrolebindings.yaml
 - ./configmap.yaml
+- ./metricsconfigmap.yaml
 - ./service.yaml
 - ./serviceaccount.yaml

--- a/definitions/k8s-resource/metricsconfigmap.yaml
+++ b/definitions/k8s-resource/metricsconfigmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  metricsRefreshInterval: 24h
+  namespaces: '{"exclude":[],"include":[]}'
+kind: ConfigMap
+metadata:
+  labels:
+    app: kyverno
+  name: kyverno-metrics
+  namespace: kyverno

--- a/definitions/manifest/deployment.yaml
+++ b/definitions/manifest/deployment.yaml
@@ -43,6 +43,9 @@ spec:
             capabilities:
               drop:
                 - all
+          env:
+            - name: METRICS_CONFIG
+              value: kyverno-metrics
       containers:
         - name: kyverno
           image: ghcr.io/kyverno/kyverno:latest
@@ -66,6 +69,8 @@ spec:
           env:
             - name: INIT_CONFIG
               value: init-config
+            - name: METRICS_CONFIG
+              value: kyverno-metrics
             - name: KYVERNO_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -91,7 +96,7 @@ spec:
               path: /health/liveness
               port: 9443
               scheme: HTTPS
-            initialDelaySeconds: 10
+            initialDelaySeconds: 15
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 2

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/sigstore/cosign v1.1.0
 	github.com/sigstore/sigstore v0.0.0-20210729211320-56a91f560f44
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -481,9 +481,6 @@ github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8l
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/dgryski/go-gk v0.0.0-20140819190930-201884a44051/go.mod h1:qm+vckxRlDt0aOla0RYJJVeqHZlWfOm2UIxHaqPB46E=
-github.com/dgryski/go-gk v0.0.0-20200319235926-a69029f61654/go.mod h1:qm+vckxRlDt0aOla0RYJJVeqHZlWfOm2UIxHaqPB46E=
-github.com/dgryski/go-lttb v0.0.0-20180810165845-318fcdf10a77/go.mod h1:Va5MyIzkU0rAM92tn3hb3Anb7oz7KcnixF49+2wOMe4=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
@@ -1493,6 +1490,8 @@ github.com/rcrowley/go-metrics v0.0.0-20190704165056-9c2d0518ed81/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/pkg/config/metricsconfig.go
+++ b/pkg/config/metricsconfig.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// read the conifgMap with name in env:METRICS_CONFIG
+// this configmap stores the information associated with Kyverno's metrics exposure
+const metricsCmName string = "METRICS_CONFIG"
+
+// MetricsConfigData stores the metrics-related configuration
+type MetricsConfigData struct {
+	client        kubernetes.Interface
+	cmName        string
+	metricsConfig MetricsConfig
+	log           logr.Logger
+}
+
+type MetricsConfig struct {
+	namespaces             namespacesConfig
+	metricsRefreshInterval time.Duration
+}
+
+type namespacesConfig struct {
+	IncludeNamespaces []string `json:"include,omitempty"`
+	ExcludeNamespaces []string `json:"exclude,omitempty"`
+}
+
+// GetExcludeNamespaces returns the namespaces to ignore for metrics exposure
+func (mcd *MetricsConfigData) GetExcludeNamespaces() []string {
+	return mcd.metricsConfig.namespaces.ExcludeNamespaces
+}
+
+// GetIncludeNamespaces returns the namespaces to specifically consider for metrics exposure
+func (mcd *MetricsConfigData) GetIncludeNamespaces() []string {
+	return mcd.metricsConfig.namespaces.IncludeNamespaces
+}
+
+func (mcd *MetricsConfigData) GetMetricsRefreshInterval() time.Duration {
+	return mcd.metricsConfig.metricsRefreshInterval
+}
+
+func (mcd *MetricsConfigData) GetMetricsConfigMapName() string {
+	return mcd.cmName
+}
+
+// NewMetricsConfigData ...
+func NewMetricsConfigData(rclient kubernetes.Interface, log logr.Logger) (*MetricsConfigData, error) {
+	// environment var is read at start only
+	if metricsCmName == "" {
+		log.Info("ConfigMap name not defined in env:METRICS_CONFIG: loading no default configuration")
+	}
+
+	mcd := MetricsConfigData{
+		client: rclient,
+		cmName: os.Getenv(metricsCmName),
+		log:    log,
+	}
+
+	kyvernoNamespace := getKyvernoNameSpace()
+	configMap, err := rclient.CoreV1().ConfigMaps(kyvernoNamespace).Get(context.TODO(), mcd.cmName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error occurred while fetching the metrics configmap at %s/%s: %w", kyvernoNamespace, mcd.cmName, err)
+	}
+	// parsing namespace-related config from the config map
+	namespacesConfigStr, found := configMap.Data["namespaces"]
+	if !found {
+		mcd.metricsConfig.namespaces.IncludeNamespaces = []string{}
+		mcd.metricsConfig.namespaces.ExcludeNamespaces = []string{}
+	} else {
+		mcd.metricsConfig.namespaces.IncludeNamespaces, mcd.metricsConfig.namespaces.ExcludeNamespaces, err = parseIncludeExcludeNamespacesFromNamespacesConfig(namespacesConfigStr)
+		if err != nil {
+			return nil, fmt.Errorf("error occurred while parsing the 'namespaces' field of metrics config map: %w", err)
+		}
+	}
+
+	// parsing metricsRefreshInterval from the config map
+	metricsRefreshInterval, found := configMap.Data["metricsRefreshInterval"]
+	if found {
+		mcd.metricsConfig.metricsRefreshInterval, err = time.ParseDuration(metricsRefreshInterval)
+		if err != nil {
+			return nil, fmt.Errorf("error occurred while parsing metricsRefreshInterval: %w", err)
+		}
+	} else {
+		mcd.metricsConfig.metricsRefreshInterval = 0
+	}
+
+	return &mcd, nil
+}
+
+func parseIncludeExcludeNamespacesFromNamespacesConfig(jsonStr string) ([]string, []string, error) {
+	var namespacesConfigObject *namespacesConfig
+	err := json.Unmarshal([]byte(jsonStr), &namespacesConfigObject)
+	if err != nil {
+		return nil, nil, err
+	}
+	return namespacesConfigObject.IncludeNamespaces, namespacesConfigObject.ExcludeNamespaces, nil
+}

--- a/pkg/metrics/admissionrequests/parsers.go
+++ b/pkg/metrics/admissionrequests/parsers.go
@@ -9,6 +9,10 @@ func ParsePromMetrics(pm metrics.PromMetrics) PromMetrics {
 	return PromMetrics(pm)
 }
 
+func ParsePromConfig(pc metrics.PromConfig) PromConfig {
+	return PromConfig(pc)
+}
+
 func ParseResourceRequestOperation(requestOperationStr string) (metrics.ResourceRequestOperation, error) {
 	switch requestOperationStr {
 	case "CREATE":

--- a/pkg/metrics/admissionrequests/types.go
+++ b/pkg/metrics/admissionrequests/types.go
@@ -5,3 +5,5 @@ import (
 )
 
 type PromMetrics metrics.PromMetrics
+
+type PromConfig metrics.PromConfig

--- a/pkg/metrics/admissionreviewduration/admissionReviewDuration.go
+++ b/pkg/metrics/admissionreviewduration/admissionReviewDuration.go
@@ -1,17 +1,28 @@
 package admissionreviewduration
 
 import (
+	"fmt"
+
 	"github.com/kyverno/kyverno/pkg/engine/response"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	prom "github.com/prometheus/client_golang/prometheus"
 )
 
-func (pm PromMetrics) registerAdmissionReviewDurationMetric(
+func (pc PromConfig) registerAdmissionReviewDurationMetric(
 	resourceKind, resourceNamespace string,
 	resourceRequestOperation metrics.ResourceRequestOperation,
 	admissionRequestLatency float64,
 ) error {
-	pm.AdmissionReviewDuration.With(prom.Labels{
+	includeNamespaces, excludeNamespaces := pc.Config.GetIncludeNamespaces(), pc.Config.GetExcludeNamespaces()
+	if (resourceNamespace != "" && resourceNamespace != "-") && metrics.ElementInSlice(resourceNamespace, excludeNamespaces) {
+		pc.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_admission_review_duration_seconds metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
+		return nil
+	}
+	if (resourceNamespace != "" && resourceNamespace != "-") && len(includeNamespaces) > 0 && !metrics.ElementInSlice(resourceNamespace, includeNamespaces) {
+		pc.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_admission_review_duration_seconds metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
+		return nil
+	}
+	pc.Metrics.AdmissionReviewDuration.With(prom.Labels{
 		"resource_kind":              resourceKind,
 		"resource_namespace":         resourceNamespace,
 		"resource_request_operation": string(resourceRequestOperation),
@@ -19,7 +30,7 @@ func (pm PromMetrics) registerAdmissionReviewDurationMetric(
 	return nil
 }
 
-func (pm PromMetrics) ProcessEngineResponses(engineResponses []*response.EngineResponse, admissionReviewLatencyDuration int64, resourceRequestOperation metrics.ResourceRequestOperation) error {
+func (pc PromConfig) ProcessEngineResponses(engineResponses []*response.EngineResponse, admissionReviewLatencyDuration int64, resourceRequestOperation metrics.ResourceRequestOperation) error {
 	if len(engineResponses) == 0 {
 		return nil
 	}
@@ -50,5 +61,5 @@ func (pm PromMetrics) ProcessEngineResponses(engineResponses []*response.EngineR
 		return nil
 	}
 	admissionReviewLatencyDurationInSeconds := float64(admissionReviewLatencyDuration) / float64(1000*1000*1000)
-	return pm.registerAdmissionReviewDurationMetric(resourceKind, resourceNamespace, resourceRequestOperation, admissionReviewLatencyDurationInSeconds)
+	return pc.registerAdmissionReviewDurationMetric(resourceKind, resourceNamespace, resourceRequestOperation, admissionReviewLatencyDurationInSeconds)
 }

--- a/pkg/metrics/admissionreviewduration/parsers.go
+++ b/pkg/metrics/admissionreviewduration/parsers.go
@@ -10,6 +10,10 @@ func ParsePromMetrics(pm metrics.PromMetrics) PromMetrics {
 	return PromMetrics(pm)
 }
 
+func ParsePromConfig(pc metrics.PromConfig) PromConfig {
+	return PromConfig(pc)
+}
+
 func ParseResourceRequestOperation(requestOperationStr string) (metrics.ResourceRequestOperation, error) {
 	switch requestOperationStr {
 	case "CREATE":

--- a/pkg/metrics/admissionreviewduration/types.go
+++ b/pkg/metrics/admissionreviewduration/types.go
@@ -5,3 +5,5 @@ import (
 )
 
 type PromMetrics metrics.PromMetrics
+
+type PromConfig metrics.PromConfig

--- a/pkg/metrics/helpers.go
+++ b/pkg/metrics/helpers.go
@@ -1,0 +1,10 @@
+package metrics
+
+func ElementInSlice(element string, slice []string) bool {
+	for _, v := range slice {
+		if v == element {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,12 +1,20 @@
 package metrics
 
 import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/kyverno/kyverno/pkg/config"
 	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/robfig/cron/v3"
 )
 
 type PromConfig struct {
 	MetricsRegistry *prom.Registry
 	Metrics         *PromMetrics
+	Config          *config.MetricsConfigData
+	Log             logr.Logger
+	cron            *cron.Cron
 }
 
 type PromMetrics struct {
@@ -18,10 +26,12 @@ type PromMetrics struct {
 	AdmissionRequests       *prom.CounterVec
 }
 
-func NewPromConfig() *PromConfig {
+func NewPromConfig(metricsConfigData *config.MetricsConfigData, log logr.Logger) (*PromConfig, error) {
 	pc := new(PromConfig)
-
+	pc.Config = metricsConfigData
+	pc.cron = cron.New()
 	pc.MetricsRegistry = prom.NewRegistry()
+	pc.Log = log
 
 	policyResultsLabels := []string{
 		"policy_validation_mode", "policy_type", "policy_background_mode", "policy_name", "policy_namespace",
@@ -109,5 +119,28 @@ func NewPromConfig() *PromConfig {
 	pc.MetricsRegistry.MustRegister(pc.Metrics.AdmissionReviewDuration)
 	pc.MetricsRegistry.MustRegister(pc.Metrics.AdmissionRequests)
 
-	return pc
+	// configuring metrics periodic refresh
+	if pc.Config.GetMetricsRefreshInterval() != 0 {
+		if len(pc.cron.Entries()) > 0 {
+			pc.Log.Info("Skipping the configuration of metrics refresh. Already found cron expiration to be set.")
+		} else {
+			_, err := pc.cron.AddFunc(fmt.Sprintf("@every %s", pc.Config.GetMetricsRefreshInterval()), func() {
+				pc.Log.Info("Resetting the metrics as per their periodic refresh")
+				pc.Metrics.PolicyResults.Reset()
+				pc.Metrics.PolicyRuleInfo.Reset()
+				pc.Metrics.PolicyChanges.Reset()
+				pc.Metrics.PolicyExecutionDuration.Reset()
+				pc.Metrics.AdmissionReviewDuration.Reset()
+				pc.Metrics.AdmissionRequests.Reset()
+			})
+			if err != nil {
+				return nil, err
+			}
+			log.Info(fmt.Sprintf("Configuring metrics refresh at a periodic rate of %s", pc.Config.GetMetricsRefreshInterval()))
+			pc.cron.Start()
+		}
+	} else {
+		pc.Log.Info("Skipping the configuration of metrics refresh as 'metricsRefreshInterval' wasn't specified in values.yaml at the time of installing kyverno")
+	}
+	return pc, nil
 }

--- a/pkg/metrics/policychanges/parsers.go
+++ b/pkg/metrics/policychanges/parsers.go
@@ -7,3 +7,7 @@ import (
 func ParsePromMetrics(pm metrics.PromMetrics) PromMetrics {
 	return PromMetrics(pm)
 }
+
+func ParsePromConfig(pc metrics.PromConfig) PromConfig {
+	return PromConfig(pc)
+}

--- a/pkg/metrics/policychanges/policyChanges.go
+++ b/pkg/metrics/policychanges/policyChanges.go
@@ -8,7 +8,7 @@ import (
 	prom "github.com/prometheus/client_golang/prometheus"
 )
 
-func (pm PromMetrics) registerPolicyChangesMetric(
+func (pc PromConfig) registerPolicyChangesMetric(
 	policyValidationMode metrics.PolicyValidationMode,
 	policyType metrics.PolicyType,
 	policyBackgroundMode metrics.PolicyBackgroundMode,
@@ -18,7 +18,16 @@ func (pm PromMetrics) registerPolicyChangesMetric(
 	if policyType == metrics.Cluster {
 		policyNamespace = "-"
 	}
-	pm.PolicyChanges.With(prom.Labels{
+	includeNamespaces, excludeNamespaces := pc.Config.GetIncludeNamespaces(), pc.Config.GetExcludeNamespaces()
+	if (policyNamespace != "" && policyNamespace != "-") && metrics.ElementInSlice(policyNamespace, excludeNamespaces) {
+		pc.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_policy_changes_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", policyNamespace, excludeNamespaces))
+		return nil
+	}
+	if (policyNamespace != "" && policyNamespace != "-") && len(includeNamespaces) > 0 && !metrics.ElementInSlice(policyNamespace, includeNamespaces) {
+		pc.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_policy_changes_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", policyNamespace, includeNamespaces))
+		return nil
+	}
+	pc.Metrics.PolicyChanges.With(prom.Labels{
 		"policy_validation_mode": string(policyValidationMode),
 		"policy_type":            string(policyType),
 		"policy_background_mode": string(policyBackgroundMode),
@@ -29,7 +38,7 @@ func (pm PromMetrics) registerPolicyChangesMetric(
 	return nil
 }
 
-func (pm PromMetrics) RegisterPolicy(policy interface{}, policyChangeType PolicyChangeType) error {
+func (pc PromConfig) RegisterPolicy(policy interface{}, policyChangeType PolicyChangeType) error {
 	switch inputPolicy := policy.(type) {
 	case *kyverno.ClusterPolicy:
 		policyValidationMode, err := metrics.ParsePolicyValidationMode(inputPolicy.Spec.ValidationFailureAction)
@@ -40,7 +49,7 @@ func (pm PromMetrics) RegisterPolicy(policy interface{}, policyChangeType Policy
 		policyType := metrics.Cluster
 		policyNamespace := "" // doesn't matter for cluster policy
 		policyName := inputPolicy.ObjectMeta.Name
-		if err = pm.registerPolicyChangesMetric(policyValidationMode, policyType, policyBackgroundMode, policyNamespace, policyName, policyChangeType); err != nil {
+		if err = pc.registerPolicyChangesMetric(policyValidationMode, policyType, policyBackgroundMode, policyNamespace, policyName, policyChangeType); err != nil {
 			return err
 		}
 		return nil
@@ -53,7 +62,7 @@ func (pm PromMetrics) RegisterPolicy(policy interface{}, policyChangeType Policy
 		policyType := metrics.Namespaced
 		policyNamespace := inputPolicy.ObjectMeta.Namespace
 		policyName := inputPolicy.ObjectMeta.Name
-		if err = pm.registerPolicyChangesMetric(policyValidationMode, policyType, policyBackgroundMode, policyNamespace, policyName, policyChangeType); err != nil {
+		if err = pc.registerPolicyChangesMetric(policyValidationMode, policyType, policyBackgroundMode, policyNamespace, policyName, policyChangeType); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/metrics/policychanges/types.go
+++ b/pkg/metrics/policychanges/types.go
@@ -13,3 +13,5 @@ const (
 )
 
 type PromMetrics metrics.PromMetrics
+
+type PromConfig metrics.PromConfig

--- a/pkg/metrics/policyexecutionduration/parsers.go
+++ b/pkg/metrics/policyexecutionduration/parsers.go
@@ -11,6 +11,10 @@ func ParsePromMetrics(pm metrics.PromMetrics) PromMetrics {
 	return PromMetrics(pm)
 }
 
+func ParsePromConfig(pc metrics.PromConfig) PromConfig {
+	return PromConfig(pc)
+}
+
 func ParseRuleTypeFromEngineRuleResponse(rule response.RuleResponse) metrics.RuleType {
 	switch rule.Type {
 	case "Validation":

--- a/pkg/metrics/policyexecutionduration/policyExecutionDuration.go
+++ b/pkg/metrics/policyexecutionduration/policyExecutionDuration.go
@@ -1,13 +1,15 @@
 package policyexecutionduration
 
 import (
+	"fmt"
+
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/engine/response"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	prom "github.com/prometheus/client_golang/prometheus"
 )
 
-func (pm PromMetrics) registerPolicyExecutionDurationMetric(
+func (pc PromConfig) registerPolicyExecutionDurationMetric(
 	policyValidationMode metrics.PolicyValidationMode,
 	policyType metrics.PolicyType,
 	policyBackgroundMode metrics.PolicyBackgroundMode,
@@ -27,7 +29,16 @@ func (pm PromMetrics) registerPolicyExecutionDurationMetric(
 	if ruleType != metrics.Generate || generateRuleLatencyType == "" {
 		generateRuleLatencyType = "-"
 	}
-	pm.PolicyExecutionDuration.With(prom.Labels{
+	includeNamespaces, excludeNamespaces := pc.Config.GetIncludeNamespaces(), pc.Config.GetExcludeNamespaces()
+	if (resourceNamespace != "" && resourceNamespace != "-") && metrics.ElementInSlice(resourceNamespace, excludeNamespaces) {
+		pc.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_policy_execution_duration_seconds metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
+		return nil
+	}
+	if (resourceNamespace != "" && resourceNamespace != "-") && len(includeNamespaces) > 0 && !metrics.ElementInSlice(resourceNamespace, includeNamespaces) {
+		pc.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_policy_execution_duration_seconds metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
+		return nil
+	}
+	pc.Metrics.PolicyExecutionDuration.With(prom.Labels{
 		"policy_validation_mode":     string(policyValidationMode),
 		"policy_type":                string(policyType),
 		"policy_background_mode":     string(policyBackgroundMode),
@@ -47,7 +58,7 @@ func (pm PromMetrics) registerPolicyExecutionDurationMetric(
 
 //policy - policy related data
 //engineResponse - resource and rule related data
-func (pm PromMetrics) ProcessEngineResponse(policy kyverno.ClusterPolicy, engineResponse response.EngineResponse, executionCause metrics.RuleExecutionCause, generateRuleLatencyType string, resourceRequestOperation metrics.ResourceRequestOperation) error {
+func (pc PromConfig) ProcessEngineResponse(policy kyverno.ClusterPolicy, engineResponse response.EngineResponse, executionCause metrics.RuleExecutionCause, generateRuleLatencyType string, resourceRequestOperation metrics.ResourceRequestOperation) error {
 
 	policyValidationMode, err := metrics.ParsePolicyValidationMode(policy.Spec.ValidationFailureAction)
 	if err != nil {
@@ -79,7 +90,7 @@ func (pm PromMetrics) ProcessEngineResponse(policy kyverno.ClusterPolicy, engine
 
 		ruleExecutionLatencyInSeconds := float64(rule.RuleStats.ProcessingTime) / float64(1000*1000*1000)
 
-		if err := pm.registerPolicyExecutionDurationMetric(
+		if err := pc.registerPolicyExecutionDurationMetric(
 			policyValidationMode,
 			policyType,
 			policyBackgroundMode,

--- a/pkg/metrics/policyexecutionduration/types.go
+++ b/pkg/metrics/policyexecutionduration/types.go
@@ -5,3 +5,5 @@ import (
 )
 
 type PromMetrics metrics.PromMetrics
+
+type PromConfig metrics.PromConfig

--- a/pkg/metrics/policyresults/parsers.go
+++ b/pkg/metrics/policyresults/parsers.go
@@ -11,6 +11,10 @@ func ParsePromMetrics(pm metrics.PromMetrics) PromMetrics {
 	return PromMetrics(pm)
 }
 
+func ParsePromConfig(pc metrics.PromConfig) PromConfig {
+	return PromConfig(pc)
+}
+
 func ParseRuleTypeFromEngineRuleResponse(rule response.RuleResponse) metrics.RuleType {
 	switch rule.Type {
 	case "Validation":

--- a/pkg/metrics/policyresults/types.go
+++ b/pkg/metrics/policyresults/types.go
@@ -5,3 +5,5 @@ import (
 )
 
 type PromMetrics metrics.PromMetrics
+
+type PromConfig metrics.PromConfig

--- a/pkg/metrics/policyruleinfo/parsers.go
+++ b/pkg/metrics/policyruleinfo/parsers.go
@@ -19,3 +19,7 @@ func ParsePolicyRuleInfoMetricChangeType(change string) (PolicyRuleInfoMetricCha
 func ParsePromMetrics(pm metrics.PromMetrics) PromMetrics {
 	return PromMetrics(pm)
 }
+
+func ParsePromConfig(pc metrics.PromConfig) PromConfig {
+	return PromConfig(pc)
+}

--- a/pkg/metrics/policyruleinfo/types.go
+++ b/pkg/metrics/policyruleinfo/types.go
@@ -12,3 +12,5 @@ const (
 )
 
 type PromMetrics metrics.PromMetrics
+
+type PromConfig metrics.PromConfig

--- a/pkg/policy/existing.go
+++ b/pkg/policy/existing.go
@@ -100,13 +100,13 @@ func (pc *PolicyController) applyAndReportPerNamespace(policy *kyverno.ClusterPo
 }
 
 func (pc *PolicyController) registerPolicyResultsMetricValidation(logger logr.Logger, policy kyverno.ClusterPolicy, engineResponse response.EngineResponse) {
-	if err := policyResults.ParsePromMetrics(*pc.promConfig.Metrics).ProcessEngineResponse(policy, engineResponse, metrics.BackgroundScan, metrics.ResourceCreated); err != nil {
+	if err := policyResults.ParsePromConfig(*pc.promConfig).ProcessEngineResponse(policy, engineResponse, metrics.BackgroundScan, metrics.ResourceCreated); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_results_total metrics for the above policy", "name", policy.Name)
 	}
 }
 
 func (pc *PolicyController) registerPolicyExecutionDurationMetricValidate(logger logr.Logger, policy kyverno.ClusterPolicy, engineResponse response.EngineResponse) {
-	if err := policyExecutionDuration.ParsePromMetrics(*pc.promConfig.Metrics).ProcessEngineResponse(policy, engineResponse, metrics.BackgroundScan, "", metrics.ResourceCreated); err != nil {
+	if err := policyExecutionDuration.ParsePromConfig(*pc.promConfig).ProcessEngineResponse(policy, engineResponse, metrics.BackgroundScan, "", metrics.ResourceCreated); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_execution_duration_seconds metrics for the above policy", "name", policy.Name)
 	}
 }

--- a/pkg/policy/validate_controller.go
+++ b/pkg/policy/validate_controller.go
@@ -198,7 +198,7 @@ func (pc *PolicyController) canBackgroundProcess(p *kyverno.ClusterPolicy) bool 
 }
 
 func (pc *PolicyController) registerPolicyRuleInfoMetricAddPolicy(logger logr.Logger, p *kyverno.ClusterPolicy) {
-	err := policyRuleInfoMetric.ParsePromMetrics(*pc.promConfig.Metrics).AddPolicy(p)
+	err := policyRuleInfoMetric.ParsePromConfig(*pc.promConfig).AddPolicy(p)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_rule_info_total metrics for the above policy's creation", "name", p.Name)
 	}
@@ -206,26 +206,26 @@ func (pc *PolicyController) registerPolicyRuleInfoMetricAddPolicy(logger logr.Lo
 
 func (pc *PolicyController) registerPolicyRuleInfoMetricUpdatePolicy(logger logr.Logger, oldP, curP *kyverno.ClusterPolicy) {
 	// removing the old rules associated metrics
-	err := policyRuleInfoMetric.ParsePromMetrics(*pc.promConfig.Metrics).RemovePolicy(oldP)
+	err := policyRuleInfoMetric.ParsePromConfig(*pc.promConfig).RemovePolicy(oldP)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_rule_info_total metrics for the above policy's updation", "name", oldP.Name)
 	}
 	// adding the new rules associated metrics
-	err = policyRuleInfoMetric.ParsePromMetrics(*pc.promConfig.Metrics).AddPolicy(curP)
+	err = policyRuleInfoMetric.ParsePromConfig(*pc.promConfig).AddPolicy(curP)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_rule_info_total metrics for the above policy's updation", "name", oldP.Name)
 	}
 }
 
 func (pc *PolicyController) registerPolicyRuleInfoMetricDeletePolicy(logger logr.Logger, p *kyverno.ClusterPolicy) {
-	err := policyRuleInfoMetric.ParsePromMetrics(*pc.promConfig.Metrics).RemovePolicy(p)
+	err := policyRuleInfoMetric.ParsePromConfig(*pc.promConfig).RemovePolicy(p)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_rule_info_total metrics for the above policy's deletion", "name", p.Name)
 	}
 }
 
 func (pc *PolicyController) registerPolicyChangesMetricAddPolicy(logger logr.Logger, p *kyverno.ClusterPolicy) {
-	err := policyChangesMetric.ParsePromMetrics(*pc.promConfig.Metrics).RegisterPolicy(p, policyChangesMetric.PolicyCreated)
+	err := policyChangesMetric.ParsePromConfig(*pc.promConfig).RegisterPolicy(p, policyChangesMetric.PolicyCreated)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_changes_total metrics for the above policy's creation", "name", p.Name)
 	}
@@ -235,13 +235,13 @@ func (pc *PolicyController) registerPolicyChangesMetricUpdatePolicy(logger logr.
 	if reflect.DeepEqual((*oldP).Spec, (*curP).Spec) {
 		return
 	}
-	err := policyChangesMetric.ParsePromMetrics(*pc.promConfig.Metrics).RegisterPolicy(oldP, policyChangesMetric.PolicyUpdated)
+	err := policyChangesMetric.ParsePromConfig(*pc.promConfig).RegisterPolicy(oldP, policyChangesMetric.PolicyUpdated)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_changes_total metrics for the above policy's updation", "name", oldP.Name)
 	}
 	// curP will require a new kyverno_policy_changes_total metric if the above update involved change in the following fields:
 	if curP.Spec.Background != oldP.Spec.Background || curP.Spec.ValidationFailureAction != oldP.Spec.ValidationFailureAction {
-		err = policyChangesMetric.ParsePromMetrics(*pc.promConfig.Metrics).RegisterPolicy(curP, policyChangesMetric.PolicyUpdated)
+		err = policyChangesMetric.ParsePromConfig(*pc.promConfig).RegisterPolicy(curP, policyChangesMetric.PolicyUpdated)
 		if err != nil {
 			logger.Error(err, "error occurred while registering kyverno_policy_changes_total metrics for the above policy's updation", "name", curP.Name)
 		}
@@ -249,7 +249,7 @@ func (pc *PolicyController) registerPolicyChangesMetricUpdatePolicy(logger logr.
 }
 
 func (pc *PolicyController) registerPolicyChangesMetricDeletePolicy(logger logr.Logger, p *kyverno.ClusterPolicy) {
-	err := policyChangesMetric.ParsePromMetrics(*pc.promConfig.Metrics).RegisterPolicy(p, policyChangesMetric.PolicyDeleted)
+	err := policyChangesMetric.ParsePromConfig(*pc.promConfig).RegisterPolicy(p, policyChangesMetric.PolicyDeleted)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_changes_total metrics for the above policy's deletion", "name", p.Name)
 	}
@@ -354,7 +354,7 @@ func (pc *PolicyController) deletePolicy(obj interface{}) {
 }
 
 func (pc *PolicyController) registerPolicyRuleInfoMetricAddNsPolicy(logger logr.Logger, p *kyverno.Policy) {
-	err := policyRuleInfoMetric.ParsePromMetrics(*pc.promConfig.Metrics).AddPolicy(p)
+	err := policyRuleInfoMetric.ParsePromConfig(*pc.promConfig).AddPolicy(p)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_rule_info_total metrics for the above policy's creation", "name", p.Name)
 	}
@@ -362,26 +362,26 @@ func (pc *PolicyController) registerPolicyRuleInfoMetricAddNsPolicy(logger logr.
 
 func (pc *PolicyController) registerPolicyRuleInfoMetricUpdateNsPolicy(logger logr.Logger, oldP, curP *kyverno.Policy) {
 	// removing the old rules associated metrics
-	err := policyRuleInfoMetric.ParsePromMetrics(*pc.promConfig.Metrics).RemovePolicy(oldP)
+	err := policyRuleInfoMetric.ParsePromConfig(*pc.promConfig).RemovePolicy(oldP)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_rule_info_total metrics for the above policy's updation", "name", oldP.Name)
 	}
 	// adding the new rules associated metrics
-	err = policyRuleInfoMetric.ParsePromMetrics(*pc.promConfig.Metrics).AddPolicy(curP)
+	err = policyRuleInfoMetric.ParsePromConfig(*pc.promConfig).AddPolicy(curP)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_rule_info_total metrics for the above policy's updation", "name", oldP.Name)
 	}
 }
 
 func (pc *PolicyController) registerPolicyRuleInfoMetricDeleteNsPolicy(logger logr.Logger, p *kyverno.Policy) {
-	err := policyRuleInfoMetric.ParsePromMetrics(*pc.promConfig.Metrics).RemovePolicy(p)
+	err := policyRuleInfoMetric.ParsePromConfig(*pc.promConfig).RemovePolicy(p)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_rule_info_total metrics for the above policy's deletion", "name", p.Name)
 	}
 }
 
 func (pc *PolicyController) registerPolicyChangesMetricAddNsPolicy(logger logr.Logger, p *kyverno.Policy) {
-	err := policyChangesMetric.ParsePromMetrics(*pc.promConfig.Metrics).RegisterPolicy(p, policyChangesMetric.PolicyCreated)
+	err := policyChangesMetric.ParsePromConfig(*pc.promConfig).RegisterPolicy(p, policyChangesMetric.PolicyCreated)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_changes_total metrics for the above policy's creation", "name", p.Name)
 	}
@@ -391,13 +391,13 @@ func (pc *PolicyController) registerPolicyChangesMetricUpdateNsPolicy(logger log
 	if reflect.DeepEqual((*oldP).Spec, (*curP).Spec) {
 		return
 	}
-	err := policyChangesMetric.ParsePromMetrics(*pc.promConfig.Metrics).RegisterPolicy(oldP, policyChangesMetric.PolicyUpdated)
+	err := policyChangesMetric.ParsePromConfig(*pc.promConfig).RegisterPolicy(oldP, policyChangesMetric.PolicyUpdated)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_changes_total metrics for the above policy's updation", "name", oldP.Name)
 	}
 	// curP will require a new kyverno_policy_changes_total metric if the above update involved change in the following fields:
 	if curP.Spec.Background != oldP.Spec.Background || curP.Spec.ValidationFailureAction != oldP.Spec.ValidationFailureAction {
-		err = policyChangesMetric.ParsePromMetrics(*pc.promConfig.Metrics).RegisterPolicy(curP, policyChangesMetric.PolicyUpdated)
+		err = policyChangesMetric.ParsePromConfig(*pc.promConfig).RegisterPolicy(curP, policyChangesMetric.PolicyUpdated)
 		if err != nil {
 			logger.Error(err, "error occurred while registering kyverno_policy_changes_total metrics for the above policy's updation", "name", curP.Name)
 		}
@@ -405,7 +405,7 @@ func (pc *PolicyController) registerPolicyChangesMetricUpdateNsPolicy(logger log
 }
 
 func (pc *PolicyController) registerPolicyChangesMetricDeleteNsPolicy(logger logr.Logger, p *kyverno.Policy) {
-	err := policyChangesMetric.ParsePromMetrics(*pc.promConfig.Metrics).RegisterPolicy(p, policyChangesMetric.PolicyDeleted)
+	err := policyChangesMetric.ParsePromConfig(*pc.promConfig).RegisterPolicy(p, policyChangesMetric.PolicyDeleted)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_changes_total metrics for the above policy's deletion", "name", p.Name)
 	}

--- a/pkg/webhooks/generation.go
+++ b/pkg/webhooks/generation.go
@@ -39,8 +39,8 @@ func (ws *WebhookServer) applyGeneratePolicies(request *v1beta1.AdmissionRequest
 	generateEngineResponsesSenderForAdmissionRequestsCountMetric := make(chan []*response.EngineResponse, 1)
 
 	go ws.handleGenerate(request, policies, policyContext.JSONContext, policyContext.AdmissionInfo, ws.configHandler, ts, &admissionReviewCompletionLatencyChannel, &generateEngineResponsesSenderForAdmissionReviewDurationMetric, &generateEngineResponsesSenderForAdmissionRequestsCountMetric)
-	go registerAdmissionReviewDurationMetricGenerate(logger, *ws.promConfig.Metrics, string(request.Operation), &admissionReviewCompletionLatencyChannel, &generateEngineResponsesSenderForAdmissionReviewDurationMetric)
-	go registerAdmissionRequestsMetricGenerate(logger, *ws.promConfig.Metrics, string(request.Operation), &generateEngineResponsesSenderForAdmissionRequestsCountMetric)
+	go registerAdmissionReviewDurationMetricGenerate(logger, *ws.promConfig, string(request.Operation), &admissionReviewCompletionLatencyChannel, &generateEngineResponsesSenderForAdmissionReviewDurationMetric)
+	go registerAdmissionRequestsMetricGenerate(logger, *ws.promConfig, string(request.Operation), &generateEngineResponsesSenderForAdmissionRequestsCountMetric)
 }
 
 //handleGenerate handles admission-requests for policies with generate rules
@@ -132,7 +132,7 @@ func (ws *WebhookServer) registerPolicyResultsMetricGeneration(logger logr.Logge
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_results_total metrics for the above policy", "name", policy.Name)
 	}
-	if err := policyResults.ParsePromMetrics(*ws.promConfig.Metrics).ProcessEngineResponse(policy, engineResponse, metrics.AdmissionRequest, resourceRequestOperationPromAlias); err != nil {
+	if err := policyResults.ParsePromConfig(*ws.promConfig).ProcessEngineResponse(policy, engineResponse, metrics.AdmissionRequest, resourceRequestOperationPromAlias); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_results_total metrics for the above policy", "name", policy.Name)
 	}
 }
@@ -142,7 +142,7 @@ func (ws *WebhookServer) registerPolicyExecutionDurationMetricGenerate(logger lo
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_execution_duration_seconds metrics for the above policy", "name", policy.Name)
 	}
-	if err := policyExecutionDuration.ParsePromMetrics(*ws.promConfig.Metrics).ProcessEngineResponse(policy, engineResponse, metrics.AdmissionRequest, "", resourceRequestOperationPromAlias); err != nil {
+	if err := policyExecutionDuration.ParsePromConfig(*ws.promConfig).ProcessEngineResponse(policy, engineResponse, metrics.AdmissionRequest, "", resourceRequestOperationPromAlias); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_execution_duration_seconds metrics for the above policy", "name", policy.Name)
 	}
 }

--- a/pkg/webhooks/mutation.go
+++ b/pkg/webhooks/mutation.go
@@ -30,8 +30,8 @@ func (ws *WebhookServer) applyMutatePolicies(request *v1beta1.AdmissionRequest, 
 	logger.V(6).Info("", "generated patches", string(mutatePatches))
 
 	admissionReviewLatencyDuration := int64(time.Since(time.Unix(ts, 0)))
-	go registerAdmissionReviewDurationMetricMutate(logger, *ws.promConfig.Metrics, string(request.Operation), mutateEngineResponses, admissionReviewLatencyDuration)
-	go registerAdmissionRequestsMetricMutate(logger, *ws.promConfig.Metrics, string(request.Operation), mutateEngineResponses)
+	go registerAdmissionReviewDurationMetricMutate(logger, *ws.promConfig, string(request.Operation), mutateEngineResponses, admissionReviewLatencyDuration)
+	go registerAdmissionRequestsMetricMutate(logger, *ws.promConfig, string(request.Operation), mutateEngineResponses)
 
 	return mutatePatches
 }
@@ -162,7 +162,7 @@ func (ws *WebhookServer) registerPolicyResultsMetricMutation(logger logr.Logger,
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_results_total metrics for the above policy", "name", policy.Name)
 	}
-	if err := policyResults.ParsePromMetrics(*ws.promConfig.Metrics).ProcessEngineResponse(policy, engineResponse, metrics.AdmissionRequest, resourceRequestOperationPromAlias); err != nil {
+	if err := policyResults.ParsePromConfig(*ws.promConfig).ProcessEngineResponse(policy, engineResponse, metrics.AdmissionRequest, resourceRequestOperationPromAlias); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_results_total metrics for the above policy", "name", policy.Name)
 	}
 }
@@ -172,7 +172,7 @@ func (ws *WebhookServer) registerPolicyExecutionDurationMetricMutate(logger logr
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_execution_duration_seconds metrics for the above policy", "name", policy.Name)
 	}
-	if err := policyExecutionDuration.ParsePromMetrics(*ws.promConfig.Metrics).ProcessEngineResponse(policy, engineResponse, metrics.AdmissionRequest, "", resourceRequestOperationPromAlias); err != nil {
+	if err := policyExecutionDuration.ParsePromConfig(*ws.promConfig).ProcessEngineResponse(policy, engineResponse, metrics.AdmissionRequest, "", resourceRequestOperationPromAlias); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_execution_duration_seconds metrics for the above policy", "name", policy.Name)
 	}
 }

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -432,27 +432,27 @@ func failureResponse(message string) *v1beta1.AdmissionResponse {
 	}
 }
 
-func registerAdmissionReviewDurationMetricMutate(logger logr.Logger, promMetrics metrics.PromMetrics, requestOperation string, engineResponses []*response.EngineResponse, admissionReviewLatencyDuration int64) {
+func registerAdmissionReviewDurationMetricMutate(logger logr.Logger, promConfig metrics.PromConfig, requestOperation string, engineResponses []*response.EngineResponse, admissionReviewLatencyDuration int64) {
 	resourceRequestOperationPromAlias, err := admissionReviewDuration.ParseResourceRequestOperation(requestOperation)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_review_duration_seconds metrics")
 	}
-	if err := admissionReviewDuration.ParsePromMetrics(promMetrics).ProcessEngineResponses(engineResponses, admissionReviewLatencyDuration, resourceRequestOperationPromAlias); err != nil {
+	if err := admissionReviewDuration.ParsePromConfig(promConfig).ProcessEngineResponses(engineResponses, admissionReviewLatencyDuration, resourceRequestOperationPromAlias); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_review_duration_seconds metrics")
 	}
 }
 
-func registerAdmissionRequestsMetricMutate(logger logr.Logger, promMetrics metrics.PromMetrics, requestOperation string, engineResponses []*response.EngineResponse) {
+func registerAdmissionRequestsMetricMutate(logger logr.Logger, promConfig metrics.PromConfig, requestOperation string, engineResponses []*response.EngineResponse) {
 	resourceRequestOperationPromAlias, err := admissionReviewDuration.ParseResourceRequestOperation(requestOperation)
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_requests_total metrics")
 	}
-	if err := admissionRequests.ParsePromMetrics(promMetrics).ProcessEngineResponses(engineResponses, resourceRequestOperationPromAlias); err != nil {
+	if err := admissionRequests.ParsePromConfig(promConfig).ProcessEngineResponses(engineResponses, resourceRequestOperationPromAlias); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_requests_total metrics")
 	}
 }
 
-func registerAdmissionReviewDurationMetricGenerate(logger logr.Logger, promMetrics metrics.PromMetrics, requestOperation string, latencyReceiver *chan int64, engineResponsesReceiver *chan []*response.EngineResponse) {
+func registerAdmissionReviewDurationMetricGenerate(logger logr.Logger, promConfig metrics.PromConfig, requestOperation string, latencyReceiver *chan int64, engineResponsesReceiver *chan []*response.EngineResponse) {
 	defer close(*latencyReceiver)
 	defer close(*engineResponsesReceiver)
 
@@ -464,12 +464,12 @@ func registerAdmissionReviewDurationMetricGenerate(logger logr.Logger, promMetri
 	}
 	// this goroutine will keep on waiting here till it doesn't receive the admission review latency int64 from the other goroutine i.e. ws.HandleGenerate
 	admissionReviewLatencyDuration := <-(*latencyReceiver)
-	if err := admissionReviewDuration.ParsePromMetrics(promMetrics).ProcessEngineResponses(engineResponses, admissionReviewLatencyDuration, resourceRequestOperationPromAlias); err != nil {
+	if err := admissionReviewDuration.ParsePromConfig(promConfig).ProcessEngineResponses(engineResponses, admissionReviewLatencyDuration, resourceRequestOperationPromAlias); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_review_duration_seconds metrics")
 	}
 }
 
-func registerAdmissionRequestsMetricGenerate(logger logr.Logger, promMetrics metrics.PromMetrics, requestOperation string, engineResponsesReceiver *chan []*response.EngineResponse) {
+func registerAdmissionRequestsMetricGenerate(logger logr.Logger, promConfig metrics.PromConfig, requestOperation string, engineResponsesReceiver *chan []*response.EngineResponse) {
 	defer close(*engineResponsesReceiver)
 	engineResponses := <-(*engineResponsesReceiver)
 
@@ -477,7 +477,7 @@ func registerAdmissionRequestsMetricGenerate(logger logr.Logger, promMetrics met
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_requests_total metrics")
 	}
-	if err := admissionRequests.ParsePromMetrics(promMetrics).ProcessEngineResponses(engineResponses, resourceRequestOperationPromAlias); err != nil {
+	if err := admissionRequests.ParsePromConfig(promConfig).ProcessEngineResponses(engineResponses, resourceRequestOperationPromAlias); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_requests_total metrics")
 	}
 }

--- a/pkg/webhooks/validation.go
+++ b/pkg/webhooks/validation.go
@@ -141,7 +141,7 @@ func registerPolicyResultsMetricValidation(promConfig *metrics.PromConfig, logge
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_results_total metrics for the above policy", "name", policy.Name)
 	}
-	if err := policyResults.ParsePromMetrics(*promConfig.Metrics).ProcessEngineResponse(policy, engineResponse, metrics.AdmissionRequest, resourceRequestOperationPromAlias); err != nil {
+	if err := policyResults.ParsePromConfig(*promConfig).ProcessEngineResponse(policy, engineResponse, metrics.AdmissionRequest, resourceRequestOperationPromAlias); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_results_total metrics for the above policy", "name", policy.Name)
 	}
 }
@@ -151,7 +151,7 @@ func registerPolicyExecutionDurationMetricValidate(promConfig *metrics.PromConfi
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_execution_duration_seconds metrics for the above policy", "name", policy.Name)
 	}
-	if err := policyExecutionDuration.ParsePromMetrics(*promConfig.Metrics).ProcessEngineResponse(policy, engineResponse, metrics.AdmissionRequest, "", resourceRequestOperationPromAlias); err != nil {
+	if err := policyExecutionDuration.ParsePromConfig(*promConfig).ProcessEngineResponse(policy, engineResponse, metrics.AdmissionRequest, "", resourceRequestOperationPromAlias); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_policy_execution_duration_seconds metrics for the above policy", "name", policy.Name)
 	}
 }
@@ -161,7 +161,7 @@ func registerAdmissionReviewDurationMetricValidate(promConfig *metrics.PromConfi
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_review_duration_seconds metrics")
 	}
-	if err := admissionReviewDuration.ParsePromMetrics(*promConfig.Metrics).ProcessEngineResponses(engineResponses, admissionReviewLatencyDuration, resourceRequestOperationPromAlias); err != nil {
+	if err := admissionReviewDuration.ParsePromConfig(*promConfig).ProcessEngineResponses(engineResponses, admissionReviewLatencyDuration, resourceRequestOperationPromAlias); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_review_duration_seconds metrics")
 	}
 }
@@ -171,7 +171,7 @@ func registerAdmissionRequestsMetricValidate(promConfig *metrics.PromConfig, log
 	if err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_requests_total metrics")
 	}
-	if err := admissionRequests.ParsePromMetrics(*promConfig.Metrics).ProcessEngineResponses(engineResponses, resourceRequestOperationPromAlias); err != nil {
+	if err := admissionRequests.ParsePromConfig(*promConfig).ProcessEngineResponses(engineResponses, resourceRequestOperationPromAlias); err != nil {
 		logger.Error(err, "error occurred while registering kyverno_admission_requests_total metrics")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yash.kukreja.98@gmail.com>

## Related issue

closes #2268 

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this

> /kind feature

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

Now, `values.yaml` will encapsulate configuration for metrics exposure as well

```yaml
config:
  metricsConfig:
    namespaces: {
      "include": [], # list of namespaces to capture metrics for. Default: metrics being captured for all namespaces except excludeNamespaces.
      "exclude": [] # list of namespaces to NOT capture metrics for. Default: []
    }
    metricsRefreshInterval: 24h # rate at which metrics should reset so as to clean up the memory footprint of kyverno metrics. Default: null, no refresh of metrics
  # Or provide an existing metrics config-map by uncommenting the below line
  # existingMetricsConfig: sample-metrics-configmap. Refer to the ./templates/metricsconfigmap.yaml for the structure of metrics configmap.
```

* `namespaces.include` - specifically, the namespaces for which the metrics will be collected. Default: metrics will be collected for all namespaces.
* `namespaces.exclude` - the namespaces for which the metrics will NOT be collected. Default: none of the namespaces are excluded.
* `metricsRefreshInterval` - The periodic rate at which the metrics of Kyverno will get cleaned. This will help in reducing the memory footprint associated with metrics collection and exposure in Kyverno. And this sort of metrics cleanup doesn't involve any loss of data because the metrics are always going to be persistently getting stored on end-user's Prometheus server.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
