### PR TITLE
remove ownerReferences when cloning resources to other namespace.

### DIFF
--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -422,6 +422,10 @@ func manageClone(log logr.Logger, apiVersion, kind, namespace, name, policy stri
 	if err != nil {
 		return nil, Skip, fmt.Errorf("source resource %s %s/%s/%s not found. %v", apiVersion, kind, rNamespace, rName, err)
 	}
+	// remove ownerReferences when cloning resources to other namespace
+	if rNamespace != namespace && obj.GetOwnerReferences() != nil {
+		obj.SetOwnerReferences(nil)
+	}
 
 	// check if resource to be generated exists
 	newResource, err := client.GetResource(apiVersion, kind, namespace, name)


### PR DESCRIPTION
Signed-off-by: Matthias Frey <matthias.frey@kit.edu>

## Related issue
closes #2276 

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

By now when kyverno clones a resource to other namespaces, it will also copy the ownerReferences of the source. This is not allowed in Kubernetes and the garbage collector will delete the new resource. (https://kubernetes.io/docs/concepts/architecture/garbage-collection/#owners-dependents)

### Proof Manifests
1. Create this secret und an get the generated uid with: `kubectl get secret -n default test-owner-secret -o yaml`
```yaml
---
apiVersion: v1
kind: Secret
metadata:
  name: test-owner-secret
  namespace: default
type: Opaque
```
2. Create the next secret with the fetched uid (Sorry if this is complicated, normally ownerReferences are set by an Operator, not manually):
```yaml
---
apiVersion: v1
data:
  TEST: VEVTVF9TT1VSQ0UK
kind: Secret
metadata:
  name: test-source-secret
  namespace: default
  ownerReferences:
    - apiVersion: v1
      blockOwnerDeletion: false
      controller: false
      kind: Secret
      name: test-owner-secret
      uid: UID_OF_OWNER_SECRET
type: Opaque
```
3. Apply the following policy
```yaml
---
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: clone-secret
spec:
  rules:
    - name: clone-secret
      match:
        resources:
          kinds:
            - Namespace
      generate:
        kind: Secret
        name: test-generated-secret
        namespace: "{{request.object.metadata.name}}"
        synchronize : true
        clone:
          namespace: default
          name: test-source-secret
```
4. create a new namespace 
```bash
kubectl create namespace test-clone
```
5. Without this fix there is no new secret created in the new namespace

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
