### PR TITLE
Support for modifying values of variables from Kubernetes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ $(GO_ACC):
 # go-acc merges the result for pks so that it be used by
 # go tool cover for reporting
 
-test: test-clean test-unit  test-cmd
+test: test-clean test-unit test-e2e test-cmd
 
 test-clean:
 	@echo "	cleaning test cache"

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ $(GO_ACC):
 # go-acc merges the result for pks so that it be used by
 # go tool cover for reporting
 
-test: test-clean test-unit test-e2e test-cmd
+test: test-clean test-unit  test-cmd
 
 test-clean:
 	@echo "	cleaning test cache"

--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -31,7 +31,7 @@ var RegexEscpReferences = regexp.MustCompile(`\\\$\(.[^\ ]*\)`)
 
 var regexVariableInit = regexp.MustCompile(`^\{\{[^{}]*\}\}`)
 
-var regexCustomValueOperatorAndParam = regexp.MustCompile(`[/|\+|\-|\*]\s*[0-9]+`)
+var regexCustomValueOperatorAndParam = regexp.MustCompile(`\s+[/|\+|\-|\*]\s+[0-9]+`)
 
 var regexCustomValueOperator = regexp.MustCompile(`[/|\+|\-|\*]`)
 
@@ -611,6 +611,10 @@ func getCustomOptionsIfNeeded(v string) (variable, op string, num float64) {
 }
 
 func processValueIfNeeded(data interface{}, variable, operator string, operatorNum float64) (interface{}, bool) {
+	if operator == "" || operatorNum <= 0 {
+		return data, false
+	}
+
 	target, ok := data.(string)
 	if !ok {
 		return data, false

--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -591,7 +591,7 @@ func processValueIfNeeded(log logr.Logger, data interface{}, originalValue, vari
 	var regexCustomValueOperator = regexp.MustCompile(`(?:add|subtract|multiply|divide|modulo)\(\S\d+(\.?\d*)[a-zA-Z]*\S\s*,\s*\S\d+(\.?\d*)\S\)`)
 
 	targetFormulas := regexCustomValueOperator.FindAllString(originalValue, -1)
-	if len(targetFormulas) < 1 {
+	if len(targetFormulas) != 1 {
 		return originalValue, false
 	}
 

--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -35,7 +35,7 @@ var regexCustomValueOperatorAndParam = regexp.MustCompile(`\s+[/|\+|\-|\*]\s+[0-
 
 var regexCustomValueOperator = regexp.MustCompile(`[/|\+|\-|\*]`)
 
-var regexCustomValueTarget = regexp.MustCompile(`\d+(\.?\d+)`)
+var regexCustomValueTarget = regexp.MustCompile(`\d+(\.?\d*)`)
 
 // IsVariable returns true if the element contains a 'valid' variable {{}}
 func IsVariable(value string) bool {

--- a/pkg/engine/variables/vars_test.go
+++ b/pkg/engine/variables/vars_test.go
@@ -1169,7 +1169,7 @@ func Test_modifyValueSuccess(t *testing.T) {
                     "name":"nginx",
                     "resources":{
                         "limits":{
-                            "cpu": "1",
+                            "cpu": "1m",
                             "memory":"2Mi"
                         },
                         "requests":{
@@ -1183,16 +1183,13 @@ func Test_modifyValueSuccess(t *testing.T) {
     }`)
 	assert.Assert(t, ctx.AddResource(resourceRaw))
 
-	var pattern interface{}
 	patternRaw := [][]byte{
-		[]byte(`"{{ request.object.spec.containers[0].resources.limits.cpu / 2 }}"`),
-		[]byte(`"{{ request.object.spec.containers[0].resources.limits.memory / 2 }}"`),
-		[]byte(`"{{ request.object.spec.containers[0].resources.requests.cpu / 2 }}"`),
-		[]byte(`"{{ request.object.spec.containers[0].resources.requests.memory / 2 }}"`),
+		[]byte("divide(`{{ request.object.spec.containers[0].resources.requests.cpu }}`, `2`)  divide(`{{ request.object.spec.containers[0].resources.requests.memory }}`, `2`)"),
+		[]byte("divide(`{{ request.object.spec.containers[0].resources.requests.memory }}`, `2`)"),
+		[]byte("divide(`{{ request.object.spec.containers[0].resources.limits.cpu }}`, `2`)"),
+		[]byte("divide(`{{ request.object.spec.containers[0].resources.limits.memory }}`, `2`)"),
 	}
 	for _, raw := range patternRaw {
-		assert.Assert(t, json.Unmarshal(raw, &pattern))
-
 		action := substituteVariablesIfAny(log.Log, ctx, DefaultVariableResolver)
 		results, err := action(&ju.ActionData{
 			Document: nil,

--- a/pkg/engine/variables/vars_test.go
+++ b/pkg/engine/variables/vars_test.go
@@ -1186,7 +1186,6 @@ func Test_SubstituteSuccess1(t *testing.T) {
 	assert.Assert(t, ctx.AddResource(resourceRaw))
 
 	var pattern interface{}
-	//patternRaw := []byte(`"{{request.object.metadata.annotations.test * 12}}"`)
 	patternRaw := []byte(`"{{ request.object.spec.containers[0].resources.requests.memory / 2 }}"`)
 	assert.Assert(t, json.Unmarshal(patternRaw, &pattern))
 


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Modify cpu requests according to cpu limits, that is  a very useful feature. For example, we need to strictly control the CPU oversold ratio of the business.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

- ClusterPolicy for modify cpu requests according to cpu limits
```
apiVersion : kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: mutate-modify-requests-limits
spec:
  rules:
  - name: mutate-modify-requests-limits
    match:
      resources:
        kinds:
        - Pod
    exclude:
      resources:
        namespaces:
        - kube-system
        - miks
    mutate:
      foreach:
      - list: "request.object.spec.containers"
        patchStrategicMerge:
          spec:
            containers:
            - name: "{{ element.name }}"
              resources:
                requests:
                  cpu: "divide(`{{ element.resources.limits.cpu }}`, `2`)"
```
- Original POD configuration
```
apiVersion: v1
kind: Pod
metadata:
  name: kyverno-test
  namespace: default
spec:
  containers:
  - name: nginx
    image: nginx:1.19
    command: ["/bin/bash", "-c", "sleep INF"]
    resources:
      requests:
        memory: "128Mi"
        cpu: "2000m"
      limits:
        memory: "128Mi"
        cpu: "500m"
```
- The result we want
```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{},"name":"kyverno-test","namespace":"default"},"spec":{"containers":[{"command":["/bin/bash","-c","sleep INF"],"image":"nginx:1.19","name":"nginx","resources":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"2000m","memory":"128Mi"}}}]}}
    lxcfs-admission-webhook.aliyun.com/status: mutated
    policies.kyverno.io/last-applied-patches: |
      mutate-update-requests-limits.mutate-update-requests-limits.kyverno.io: replaced /spec/containers/0/resources/requests/cpu
  creationTimestamp: "2021-11-08T12:39:54Z"
  name: kyverno-test
  namespace: default
  resourceVersion: "61763548"
  uid: c8627eed-6746-4360-9f8d-fe70ef7cf840
spec:
  containers:
  - command:
    - /bin/bash
    - -c
    - sleep INF
    image: nginx:1.19
    imagePullPolicy: IfNotPresent
    name: nginx
    resources:
      limits:
        cpu: 500m
        memory: 128Mi
      requests:
        cpu: 250m
        memory: 128Mi
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
