### PR TITLE
Add `images` to allowed variables

### DIFF
--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -258,7 +258,7 @@ func PolicyHasNonAllowedVariables(policy v1.ClusterPolicy) error {
 		matchesAll := RegexVariables.FindAllStringSubmatch(string(ruleJSON), -1)
 		matchesAllowed := AllowedVariables.FindAllStringSubmatch(string(ruleJSON), -1)
 		if (len(matchesAll) > len(matchesAllowed)) && len(rule.Context) == 0 {
-			allowed := "{{request.*}}, {{element.*}}, {{serviceAccountName}}, {{serviceAccountNamespace}}, {{@}}, and context variables"
+			allowed := "{{request.*}}, {{element.*}}, {{serviceAccountName}}, {{serviceAccountNamespace}}, {{@}}, {{images.*}} and context variables"
 			return fmt.Errorf("rule \"%s\" has forbidden variables. Allowed variables are: %s", rule.Name, allowed)
 		}
 	}

--- a/pkg/kyverno/common/regex.go
+++ b/pkg/kyverno/common/regex.go
@@ -7,8 +7,8 @@ import (
 // RegexVariables represents regex for '{{}}'
 var RegexVariables = regexp.MustCompile(`\{\{[^{}]*\}\}`)
 
-// AllowedVariables represents regex for {{request.}}, {{serviceAccountName}}, {{serviceAccountNamespace}}, {{@}} and functions e.g. {{divide(<num>,<num>))}}
-var AllowedVariables = regexp.MustCompile(`\{\{\s*(request\.|serviceAccountName|serviceAccountNamespace|element\.|@|([a-z_0-9]+\())[^{}]*\}\}`)
+// AllowedVariables represents regex for {{request.}}, {{serviceAccountName}}, {{serviceAccountNamespace}}, {{@}}, {{element.}}, {{images.}}
+var AllowedVariables = regexp.MustCompile(`\{\{\s*(request\.|serviceAccountName|serviceAccountNamespace|element\.|@|images\.|([a-z_0-9]+\())[^{}]*\}\}`)
 
 // AllowedVariables represents regex for {{request.}}, {{serviceAccountName}}, {{serviceAccountNamespace}}
 var WildCardAllowedVariables = regexp.MustCompile(`\{\{\s*(request\.|serviceAccountName|serviceAccountNamespace)[^{}]*\}\}`)


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shutting06@gmail.com>

## Related issue

Added variable `images` to the allowed variables list.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.5.2
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Added variable `images` to the allowed variables list.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

The following policy is created successfully with this change while prevented by Kyverno 1.5.1.
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: if-baltic-restrict-privileged-containers
spec:
  validationFailureAction: enforce
  background: true
  rules:
  - name: privileged-init-containers
    match:
      resources:
        kinds:
        - Pod    
    preconditions:
      - key: "consul-k8s-control-plane*"
        operator: NotIn
        value: "{{ images.initContainers.*.name }}"
    validate:
      message: >-
        Privileged mode is disallowed. The fields spec.initContainers[*].securityContext.privileged
        must not be set to true.
      pattern:
        spec:              
          =(initContainers):
          - =(securityContext):
              =(privileged): "false"
```

```
✗ kg cpol if-baltic-restrict-privileged-containers -o yaml | k neat
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  annotations:
    pod-policies.kyverno.io/autogen-controllers: DaemonSet,Deployment,Job,StatefulSet,CronJob
  name: if-baltic-restrict-privileged-containers
spec:
  background: true
  failurePolicy: Fail
  rules:
  - match:
      resources:
        kinds:
        - Pod
    name: privileged-init-containers
    preconditions:
    - key: consul-k8s-control-plane*
      operator: NotIn
      value: '{{ images.initContainers.*.name }}'
    validate:
      message: Privileged mode is disallowed. The fields spec.initContainers[*].securityContext.privileged
        must not be set to true.
      pattern:
        spec:
          =(initContainers):
          - =(securityContext):
              =(privileged): "false"
  - match:
      resources:
        kinds:
        - DaemonSet
        - Deployment
        - Job
        - StatefulSet
    name: autogen-privileged-init-containers
    preconditions:
    - key: consul-k8s-control-plane*
      operator: NotIn
      value: '{{ images.initContainers.*.name }}'
    validate:
      message: Privileged mode is disallowed. The fields spec.initContainers[*].securityContext.privileged
        must not be set to true.
      pattern:
        spec:
          template:
            spec:
              =(initContainers):
              - =(securityContext):
                  =(privileged): "false"
  - match:
      resources:
        kinds:
        - CronJob
    name: autogen-cronjob-privileged-init-containers
    preconditions:
    - key: consul-k8s-control-plane*
      operator: NotIn
      value: '{{ images.initContainers.*.name }}'
    validate:
      message: Privileged mode is disallowed. The fields spec.initContainers[*].securityContext.privileged
        must not be set to true.
      pattern:
        spec:
          jobTemplate:
            spec:
              template:
                spec:
                  =(initContainers):
                  - =(securityContext):
                      =(privileged): "false"
  validationFailureAction: enforce
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- x[] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
