### PR TITLE
Bug fix | CLI `apply` command | not filtering the resources from cluster 

### DIFF
--- a/pkg/kyverno/common/fetch.go
+++ b/pkg/kyverno/common/fetch.go
@@ -32,7 +32,10 @@ func GetResources(policies []*v1.ClusterPolicy, resourcePaths []string, dClient 
 
 	for _, policy := range policies {
 		for _, rule := range policy.Spec.Rules {
-			resourceTypesMap = getKindsFromPolicy(rule)
+			resourceTypesInRule := getKindsFromPolicy(rule)
+			for resourceKind := range resourceTypesInRule {
+				resourceTypesMap[resourceKind] = true
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue
issue reported in slack - https://kubernetes.slack.com/archives/CLGR9BJU9/p1631904964399300

## Milestone of this PR
`/milestone 1.5.0`.

## What type of PR is this
> /kind bug

## Proposed Changes

### Proof Manifests
apply the following pod manifest in cluster:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx2
spec:
  containers:
    - name: nginx
      image: nginx
      ports:
        - containerPort: 30000
          hostPort: 30000
```

now test it using the Kyverno CLI apply command with the following policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: block-pod-host-port-node-port-collision
spec:
  validationFailureAction: audit
  rules:
  - name: check-host-port
    match:
      resources:
        kinds:
        - Pod
    validate:
      message: "Pods may not request use of a host port that overlaps with the cluster's Service node port range."
      pattern:
        spec:
          containers:
          - =(ports):
            - =(hostPort): "<30000 | >32767"
```
```
$ kyverno apply policy.yaml --cluster
Applying 1 policy to 18 resources... 
(Total number of result count may vary as the policy is mutated by Kyverno. To check the mutated policy please try with log level 5)

policy block-pod-host-port-node-port-collision -> resource default/Pod/nginx2 failed: 
1. check-host-port: validation error: Pods may not request use of a host port that overlaps with the cluster's Service node port range. Rule check-host-port failed at path /spec/containers/0/ports/0/hostPort/ 

pass: 17, fail: 1, warn: 0, error: 0, skip: 36 
exit status 1
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

