### PR TITLE
Added time_since() custom JMESPath function

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -57,21 +57,21 @@ const zeroDivisionError = errorPrefix + "Zero divisor passed"
 const nonIntModuloError = errorPrefix + "Non-integer argument(s) passed for modulo"
 
 var layouts = map[string]string{
-	"ANSIC":       time.ANSIC,
-	"UnixDate":    time.UnixDate,
-	"RubyDate":    time.RubyDate,
-	"RFC822":      time.RFC822,
-	"RFC822Z":     time.RFC822Z,
-	"RFC850":      time.RFC850,
-	"RFC1123":     time.RFC1123,
-	"RFC1123Z":    time.RFC1123Z,
-	"RFC3339":     time.RFC3339,
-	"RFC3339Nano": time.RFC3339Nano,
-	"Kitchen":     time.Kitchen,
-	"Stamp":       time.Stamp,
-	"StampMilli":  time.StampMilli,
-	"StampMicro":  time.StampMicro,
-	"StampNano":   time.StampNano,
+	"ANSIC":       "Mon Jan _2 15:04:05 2006",
+	"UnixDate":    "Mon Jan _2 15:04:05 MST 2006",
+	"RubyDate":    "Mon Jan 02 15:04:05 -0700 2006",
+	"RFC822":      "02 Jan 06 15:04 MST",
+	"RFC822Z":     "02 Jan 06 15:04 -0700",
+	"RFC850":      "Monday, 02-Jan-06 15:04:05 MST",
+	"RFC1123":     "Mon, 02 Jan 2006 15:04:05 MST",
+	"RFC1123Z":    "Mon, 02 Jan 2006 15:04:05 -0700",
+	"RFC3339":     "2006-01-02T15:04:05Z07:00",
+	"RFC3339Nano": "2006-01-02T15:04:05.999999999Z07:00",
+	"Kitchen":     "3:04PM",
+	"Stamp":       "Jan _2 15:04:05",
+	"StampMilli":  "Jan _2 15:04:05.000",
+	"StampMicro":  "Jan _2 15:04:05.000000",
+	"StampNano":   "Jan _2 15:04:05.000000000",
 }
 
 func getFunctions() []*gojmespath.FunctionEntry {
@@ -581,46 +581,39 @@ func jpBase64Encode(arguments []interface{}) (interface{}, error) {
 
 func jpTimeSince(arguments []interface{}) (interface{}, error) {
 	var err error
-	layout_, err := validateArg("", arguments, 0, reflect.String)
+	temp, err := validateArg("", arguments, 0, reflect.String)
 	if err != nil {
 		return nil, err
 	}
 
-	layout := layout_.String()
+	layout := temp.String()
 	if val, ok := layouts[layout]; ok {
 		layout = val
 	}
 
-	timestamp_1, err := validateArg("", arguments, 1, reflect.String)
+	ts1, err := validateArg("", arguments, 1, reflect.String)
 	if err != nil {
 		return nil, err
 	}
 
-	timestamp_2, err := validateArg("", arguments, 2, reflect.String)
+	ts2, err := validateArg("", arguments, 2, reflect.String)
 	if err != nil {
 		return nil, err
 	}
 
-	timestamp1 := timestamp_1.String()
-	timestamp2 := timestamp_2.String()
-
-	t1, err := time.Parse(layout, timestamp1)
+	t1, err := time.Parse(layout, ts1.String())
 	if err != nil {
 		return nil, err
 	}
 
 	t2 := time.Now()
 
-	if timestamp2 != "" {
-		t2, err = time.Parse(layout, timestamp2)
+	if ts2.String() != "" {
+		t2, err = time.Parse(layout, ts2.String())
 
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if err != nil {
-		return nil, err
 	}
 
 	return t2.Sub(t1).String(), nil

--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -57,7 +57,6 @@ const zeroDivisionError = errorPrefix + "Zero divisor passed"
 const nonIntModuloError = errorPrefix + "Non-integer argument(s) passed for modulo"
 
 var layouts = map[string]string{
-	"Layout":      time.Layout,
 	"ANSIC":       time.ANSIC,
 	"UnixDate":    time.UnixDate,
 	"RubyDate":    time.RubyDate,

--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -235,6 +235,7 @@ func getFunctions() []*gojmespath.FunctionEntry {
 			Arguments: []ArgSpec{
 				{Types: []JpType{JpString}},
 				{Types: []JpType{JpString}},
+				{Types: []JpType{JpString}},
 			},
 			Handler: jpTimeSince,
 		},
@@ -590,19 +591,39 @@ func jpTimeSince(arguments []interface{}) (interface{}, error) {
 		layout = val
 	}
 
-	timestamp_, err := validateArg("", arguments, 1, reflect.String)
+	timestamp_1, err := validateArg("", arguments, 1, reflect.String)
 	if err != nil {
 		return nil, err
 	}
 
-	timestamp := timestamp_.String()
-
-	t1, err := time.Parse(layout, timestamp)
+	timestamp_2, err := validateArg("", arguments, 2, reflect.String)
 	if err != nil {
 		return nil, err
 	}
 
-	return time.Since(t1).String(), nil
+	timestamp1 := timestamp_1.String()
+	timestamp2 := timestamp_2.String()
+
+	t1, err := time.Parse(layout, timestamp1)
+	if err != nil {
+		return nil, err
+	}
+
+	t2 := time.Now()
+
+	if timestamp2 != "" {
+		t2, err = time.Parse(layout, timestamp2)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return t2.Sub(t1).String(), nil
 }
 
 // InterfaceToString casts an interface to a string type

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -506,23 +506,32 @@ func Test_Base64Decode_Secret(t *testing.T) {
 }
 
 func Test_TimeSince(t *testing.T) {
-	jp, err := New("time_since('RFC822', '02 Jan 21 15:04 MST', '10 Jan 21 03:14 MST')")
-	assert.NilError(t, err)
+	testCases := []struct {
+		test           string
+		expectedResult string
+	}{
+		{
+			test:           "time_since('RFC822', '02 Jan 21 15:04 MST', '10 Jan 21 03:14 MST')",
+			expectedResult: "180h10m0s",
+		},
+		{
+			test:           "time_since('UnixDate', 'Mon Jan 02 15:04:05 MST 2021', 'Mon Jan 10 03:14:16 MST 2021')",
+			expectedResult: "180h10m11s",
+		},
+	}
 
-	result, err := jp.Search("")
-	assert.NilError(t, err)
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			query, err := New(tc.test)
+			assert.NilError(t, err)
 
-	diff, ok := result.(string)
-	assert.Assert(t, ok)
-	assert.Equal(t, diff, "180h10m0s")
+			res, err := query.Search("")
+			assert.NilError(t, err)
 
-	jp, err = New("time_since('UnixDate', 'Mon Jan 02 15:04:05 MST 2021', 'Mon Jan 10 03:14:16 MST 2021')")
-	assert.NilError(t, err)
+			result, ok := res.(string)
+			assert.Assert(t, ok)
 
-	result, err = jp.Search("")
-	assert.NilError(t, err)
-
-	diff, ok = result.(string)
-	assert.Assert(t, ok)
-	assert.Equal(t, diff, "180h10m11s")
+			assert.Equal(t, result, tc.expectedResult)
+		})
+	}
 }

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -511,11 +511,11 @@ func Test_TimeSince(t *testing.T) {
 		expectedResult string
 	}{
 		{
-			test:           "time_since('RFC822', '02 Jan 21 15:04 MST', '10 Jan 21 03:14 MST')",
+			test:           "time_since('', '2021-01-02T15:04:05-07:00', '2021-01-10T03:14:05-07:00')",
 			expectedResult: "180h10m0s",
 		},
 		{
-			test:           "time_since('UnixDate', 'Mon Jan 02 15:04:05 MST 2021', 'Mon Jan 10 03:14:16 MST 2021')",
+			test:           "time_since('Mon Jan _2 15:04:05 MST 2006', 'Mon Jan 02 15:04:05 MST 2021', 'Mon Jan 10 03:14:16 MST 2021')",
 			expectedResult: "180h10m11s",
 		},
 	}

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -504,3 +504,25 @@ func Test_Base64Decode_Secret(t *testing.T) {
 	assert.Assert(t, ok)
 	assert.Equal(t, string(result), "Hello, world!")
 }
+
+func Test_TimeSince(t *testing.T) {
+	jp, err := New("time_since('RFC822', '02 Jan 21 15:04 MST', '10 Jan 21 03:14 MST')")
+	assert.NilError(t, err)
+
+	result, err := jp.Search("")
+	assert.NilError(t, err)
+
+	diff, ok := result.(string)
+	assert.Assert(t, ok)
+	assert.Equal(t, diff, "180h10m0s")
+
+	jp, err = New("time_since('UnixDate', 'Mon Jan 02 15:04:05 MST 2021', 'Mon Jan 10 03:14:16 MST 2021')")
+	assert.NilError(t, err)
+
+	result, err = jp.Search("")
+	assert.NilError(t, err)
+
+	diff, ok = result.(string)
+	assert.Assert(t, ok)
+	assert.Equal(t, diff, "180h10m11s")
+}


### PR DESCRIPTION
Signed-off-by: Kumar Mallikarjuna <kumarmallikarjuna1@gmail.com>

cc - @JimBugwadia 

## Related issue
Closes #2606 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.6.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
- Add `time_since('<layout>', '<time1>', '<time2>')` JMESPath function
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Policy
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: test-policy
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: test-rule
    match:
      resources:
        kinds:
          - Pod
    validate:
      message: "Denied"
      deny:
        conditions:
        - key: "{{ time_since('', '2021-01-02T15:04:05-07:00', '2021-01-10T03:14:05-07:00') }}"
          operator: GreaterThan
          value: 48h
```

Pod
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: myapp
spec:
  containers:
    - name: my-container
      image: nginx
```

Pod is not created.

Policy
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: test-policy
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: test-rule
    match:
      resources:
        kinds:
          - Pod
    validate:
      message: "Denied"
      deny:
        conditions:
        - key: "{{ time_since('Mon Jan _2 15:04:05 MST 2006', 'Mon Jan 02 15:04:05 MST 2021', '') }}"
          operator: GreaterThan
          value: 48h
```

Pod
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: myapp
spec:
  containers:
    - name: my-container
      image: nginx
```

Pod is not created.
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments
- Can we instead have `time_since('<layout>', '<time1>', '<time2>')` which returns the `<time2>-<time1>` and when `<time2>` is an empty string, the current time is used instead?
- How to add tests for this since currently, we are using `time.Now()`?
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
