### PR TITLE
Validate GVK while installing policy  & Fix any/all matching logic

### DIFF
--- a/pkg/policy/existing.go
+++ b/pkg/policy/existing.go
@@ -30,7 +30,6 @@ func (pc *PolicyController) processExistingResources(policy *kyverno.ClusterPoli
 		}
 
 		match := rule.MatchResources
-		exclude := rule.ExcludeResources
 
 		for _, value := range match.Any {
 			pc.processExistingKinds(value.ResourceDescription.Kinds, policy, rule, logger)
@@ -38,13 +37,6 @@ func (pc *PolicyController) processExistingResources(policy *kyverno.ClusterPoli
 		for _, value := range match.All {
 			pc.processExistingKinds(value.ResourceDescription.Kinds, policy, rule, logger)
 		}
-		for _, value := range exclude.All {
-			pc.processExistingKinds(value.ResourceDescription.Kinds, policy, rule, logger)
-		}
-		for _, value := range exclude.Any {
-			pc.processExistingKinds(value.ResourceDescription.Kinds, policy, rule, logger)
-		}
-
 		pc.processExistingKinds(match.Kinds, policy, rule, logger)
 	}
 }

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -177,17 +177,31 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 
 		// Validate Kind with match resource kinds
 		match := rule.MatchResources
+		exclude := rule.MatchResources
 		for _, value := range match.Any {
 			err := validateKinds(value.ResourceDescription.Kinds, mock, client, p)
 
 			if err != nil {
-				return fmt.Errorf("match resource kind is invalid ")
+				return fmt.Errorf("the kind defined in the any match resource is invalid")
 			}
 		}
 		for _, value := range match.All {
 			err := validateKinds(value.ResourceDescription.Kinds, mock, client, p)
 			if err != nil {
-				return fmt.Errorf("match resource kind is invalid ")
+				return fmt.Errorf("the kind defined in the all match resource is invalid")
+			}
+		}
+		for _, value := range exclude.Any {
+			err := validateKinds(value.ResourceDescription.Kinds, mock, client, p)
+
+			if err != nil {
+				return fmt.Errorf("the kind defined in the any exclude resource is invalid")
+			}
+		}
+		for _, value := range exclude.All {
+			err := validateKinds(value.ResourceDescription.Kinds, mock, client, p)
+			if err != nil {
+				return fmt.Errorf("the kind defined in the all exclude resource is invalid")
 			}
 		}
 		err := validateKinds(rule.MatchResources.Kinds, mock, client, p)

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -178,7 +178,11 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 
 		// Validate Kind with match resource kinds
 		for _, kind := range rule.MatchResources.Kinds {
-			_, k := c.GetKindFromGVK(kind)
+			gv, k := c.GetKindFromGVK(kind)
+			_, _, err := client.DiscoveryClient.FindResource(gv, k)
+			if err != nil || strings.ToLower(k) == k {
+				return fmt.Errorf("match resource kind  %s is invalid ", k)
+			}
 			if k == p.Kind {
 				return fmt.Errorf("kind and match resource kind should not be the same.")
 			}

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -177,7 +177,7 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 
 		// Validate Kind with match resource kinds
 		match := rule.MatchResources
-		exclude := rule.MatchResources
+		exclude := rule.ExcludeResources
 		for _, value := range match.Any {
 			err := validateKinds(value.ResourceDescription.Kinds, mock, client, p)
 			if err != nil {

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -179,10 +179,13 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 		// Validate Kind with match resource kinds
 		for _, kind := range rule.MatchResources.Kinds {
 			gv, k := c.GetKindFromGVK(kind)
-			_, _, err := client.DiscoveryClient.FindResource(gv, k)
-			if err != nil || strings.ToLower(k) == k {
-				return fmt.Errorf("match resource kind  %s is invalid ", k)
+			if !mock {
+				_, _, err := client.DiscoveryClient.FindResource(gv, k)
+				if err != nil || strings.ToLower(k) == k {
+					return fmt.Errorf("match resource kind  %s is invalid ", k)
+				}
 			}
+
 			if k == p.Kind {
 				return fmt.Errorf("kind and match resource kind should not be the same.")
 			}

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -180,7 +180,6 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 		exclude := rule.MatchResources
 		for _, value := range match.Any {
 			err := validateKinds(value.ResourceDescription.Kinds, mock, client, p)
-
 			if err != nil {
 				return fmt.Errorf("the kind defined in the any match resource is invalid")
 			}
@@ -207,6 +206,10 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 		err := validateKinds(rule.MatchResources.Kinds, mock, client, p)
 		if err != nil {
 			return fmt.Errorf("match resource kind is invalid ")
+		}
+		err = validateKinds(rule.ExcludeResources.Kinds, mock, client, p)
+		if err != nil {
+			return fmt.Errorf("exclude resource kind is invalid ")
 		}
 
 		// Validate string values in labels


### PR DESCRIPTION
## Related issue
Signed-off-by: Vyankatesh vyankateshkd@gmail.com

## Related issue
closes https://github.com/kyverno/kyverno/issues/2386
closes https://github.com/kyverno/kyverno/issues/2389
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--
`/milestone 1.5.0
Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
- Handle case-sensitive GVK properly in engine
- Fix any/all matching logic in the background controller
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: test
spec:
  background: true
  validationFailureAction: audit
  rules:
    - name: test
      match:
        resources:
          kinds:
            - configmap
      validate:
        message: "Metadata label 'name' is required."
        pattern:
          metadata:
            labels:
              name: "?*"

```
Any/All policy
```yaml

apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: enforce
  rules:
  - name: no-labels
    match:
      any:
        - resources:
            kinds: 
            - configmap
    validate:
      message: "label 'app.kubernetes.io/name' is required"
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"

```

```
Error from server: error when creating ".\\yamls\\policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: the kind defined in the any match resource is invalid
```

```yaml

apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: enforce
  rules:
  - name: no-labels
    match:
      all:
        - resources:
            kinds: 
            - configmap
    validate:
      message: "label 'app.kubernetes.io/name' is required"
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"

```
```
Error from server: error when creating ".\\yamls\\policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: the kind defined in the all match resource is invalid
```

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: enforce
  rules:
  - name: no-labels
    match:
      all:
      - resources:
          kinds: 
          - Pod
    exclude:
      any:
      - resources:
          kinds: 
          - pod
          names: ["dev"]
    validate:
      message: "label 'app.kubernetes.io/name' is required"
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"
```
```
Error from server: error when creating ".\\yamls\\policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: the kind defined in the any exclude resource is invalid
```

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: enforce
  rules:
  - name: no-labels
    match:
      all:
      - resources:
          kinds: 
          - Pod
    exclude:
      all:
      - resources:
          kinds: 
          - pod
          names: ["dev"]
    validate:
      message: "label 'app.kubernetes.io/name' is required"
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"

```

```
Error from server: error when creating ".\\yamls\\policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: the kind defined in the all exclude resource is invalid
```
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: enforce
  rules:
  - name: no-labels
    match:
      all:
      - resources:
          kinds: 
          - Pod
    exclude:
      resources:
          kinds: 
          - pod
          names: ["dev"]
    validate:
      message: "label 'app.kubernetes.io/name' is required"
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"

```
```
Error from server: error when creating ".\\yamls\\policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: exclude resource kind is invalid
```
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
