### PR TITLE
Fix memory issue - RCR conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cornelk/hashmap v1.0.1
 	github.com/dchest/siphash v1.2.1 // indirect
 	github.com/distribution/distribution v2.7.1+incompatible
+	github.com/docker/cli v20.10.10+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.5.0
 	github.com/fatih/color v1.12.0
 	github.com/gardener/controller-manager-library v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,8 @@ require (
 )
 
 replace (
+	github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017 => github.com/docker/cli v20.10.10+incompatible
+	github.com/docker/cli v20.10.7+incompatible => github.com/docker/cli v20.10.10+incompatible
 	github.com/docker/cli v20.10.8+incompatible => github.com/docker/cli v20.10.10+incompatible
 	github.com/evanphx/json-patch/v5 => github.com/kyverno/json-patch/v5 v5.5.1-0.20210915204938-7578f4ee9c77
 	github.com/go-logr/logr => github.com/go-logr/logr v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 )
 
 replace (
+	github.com/docker/cli v20.10.8+incompatible => github.com/docker/cli v20.10.10+incompatible
 	github.com/evanphx/json-patch/v5 => github.com/kyverno/json-patch/v5 v5.5.1-0.20210915204938-7578f4ee9c77
 	github.com/go-logr/logr => github.com/go-logr/logr v0.4.0
 	github.com/gorilla/rpc v1.2.0+incompatible => github.com/gorilla/rpc v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -511,6 +511,8 @@ github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop
 github.com/docker/cli v20.10.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.8+incompatible h1:/zO/6y9IOpcehE49yMRTV9ea0nBpb8OeqSskXLNfH1E=
 github.com/docker/cli v20.10.8+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v20.10.10+incompatible h1:kcbwdgWbrBOH8QwQzaJmyriHwF7XIl4HT1qh0HTRys4=
+github.com/docker/cli v20.10.10+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,6 @@ github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/
 github.com/distribution/distribution v2.7.1+incompatible h1:aGFx4EvJWKEh//lHPLwFhFgwFHKH06TzNVPamrMn04M=
 github.com/distribution/distribution v2.7.1+incompatible/go.mod h1:EgLm2NgWtdKgzF9NpMzUKgzmR7AMmb0VQi2B+ZzDRjc=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
-github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/cli v20.10.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.10+incompatible h1:kcbwdgWbrBOH8QwQzaJmyriHwF7XIl4HT1qh0HTRys4=
 github.com/docker/cli v20.10.10+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=

--- a/go.sum
+++ b/go.sum
@@ -509,8 +509,6 @@ github.com/distribution/distribution v2.7.1+incompatible/go.mod h1:EgLm2NgWtdKgz
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/cli v20.10.8+incompatible h1:/zO/6y9IOpcehE49yMRTV9ea0nBpb8OeqSskXLNfH1E=
-github.com/docker/cli v20.10.8+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.10+incompatible h1:kcbwdgWbrBOH8QwQzaJmyriHwF7XIl4HT1qh0HTRys4=
 github.com/docker/cli v20.10.10+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shutting06@gmail.com>

## Related issue
https://github.com/kyverno/kyverno/issues/2427
https://github.com/kyverno/kyverno/issues/2524

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
1.5.2
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
This PR switches to use JSON marshaler to convert typed `ReportChangeRequest` to unstructured `ReportChangeRequest`. This change was made based on the observation of the following profiling data:
```
## testing setup
Kyverno-policies, 5 corncobs installed, background = false

# k -n kyverno top pod
NAME                       CPU(cores)   MEMORY(bytes)
kyverno-64bdb56c76-mb5sm   1209m        381Mi


         0     0%     0%    67.02MB 53.05%  github.com/kyverno/kyverno/pkg/policyreport.(*Generator).processNextWorkItem
         0     0%     0%    67.02MB 53.05%  github.com/kyverno/kyverno/pkg/policyreport.(*Generator).processNextWorkItem.func1
         0     0%     0%    67.02MB 53.05%  github.com/kyverno/kyverno/pkg/policyreport.(*Generator).runWorker
         0     0%     0%    67.02MB 53.05%  github.com/kyverno/kyverno/pkg/policyreport.(*Generator).syncHandler
         0     0%     0%    65.03MB 51.48%  github.com/kyverno/kyverno/pkg/policyreport.(*requestBuilder).build


# k -n kyverno top pod
NAME                       CPU(cores)   MEMORY(bytes)
kyverno-64bdb56c76-mb5sm   1149m        514Mi


         0     0%     0%   134.98MB 56.93%  k8s.io/apimachinery/pkg/util/wait.Until
         0     0%     0%   131.96MB 55.65%  github.com/kyverno/kyverno/pkg/policyreport.(*Generator).processNextWorkItem
         0     0%     0%   131.96MB 55.65%  github.com/kyverno/kyverno/pkg/policyreport.(*Generator).processNextWorkItem.func1
         0     0%     0%   131.96MB 55.65%  github.com/kyverno/kyverno/pkg/policyreport.(*Generator).runWorker
         0     0%     0%   131.96MB 55.65%  github.com/kyverno/kyverno/pkg/policyreport.(*Generator).syncHandler
         0     0%     0%   126.57MB 53.38%  github.com/kyverno/kyverno/pkg/policyreport.(*requestBuilder).build
       2MB  0.84%  0.84%   105.56MB 44.52%  k8s.io/apimachinery/pkg/runtime.(*unstructuredConverter).ToUnstructured



# k -n kyverno top pod
NAME                       CPU(cores)   MEMORY(bytes)
kyverno-64bdb56c76-mb5sm   875m         618Mi


         0     0%     0%   191.19MB 62.77%  k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
         0     0%     0%   190.68MB 62.61%  github.com/kyverno/kyverno/pkg/policyreport.(*Generator).processNextWorkItem
         0     0%     0%   190.68MB 62.61%  github.com/kyverno/kyverno/pkg/policyreport.(*Generator).processNextWorkItem.func1
         0     0%     0%   190.68MB 62.61%  github.com/kyverno/kyverno/pkg/policyreport.(*Generator).runWorker
         0     0%     0%   190.68MB 62.61%  github.com/kyverno/kyverno/pkg/policyreport.(*Generator).syncHandler
         0     0%     0%   184.10MB 60.44%  github.com/kyverno/kyverno/pkg/policyreport.(*requestBuilder).build
```


<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Memory usage after this change, you can see `(*requestBuilder).build` no longer consumes the most of memories.
```
## testing setup
Kyverno-policies, 10 corncobs installed, background = false

Memory: 62Mi - 91Mi - 85Mi - 94 Mi - 72 Mi - 97 Mi - 86Mi - 111Mi - 74Mi


# Heap data when memory was 97 Mi

(pprof) top30 -cum
Showing nodes accounting for 21.02MB, 42.72% of 49.21MB total
Showing top 30 nodes out of 201
      flat  flat%   sum%        cum   cum%
   21.02MB 42.72% 42.72%    21.02MB 42.72%  runtime.allocm
         0     0% 42.72%    21.02MB 42.72%  runtime.newm
         0     0% 42.72%    21.02MB 42.72%  runtime.resetspinning
         0     0% 42.72%    21.02MB 42.72%  runtime.schedule
         0     0% 42.72%    21.02MB 42.72%  runtime.startm
         0     0% 42.72%    21.02MB 42.72%  runtime.wakep
         0     0% 42.72%    15.01MB 30.51%  runtime.mstart
         0     0% 42.72%    15.01MB 30.51%  runtime.mstart0
         0     0% 42.72%    15.01MB 30.51%  runtime.mstart1
         0     0% 42.72%     6.01MB 12.21%  runtime.mcall
         0     0% 42.72%     6.01MB 12.21%  runtime.park_m
         0     0% 42.72%     6.01MB 12.20%  runtime.main
         0     0% 42.72%     5.49MB 11.16%  k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive
         0     0% 42.72%     5.49MB 11.16%  k8s.io/client-go/rest/watch.(*Decoder).Decode
         0     0% 42.72%     4.07MB  8.27%  github.com/json-iterator/go.(*Iterator).ReadVal
         0     0% 42.72%     4.07MB  8.27%  github.com/json-iterator/go.(*frozenConfig).Unmarshal
         0     0% 42.72%     4.07MB  8.27%  github.com/json-iterator/go.(*structFieldDecoder).Decode
         0     0% 42.72%     4.07MB  8.27%  k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).Decode
         0     0% 42.72%     3.57MB  7.26%  github.com/json-iterator/go.(*sliceDecoder).Decode
         0     0% 42.72%     3.57MB  7.26%  github.com/json-iterator/go.(*sliceDecoder).doDecode
         0     0% 42.72%     3.57MB  7.26%  k8s.io/apimachinery/pkg/runtime.WithoutVersionDecoder.Decode
         0     0% 42.72%     3.50MB  7.12%  github.com/kyverno/kyverno/pkg/policyreport.(*ReportGenerator).processNextWorkItem
         0     0% 42.72%     3.50MB  7.12%  github.com/kyverno/kyverno/pkg/policyreport.(*ReportGenerator).runWorker
         0     0% 42.72%     3.50MB  7.12%  github.com/kyverno/kyverno/pkg/policyreport.(*ReportGenerator).syncHandler
         0     0% 42.72%     3.50MB  7.12%  github.com/kyverno/kyverno/pkg/policyreport.(*ReportGenerator).updateReport
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments
~~Once enabled background mode, I see memory went up and down within range 90Mi to 140Mi. Will continue monitoring usage and send follow-up PRs if necessary.~~

Updated:

1. Memory usage is fluctuating between 99Mi and 137Mi within 5 hours, the cluster has 5 CronJobs which run every minute. Policies are enabled with the background scan.

2. With 20 CronJobs scheduled over 10h, the memory usage is between 130Mi - 170Mi.

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
