### PR TITLE
Fix | Support gvk in CLI for policies applied on cluster

### DIFF
--- a/pkg/kyverno/common/fetch.go
+++ b/pkg/kyverno/common/fetch.go
@@ -33,6 +33,10 @@ func GetResources(policies []*v1.ClusterPolicy, resourcePaths []string, dClient 
 	for _, policy := range policies {
 		for _, rule := range policy.Spec.Rules {
 			for _, kind := range rule.MatchResources.Kinds {
+				if strings.Contains(kind, "/") {
+					lastElement := kind[strings.LastIndex(kind, "/")+1:]
+					resourceTypesMap[lastElement] = true
+				}
 				resourceTypesMap[kind] = true
 			}
 		}


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue

closes https://github.com/kyverno/kyverno/issues/2363

## Milestone of this PR

Add the milestone label by commenting `/milestone 1.4.3`.

## What type of PR is this
> /kind bug

## Proposed Changes
Extracting `kind` from the policy `kinds` by string operations.

### Proof Manifests
policy.yaml:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: container-image-latest
  annotations:
    policies.kyverno.io/owner: Red Hat CoP
    policies.kyverno.io/category: Workload Management
    policies.kyverno.io/description: Check a Deployment is not using the latest tag for their image
spec:
  validationFailureAction: enforce
  rules:
  - name: validate-resources
    match:
      resources:
        kinds:
        - apps/v1/Deployment
    validate:
      message: "{{request.object.kind}}/{{request.object.metadata.name}}: one of its containers is using the latest tag for its image, which is an anti-pattern."
      pattern:
        spec:
          template:
            spec:
              containers:
              - name: "*"
                image: "!*:latest"
```
apply the following deployment in cluster:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/name: Foo
  name: imageuseslatesttag
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: Foo
  template:
    metadata:
      labels:
        app.kubernetes.io/name: Foo
    spec:
      containers:
        - name: bar
          image: quay.io/redhat-cop/openshift-applier:latest
```

Now apply the policy on the deployment:
```
$ kyverno apply policy.yaml --cluster

Applying 1 policy to 5 resources... 
(Total number of result count may vary as the policy is mutated by Kyverno. To check the mutated policy please try with log level 5)

policy container-image-latest -> resource default/Deployment/imageuseslatesttag failed: 
1. validate-resources: validation error: Deployment/imageuseslatesttag: one of its containers is using the latest tag for its image, which is an anti-pattern. Rule validate-resources failed at path /spec/template/spec/containers/0/image/ 

pass: 4, fail: 1, warn: 0, error: 0, skip: 0 
exit status 1
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

