### PR TITLE
Fix: RuleResult label to be correctly populated while registering respective metrics

### DIFF
--- a/pkg/metrics/policyexecutionduration/policyExecutionDuration.go
+++ b/pkg/metrics/policyexecutionduration/policyExecutionDuration.go
@@ -83,9 +83,21 @@ func (pc PromConfig) ProcessEngineResponse(policy kyverno.ClusterPolicy, engineR
 	for _, rule := range ruleResponses {
 		ruleName := rule.Name
 		ruleType := ParseRuleTypeFromEngineRuleResponse(rule)
-		ruleResult := metrics.Fail
-		if rule.Status == response.RuleStatusPass {
+
+		var ruleResult metrics.RuleResult
+		switch rule.Status {
+		case response.RuleStatusPass:
 			ruleResult = metrics.Pass
+		case response.RuleStatusFail:
+			ruleResult = metrics.Fail
+		case response.RuleStatusWarn:
+			ruleResult = metrics.Warn
+		case response.RuleStatusError:
+			ruleResult = metrics.Error
+		case response.RuleStatusSkip:
+			ruleResult = metrics.Skip
+		default:
+			ruleResult = metrics.Fail
 		}
 
 		ruleExecutionLatencyInSeconds := float64(rule.RuleStats.ProcessingTime) / float64(1000*1000*1000)

--- a/pkg/metrics/policyresults/policyResults.go
+++ b/pkg/metrics/policyresults/policyResults.go
@@ -76,9 +76,21 @@ func (pc PromConfig) ProcessEngineResponse(policy kyverno.ClusterPolicy, engineR
 	for _, rule := range ruleResponses {
 		ruleName := rule.Name
 		ruleType := ParseRuleTypeFromEngineRuleResponse(rule)
-		ruleResult := metrics.Fail
-		if rule.Status == response.RuleStatusPass {
+
+		var ruleResult metrics.RuleResult
+		switch rule.Status {
+		case response.RuleStatusPass:
 			ruleResult = metrics.Pass
+		case response.RuleStatusFail:
+			ruleResult = metrics.Fail
+		case response.RuleStatusWarn:
+			ruleResult = metrics.Warn
+		case response.RuleStatusError:
+			ruleResult = metrics.Error
+		case response.RuleStatusSkip:
+			ruleResult = metrics.Skip
+		default:
+			ruleResult = metrics.Fail
 		}
 
 		if err := pc.registerPolicyResultsMetric(


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yash.kukreja.98@gmail.com>

## Related issue

closes #2629 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
> /kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

From now on, the `rule_result` label will have the following values depending on the policy's execution:
- pass
- fail
- warn
- error
- skip

In the issue described, the metrics' wrongly reported `rule_result=fail` would be `rule_result=skip` from now on considering preconditions not being not met.

```
# HELP kyverno_policy_results_total can be used to track the results associated with the policies applied in the user’s cluster, at the level from rule to policy to admission requests.
# TYPE kyverno_policy_results_total counter
kyverno_policy_results_total{policy_background_mode="false",policy_name="set-service-defaults",policy_namespace="-",policy_type="cluster",policy_validation_mode="enforce",resource_kind="Service",resource_namespace="default",resource_request_operation="create",rule_execution_cause="admission_request",rule_name="set-service-defaults",rule_result="skip",rule_type="mutate"} 1
```

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

Slack conversation: https://kubernetes.slack.com/archives/CLGR9BJU9/p1635458987180000
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
