### PR TITLE
*Range Operators

### DIFF
--- a/pkg/engine/operator/operator.go
+++ b/pkg/engine/operator/operator.go
@@ -20,8 +20,10 @@ const (
 	More Operator = ">"
 	// Less stands for <
 	Less Operator = "<"
-	// Range stands for -
-	Range Operator = "-"
+	// InRange stands for -
+	InRange Operator = "-"
+	// NotInRange stands for !-
+	NotInRange Operator = "!-"
 )
 
 //ReferenceSign defines the operator for anchor reference
@@ -53,8 +55,12 @@ func GetOperatorFromStringPattern(pattern string) Operator {
 		return NotEqual
 	}
 
+	if match, _ := regexp.Match(`^(\d+(\.\d+)?)([^-]*)!-(\d+(\.\d+)?)([^-]*)$`, []byte(pattern)); match {
+		return NotInRange
+	}
+
 	if match, _ := regexp.Match(`^(\d+(\.\d+)?)([^-]*)-(\d+(\.\d+)?)([^-]*)$`, []byte(pattern)); match {
-		return Range
+		return InRange
 	}
 
 	return Equal

--- a/pkg/engine/operator/operator_test.go
+++ b/pkg/engine/operator/operator_test.go
@@ -19,9 +19,17 @@ func TestGetOperatorFromStringPattern_OnlyOperator(t *testing.T) {
 }
 
 func TestGetOperatorFromStringPattern_RangeOperator(t *testing.T) {
-	assert.Equal(t, GetOperatorFromStringPattern("0-1"), Range)
-	assert.Equal(t, GetOperatorFromStringPattern("0Mi-1024Mi"), Range)
+	assert.Equal(t, GetOperatorFromStringPattern("0-1"), InRange)
+	assert.Equal(t, GetOperatorFromStringPattern("0Mi-1024Mi"), InRange)
+
+	assert.Equal(t, GetOperatorFromStringPattern("0!-1"), NotInRange)
+	assert.Equal(t, GetOperatorFromStringPattern("0Mi!-1024Mi"), NotInRange)
+
 	assert.Equal(t, GetOperatorFromStringPattern("text1024Mi-2048Mi"), Equal)
 	assert.Equal(t, GetOperatorFromStringPattern("test-value"), Equal)
 	assert.Equal(t, GetOperatorFromStringPattern("value-*"), Equal)
+
+	assert.Equal(t, GetOperatorFromStringPattern("text1024Mi!-2048Mi"), Equal)
+	assert.Equal(t, GetOperatorFromStringPattern("test!-value"), Equal)
+	assert.Equal(t, GetOperatorFromStringPattern("value!-*"), Equal)
 }

--- a/pkg/engine/validate/pattern.go
+++ b/pkg/engine/validate/pattern.go
@@ -179,16 +179,26 @@ func checkForAndConditionsAndValidate(log logr.Logger, value interface{}, patter
 func validateValueWithStringPattern(log logr.Logger, value interface{}, pattern string) bool {
 	operatorVariable := operator.GetOperatorFromStringPattern(pattern)
 
-	// Upon encountering Range operator split the string by `-` and basically
-	// verify the result of (x >= leftEndpoint && x <= rightEndpoint)
-	if operatorVariable == operator.Range {
+	// Upon encountering InRange operator split the string by `-` and basically
+	// verify the result of (x >= leftEndpoint & x <= rightEndpoint)
+	if operatorVariable == operator.InRange {
 		gt := validateValueWithStringPattern(log, value, fmt.Sprintf(">=%s", strings.Split(pattern, "-")[0]))
 		if !gt {
 			return false
 		}
-
 		pattern = fmt.Sprintf("<=%s", strings.Split(pattern, "-")[1])
 		operatorVariable = operator.LessEqual
+	}
+
+	// Upon encountering NotInRange operator split the string by `!-` and basically
+	// verify the result of (x < leftEndpoint | x > rightEndpoint)
+	if operatorVariable == operator.NotInRange {
+		gt := validateValueWithStringPattern(log, value, fmt.Sprintf("<%s", strings.Split(pattern, "!-")[0]))
+		if gt {
+			return true
+		}
+		pattern = fmt.Sprintf(">%s", strings.Split(pattern, "!-")[1])
+		operatorVariable = operator.More
 	}
 
 	pattern = pattern[len(operatorVariable):]

--- a/pkg/engine/validate/pattern_test.go
+++ b/pkg/engine/validate/pattern_test.go
@@ -316,18 +316,34 @@ func TestValidateValueWithStringPattern_Ranges(t *testing.T) {
 	assert.Assert(t, validateValueWithStringPattern(log.Log, 2, "0-2"))
 	assert.Assert(t, !validateValueWithStringPattern(log.Log, 3, "0-2"))
 
+	assert.Assert(t, validateValueWithStringPattern(log.Log, 0, "10!-20"))
+	assert.Assert(t, !validateValueWithStringPattern(log.Log, 15, "10!-20"))
+	assert.Assert(t, validateValueWithStringPattern(log.Log, 25, "10!-20"))
+
 	assert.Assert(t, !validateValueWithStringPattern(log.Log, 0, "0.00001-2.00001"))
 	assert.Assert(t, validateValueWithStringPattern(log.Log, 1, "0.00001-2.00001"))
 	assert.Assert(t, validateValueWithStringPattern(log.Log, 2, "0.00001-2.00001"))
 	assert.Assert(t, !validateValueWithStringPattern(log.Log, 2.0001, "0.00001-2.00001"))
 
+	assert.Assert(t, validateValueWithStringPattern(log.Log, 0, "0.00001!-2.00001"))
+	assert.Assert(t, !validateValueWithStringPattern(log.Log, 1, "0.00001!-2.00001"))
+	assert.Assert(t, !validateValueWithStringPattern(log.Log, 2, "0.00001!-2.00001"))
+	assert.Assert(t, validateValueWithStringPattern(log.Log, 2.0001, "0.00001!-2.00001"))
+
 	assert.Assert(t, validateValueWithStringPattern(log.Log, 2, "2-2"))
+	assert.Assert(t, !validateValueWithStringPattern(log.Log, 2, "2!-2"))
 
 	assert.Assert(t, validateValueWithStringPattern(log.Log, 2.99999, "2.99998-3"))
+	assert.Assert(t, validateValueWithStringPattern(log.Log, 2.99997, "2.99998!-3"))
+	assert.Assert(t, validateValueWithStringPattern(log.Log, 3.00001, "2.99998!-3"))
 
 	assert.Assert(t, validateValueWithStringPattern(log.Log, "256Mi", "128Mi-512Mi"))
 	assert.Assert(t, !validateValueWithStringPattern(log.Log, "1024Mi", "128Mi-512Mi"))
 	assert.Assert(t, !validateValueWithStringPattern(log.Log, "64Mi", "128Mi-512Mi"))
+
+	assert.Assert(t, !validateValueWithStringPattern(log.Log, "256Mi", "128Mi!-512Mi"))
+	assert.Assert(t, validateValueWithStringPattern(log.Log, "1024Mi", "128Mi!-512Mi"))
+	assert.Assert(t, validateValueWithStringPattern(log.Log, "64Mi", "128Mi!-512Mi"))
 }
 
 func TestValidateNumberWithStr_LessFloatAndInt(t *testing.T) {


### PR DESCRIPTION
## Related issue

https://github.com/kyverno/kyverno/issues/1910

## Milestone of this PR

1.6.0

## What type of PR is this

/kind feature

## Proposed Changes

Implementation of the `-` (`InRange`) and `!-` (`NotInRange` - negative counterpart) operators.

In both scenarios, the expressions with the `*Range` operators are translated inside the `validateValueWithStringPattern` function to one of the equivalent expressions:

* `value >= leftEndpoint & value <= rightEndpoint`
* `value < leftEndpoint | value > rightEndpoint`

### Proof Manifests

#### `InRange` operator

```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: restrict-port
spec:
  validationFailureAction: enforce
  rules:
  - name: restrict-port-range
    match:
      resources:
        kinds:
        - Service
    validate:
      message: Ports must be between 32000-33000
      pattern:
        spec:
          ports:
          - port: 32000-33000
```

```
apiVersion: v1
kind: Service
metadata:
  name: my-service
spec:
  type: ClusterIP
  ports:
    - port: 31111
```

```
Error from server: error when creating "svc.yaml": admission webhook "validate.kyverno.svc-fail" denied the request:

resource Service/default/my-service was blocked due to the following policies

restrict-port:
  restrict-port-range: 'validation error: Ports must be between 32000-33000. Rule
    restrict-port-range failed at path /spec/ports/0/port/'
```

#### `NotInRange` operator

```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: protect-port-range
spec:
  validationFailureAction: enforce
  rules:
  - name: protect-port-range
    match:
      resources:
        kinds:
        - Service
    validate:
      message: Ports must not be between 32000-33000
      pattern:
        spec:
          ports:
          - port: 32000!-33000
```

```
apiVersion: v1
kind: Service
metadata:
  name: my-service
spec:
  type: ClusterIP
  ports:
    - port: 32500
```

```
Error from server: error when creating "nsvc.yaml": admission webhook "validate.kyverno.svc-fail" denied the request:

resource Service/default/my-service was blocked due to the following policies

protect-port-range:
  protect-port-range: 'validation error: Ports must not be between 32000-33000. Rule
    protect-port-range failed at path /spec/ports/0/port/'
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [x] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is: https://github.com/kyverno/website/pull/363
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

N/A
