### PR TITLE
Add Support for previouse test file structure

### DIFF
--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -82,6 +82,7 @@ type TestResults struct {
 	Policy   string              `json:"policy"`
 	Rule     string              `json:"rule"`
 	Result   report.PolicyResult `json:"result"`
+	Status   report.PolicyResult `json:"status"`
 	Resource string              `json:"resource"`
 }
 
@@ -428,6 +429,9 @@ func printTestResult(resps map[string]report.PolicyReportResult, testResults []T
 			rc.fail++
 			table = append(table, res)
 			continue
+		}
+		if v.Result == "" && v.Status != "" {
+			v.Result = v.Status
 		}
 		if testRes.Result == v.Result {
 			if testRes.Result == report.StatusSkip {

--- a/test/cli/test/simple/test.yaml
+++ b/test/cli/test/simple/test.yaml
@@ -7,20 +7,20 @@ results:
   - policy: disallow-latest-tag
     rule: require-image-tag
     resource: test-require-image-tag-pass
-    result: pass
+    status: pass
   - policy: disallow-latest-tag
     rule: require-image-tag
     resource: test-require-image-tag-fail
-    result: fail
+    status: fail
   - policy: disallow-latest-tag
     rule: validate-image-tag
     resource: test-validate-image-tag-ignore
-    result: skip
+    status: skip
   - policy: disallow-latest-tag
     rule: validate-image-tag
     resource: test-validate-image-tag-fail
-    result: fail
+    status: fail
   - policy: disallow-latest-tag
     rule: validate-image-tag
     resource: test-validate-image-tag-pass
-    result: pass
+    status: pass


### PR DESCRIPTION
Signed-off-by: Frank Jogeleit <frank.jogeleit@web.de>

## Related issue

#2325

## What type of PR is this

/kind bug
/kind cleanup

## Proposed Changes

Add support for the previous `status` key in addition to the new `result` key.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

