### PR TITLE
Improving check during generated resource updation

### DIFF
--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -435,7 +435,15 @@ func applyRule(log logr.Logger, client *dclient.Client, rule kyverno.Rule, resou
 				label["policy.kyverno.io/synchronize"] = "enable"
 				newResource.SetLabels(label)
 
-				if _, err := ValidateResourceWithPattern(logger, generatedObj.Object, rdata); err != nil {
+				if genAPIVersion == "" {
+					generatedResourceAPIVersion := generatedObj.GetAPIVersion()
+					newResource.SetAPIVersion(generatedResourceAPIVersion)
+				}
+				if genNamespace == "" {
+					newResource.SetNamespace("default")
+				}
+
+				if _, err := ValidateResourceWithPattern(logger, generatedObj.Object, newResource.Object); err != nil {
 					_, err = client.UpdateResource(genAPIVersion, genKind, genNamespace, newResource, false)
 					if err != nil {
 						logger.Error(err, "failed to update resource")


### PR DESCRIPTION
Signed-off-by: NoSkillGirl <singhpooja240393@gmail.com>

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR

`/milestone 1.6.0`


## What type of PR is this

> /kind bug

## Proposed Changes
Added optional parameter check before comparing the generated resource to resource provided in generate policy.

In generate policy, it is not necessary to mention the apiversion and namespace for the generated resource.
https://github.com/kyverno/kyverno/blob/e401d57b3551722a1e906dedd4e56e08024f726f/pkg/api/kyverno/v1/policy_types.go#L619

when we compare the generated resource and the new resource to be generated in the following code, if the user have not mentioned the apiversion the comparison will fail with apiversion. And will not check the further structure.
https://github.com/kyverno/kyverno/blob/9252470d4764dd7e452afad6d5e04e2895dccca1/pkg/generate/generate.go#L438

For resolving this, we are adding the apiversion to the new resource by extracting it from the generated resource. And if the namespace is not mentioned we are considering it as `default` namespace.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
