### PR TITLE
Check client if nil before loading resource list

### DIFF
--- a/pkg/engine/jsonContext.go
+++ b/pkg/engine/jsonContext.go
@@ -162,6 +162,10 @@ func fetchAPIData(log logr.Logger, entry kyverno.ContextEntry, ctx *PolicyContex
 }
 
 func loadResourceList(ctx *PolicyContext, p *APIPath) ([]byte, error) {
+	if ctx.Client == nil {
+		return nil, fmt.Errorf("API client is not available")
+	}
+
 	l, err := ctx.Client.ListResource(p.Version, p.ResourceType, p.Namespace, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Related issue

> None (This PR)

[Unlike loading resource](https://github.com/kyverno/kyverno/blob/65fd07eac66da7078837296b2c91ee0978b0f6b3/pkg/engine/jsonContext.go#L174-L176), current implementation doesn't check if client is nil or not when loading resource list.

## Milestone of this PR

<!-- Add the milestone label by commenting `/milestone 1.2.3`. -->

## What type of PR is this

/kind bug

## Proposed Changes

This commit checks if client is nil or not before loading resource list.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

None