### PR TITLE
Renames patches annotations to last-applied-patches

### DIFF
--- a/pkg/webhooks/annotations.go
+++ b/pkg/webhooks/annotations.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
@@ -49,6 +50,12 @@ func generateAnnotationPatches(engineResponses []*response.EngineResponse, log l
 		annotations = make(map[string]string)
 	}
 
+	if val, ok := annotations["policies.kyverno.io/patches"]; ok {
+		annotations["policies.kyverno.io/last-applied-patches"] = val
+		delete(annotations, "policies.kyverno.io/patches")
+	}
+
+	fmt.Println("HELLO ANNOTATION", annotations["policies.kyverno.io/last-applied-patches"])
 	var patchResponse annresponse
 	value := annotationFromEngineResponses(engineResponses, log)
 	if value == nil {

--- a/pkg/webhooks/annotations.go
+++ b/pkg/webhooks/annotations.go
@@ -49,7 +49,6 @@ func generateAnnotationPatches(engineResponses []*response.EngineResponse, log l
 
 	if annotations == nil {
 		annotations = make(map[string]string)
-		//annotations["policies.kyverno.io/patches"] = "present" //uncomment the comment on the left to test for removal of old patches "policies.kyverno.io/patches"
 	}
 
 	var patchResponse annresponse
@@ -66,6 +65,7 @@ func generateAnnotationPatches(engineResponses []*response.EngineResponse, log l
 				Op:   "remove",
 				Path: "/metadata/annotations/policies.kyverno.io/patches",
 			}
+			delete(annotations, "policies.kyverno.io/patches")
 			patchByte, _ := json.Marshal(patchResponse)
 			patchBytes = append(patchBytes, patchByte)
 		}
@@ -84,6 +84,7 @@ func generateAnnotationPatches(engineResponses []*response.EngineResponse, log l
 					Op:   "remove",
 					Path: "/metadata/annotations/" + oldAnnotation,
 				}
+				delete(annotations, "policies.kyverno.io/patches")
 				patchByte, _ := json.Marshal(patchResponse)
 				patchBytes = append(patchBytes, patchByte)
 			}

--- a/pkg/webhooks/annotations.go
+++ b/pkg/webhooks/annotations.go
@@ -2,7 +2,6 @@ package webhooks
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
@@ -55,7 +54,6 @@ func generateAnnotationPatches(engineResponses []*response.EngineResponse, log l
 		delete(annotations, "policies.kyverno.io/patches")
 	}
 
-	fmt.Println("HELLO ANNOTATION", annotations["policies.kyverno.io/last-applied-patches"])
 	var patchResponse annresponse
 	value := annotationFromEngineResponses(engineResponses, log)
 	if value == nil {

--- a/pkg/webhooks/annotations.go
+++ b/pkg/webhooks/annotations.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	policyAnnotation = "policies.kyverno.io~1patches"
+	policyAnnotation = "policies.kyverno.io~1last-applied-patches"
 )
 
 type rulePatch struct {

--- a/pkg/webhooks/annotations_test.go
+++ b/pkg/webhooks/annotations_test.go
@@ -26,12 +26,12 @@ func newPolicyResponse(policy, rule string, patchesStr []string, success bool) r
 	}
 }
 
-func newEngineResponse(policy, rule string, patchesStr []string, success bool, annotation map[string]string) *response.EngineResponse {
+func newEngineResponse(policy, rule string, patchesStr []string, success bool, annotation map[string]interface{}) *response.EngineResponse {
 	return &response.EngineResponse{
 		PatchedResource: unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"metadata": map[string]interface{}{
-					"annotation": annotation,
+					"annotations": annotation,
 				},
 			},
 		},
@@ -49,7 +49,7 @@ func Test_empty_annotation(t *testing.T) {
 }
 
 func Test_exist_annotation(t *testing.T) {
-	annotation := map[string]string{
+	annotation := map[string]interface{}{
 		"test": "annotation",
 	}
 
@@ -57,12 +57,12 @@ func Test_exist_annotation(t *testing.T) {
 	engineResponse := newEngineResponse("mutate-container", "default-imagepullpolicy", []string{patchStr}, true, annotation)
 	annPatches := generateAnnotationPatches([]*response.EngineResponse{engineResponse}, log.Log)
 
-	expectedPatches := `{"op":"add","path":"/metadata/annotations","value":{"policies.kyverno.io/last-applied-patches":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}}`
+	expectedPatches := `{"op":"add","path":"/metadata/annotations/policies.kyverno.io~1last-applied-patches","value":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}`
 	assert.Assert(t, string(annPatches[0]) == expectedPatches)
 }
 
 func Test_exist_kyverno_annotation(t *testing.T) {
-	annotation := map[string]string{
+	annotation := map[string]interface{}{
 		"policies.kyverno.patches": "old-annotation",
 	}
 
@@ -70,26 +70,24 @@ func Test_exist_kyverno_annotation(t *testing.T) {
 	engineResponse := newEngineResponse("mutate-container", "default-imagepullpolicy", []string{patchStr}, true, annotation)
 	annPatches := generateAnnotationPatches([]*response.EngineResponse{engineResponse}, log.Log)
 
-	expectedPatches := `{"op":"add","path":"/metadata/annotations","value":{"policies.kyverno.io/last-applied-patches":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}}`
+	expectedPatches := `{"op":"add","path":"/metadata/annotations/policies.kyverno.io~1last-applied-patches","value":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}`
 	assert.Assert(t, string(annPatches[0]) == expectedPatches)
 }
 
 func Test_annotation_nil_patch(t *testing.T) {
-	annotation := map[string]string{
+	annotation := map[string]interface{}{
 		"policies.kyverno.patches": "old-annotation",
 	}
-
 	engineResponse := newEngineResponse("mutate-container", "default-imagepullpolicy", nil, true, annotation)
 	annPatches := generateAnnotationPatches([]*response.EngineResponse{engineResponse}, log.Log)
 	assert.Assert(t, annPatches == nil)
-
 	engineResponseNew := newEngineResponse("mutate-container", "default-imagepullpolicy", []string{""}, true, annotation)
 	annPatchesNew := generateAnnotationPatches([]*response.EngineResponse{engineResponseNew}, log.Log)
 	assert.Assert(t, annPatchesNew == nil)
 }
 
 func Test_annotation_failed_Patch(t *testing.T) {
-	annotation := map[string]string{
+	annotation := map[string]interface{}{
 		"policies.kyverno.patches": "old-annotation",
 	}
 
@@ -99,16 +97,16 @@ func Test_annotation_failed_Patch(t *testing.T) {
 	assert.Assert(t, annPatches == nil)
 }
 
-// func Test_exist_patches(t *testing.T) {
-// 	annotation := map[string]string{
-// 		"policies.kyverno.io/patches": "present",
-// 	}
-// 	patchStr := `{ "op": "replace", "path": "/spec/containers/0/imagePullPolicy", "value": "IfNotPresent" }`
-// 	engineResponse := newEngineResponse("mutate-container", "default-imagepullpolicy", []string{patchStr}, true, annotation)
-// 	annPatches := generateAnnotationPatches([]*response.EngineResponse{engineResponse}, log.Log)
-// 	expectedPatches1 := `{"op":"remove","path":"/metadata/annotations/policies.kyverno.io~1patches","value":null}`
-// 	expectedPatches2 := `{"op":"add","path":"/metadata/annotations/policies.kyverno.io~1last-applied-patches","value":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}`
-// 	assert.Assert(t, string(annPatches[0]) == expectedPatches1)
-// 	assert.Assert(t, string(annPatches[1]) == expectedPatches2)
-// }
-// uncomment the above test case and line 52 in "annotations.go" and comment the other tests to test for removal of old patches "policies.kyverno.io/patches" from resources
+func Test_exist_patches(t *testing.T) {
+	annotation := map[string]interface{}{
+		"policies.kyverno.io/patches": "present",
+	}
+	patchStr := `{ "op": "replace", "path": "/spec/containers/0/imagePullPolicy", "value": "IfNotPresent" }`
+	engineResponse := newEngineResponse("mutate-container", "default-imagepullpolicy", []string{patchStr}, true, annotation)
+	annPatches := generateAnnotationPatches([]*response.EngineResponse{engineResponse}, log.Log)
+	expectedPatches1 := `{"op":"remove","path":"/metadata/annotations/policies.kyverno.io~1patches","value":null}`
+	expectedPatches2 := `{"op":"add","path":"/metadata/annotations/policies.kyverno.io~1last-applied-patches","value":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}`
+
+	assert.Assert(t, string(annPatches[0]) == expectedPatches1)
+	assert.Assert(t, string(annPatches[1]) == expectedPatches2)
+}

--- a/pkg/webhooks/annotations_test.go
+++ b/pkg/webhooks/annotations_test.go
@@ -45,7 +45,7 @@ func Test_empty_annotation(t *testing.T) {
 
 	annPatches := generateAnnotationPatches([]*response.EngineResponse{engineResponse}, log.Log)
 	expectedPatches := `{"op":"add","path":"/metadata/annotations","value":{"policies.kyverno.io/last-applied-patches":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}}`
-	assert.Assert(t, string(annPatches) == expectedPatches)
+	assert.Assert(t, string(annPatches[0]) == expectedPatches)
 }
 
 func Test_exist_annotation(t *testing.T) {
@@ -58,7 +58,7 @@ func Test_exist_annotation(t *testing.T) {
 	annPatches := generateAnnotationPatches([]*response.EngineResponse{engineResponse}, log.Log)
 
 	expectedPatches := `{"op":"add","path":"/metadata/annotations","value":{"policies.kyverno.io/last-applied-patches":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}}`
-	assert.Assert(t, string(annPatches) == expectedPatches)
+	assert.Assert(t, string(annPatches[0]) == expectedPatches)
 }
 
 func Test_exist_kyverno_annotation(t *testing.T) {
@@ -71,7 +71,7 @@ func Test_exist_kyverno_annotation(t *testing.T) {
 	annPatches := generateAnnotationPatches([]*response.EngineResponse{engineResponse}, log.Log)
 
 	expectedPatches := `{"op":"add","path":"/metadata/annotations","value":{"policies.kyverno.io/last-applied-patches":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}}`
-	assert.Assert(t, string(annPatches) == expectedPatches)
+	assert.Assert(t, string(annPatches[0]) == expectedPatches)
 }
 
 func Test_annotation_nil_patch(t *testing.T) {
@@ -98,3 +98,17 @@ func Test_annotation_failed_Patch(t *testing.T) {
 
 	assert.Assert(t, annPatches == nil)
 }
+
+// func Test_exist_patches(t *testing.T) {
+// 	annotation := map[string]string{
+// 		"policies.kyverno.io/patches": "present",
+// 	}
+// 	patchStr := `{ "op": "replace", "path": "/spec/containers/0/imagePullPolicy", "value": "IfNotPresent" }`
+// 	engineResponse := newEngineResponse("mutate-container", "default-imagepullpolicy", []string{patchStr}, true, annotation)
+// 	annPatches := generateAnnotationPatches([]*response.EngineResponse{engineResponse}, log.Log)
+// 	expectedPatches1 := `{"op":"remove","path":"/metadata/annotations/policies.kyverno.io~1patches","value":null}`
+// 	expectedPatches2 := `{"op":"add","path":"/metadata/annotations/policies.kyverno.io~1last-applied-patches","value":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}`
+// 	assert.Assert(t, string(annPatches[0]) == expectedPatches1)
+// 	assert.Assert(t, string(annPatches[1]) == expectedPatches2)
+// }
+// uncomment the above test case and line 52 in "annotations.go" and comment the other tests to test for removal of old patches "policies.kyverno.io/patches" from resources

--- a/pkg/webhooks/annotations_test.go
+++ b/pkg/webhooks/annotations_test.go
@@ -44,7 +44,7 @@ func Test_empty_annotation(t *testing.T) {
 	engineResponse := newEngineResponse("mutate-container", "default-imagepullpolicy", []string{patchStr}, true, nil)
 
 	annPatches := generateAnnotationPatches([]*response.EngineResponse{engineResponse}, log.Log)
-	expectedPatches := `{"op":"add","path":"/metadata/annotations","value":{"policies.kyverno.io/patches":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}}`
+	expectedPatches := `{"op":"add","path":"/metadata/annotations","value":{"policies.kyverno.io/last-applied-patches":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}}`
 	assert.Assert(t, string(annPatches) == expectedPatches)
 }
 
@@ -57,7 +57,7 @@ func Test_exist_annotation(t *testing.T) {
 	engineResponse := newEngineResponse("mutate-container", "default-imagepullpolicy", []string{patchStr}, true, annotation)
 	annPatches := generateAnnotationPatches([]*response.EngineResponse{engineResponse}, log.Log)
 
-	expectedPatches := `{"op":"add","path":"/metadata/annotations","value":{"policies.kyverno.io/patches":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}}`
+	expectedPatches := `{"op":"add","path":"/metadata/annotations","value":{"policies.kyverno.io/last-applied-patches":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}}`
 	assert.Assert(t, string(annPatches) == expectedPatches)
 }
 
@@ -70,7 +70,7 @@ func Test_exist_kyverno_annotation(t *testing.T) {
 	engineResponse := newEngineResponse("mutate-container", "default-imagepullpolicy", []string{patchStr}, true, annotation)
 	annPatches := generateAnnotationPatches([]*response.EngineResponse{engineResponse}, log.Log)
 
-	expectedPatches := `{"op":"add","path":"/metadata/annotations","value":{"policies.kyverno.io/patches":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}}`
+	expectedPatches := `{"op":"add","path":"/metadata/annotations","value":{"policies.kyverno.io/last-applied-patches":"default-imagepullpolicy.mutate-container.kyverno.io: replaced /spec/containers/0/imagePullPolicy\n"}}`
 	assert.Assert(t, string(annPatches) == expectedPatches)
 }
 

--- a/pkg/webhooks/mutation.go
+++ b/pkg/webhooks/mutation.go
@@ -106,7 +106,9 @@ func (ws *WebhookServer) handleMutation(
 
 	// generate annotations
 	if annPatches := generateAnnotationPatches(engineResponses, logger); annPatches != nil {
-		patches = append(patches, annPatches)
+		for _, ap := range annPatches {
+			patches = append(patches, ap)
+		}
 	}
 
 	// REPORTING EVENTS

--- a/pkg/webhooks/mutation.go
+++ b/pkg/webhooks/mutation.go
@@ -106,9 +106,7 @@ func (ws *WebhookServer) handleMutation(
 
 	// generate annotations
 	if annPatches := generateAnnotationPatches(engineResponses, logger); annPatches != nil {
-		for _, ap := range annPatches {
-			patches = append(patches, ap)
-		}
+		patches = append(patches, annPatches...)
 	}
 
 	// REPORTING EVENTS


### PR DESCRIPTION
Signed-off-by: anushkamittal20 <anumittal4641@gmail.com>

## Related issue
Closes #1528 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR

milestone 1.5.0

## What type of PR is this

Renames `patches` annotations to `last-applied-patches` to reflect on last executed patches in annotations

> /kind feature


## Proposed Changes
The PR aims to clarify to the user that the patch added was last one to be added and so proposes to change the terminology `last-applied-patches` instead of just `patches`
New annotation will take the value `policyAnnotation = "policies.kyverno.io~1last-applied-patches"`  and if there is an already existing annotation we add a JSONpatch to remove that annotation.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests



```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: kuard
  annotations:
    policies.kyverno.io/patches: Workload Management
  labels:
    app: kuard
spec:
  rules:
  - host: kuard
    http:
      paths:
      - backend:
          service: 
            name: kuard
            port: 
              number: 8080
        path: /
        pathType: ImplementationSpecific
```
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: mutate-ingress-host
spec:
  rules:
  - name: mutate-rules-host
    match:
      resources:
        kinds:
        - Ingress
    mutate:
      patchesJson6902: |-
        - op: replace
          path: /spec/rules/0/host
          value: some.mycompany.com

```
When you check the resource yaml you can see `/patches` removed and `/last-applied-patches` added. I have also added test case `Test_exist_patches` to check the working od this.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR --> (didn't find any specific documentation)
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
