### PR TITLE
JMESPath: Arithmetic Operators

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -38,11 +38,18 @@ var (
 	regexReplaceAllLiteral = "regex_replace_all_literal"
 	regexMatch             = "regex_match"
 	labelMatch             = "label_match"
+	add                    = "add"
+	subtract               = "subtract"
+	multiply               = "multiply"
+	divide                 = "divide"
+	modulo                 = "modulo"
 )
 
 const errorPrefix = "JMESPath function '%s': "
 const invalidArgumentTypeError = errorPrefix + "%d argument is expected of %s type"
 const genericError = errorPrefix + "%s"
+const zeroDivisionError = errorPrefix + "Zero divisor passed"
+const nonIntModuloError = errorPrefix + "Non-integer argument(s) passed for modulo"
 
 func getFunctions() []*gojmespath.FunctionEntry {
 	return []*gojmespath.FunctionEntry{
@@ -145,6 +152,46 @@ func getFunctions() []*gojmespath.FunctionEntry {
 				{Types: []JpType{JpObject}},
 			},
 			Handler: jpLabelMatch,
+		},
+		{
+			Name: add,
+			Arguments: []ArgSpec{
+				{Types: []JpType{JpNumber}},
+				{Types: []JpType{JpNumber}},
+			},
+			Handler: jpAdd,
+		},
+		{
+			Name: subtract,
+			Arguments: []ArgSpec{
+				{Types: []JpType{JpNumber}},
+				{Types: []JpType{JpNumber}},
+			},
+			Handler: jpSubtract,
+		},
+		{
+			Name: multiply,
+			Arguments: []ArgSpec{
+				{Types: []JpType{JpNumber}},
+				{Types: []JpType{JpNumber}},
+			},
+			Handler: jpMultiply,
+		},
+		{
+			Name: divide,
+			Arguments: []ArgSpec{
+				{Types: []JpType{JpNumber}},
+				{Types: []JpType{JpNumber}},
+			},
+			Handler: jpDivide,
+		},
+		{
+			Name: modulo,
+			Arguments: []ArgSpec{
+				{Types: []JpType{JpNumber}},
+				{Types: []JpType{JpNumber}},
+			},
+			Handler: jpModulo,
 		},
 	}
 
@@ -358,6 +405,100 @@ func jpLabelMatch(arguments []interface{}) (interface{}, error) {
 	}
 
 	return true, nil
+}
+
+func jpAdd(arguments []interface{}) (interface{}, error) {
+	var err error
+	op1, err := validateArg(divide, arguments, 0, reflect.Float64)
+	if err != nil {
+		return nil, err
+	}
+
+	op2, err := validateArg(divide, arguments, 1, reflect.Float64)
+	if err != nil {
+		return nil, err
+	}
+
+	return op1.Float() + op2.Float(), nil
+}
+
+func jpSubtract(arguments []interface{}) (interface{}, error) {
+	var err error
+	op1, err := validateArg(divide, arguments, 0, reflect.Float64)
+	if err != nil {
+		return nil, err
+	}
+
+	op2, err := validateArg(divide, arguments, 1, reflect.Float64)
+	if err != nil {
+		return nil, err
+	}
+
+	return op1.Float() - op2.Float(), nil
+}
+
+func jpMultiply(arguments []interface{}) (interface{}, error) {
+	var err error
+	op1, err := validateArg(divide, arguments, 0, reflect.Float64)
+	if err != nil {
+		return nil, err
+	}
+
+	op2, err := validateArg(divide, arguments, 1, reflect.Float64)
+	if err != nil {
+		return nil, err
+	}
+
+	return op1.Float() * op2.Float(), nil
+}
+
+func jpDivide(arguments []interface{}) (interface{}, error) {
+	var err error
+	op1, err := validateArg(divide, arguments, 0, reflect.Float64)
+	if err != nil {
+		return nil, err
+	}
+
+	op2, err := validateArg(divide, arguments, 1, reflect.Float64)
+	if err != nil {
+		return nil, err
+	}
+
+	if op2.Float() == 0 {
+		return nil, fmt.Errorf(zeroDivisionError, divide)
+	}
+
+	return op1.Float() / op2.Float(), nil
+}
+
+func jpModulo(arguments []interface{}) (interface{}, error) {
+	var err error
+	op1, err := validateArg(divide, arguments, 0, reflect.Float64)
+	if err != nil {
+		return nil, err
+	}
+
+	op2, err := validateArg(divide, arguments, 1, reflect.Float64)
+	if err != nil {
+		return nil, err
+	}
+
+	val1 := int64(op1.Float())
+	val2 := int64(op2.Float())
+
+	if op1.Float() != float64(val1) {
+		return nil, fmt.Errorf(nonIntModuloError, modulo)
+	}
+
+	if op2.Float() != float64(val2) {
+		return nil, fmt.Errorf(nonIntModuloError, modulo)
+	}
+
+	if val2 == 0 {
+		return nil, fmt.Errorf(zeroDivisionError, modulo)
+	}
+
+	return val1 % val2, nil
 }
 
 // InterfaceToString casts an interface to a string type

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -301,3 +301,63 @@ func Test_labelMatch(t *testing.T) {
 	}
 
 }
+
+func TestJMESPathFunctions_Add(t *testing.T) {
+	jp, err := New("add(`12`, `13`)")
+	assert.NilError(t, err)
+
+	result, err := jp.Search("")
+	assert.NilError(t, err)
+
+	equal, ok := result.(float64)
+	assert.Assert(t, ok)
+	assert.Equal(t, equal, 25.0)
+}
+
+func TestJMESPathFunctions_Subtract(t *testing.T) {
+	jp, err := New("subtract(`12`, `7`)")
+	assert.NilError(t, err)
+
+	result, err := jp.Search("")
+	assert.NilError(t, err)
+
+	equal, ok := result.(float64)
+	assert.Assert(t, ok)
+	assert.Equal(t, equal, 5.0)
+}
+
+func TestJMESPathFunctions_Multiply(t *testing.T) {
+	jp, err := New("multiply(`3`, `2.5`)")
+	assert.NilError(t, err)
+
+	result, err := jp.Search("")
+	assert.NilError(t, err)
+
+	equal, ok := result.(float64)
+	assert.Assert(t, ok)
+	assert.Equal(t, equal, 7.5)
+}
+
+func TestJMESPathFunctions_Divide(t *testing.T) {
+	jp, err := New("divide(`12`, `1.5`)")
+	assert.NilError(t, err)
+
+	result, err := jp.Search("")
+	assert.NilError(t, err)
+
+	equal, ok := result.(float64)
+	assert.Assert(t, ok)
+	assert.Equal(t, equal, 8.0)
+}
+
+func TestJMESPathFunctions_Modulo(t *testing.T) {
+	jp, err := New("modulo(`12`, `7`)")
+	assert.NilError(t, err)
+
+	result, err := jp.Search("")
+	assert.NilError(t, err)
+
+	equal, ok := result.(int64)
+	assert.Assert(t, ok)
+	assert.Equal(t, equal, int64(5))
+}

--- a/pkg/kyverno/common/regex.go
+++ b/pkg/kyverno/common/regex.go
@@ -7,8 +7,8 @@ import (
 // RegexVariables represents regex for '{{}}'
 var RegexVariables = regexp.MustCompile(`\{\{[^{}]*\}\}`)
 
-// AllowedVariables represents regex for {{request.}}, {{serviceAccountName}}, {{serviceAccountNamespace}} and {{@}}
-var AllowedVariables = regexp.MustCompile(`\{\{\s*[request\.|serviceAccountName|serviceAccountNamespace|@][^{}]*\}\}`)
+// AllowedVariables represents regex for {{request.}}, {{serviceAccountName}}, {{serviceAccountNamespace}}, {{@}} and {{divide(<num>,<num>))}} (#2409)
+var AllowedVariables = regexp.MustCompile(`\{\{\s*[request\.|serviceAccountName|serviceAccountNamespace|@|divide][^{}]*\}\}`)
 
 // IsHttpRegex represents regex for starts with http:// or https://
 var IsHttpRegex = regexp.MustCompile("^(http|https)://")


### PR DESCRIPTION
Signed-off-by: Kumar Mallikarjuna <kumarmallikarjuna1@gmail.com>

cc - @realshuting 
## Related issue
Closes #604 
Closes #2409 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Adds arithmetic operators to our custom JMESPath functions suite.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
#### Policy
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: variablethis
spec:
  background: false
  rules:
    - name: variablethis
      match:
        resources:
          kinds:
            - Pod
      mutate:
        overlay:
          spec:
            containers:
              - (image): "*"
                resources:
                  requests:
                    memory: "{{ add(`12`,`13`) }}Mi"
                    cpu: "250m"
                  limits:
                    memory: "{{ @ }}"
                    cpu: "{{ @ }}"
```
#### Pod
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: myapp-pod
  labels:
    app: myapp
spec:
  containers:
    - name: myapp-container
      image: busybox
      command: ["sh", "-c", "echo Hello Kubernetes! && sleep 3600"]
      resources:
        requests:
          memory: "64Mi"
          cpu: "150m"
        limits:
          memory: "128Mi"
          cpu: "500m"
    - name: myapp-container2
      image: busybox
      command: ["sh", "-c", "echo Hello Kubernetes! && sleep 3600"]
      resources:
        requests:
          memory: "64Mi"
          cpu: "150m"
        limits:
          memory: "128Mi"
          cpu: "500m"
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
