### PR TITLE
Fix policy report reconciliation on resource/policy deletion

### DIFF
--- a/pkg/policyreport/reportcontroller.go
+++ b/pkg/policyreport/reportcontroller.go
@@ -319,6 +319,7 @@ func (g *ReportGenerator) syncHandler(key string) (aggregatedRequests interface{
 	g.log.V(4).Info("syncing policy report", "key", key)
 
 	if policy, rule, ok := isDeletedPolicyKey(key); ok {
+		g.log.V(4).Info("sync policy report on policy deletion")
 		return g.removePolicyEntryFromReport(policy, rule)
 	}
 
@@ -332,7 +333,9 @@ func (g *ReportGenerator) syncHandler(key string) (aggregatedRequests interface{
 	if old, err = g.createReportIfNotPresent(namespace, new, aggregatedRequests); err != nil {
 		return aggregatedRequests, err
 	}
+
 	if old == nil {
+		g.log.V(4).Info("no existing policy report is found, clean up related report change requests")
 		g.cleanupReportRequests(aggregatedRequests)
 		return nil, nil
 	}
@@ -629,6 +632,7 @@ func (g *ReportGenerator) updateReport(old interface{}, new *unstructured.Unstru
 		g.log.V(4).Info("empty report to update")
 		return nil
 	}
+	g.log.V(4).Info("reconcile policy report")
 
 	oldUnstructured := make(map[string]interface{})
 
@@ -655,6 +659,7 @@ func (g *ReportGenerator) updateReport(old interface{}, new *unstructured.Unstru
 		new.SetResourceVersion(oldTyped.GetResourceVersion())
 	}
 
+	g.log.V(4).Info("update results entries")
 	obj, _, err := updateResults(oldUnstructured, new.UnstructuredContent(), aggregatedRequests)
 	if err != nil {
 		return fmt.Errorf("failed to update results entry: %v", err)


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shutting06@gmail.com>

## Related issue
Close https://github.com/kyverno/kyverno/issues/2534.
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.5.2
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
In this PR https://github.com/kyverno/kyverno/pull/2387 we added a `appVersion` label to RCRs on resource creation, while this label also needs to be added when the resource/policy is deleted. This PR adds the required label.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
With the policy report generated for the Deployment:
```
✗ k get polr
NAME              PASS   FAIL   WARN   ERROR   SKIP   AGE
polr-ns-default   8      0      0      0       0      5m52s
```
The report was updated correctly when the Deployment was deleted:
```
✗ k get polr
NAME              PASS   FAIL   WARN   ERROR   SKIP   AGE
polr-ns-default   0      0      0      0       0      11m
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
