### PR TITLE
Add CODEOWNERS file for maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Areas of code where @marcelmue always wants to be a reviewer/notified.
+/pkg/webhooks @marcelmue
+/pkg/policy/mutate @marcelmue
+/pkg/engine @marcelmue


### PR DESCRIPTION
Signed-off-by: Marcel Mueller <marcel.mueller1@rwth-aachen.de>

## Proposed Changes

We discussed this briefly during the last contributors meeting. The goal is to ensure that maintainers get marked as reviewers in areas of code they are interesting in.

Documentation for CODEOWNERS: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
