### PR TITLE
Fix Autogen issue for any/all block and Support gvk in match kind block

### DIFF
--- a/pkg/policymutation/cronjob.go
+++ b/pkg/policymutation/cronjob.go
@@ -34,9 +34,22 @@ func generateCronJobRule(rule kyverno.Rule, controllers string, log logr.Logger)
 	}
 	cronJobRule.Name = name
 
-	cronJobRule.MatchResources.Kinds = []string{engine.PodControllerCronJob}
-	if (jobRule.ExcludeResources) != nil && (len(jobRule.ExcludeResources.Kinds) > 0) {
-		cronJobRule.ExcludeResources.Kinds = []string{engine.PodControllerCronJob}
+	if len(jobRule.MatchResources.Any) > 0 {
+		cronJobRule.MatchResources.Any[0].Kinds = []string{engine.PodControllerCronJob}
+	} else if len(jobRule.MatchResources.All) > 0 {
+		cronJobRule.MatchResources.All[0].Kinds = []string{engine.PodControllerCronJob}
+	} else {
+		cronJobRule.MatchResources.Kinds = []string{engine.PodControllerCronJob}
+	}
+
+	if (jobRule.ExcludeResources) != nil && len(jobRule.ExcludeResources.Any) > 0 {
+		cronJobRule.ExcludeResources.Any[0].Kinds = []string{engine.PodControllerCronJob}
+	} else if (jobRule.ExcludeResources) != nil && len(jobRule.ExcludeResources.All) > 0 {
+		cronJobRule.ExcludeResources.All[0].Kinds = []string{engine.PodControllerCronJob}
+	} else {
+		if (jobRule.ExcludeResources) != nil && (len(jobRule.ExcludeResources.Kinds) > 0) {
+			cronJobRule.ExcludeResources.Kinds = []string{engine.PodControllerCronJob}
+		}
 	}
 
 	if (jobRule.Mutation != nil) && (jobRule.Mutation.Overlay != nil) {

--- a/pkg/policymutation/policymutation_test.go
+++ b/pkg/policymutation/policymutation_test.go
@@ -52,9 +52,51 @@ func Test_Any(t *testing.T) {
 		t.Log(errs)
 	}
 
+	fmt.Println("utils.JoinPatches(patches)erterter", string(utils.JoinPatches(rulePatches)))
+
 	expectedPatches := [][]byte{
-		[]byte(`{"path":"/spec/rules/1","op":"add","value":{"name":"autogen-validate-hostPath","match":{"any":[{"resources":{"kinds":["Pod"]}}],"resources":{"kinds":["DaemonSet","Deployment","Job","StatefulSet"]}},"validate":{"message":"Host path volumes are not allowed","pattern":{"spec":{"template":{"spec":{"=(volumes)":[{"X(hostPath)":"null"}]}}}}}}}`),
-		[]byte(`{"path":"/spec/rules/2","op":"add","value":{"name":"autogen-cronjob-validate-hostPath","match":{"any":[{"resources":{"kinds":["Pod"]}}],"resources":{"kinds":["CronJob"]}},"validate":{"message":"Host path volumes are not allowed","pattern":{"spec":{"jobTemplate":{"spec":{"template":{"spec":{"=(volumes)":[{"X(hostPath)":"null"}]}}}}}}}}}`),
+		[]byte(`{"path":"/spec/rules/1","op":"add","value":{"name":"autogen-validate-hostPath","match":{"any":[{"resources":{"kinds":["DaemonSet","Deployment","Job","StatefulSet"]}}],"resources":{"kinds":["Pod"]}},"validate":{"message":"Host path volumes are not allowed","pattern":{"spec":{"template":{"spec":{"=(volumes)":[{"X(hostPath)":"null"}]}}}}}}}`),
+		[]byte(`{"path":"/spec/rules/2","op":"add","value":{"name":"autogen-cronjob-validate-hostPath","match":{"any":[{"resources":{"kinds":["CronJob"]}}],"resources":{"kinds":["Pod"]}},"validate":{"message":"Host path volumes are not allowed","pattern":{"spec":{"jobTemplate":{"spec":{"template":{"spec":{"=(volumes)":[{"X(hostPath)":"null"}]}}}}}}}}}`),
+	}
+
+	for i, ep := range expectedPatches {
+		assert.Equal(t, string(rulePatches[i]), string(ep),
+			fmt.Sprintf("unexpected patch: %s\nexpected: %s", rulePatches[i], ep))
+	}
+}
+
+func Test_All(t *testing.T) {
+	dir, err := os.Getwd()
+	baseDir := filepath.Dir(filepath.Dir(dir))
+	assert.NilError(t, err)
+	file, err := ioutil.ReadFile(baseDir + "/test/best_practices/disallow_bind_mounts.yaml")
+	if err != nil {
+		t.Log(err)
+	}
+	policies, err := utils.GetPolicy(file)
+	if err != nil {
+		t.Log(err)
+	}
+
+	policy := policies[0]
+	policy.Spec.Rules[0].MatchResources.All = kyverno.ResourceFilters{
+		{
+			ResourceDescription: kyverno.ResourceDescription{
+				Kinds: []string{"Pod"},
+			},
+		},
+	}
+
+	rulePatches, errs := generateRulePatches(*policy, engine.PodControllers, log.Log)
+	if len(errs) != 0 {
+		t.Log(errs)
+	}
+
+	fmt.Println("utils.JoinPatches(patches)erterter", string(utils.JoinPatches(rulePatches)))
+
+	expectedPatches := [][]byte{
+		[]byte(`{"path":"/spec/rules/1","op":"add","value":{"name":"autogen-validate-hostPath","match":{"all":[{"resources":{"kinds":["DaemonSet","Deployment","Job","StatefulSet"]}}],"resources":{"kinds":["Pod"]}},"validate":{"message":"Host path volumes are not allowed","pattern":{"spec":{"template":{"spec":{"=(volumes)":[{"X(hostPath)":"null"}]}}}}}}}`),
+		[]byte(`{"path":"/spec/rules/2","op":"add","value":{"name":"autogen-cronjob-validate-hostPath","match":{"all":[{"resources":{"kinds":["CronJob"]}}],"resources":{"kinds":["Pod"]}},"validate":{"message":"Host path volumes are not allowed","pattern":{"spec":{"jobTemplate":{"spec":{"template":{"spec":{"=(volumes)":[{"X(hostPath)":"null"}]}}}}}}}}}`),
 	}
 
 	for i, ep := range expectedPatches {

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	kyverno "github.com/kyverno/kyverno/pkg/api/kyverno/v1"
+	common "github.com/kyverno/kyverno/pkg/common"
 	client "github.com/kyverno/kyverno/pkg/dclient"
 	engineutils "github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/minio/pkg/wildcard"
@@ -27,6 +28,16 @@ var regexVersion = regexp.MustCompile(`v(\d+).(\d+).(\d+)\.*`)
 func contains(list []string, element string, fn func(string, string) bool) bool {
 	for _, e := range list {
 		if fn(e, element) {
+			return true
+		}
+	}
+	return false
+}
+
+func ContainsPod(list []string, element string) bool {
+	for _, e := range list {
+		_, k := common.GetKindFromGVK(e)
+		if k == element {
 			return true
 		}
 	}


### PR DESCRIPTION
## Related issue
Signed-off-by: Vyankatesh vyankateshkd@gmail.com

## Related issue
closes https://github.com/kyverno/kyverno/issues/2415
closes https://github.com/kyverno/kyverno/issues/2301

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.5.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
 /kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
  - Fixed GVK format for Auto-gen rule.
  - Fix Autogen-rule for Any/All match selector, If the selector is defined, no additional rule added.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Policy.yaml

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-latest-tag
  annotations:
    policies.kyverno.io/title: Disallow Latest Tag
    policies.kyverno.io/category: Best Practices
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod
    policies.kyverno.io/description: >-
      The ':latest' tag is mutable and can lead to unexpected errors if the 
      image changes. A best practice is to use an immutable tag that maps to 
      a specific version of an application Pod. This policy validates that the image
      specifies a tag and that it is not called `latest`.      
spec:
  validationFailureAction: audit
  rules:
  - name: require-image-tag
    match:
      resources:
        kinds:
        - Pod
    validate:
      message: "An image tag is required."  
      pattern:
        spec:
          containers:
          - image: "*:*"
  - name: validate-image-tag
    match:
      resources:
        kinds:
        - v1/Pod
    validate:
      message: "Using a mutable image tag e.g. 'latest' is not allowed."
      pattern:
        spec:
          containers:
          - image: "!*:latest"
```



Policy After install in cluster generate Auto-gen rules

```yaml

kubectl get cpol  disallow-latest-tag -o yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"annotations":{"policies.kyverno.io/category":"Best Practices","policies.kyverno.io/description":"The ':latest' tag is mutable and can lead to unexpected errors if the  image changes. A best practice is to use an immutable tag that maps to  a specific version of an application Pod. This policy validates that the image specifies a tag and that it is not called `latest`.      ","policies.kyverno.io/severity":"medium","policies.kyverno.io/subject":"Pod","policies.kyverno.io/title":"Disallow Latest Tag"},"name":"disallow-latest-tag"},"spec":{"rules":[{"match":{"resources":{"kinds":["Pod"]}},"name":"require-image-tag","validate":{"message":"An image tag is required.","pattern":{"spec":{"containers":[{"image":"*:*"}]}}}},{"match":{"resources":{"kinds":["v1/Pod"]}},"name":"validate-image-tag","validate":{"message":"Using a mutable image tag e.g. 'latest' is not allowed.","pattern":{"spec":{"containers":[{"image":"!*:latest"}]}}}}],"validationFailureAction":"audit"}}
    pod-policies.kyverno.io/autogen-controllers: DaemonSet,Deployment,Job,StatefulSet,CronJob
    policies.kyverno.io/category: Best Practices
    policies.kyverno.io/description: 'The '':latest'' tag is mutable and can lead
      to unexpected errors if the  image changes. A best practice is to use an immutable
      tag that maps to  a specific version of an application Pod. This policy validates
      that the image specifies a tag and that it is not called `latest`.      '
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod
    policies.kyverno.io/title: Disallow Latest Tag
  creationTimestamp: "2021-09-28T19:49:48Z"
  generation: 2
  name: disallow-latest-tag
  resourceVersion: "30014"
  uid: 0772caa2-df55-4530-bdd5-6a72d5fd1f20
spec:
  background: true
  rules:
  - exclude:
      resources: {}
    generate:
      clone: {}
    match:
      resources:
        kinds:
        - Pod
    mutate: {}
    name: require-image-tag
    validate:
      message: An image tag is required.
      pattern:
        spec:
          containers:
          - image: '*:*'
  - exclude:
      resources: {}
    generate:
      clone: {}
    match:
      resources:
        kinds:
        - v1/Pod
    mutate: {}
    name: validate-image-tag
    validate:
      message: Using a mutable image tag e.g. 'latest' is not allowed.
      pattern:
        spec:
          containers:
          - image: '!*:latest'
  - exclude:
      resources: {}
    generate:
      clone: {}
    match:
      resources:
        kinds:
        - DaemonSet
        - Deployment
        - Job
        - StatefulSet
    mutate: {}
    name: autogen-require-image-tag
    validate:
      message: An image tag is required.
      pattern:
        spec:
          template:
            spec:
              containers:
              - image: '*:*'
  - exclude:
      resources: {}
    generate:
      clone: {}
    match:
      resources:
        kinds:
        - CronJob
    mutate: {}
    name: autogen-cronjob-require-image-tag
    validate:
      message: An image tag is required.
      pattern:
        spec:
          jobTemplate:
            spec:
              template:
                spec:
                  containers:
                  - image: '*:*'
  - exclude:
      resources: {}
    generate:
      clone: {}
    match:
      resources:
        kinds:
        - DaemonSet
        - Deployment
        - Job
        - StatefulSet
    mutate: {}
    name: autogen-validate-image-tag
    validate:
      message: Using a mutable image tag e.g. 'latest' is not allowed.
      pattern:
        spec:
          template:
            spec:
              containers:
              - image: '!*:latest'
  - exclude:
      resources: {}
    generate:
      clone: {}
    match:
      resources:
        kinds:
        - CronJob
    mutate: {}
    name: autogen-cronjob-validate-image-tag
    validate:
      message: Using a mutable image tag e.g. 'latest' is not allowed.
      pattern:
        spec:
          jobTemplate:
            spec:
              template:
                spec:
                  containers:
                  - image: '!*:latest'
  validationFailureAction: audit
``` 
1. match.resources.kinds
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
  annotations:
    policies.kyverno.io/title: Require Labels
    policies.kyverno.io/category: Best Practices
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod, Label
    policies.kyverno.io/description: >-
      Define and use labels that identify semantic attributes of your application or Deployment.
      A common set of labels allows tools to work collaboratively, describing objects in a common manner that 
      all tools can understand. The recommended labels describe applications in a way that can be 
      queried. This policy validates that the label `app.kubernetes.io/name` is specified with some value.      
spec:
  validationFailureAction: audit
  rules:
  - name: check-for-labels
    match:
      resources:
        kinds:
        - Pod
        selector:
              matchLabels:
                app: critical
    validate:
      message: "The label `app.kubernetes.io/name` is required."
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"

```


Policy (match/All): 
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels-all
  annotations:
    policies.kyverno.io/title: Require Labels
    policies.kyverno.io/category: Best Practices
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod, Label
    policies.kyverno.io/description: >-
      Define and use labels that identify semantic attributes of your application or Deployment.
      A common set of labels allows tools to work collaboratively, describing objects in a common manner that 
      all tools can understand. The recommended labels describe applications in a way that can be 
      queried. This policy validates that the label `app.kubernetes.io/name` is specified with some value.      
spec:
  validationFailureAction: enforce
  background: false
  rules:
    - name: match-criticals-except-given-rbac
      match:
        all:
        - resources:
            kinds:
            - Pod
            selector:
              matchLabels:
                app: critical
      validate:
        message: "The label `app.kubernetes.io/name` is required."
        pattern:
          metadata:
            labels:
              app.kubernetes.io/name: "?*"

```
policy2 (match/any): 


```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels-any
  annotations:
    policies.kyverno.io/title: Require Labels
    policies.kyverno.io/category: Best Practices
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod, Label
    policies.kyverno.io/description: >-
      Define and use labels that identify semantic attributes of your application or Deployment.
      A common set of labels allows tools to work collaboratively, describing objects in a common manner that 
      all tools can understand. The recommended labels describe applications in a way that can be 
      queried. This policy validates that the label `app.kubernetes.io/name` is specified with some value.      
spec:
  validationFailureAction: enforce
  background: false
  rules:
    - name: match-criticals-except-given-rbac
      match:
        any:
        - resources:
            kinds:
            - Pod
            selector:
              matchLabels:
                app: critical
      validate:
        message: "The label `app.kubernetes.io/name` is required."
        pattern:
          metadata:
            labels:
              app.kubernetes.io/name: "?*"
```
exclude.resources.kinds

```yaml

apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: validate-disallow-default-serviceaccount
spec:
  rules:
  - name: prevent-mounting-default-serviceaccount
    exclude:
      resources:
        kinds: 
        - Job
    match:
      resources:
        kinds:
        - Pod
    validate:
      message: "Prevent mounting of default service account"
      pattern:
        spec:
          serviceAccountName: "!default"
```
exclude.all[].resources.kinds
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels-all
  annotations:
    policies.kyverno.io/title: Require Labels
    policies.kyverno.io/category: Best Practices
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod, Label
    policies.kyverno.io/description: >-
      Define and use labels that identify semantic attributes of your application or Deployment.
      A common set of labels allows tools to work collaboratively, describing objects in a common manner that 
      all tools can understand. The recommended labels describe applications in a way that can be 
      queried. This policy validates that the label `app.kubernetes.io/name` is specified with some value.      
spec:
  validationFailureAction: enforce
  background: false
  rules:
    - name: match-criticals-except-given-rbac
      match:
        resources:
          kinds:
          - Pod
      exclude:
        all:
        - resources:
            kinds:
            - Job
      validate:
        message: "The label `app.kubernetes.io/name` is required."
        pattern:
          metadata:
            labels:
              app.kubernetes.io/name: "?*"

```
exclude.any[].resources.kinds
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels-any
  annotations:
    policies.kyverno.io/title: Require Labels
    policies.kyverno.io/category: Best Practices
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod, Label
    policies.kyverno.io/description: >-
      Define and use labels that identify semantic attributes of your application or Deployment.
      A common set of labels allows tools to work collaboratively, describing objects in a common manner that 
      all tools can understand. The recommended labels describe applications in a way that can be 
      queried. This policy validates that the label `app.kubernetes.io/name` is specified with some value.      
spec:
  validationFailureAction: enforce
  background: false
  rules:
    - name: match-criticals-except-given-rbac
      match:
        resources:
          kinds:
          - Pod
      exclude:
        any:
        - resources:
            kinds:
            - Job
      validate:
        message: "The label `app.kubernetes.io/name` is required."
        pattern:
          metadata:
            labels:
              app.kubernetes.io/name: "?*"

```


<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
