### PR TITLE
Block scalars for value files

### DIFF
--- a/pkg/engine/jsonContext.go
+++ b/pkg/engine/jsonContext.go
@@ -33,11 +33,14 @@ func LoadContext(logger logr.Logger, contextEntries []kyverno.ContextEntry, resC
 		variables := rule.Values
 
 		for key, value := range variables {
-			tmp := map[string]interface{}{key: value}
-			tmp = parseMultilineBlockBody(tmp)
-			value, _ := json.Marshal(tmp[key])
+			if trimmedTypedValue := strings.Trim(value, "\n"); strings.Contains(trimmedTypedValue, "\n") {
+				tmp := map[string]interface{}{key: value}
+				tmp = parseMultilineBlockBody(tmp)
+				new_val, _ := json.Marshal(tmp[key])
+				value = string(new_val)
+			}
 
-			jsonData := pkgcommon.VariableToJSON(key, string(value))
+			jsonData := pkgcommon.VariableToJSON(key, value)
 
 			if err := ctx.JSONContext.AddJSON(jsonData); err != nil {
 				return err

--- a/pkg/engine/jsonContext.go
+++ b/pkg/engine/jsonContext.go
@@ -33,7 +33,12 @@ func LoadContext(logger logr.Logger, contextEntries []kyverno.ContextEntry, resC
 		variables := rule.Values
 
 		for key, value := range variables {
-			jsonData := pkgcommon.VariableToJSON(key, value)
+			tmp := map[string]interface{}{key: value}
+			tmp = parseMultilineBlockBody(tmp)
+			value, _ := json.Marshal(tmp[key])
+
+			jsonData := pkgcommon.VariableToJSON(key, string(value))
+
 			if err := ctx.JSONContext.AddJSON(jsonData); err != nil {
 				return err
 			}

--- a/test/cli/test/variables/cm-blk-scalar-example.yaml
+++ b/test/cli/test/variables/cm-blk-scalar-example.yaml
@@ -1,0 +1,25 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cm-blk-scalar-example
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: validate-blk-role-annotation
+    context:
+      - name: roles-dictionary
+        configMap:
+          name: roles-dictionary
+          namespace: default
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "The role {{ request.object.metadata.annotations.role }} is not in the allowed list of roles: {{ \"roles-dictionary\".data.\"allowed-roles\" }}."
+      deny:
+        conditions:
+        - key: "{{ request.object.metadata.annotations.role }}"
+          operator: NotIn
+          value:  "{{ \"roles-dictionary\".data.\"allowed-roles\" }}"

--- a/test/cli/test/variables/resources.yaml
+++ b/test/cli/test/variables/resources.yaml
@@ -41,3 +41,25 @@ spec:
   containers:
   - name: nginx
     image: nginx:1.12
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-blk-web
+  annotations:
+    role: web
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-blk-app
+  annotations:
+    role: app
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.12

--- a/test/cli/test/variables/test.yaml
+++ b/test/cli/test/variables/test.yaml
@@ -2,6 +2,7 @@ name: test-variables
 policies:
   - cm-variable-example.yaml
   - cm-array-example.yaml
+  - cm-blk-scalar-example.yaml
 resources:
   - resources.yaml
 variables: variables.yaml
@@ -21,4 +22,12 @@ results:
   - policy: cm-array-example
     rule: validate-role-annotation
     resource: test-app
+    result: pass
+  - policy: cm-blk-scalar-example
+    rule: validate-blk-role-annotation
+    resource: test-blk-web
+    result: fail
+  - policy: cm-blk-scalar-example
+    rule: validate-blk-role-annotation
+    resource: test-blk-app
     result: pass

--- a/test/cli/test/variables/variables.yaml
+++ b/test/cli/test/variables/variables.yaml
@@ -23,3 +23,17 @@ policies:
       - name: test-app
         values:
           request.object.metadata.annotations.role: app
+  - name: cm-blk-scalar-example
+    rules:
+      - name: validate-blk-role-annotation
+        values:
+          roles-dictionary.data.allowed-roles: |-
+            app
+            test
+    resources:
+      - name: test-blk-web
+        values:
+          request.object.metadata.annotations.role: web
+      - name: test-blk-app
+        values:
+          request.object.metadata.annotations.role: app


### PR DESCRIPTION
Signed-off-by: Kumar Mallikarjuna <kumarmallikarjuna1@gmail.com>

## Related issue
#2245 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Parses Multiline Blocks from value files, similar to the webhook as done by function `fetchConfigMap()` in `pkg/engine/jsonContext.go`
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
#### Policy
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: cm-array-example
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: validate-role-annotation
    context:
      - name: roles-dictionary
        configMap:
          name: roles-dictionary
          namespace: default
    match:
      resources:
        kinds:
        - Deployment
    validate:
      message: "The role {{ request.object.metadata.annotations.role }} is not in the allowed list of roles: {{ \"roles-dictionary\".data.\"allowed-roles\" }}."
      deny:
        conditions:
        - key: "{{ request.object.metadata.annotations.role }}"
          operator: NotIn
          value:  "{{ \"roles-dictionary\".data.\"allowed-roles\" }}"

```
#### Values File
``` yaml
policies:
  - name: cm-array-example
    rules:
      - name: validate-role-annotation
        values:
          roles-dictionary.data.allowed-roles: |-
            cluster-admin
            cluster-operator
            tenant-admin
```
#### Deployment
``` yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: busybox
  annotations:
    role: super-user
  labels:
    app: busybox
spec:
  replicas: 1
  selector:
    matchLabels:
      app: busybox
  template:
    metadata:
      labels:
        app: busybox
    spec:
      containers:
        - image: busybox:1.28
          name: busybox
          command: ["sleep", "9999"]
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
