### PR TITLE
NetworkPolicy: `from` should be an array of objects

### DIFF
--- a/charts/kyverno/templates/networkpolicy.yaml
+++ b/charts/kyverno/templates/networkpolicy.yaml
@@ -15,20 +15,20 @@ spec:
   ingress:
   - from:
       {{- with .Values.networkPolicy }}
-      namespaceSelector:
-        matchExpressions:
-          {{- toYaml .namespaceExpressions | nindent 8 }}
-        matchLabels:
-          {{- range $key, $value := .namespaceLabels }}
-          {{ $key | quote }}: {{ $value | quote }}
-          {{- end }}
-      podSelector:
-        matchExpressions:
-          {{- toYaml .podExpressions | nindent 8 }}
-        matchLabels:
-          {{- range $key, $value := .podLabels }}
-          {{ $key | quote }}: {{ $value | quote }}
-          {{- end }}
+      - namespaceSelector:
+          matchExpressions:
+            {{- toYaml .namespaceExpressions | nindent 8 }}
+          matchLabels:
+            {{- range $key, $value := .namespaceLabels }}
+            {{ $key | quote }}: {{ $value | quote }}
+            {{- end }}
+        podSelector:
+          matchExpressions:
+            {{- toYaml .podExpressions | nindent 8 }}
+          matchLabels:
+            {{- range $key, $value := .podLabels }}
+            {{ $key | quote }}: {{ $value | quote }}
+            {{- end }}
       {{- end }}
     ports:
     - protocol: TCP

--- a/charts/kyverno/templates/networkpolicy.yaml
+++ b/charts/kyverno/templates/networkpolicy.yaml
@@ -17,14 +17,14 @@ spec:
       {{- with .Values.networkPolicy }}
       - namespaceSelector:
           matchExpressions:
-            {{- toYaml .namespaceExpressions | nindent 8 }}
+            {{- toYaml .namespaceExpressions | nindent 10 }}
           matchLabels:
             {{- range $key, $value := .namespaceLabels }}
             {{ $key | quote }}: {{ $value | quote }}
             {{- end }}
         podSelector:
           matchExpressions:
-            {{- toYaml .podExpressions | nindent 8 }}
+            {{- toYaml .podExpressions | nindent 10 }}
           matchLabels:
             {{- range $key, $value := .podLabels }}
             {{ $key | quote }}: {{ $value | quote }}


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

`from` in kyverno Helm Chart should be an array of objects instead of an object.
changes as per slack discussion: https://kubernetes.slack.com/archives/CLGR9BJU9/p1632167129427100

cc: @realshuting  @antoineozenne @diranged

```
---
# Source: kyverno/templates/networkpolicy.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  labels: 
    app.kubernetes.io/component: kyverno
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: kyverno
    app.kubernetes.io/part-of: kyverno
    app.kubernetes.io/version: "v2.0.4"
    helm.sh/chart: kyverno-v2.0.4
    app: kyverno
  name: RELEASE-NAME-kyverno
  namespace: default
spec:
  podSelector:
    matchLabels:
      app: kyverno
  policyTypes:
  - Ingress
  ingress:
  - from:
      - namespaceSelector:
          matchExpressions:
          - {}
          matchLabels:
        podSelector:
          matchExpressions:
          - {}
          matchLabels:
    ports:
    - protocol: TCP
      port: 9443 # webhook access
  # Allow prometheus scrapes for metrics
  - ports:
      - port: 8000
```