### PR TITLE
fix cmd line tests

### DIFF
--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -923,9 +923,12 @@ func processMutateEngineResponse(policy *v1.ClusterPolicy, mutateResponse *respo
 				if mutateResponseRule.Status == response.RuleStatusPass {
 					rc.Pass++
 					printMutatedRes = true
+				} else if mutateResponseRule.Status == response.RuleStatusSkip {
+					fmt.Printf("\nskipped mutate policy %s -> resource %s", policy.Name, resPath)
+					rc.Skip++
 				} else {
 					if printCount < 1 {
-						fmt.Printf("\nFailed to apply mutate policy %s -> resource %s", policy.Name, resPath)
+						fmt.Printf("\nfailed to apply mutate policy %s -> resource %s", policy.Name, resPath)
 						printCount++
 					}
 					fmt.Printf("%d. %s - %s \n", i+1, mutateResponseRule.Name, mutateResponseRule.Message)

--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -403,6 +403,7 @@ func buildPolicyResults(resps []*response.EngineResponse, testResults []TestResu
 			if rule.Type != utils.Mutation.String() {
 				continue
 			}
+
 			var resultsKey []string
 			var resultKey string
 
@@ -415,15 +416,25 @@ func buildPolicyResults(resps []*response.EngineResponse, testResults []TestResu
 				} else {
 					continue
 				}
-				var x string
-				for _, path := range patcheResourcePath {
-					result.Result = report.StatusFail
-					x = getAndComparePatchedResource(path, resp.PatchedResource, isGit, policyResourcePath, fs)
-					if x == "pass" {
-						result.Result = report.StatusPass
-						break
+
+				if rule.Status == response.RuleStatusSkip {
+					result.Result = report.StatusSkip
+
+				} else if rule.Status == response.RuleStatusError {
+					result.Result = report.StatusError
+
+				} else {
+					var x string
+					for _, path := range patcheResourcePath {
+						result.Result = report.StatusFail
+						x = getAndComparePatchedResource(path, resp.PatchedResource, isGit, policyResourcePath, fs)
+						if x == "pass" {
+							result.Result = report.StatusPass
+							break
+						}
 					}
 				}
+
 				results[resultKey] = result
 			}
 		}
@@ -648,6 +659,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, valuesFile s
 			pvInfos = append(pvInfos, info)
 		}
 	}
+
 	resultsMap, testResults := buildPolicyResults(engineResponses, values.Results, pvInfos, policyResourcePath, fs, isGit)
 	resultErr := printTestResult(resultsMap, testResults, rc)
 	if resultErr != nil {


### PR DESCRIPTION
Signed-off-by: Jim Bugwadia <jim@nirmata.com>

Fix command line mutate tests. Previously result status was not handled, and all skip results caused failures.