### PR TITLE
Scan Kyverno images on build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -113,6 +113,16 @@ jobs:
         run: |
           make docker-build-kyverno
 
+      - name: Trivy Scan Image
+        uses: aquasecurity/trivy-action@master
+        with: 
+          image-ref: 'ghcr.io/kyverno/kyverno:latest'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
   build-kyverno-cli:
     runs-on: ubuntu-latest
     needs: pre-checks

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,6 +84,16 @@ jobs:
         run: |
           make docker-publish-kyverno
 
+      - name: Trivy Scan Image
+        uses: aquasecurity/trivy-action@master
+        with: 
+          image-ref: 'ghcr.io/kyverno/kyverno:latest'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
   release-kyverno-cli:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Related issue
Fixes #1557 & #2432 

## What type of PR is this
/kind feature

## Proposed Changes
[ArtifactHub](https://artifacthub.io/packages/helm/kyverno/kyverno?modal=security-report) generates security reports for major CNCF projects. I discussed in their slack channel and they told me they use Trivy under the hood. Trivy has a good community maintenance and support and is reliable too.

Hence using [trivy-actions](https://github.com/aquasecurity/trivy-action), we now scan our Kyverno images. On each build or release, we check for any vulnerabilities in our integrated third-party modules/libraries. If there's any CVE with a Severity of HIGH or CRITICAL. The CI would fail.

### Proof Manifests
To test this, I tried out scanning 2 Kyverno images,
- One is the latest one that does not have any vulnerabilities. The CI passes [here](https://github.com/ShubhamPalriwala/kyverno/actions/runs/1304549672) on my forked repo.
- The other had 2 High level vulnerabilities due to the minio package. This was present in our v1.4.3 release. The CI fails [here](https://github.com/ShubhamPalriwala/kyverno/actions/runs/1306531624) as it found vulnerabilities.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
