### PR TITLE
Fix skipped policy message is displayed even if variable is passed

### DIFF
--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -334,7 +334,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, valuesFile s
 	}
 
 	fmt.Printf("\nExecuting %s...", values.Name)
-
+	valuesFile = values.Variables
 	variables, globalValMap, valuesMap, namespaceSelectorMap, err := common.GetVariable(variablesString, values.Variables, fs, isGit, policyResourcePath)
 	if err != nil {
 		if !sanitizederror.IsErrorSanitized(err) {
@@ -384,9 +384,6 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, valuesFile s
 		fmt.Printf("\napplying %s to %s... \n", msgPolicies, msgResources)
 	}
 
-	if variablesString != "" {
-		variables = common.SetInStoreContext(mutatedPolicies, variables)
-	}
 	for _, policy := range mutatedPolicies {
 		err := policy2.Validate(policy, nil, true, openAPIController)
 		if err != nil {


### PR DESCRIPTION
## Related issue
Signed-off-by: Vyankatesh vyankateshkd@gmail.com

## Related issue
closes https://github.com/kyverno/kyverno/issues/2445

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.
/milestone 1.5.0
-->
## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
policy.yaml
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: block-updates-deletes
  annotations:
    policies.kyverno.io/title: Block Updates and Deletes
    policies.kyverno.io/category: Sample
    policies.kyverno.io/subject: RBAC
    policies.kyverno.io/description: >-
      Kubernetes RBAC allows for controls on kinds of resources or those
      with specific names. But it does not have the type of granularity often
      required in more complex environments. This policy restricts updates and deletes to any
      Service resource that contains the label `protected=true` unless by
      a cluster-admin.
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: block-updates-deletes
    match:
      resources:
        kinds:
        - Service
        selector:
          matchLabels:
            protected: "true"
    exclude:
      clusterRoles:
      - cluster-admin
    validate:
      message: "This resource is protected and changes are not allowed. Please seek a cluster-admin."
      deny:
        conditions:
          - key: "{{request.operation}}"
            operator: In
            value:
            - DELETE
            - UPDATE
 ```
 resource.yaml
 ```
apiVersion: v1
kind: Service
metadata:
  name: my-service-1
  labels:
    protected: "true"
spec:
  selector:
    app: myapp
  ports:
    - protocol: TCP
      port: 80
      targetPort: 9376

---
apiVersion: v1
kind: Service
metadata:
  name: my-service-2
  labels:
    protected: "true"
spec:
  selector:
    app: myapp
  ports:
    - protocol: TCP
      port: 80
      targetPort: 9376
```
values.yaml
```
policies:
  - name: block-updates-deletes
    rules:
      - name: block-updates-deletes
    resources:
      - name: my-service-1
        values: 
          request.operation: CREATE
      - name: my-service-2
        values: 
          request.operation: UPDATE
```
test.yaml
```
name: block-updates-deletes
policies:
  -  policy.yaml
resources:
  -  res.yaml
variables: variable.yaml
results:
  - policy: block-updates-deletes
    rule: block-updates-deletes
    resource: my-service-1
    kind: Service
    result: pass
  - policy: block-updates-deletes
    rule: block-updates-deletes
    resource: my-service-2
    kind: Service
    result: fail
````


Executing block-updates-deletes...
applying 1 policy to 2 resources...


│───│───────────────────────│───────────────────────│──────────────│────────│
│ # │ POLICY                │ RULE                  │ RESOURCE     │ RESULT │
│───│───────────────────────│───────────────────────│──────────────│────────│
│ 1 │ block-updates-deletes │ block-updates-deletes │ my-service-1 │ Pass   │
│ 2 │ block-updates-deletes │ block-updates-deletes │ my-service-2 │ Pass   │
│───│───────────────────────│───────────────────────│──────────────│────────│
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
