### PR TITLE
allowing users to skip policy validation when mutating resources

### DIFF
--- a/definitions/crds/kyverno.io_clusterpolicies.yaml
+++ b/definitions/crds/kyverno.io_clusterpolicies.yaml
@@ -1518,6 +1518,11 @@ spec:
                       type: array
                   type: object
                 type: array
+              shemaValidation:
+                description: ShemaValidation controls skipping policy validation checks.
+                  Optional. Default value is "true". The value must be set to "false"
+                  if policy should skip validation checks.
+                type: boolean
               validationFailureAction:
                 description: ValidationFailureAction controls if a validation policy
                   rule failure should disallow the admission review request (enforce),

--- a/definitions/crds/kyverno.io_clusterpolicies.yaml
+++ b/definitions/crds/kyverno.io_clusterpolicies.yaml
@@ -1518,10 +1518,10 @@ spec:
                       type: array
                   type: object
                 type: array
-              shemaValidation:
-                description: ShemaValidation controls skipping policy validation checks.
-                  Optional. Default value is "true". The value must be set to "false"
-                  if policy should skip validation checks.
+              schemaValidation:
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
                 type: boolean
               validationFailureAction:
                 description: ValidationFailureAction controls if a validation policy

--- a/definitions/crds/kyverno.io_policies.yaml
+++ b/definitions/crds/kyverno.io_policies.yaml
@@ -1519,10 +1519,10 @@ spec:
                       type: array
                   type: object
                 type: array
-              shemaValidation:
-                description: ShemaValidation controls skipping policy validation checks.
-                  Optional. Default value is "true". The value must be set to "false"
-                  if policy should skip validation checks.
+              schemaValidation:
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
                 type: boolean
               validationFailureAction:
                 description: ValidationFailureAction controls if a validation policy

--- a/definitions/crds/kyverno.io_policies.yaml
+++ b/definitions/crds/kyverno.io_policies.yaml
@@ -1519,6 +1519,11 @@ spec:
                       type: array
                   type: object
                 type: array
+              shemaValidation:
+                description: ShemaValidation controls skipping policy validation checks.
+                  Optional. Default value is "true". The value must be set to "false"
+                  if policy should skip validation checks.
+                type: boolean
               validationFailureAction:
                 description: ValidationFailureAction controls if a validation policy
                   rule failure should disallow the admission review request (enforce),

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -956,10 +956,10 @@ spec:
                       type: array
                   type: object
                 type: array
-              shemaValidation:
-                description: ShemaValidation controls skipping policy validation checks.
-                  Optional. Default value is "true". The value must be set to "false"
-                  if policy should skip validation checks.
+              schemaValidation:
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
                 type: boolean
               validationFailureAction:
                 description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
@@ -2710,12 +2710,10 @@ spec:
                       type: array
                   type: object
                 type: array
-              shemaValidation:
-                description: ShemaValidation controls if rules are applied to existing
-                  resources during a background scan. Optional. Default value is "true".
-                  The value must be set to "false" if the policy rule uses variables
-                  that are only available in the admission review request (e.g. user
-                  name).
+              schemaValidation:
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
                 type: boolean
               validationFailureAction:
                 description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -956,6 +956,11 @@ spec:
                       type: array
                   type: object
                 type: array
+              shemaValidation:
+                description: ShemaValidation controls skipping policy validation checks.
+                  Optional. Default value is "true". The value must be set to "false"
+                  if policy should skip validation checks.
+                type: boolean
               validationFailureAction:
                 description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
                 type: string
@@ -2705,6 +2710,13 @@ spec:
                       type: array
                   type: object
                 type: array
+              shemaValidation:
+                description: ShemaValidation controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
+                type: boolean
               validationFailureAction:
                 description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
                 type: string

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -943,10 +943,8 @@ spec:
                       type: array
                   type: object
                 type: array
-              shemaValidation:
-                description: ShemaValidation controls skipping policy validation checks.
-                  Optional. Default value is "true". The value must be set to "false"
-                  if policy should skip validation checks.
+              schemaValidation:
+                description: SchemaValidation skips policy validation checks. Optional.The default value is set to "true", it must be set to "false" to disable the validation checks.
                 type: boolean
               validationFailureAction:
                 description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
@@ -2669,12 +2667,8 @@ spec:
                       type: array
                   type: object
                 type: array
-              shemaValidation:
-                description: ShemaValidation controls if rules are applied to existing
-                  resources during a background scan. Optional. Default value is "true".
-                  The value must be set to "false" if the policy rule uses variables
-                  that are only available in the admission review request (e.g. user
-                  name).
+              schemaValidation:
+                description: SchemaValidation skips policy validation checks. Optional.The default value is set to "true", it must be set to "false" to disable the validation checks.
                 type: boolean
               validationFailureAction:
                 description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -943,6 +943,11 @@ spec:
                       type: array
                   type: object
                 type: array
+              shemaValidation:
+                description: ShemaValidation controls skipping policy validation checks.
+                  Optional. Default value is "true". The value must be set to "false"
+                  if policy should skip validation checks.
+                type: boolean
               validationFailureAction:
                 description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
                 type: string
@@ -2664,6 +2669,13 @@ spec:
                       type: array
                   type: object
                 type: array
+              shemaValidation:
+                description: ShemaValidation controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
+                type: boolean
               validationFailureAction:
                 description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
                 type: string

--- a/pkg/api/kyverno/v1/policy_types.go
+++ b/pkg/api/kyverno/v1/policy_types.go
@@ -54,6 +54,12 @@ type Spec struct {
 	// uses variables that are only available in the admission review request (e.g. user name).
 	// +optional
 	Background *bool `json:"background,omitempty" yaml:"background,omitempty"`
+
+	// ShemaValidation controls skipping policy validation checks.
+	// Optional. Default value is "true". The value must be set to "false" if policy should
+	// skip validation checks.
+	// +optional
+	ShemaValidation *bool `json:"shemaValidation,omitempty" yaml:"shemaValidation,omitempty"`
 }
 
 // Rule defines a validation, mutation, or generation control for matching resources.

--- a/pkg/api/kyverno/v1/policy_types.go
+++ b/pkg/api/kyverno/v1/policy_types.go
@@ -55,11 +55,10 @@ type Spec struct {
 	// +optional
 	Background *bool `json:"background,omitempty" yaml:"background,omitempty"`
 
-	// ShemaValidation controls skipping policy validation checks.
-	// Optional. Default value is "true". The value must be set to "false" if policy should
-	// skip validation checks.
+	// SchemaValidation skips policy validation checks.
+	// Optional. The default value is set to "true", it must be set to "false" to disable the validation checks.
 	// +optional
-	ShemaValidation *bool `json:"shemaValidation,omitempty" yaml:"shemaValidation,omitempty"`
+	SchemaValidation *bool `json:"schemaValidation,omitempty" yaml:"schemaValidation,omitempty"`
 }
 
 // Rule defines a validation, mutation, or generation control for matching resources.

--- a/pkg/openapi/validation.go
+++ b/pkg/openapi/validation.go
@@ -167,7 +167,7 @@ func (o *Controller) ValidatePolicyMutation(policy v1.ClusterPolicy) error {
 			return err
 		}
 
-		if policy.Spec.ShemaValidation == nil || *policy.Spec.ShemaValidation == true {
+		if policy.Spec.ShemaValidation == nil || *policy.Spec.ShemaValidation {
 			err = o.ValidateResource(*patchedResource.DeepCopy(), "", kind)
 			if err != nil {
 				return err

--- a/pkg/openapi/validation.go
+++ b/pkg/openapi/validation.go
@@ -167,7 +167,7 @@ func (o *Controller) ValidatePolicyMutation(policy v1.ClusterPolicy) error {
 			return err
 		}
 
-		if policy.Spec.ShemaValidation == nil || *policy.Spec.ShemaValidation {
+		if policy.Spec.SchemaValidation == nil || *policy.Spec.SchemaValidation {
 			err = o.ValidateResource(*patchedResource.DeepCopy(), "", kind)
 			if err != nil {
 				return err

--- a/pkg/openapi/validation.go
+++ b/pkg/openapi/validation.go
@@ -167,10 +167,13 @@ func (o *Controller) ValidatePolicyMutation(policy v1.ClusterPolicy) error {
 			return err
 		}
 
-		err = o.ValidateResource(*patchedResource.DeepCopy(), "", kind)
-		if err != nil {
-			return err
+		if policy.Spec.ShemaValidation == nil || *policy.Spec.ShemaValidation == true {
+			err = o.ValidateResource(*patchedResource.DeepCopy(), "", kind)
+			if err != nil {
+				return err
+			}
 		}
+
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Vyankatesh vyankateshkd@gmail.com

## Related issue
closes https://github.com/kyverno/kyverno/issues/2185
closes https://github.com/kyverno/kyverno/issues/2100
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->


## Milestone of this PR
/milestone 1.4.3
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
Introduce a key under the spec which allows skipping policy validation checks.
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
old_Policy.yaml
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: policy-change-memory-limits
  # env array needs to exist (least one env var is present)
  annotations:
    pod-policies.kyverno.io/autogen-controllers: None
spec:
  background: false
  rules:
  - name: pod-containers-1-inject-image
    match:
      resources:
        kinds:
        - Pod
    preconditions:
      all:
      - key: "{{request.object.spec.containers[] | length(@)}}"
        operator: Equals
        value: "1"
    mutate:
      patchesJson6902: |-
        - op: add
          path: "/spec/containers/0/env/-"
          value: {"name":"K8S_IMAGE","value":"{{request.object.spec.containers[0].image}}"}
  - name: pod-containers-2-inject-image
    match:
      resources:
        kinds:
        - Pod
    preconditions:
      all:
      - key: "{{request.object.spec.containers[] | length(@)}}"
        operator: Equals
        value: "2"
    mutate:
      patchesJson6902: |-
        - op: add
          path: "/spec/containers/0/env/-"
          value: {"name":"K8S_IMAGE","value":"{{request.object.spec.containers[0].image}}"}
        - op: add
          path: "/spec/containers/1/env/-"
          value: {"name":"K8S_IMAGE","value":"{{request.object.spec.containers[1].image}}"}
```
output: 
```
Error from server: error when creating ".\\yamls\\2185\\policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: ValidationError(io.k8s.api.core.v1.Pod.spec.containers[1].env): invalid type for io.k8s.api.core.v1.Container.env: got "map", expected "array"
ValidationError(io.k8s.api.core.v1.Pod.spec.containers[1]): missing required field "name" in io.k8s.api.core.v1.Container
```

After Adding 

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: policy-change-memory-limit
  # env array needs to exist (least one env var is present)
  annotations:
    pod-policies.kyverno.io/autogen-controllers: None
spec:
  background: false
  schemaValidation: false
  rules:
  - name: pod-containers-1-inject-image
    match:
      resources:
        kinds:
        - Pod
    preconditions:
      all:
      - key: "{{request.object.spec.containers[] | length(@)}}"
        operator: Equals
        value: "1"
    mutate:
      patchesJson6902: |-
        - op: add
          path: "/spec/containers/0/env/-"
          value: {"name":"K8S_IMAGE","value":"{{request.object.spec.containers[0].image}}"}
  - name: pod-containers-2-inject-image
    match:
      resources:
        kinds:
        - Pod
    preconditions:
      all:
      - key: "{{request.object.spec.containers[] | length(@)}}"
        operator: Equals
        value: "2"
    mutate:
      patchesJson6902: |-
        - op: add
          path: "/spec/containers/0/env/-"
          value: {"name":"K8S_IMAGE","value":"{{request.object.spec.containers[0].image}}"}
        - op: add
          path: "/spec/containers/1/env/-"
          value: {"name":"K8S_IMAGE","value":"{{request.object.spec.containers[1].image}}"}


```
output: 
`clusterpolicy.kyverno.io/policy-change-memory-limits created`

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
