### PR TITLE
Fix: kyverno-pre panic when checking kubernetes version

### DIFF
--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -91,6 +91,15 @@ func Test_higherVersion(t *testing.T) {
 
 	v, err = isVersionHigher("v1.5.9-rc2", 1, 5, 9)
 	assert.Assert(t, v == false && err == nil)
+
+	v, err = isVersionHigher("v1.5.9", 2, 1, 0)
+	assert.Assert(t, v == false && err == nil)
+
+	v, err = isVersionHigher("v2.1.0", 1, 5, 9)
+	assert.Assert(t, v == true && err == nil)
+
+	v, err = isVersionHigher("v1.5.9-x-v1.5.9.x", 1, 5, 8)
+	assert.Assert(t, v == true && err == nil)
 }
 
 func Test_ConvertResource(t *testing.T) {


### PR DESCRIPTION


## Related issue

Fix #2613 

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
 /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Get first match version pattern when checking the k8s version. And fix the version comparsion logic bug.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
