### PR TITLE
Enqueue the GRs when triggred resource is deleted

### DIFF
--- a/pkg/webhooks/generation.go
+++ b/pkg/webhooks/generation.go
@@ -384,7 +384,7 @@ func (ws *WebhookServer) handleDelete(request *v1beta1.AdmissionRequest) {
 	}
 
 	resLabels := resource.GetLabels()
-	if resLabels["app.kubernetes.io/managed-by"] == "kyverno" && resLabels["policy.kyverno.io/synchronize"] == "enable" && request.Operation == v1beta1.Delete {
+	if resLabels["app.kubernetes.io/managed-by"] == "kyverno" && request.Operation == v1beta1.Delete {
 		grName := resLabels["policy.kyverno.io/gr-name"]
 		gr, err := ws.grLister.Get(grName)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue
closes https://github.com/kyverno/kyverno/issues/2332

## Milestone of this PR
 `/milestone 1.5.0`.


## What type of PR is this
> /kind bug
> /kind cleanup

## Proposed Changes
When `synchronize` is `true` - when the triggred resource is deleted the `generateRequest` get updated. On updation of the 
`generateRequests` the cleanup controller will enqueue the `generateRequests` for deletion.

While when `synchronize` is `false` - when the triggred resource is deleted the `generateRequest` is not getting updated. And `generateRequests` is not getting enqueued for deletion. 

Now, the same process will be followed when a triggred resource is deleted. As the `generateRequests` will be enqueue only if the GR is added, deleted or updated:
```
c.grInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
		AddFunc:    c.addGR,
		UpdateFunc: c.updateGR,
		DeleteFunc: c.deleteGR,
})
```

### Proof Manifests
1. Create the sample policy from [here](https://github.com/kyverno/kyverno/issues/2229#issuecomment-907627727).
2. Create a Service resource. For example:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: lbtest
spec:
  selector:
    app: lbtest
  type: LoadBalancer
  ports:
  - port: 80
    targetPort: 8080
    protocol: TCP
```
3. See that a ConfigMap is generated as expected.
4. Delete the Service.
5. See that the ConfigMap and GenerateRequest are deleted.
6. Now try regenerating the ConfigMap by applying the same service.
7. The ConfigMap will be created successfully.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

