### PR TITLE
supporting request object for generate policies

### DIFF
--- a/charts/kyverno/templates/crds.yaml
+++ b/charts/kyverno/templates/crds.yaml
@@ -2030,6 +2030,16 @@ spec:
               context:
                 description: Context ...
                 properties:
+                  admissionRequestInfo:
+                    description: Adding required request information to GR
+                    properties:
+                      admissionRequest:
+                        description: Adding Admission Request to GR.
+                        type: string
+                      operation:
+                        description: Current request operation
+                        type: string
+                    type: object
                   userInfo:
                     description: RequestInfo contains permission info carried in an admission request.
                     properties:

--- a/definitions/crds/kyverno.io_generaterequests.yaml
+++ b/definitions/crds/kyverno.io_generaterequests.yaml
@@ -108,6 +108,16 @@ spec:
                             type: string
                         type: object
                     type: object
+                  admissionRequestInfo:
+                    description: Adding required request information to GR
+                    properties:
+                      admissionRequest:
+                        description: Adding Admission Request to GR.
+                        type: string
+                      operation:
+                        description: Current request operation
+                        type: string
+                    type: object
                 type: object
               policy:
                 description: Specifies the name of the policy.

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -3058,6 +3058,16 @@ spec:
                             type: string
                         type: object
                     type: object
+                  admissionRequestInfo:
+                    description: Adding required request information to GR
+                    properties:
+                      admissionRequest:
+                        description: Adding Admission Request to GR.
+                        type: string
+                      operation:
+                        description: Current request operation
+                        type: string
+                    type: object
                 type: object
               policy:
                 description: Specifies the name of the policy.

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -3010,6 +3010,16 @@ spec:
               context:
                 description: Context ...
                 properties:
+                  admissionRequestInfo:
+                    description: Adding required request information to GR
+                    properties:
+                      admissionRequest:
+                        description: Adding Admission Request to GR.
+                        type: string
+                      operation:
+                        description: Current request operation
+                        type: string
+                    type: object
                   userInfo:
                     description: RequestInfo contains permission info carried in an
                       admission request.
@@ -3057,16 +3067,6 @@ spec:
                               among all active users.
                             type: string
                         type: object
-                    type: object
-                  admissionRequestInfo:
-                    description: Adding required request information to GR
-                    properties:
-                      admissionRequest:
-                        description: Adding Admission Request to GR.
-                        type: string
-                      operation:
-                        description: Current request operation
-                        type: string
                     type: object
                 type: object
               policy:

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -2976,6 +2976,16 @@ spec:
               context:
                 description: Context ...
                 properties:
+                  admissionRequestInfo:
+                    description: Adding required request information to GR
+                    properties:
+                      admissionRequest:
+                        description: Adding Admission Request to GR.
+                        type: string
+                      operation:
+                        description: Current request operation
+                        type: string
+                    type: object
                   userInfo:
                     description: RequestInfo contains permission info carried in an
                       admission request.

--- a/pkg/api/kyverno/v1/generaterequest_types.go
+++ b/pkg/api/kyverno/v1/generaterequest_types.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"k8s.io/api/admission/v1beta1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -45,6 +46,15 @@ type GenerateRequestSpec struct {
 type GenerateRequestContext struct {
 	// +optional
 	UserRequestInfo RequestInfo `json:"userInfo,omitempty" yaml:"userInfo,omitempty"`
+	// +optional
+	AdmissionRequestInfo AdmissionRequestInfoObject `json:"admissionRequestInfo,omitempty" yaml:"admissionRequestInfo,omitempty"`
+}
+
+type AdmissionRequestInfoObject struct {
+	// +optional
+	AdmissionRequest string `json:"admissionRequest,omitempty" yaml:"admissionRequest,omitempty"`
+	// +optional
+	Operation v1beta1.Operation `json:"operation,omitempty" yaml:"operation,omitempty"`
 }
 
 // RequestInfo contains permission info carried in an admission request.

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/kyverno/kyverno/pkg/engine/variables"
 	kyvernoutils "github.com/kyverno/kyverno/pkg/utils"
+	"k8s.io/api/admission/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -96,6 +97,18 @@ func (c *Controller) applyGenerate(resource unstructured.Unstructured, gr kyvern
 		}
 
 		logger.Error(err, "error in fetching policy")
+		return nil, err
+	}
+
+	requestString := gr.Spec.Context.AdmissionRequestInfo.AdmissionRequest
+	var request v1beta1.AdmissionRequest
+	err = json.Unmarshal([]byte(requestString), &request)
+	if err != nil {
+		logger.Error(err, "error parsing the request string")
+	}
+
+	if err := ctx.AddRequest(&request); err != nil {
+		logger.Error(err, "failed to load request in context")
 		return nil, err
 	}
 

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -107,6 +107,10 @@ func (c *Controller) applyGenerate(resource unstructured.Unstructured, gr kyvern
 		logger.Error(err, "error parsing the request string")
 	}
 
+	if gr.Spec.Context.AdmissionRequestInfo.Operation == v1beta1.Update {
+		request.Operation = gr.Spec.Context.AdmissionRequestInfo.Operation
+	}
+
 	if err := ctx.AddRequest(&request); err != nil {
 		logger.Error(err, "failed to load request in context")
 		return nil, err

--- a/pkg/generate/generate_controller.go
+++ b/pkg/generate/generate_controller.go
@@ -230,6 +230,7 @@ func (c *Controller) updateGenericResource(old, cur interface{}) {
 
 	// re-evaluate the GR as the resource was updated
 	for _, gr := range grs {
+		gr.Spec.Context.AdmissionRequestInfo.Operation = "update"
 		c.enqueueGenerateRequest(gr)
 	}
 }
@@ -286,6 +287,7 @@ func (c *Controller) updatePolicy(old, cur interface{}) {
 
 	// re-evaluate the GR as the policy was updated
 	for _, gr := range grs {
+		gr.Spec.Context.AdmissionRequestInfo.Operation = "update"
 		c.enqueueGenerateRequest(gr)
 	}
 }

--- a/pkg/generate/generate_controller.go
+++ b/pkg/generate/generate_controller.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"time"
 
+	"k8s.io/api/admission/v1beta1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/go-logr/logr"
@@ -230,7 +231,7 @@ func (c *Controller) updateGenericResource(old, cur interface{}) {
 
 	// re-evaluate the GR as the resource was updated
 	for _, gr := range grs {
-		gr.Spec.Context.AdmissionRequestInfo.Operation = "update"
+		gr.Spec.Context.AdmissionRequestInfo.Operation = v1beta1.Update
 		c.enqueueGenerateRequest(gr)
 	}
 }
@@ -287,7 +288,7 @@ func (c *Controller) updatePolicy(old, cur interface{}) {
 
 	// re-evaluate the GR as the policy was updated
 	for _, gr := range grs {
-		gr.Spec.Context.AdmissionRequestInfo.Operation = "update"
+		gr.Spec.Context.AdmissionRequestInfo.Operation = v1beta1.Update
 		c.enqueueGenerateRequest(gr)
 	}
 }


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue

closes https://github.com/kyverno/kyverno/issues/2226
closes https://github.com/kyverno/kyverno/issues/2095

## Milestone of this PR
`/milestone 1.5.0`.

## What type of PR is this

> /kind bug

## Proposed Changes
Related Doc - https://docs.google.com/document/d/143RzgN6m5iJmXlOWnHsI1pPll0WE4JUXmKn-TjzJxbY/edit

When `applyGenerate` calls `engine.Generate`, `policyContext.JSONContext` has resource, user info, service account, and image info. But request operation is not added here. Because of which pre-condition evaluation fails as request.operation is not available in the policy context.

Approach:
Updated the `GenerateRequestContext` struct to store the admission request.
```
type GenerateRequestContext struct {
   // +optional
   UserRequestInfo RequestInfo `json:"userInfo,omitempty" yaml:"userInfo,omitempty"`
   // +optional
   AdmissionRequestInfo AdmissionRequestInfoObject `json:"admissionRequestInfo,omitempty" yaml:"admissionRequestInfo,omitempty"`
}
 
type AdmissionRequestInfoObject struct {
   // +optional
   AdmissionRequest string `json:"admissionRequest,omitempty" yaml:"admissionRequest,omitempty"`
   // +optional
   Operation v1beta1.Operation `json:"operation,omitempty" yaml:"operation,omitempty"`
}
```

Passing the admission request details while creating the `GenerateRequestSpec` - https://github.com/kyverno/kyverno/blob/6672a0caa374e9c1c125636f5199aa8071be772b/pkg/webhooks/generation.go#L434

With this we will have the request details in the GR and now with this we can have all request variables while processing the GR.


### Proof Manifests

Example 1:

1. Apply the following policy:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: policy-k13.06.3-cdi-upload-server
spec:
  background: false
  rules:
  - name: generate-networkpolicy
    match:
      resources:
        kinds:
        - Pod
        selector:
          matchLabels:
            acme.cert-manager.io/http01-solver: "true"
    preconditions:
      - key: "{{ request.operation }}"
        operator: Equals
        value: "CREATE"
    generate:
      kind: NetworkPolicy
      name: letsencrypt-http-solver-policy
      synchronize: true
      namespace: "{{request.object.metadata.namespace}}"
      data:
        spec:
          podSelector:
            matchLabels:
              acme.cert-manager.io/http01-solver: "true"
          ingress:
          - {}
```
2. Apply the following pod manifest:
```
apiVersion: v1
kind: Pod
metadata:
  name: nginx-pod
  namespace: test
  labels:
    acme.cert-manager.io/http01-solver: "true"
spec:
  containers:
  - name: nginx
    image: nginx
```
3. Check the network policy in `test` namespace.
```
NAME                             POD-SELECTOR                              AGE
letsencrypt-http-solver-policy   acme.cert-manager.io/http01-solver=true   31s
```

Example 2:
1. Apply the following policy:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: add-networkpolicy
  annotations:
    policies.kyverno.io/category: Workload Management
    policies.kyverno.io/description: By default, Kubernetes allows communications across
      all pods within a cluster. Network policies and, a CNI that supports network policies,
      must be used to restrict communications. A default NetworkPolicy should be configured
      for each namespace to default deny all ingress traffic to the pods in the namespace.
      Application teams can then configure additional NetworkPolicy resources to allow
      desired traffic to application pods from select sources.
spec:
  rules:
  - name: default-deny-ingress
    match:
      resources:
        kinds:
        - Namespace
    generate:
      kind: NetworkPolicy
      name: default-deny-ingress
      namespace: "{{request.object.metadata.name}}"
      synchronize: true
      data:
        spec:
          # select all pods in the namespace
          podSelector: {}
          policyTypes:
          - Ingress
```

2. Apply the following namespace manifest
```
kind: Namespace
apiVersion: v1
metadata:
  name: devtest
```

3. Check for network policy
```
$ kubectl get netpol -A                                                   
NAMESPACE   NAME                   POD-SELECTOR   AGE
devtest     default-deny-ingress   <none>         7s
```

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.


