### PR TITLE
Fixes in new operators

### DIFF
--- a/pkg/engine/variables/evaluate_test.go
+++ b/pkg/engine/variables/evaluate_test.go
@@ -291,6 +291,8 @@ func TestEvaluate(t *testing.T) {
 		{kyverno.Condition{Key: 5.5, Operator: kyverno.AllNotIn, Value: []interface{}{1, 1.5, 2, 3}}, true},
 		{kyverno.Condition{Key: "5", Operator: kyverno.AllNotIn, Value: []interface{}{"1", "2", "3"}}, true},
 		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "4.4.4.4"}, Operator: kyverno.AllNotIn, Value: []interface{}{"1.1.1.1", "2.2.2.2", "3.3.3.3"}}, true},
+		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "4.4.4.4"}, Operator: kyverno.AllNotIn, Value: []interface{}{"1.1.1.1", "2.2.2.2", "3.3.3.3", "1.1.1.1"}}, true},
+		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "4.4.4.4", "1.1.1.1"}, Operator: kyverno.AllNotIn, Value: []interface{}{"1.1.1.1", "2.2.2.2", "3.3.3.3", "1.1.1.1", "4.4.4.4"}}, false},
 		{kyverno.Condition{Key: []interface{}{"5.5.5.5", "4.4.4.4"}, Operator: kyverno.AllNotIn, Value: []interface{}{"1.1.1.1", "2.2.2.2", "3.3.3.3"}}, true},
 		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "4.4.4.4"}, Operator: kyverno.AllNotIn, Value: "2.2.2.2"}, true},
 

--- a/pkg/engine/variables/evaluate_test.go
+++ b/pkg/engine/variables/evaluate_test.go
@@ -290,7 +290,7 @@ func TestEvaluate(t *testing.T) {
 		{kyverno.Condition{Key: 5, Operator: kyverno.AllNotIn, Value: []interface{}{1, 2, 3}}, true},
 		{kyverno.Condition{Key: 5.5, Operator: kyverno.AllNotIn, Value: []interface{}{1, 1.5, 2, 3}}, true},
 		{kyverno.Condition{Key: "5", Operator: kyverno.AllNotIn, Value: []interface{}{"1", "2", "3"}}, true},
-		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "4.4.4.4"}, Operator: kyverno.AllNotIn, Value: []interface{}{"1.1.1.1", "2.2.2.2", "3.3.3.3"}}, false},
+		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "4.4.4.4"}, Operator: kyverno.AllNotIn, Value: []interface{}{"1.1.1.1", "2.2.2.2", "3.3.3.3"}}, true},
 		{kyverno.Condition{Key: []interface{}{"5.5.5.5", "4.4.4.4"}, Operator: kyverno.AllNotIn, Value: []interface{}{"1.1.1.1", "2.2.2.2", "3.3.3.3"}}, true},
 		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "4.4.4.4"}, Operator: kyverno.AllNotIn, Value: "2.2.2.2"}, true},
 

--- a/pkg/engine/variables/evaluate_test.go
+++ b/pkg/engine/variables/evaluate_test.go
@@ -265,6 +265,7 @@ func TestEvaluate(t *testing.T) {
 
 		// Any In
 		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "5.5.5.5"}, Operator: kyverno.AnyIn, Value: []interface{}{"1.1.1.1", "2.2.2.2", "3.3.3.3"}}, true},
+		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "5.5.5.5"}, Operator: kyverno.AnyIn, Value: "1.1.1.1"}, true},
 		{kyverno.Condition{Key: []interface{}{"4.4.4.4", "5.5.5.5"}, Operator: kyverno.AnyIn, Value: []interface{}{"1.1.1.1", "2.2.2.2", "3.3.3.3"}}, false},
 		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "5.5.5.5"}, Operator: kyverno.AnyIn, Value: []interface{}{"1.1.1.1"}}, true},
 		{kyverno.Condition{Key: []interface{}{1, 2}, Operator: kyverno.AnyIn, Value: []interface{}{1, 2, 3, 4}}, true},
@@ -279,6 +280,7 @@ func TestEvaluate(t *testing.T) {
 		{kyverno.Condition{Key: []interface{}{1, 2}, Operator: kyverno.AllIn, Value: []interface{}{1, 2, 3, 4}}, true},
 		{kyverno.Condition{Key: []interface{}{1, 5}, Operator: kyverno.AllIn, Value: []interface{}{1, 2, 3, 4}}, false},
 		{kyverno.Condition{Key: []interface{}{5}, Operator: kyverno.AllIn, Value: []interface{}{1, 2, 3, 4}}, false},
+		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "5.5.5.5"}, Operator: kyverno.AllIn, Value: "5.5.5.5"}, false},
 
 		// All Not In
 		{kyverno.Condition{Key: 1, Operator: kyverno.AllNotIn, Value: []interface{}{1, 2, 3}}, false},
@@ -290,6 +292,7 @@ func TestEvaluate(t *testing.T) {
 		{kyverno.Condition{Key: "5", Operator: kyverno.AllNotIn, Value: []interface{}{"1", "2", "3"}}, true},
 		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "4.4.4.4"}, Operator: kyverno.AllNotIn, Value: []interface{}{"1.1.1.1", "2.2.2.2", "3.3.3.3"}}, false},
 		{kyverno.Condition{Key: []interface{}{"5.5.5.5", "4.4.4.4"}, Operator: kyverno.AllNotIn, Value: []interface{}{"1.1.1.1", "2.2.2.2", "3.3.3.3"}}, true},
+		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "4.4.4.4"}, Operator: kyverno.AllNotIn, Value: "2.2.2.2"}, true},
 
 		// Any Not In
 		{kyverno.Condition{Key: 1, Operator: kyverno.AnyNotIn, Value: []interface{}{1, 2, 3}}, false},
@@ -300,6 +303,7 @@ func TestEvaluate(t *testing.T) {
 		{kyverno.Condition{Key: 5.5, Operator: kyverno.AnyNotIn, Value: []interface{}{1, 1.5, 2, 3}}, true},
 		{kyverno.Condition{Key: "5", Operator: kyverno.AnyNotIn, Value: []interface{}{"1", "2", "3"}}, true},
 		{kyverno.Condition{Key: []interface{}{"1.1.1.1", "4.4.4.4"}, Operator: kyverno.AnyNotIn, Value: []interface{}{"1.1.1.1", "2.2.2.2", "3.3.3.3"}}, true},
+		{kyverno.Condition{Key: []interface{}{"5.5.5.5", "4.4.4.4"}, Operator: kyverno.AnyNotIn, Value: "4.4.4.4"}, true},
 		{kyverno.Condition{Key: []interface{}{"5.5.5.5", "4.4.4.4"}, Operator: kyverno.AnyNotIn, Value: []interface{}{"1.1.1.1", "2.2.2.2", "3.3.3.3"}}, true},
 	}
 

--- a/pkg/engine/variables/operator/allin.go
+++ b/pkg/engine/variables/operator/allin.go
@@ -84,9 +84,13 @@ func allSetExistsInArray(key []string, value interface{}, log logr.Logger, allNo
 		}
 
 		var arr []string
-		if err := json.Unmarshal([]byte(valuesAvailable), &arr); err != nil {
-			log.Error(err, "failed to unmarshal value to JSON string array", "key", key, "value", value)
-			return true, false
+		if json.Valid([]byte(valuesAvailable)) {
+			if err := json.Unmarshal([]byte(valuesAvailable), &arr); err != nil {
+				log.Error(err, "failed to unmarshal value to JSON string array", "key", key, "value", value)
+				return true, false
+			}
+		} else {
+			arr = append(arr, valuesAvailable)
 		}
 		if allNotIn {
 			return false, isAllNotIn(key, arr)

--- a/pkg/engine/variables/operator/allin.go
+++ b/pkg/engine/variables/operator/allin.go
@@ -124,10 +124,11 @@ func isAllNotIn(key []string, value []string) bool {
 		for _, valValue := range value {
 			if wildcard.Match(valKey, valValue) {
 				found++
+				break
 			}
 		}
 	}
-	return !(found == len(key))
+	return found != len(key)
 
 }
 

--- a/pkg/engine/variables/operator/allin.go
+++ b/pkg/engine/variables/operator/allin.go
@@ -119,14 +119,16 @@ func isAllIn(key []string, value []string) bool {
 
 // isAllNotIn checks if all the values in S1 are not in S2
 func isAllNotIn(key []string, value []string) bool {
+	found := 0
 	for _, valKey := range key {
 		for _, valValue := range value {
 			if wildcard.Match(valKey, valValue) {
-				return false
+				found++
 			}
 		}
 	}
-	return true
+	return !(found == len(key))
+
 }
 
 func (allin AllInHandler) validateValueWithBoolPattern(_ bool, _ interface{}) bool {

--- a/pkg/engine/variables/operator/anyin.go
+++ b/pkg/engine/variables/operator/anyin.go
@@ -86,9 +86,13 @@ func anySetExistsInArray(key []string, value interface{}, log logr.Logger, anyNo
 		}
 
 		var arr []string
-		if err := json.Unmarshal([]byte(valuesAvailable), &arr); err != nil {
-			log.Error(err, "failed to unmarshal value to JSON string array", "key", key, "value", value)
-			return true, false
+		if json.Valid([]byte(valuesAvailable)) {
+			if err := json.Unmarshal([]byte(valuesAvailable), &arr); err != nil {
+				log.Error(err, "failed to unmarshal value to JSON string array", "key", key, "value", value)
+				return true, false
+			}
+		} else {
+			arr = append(arr, valuesAvailable)
 		}
 		if anyNotIn {
 			return false, isAnyNotIn(key, arr)

--- a/pkg/engine/variables/operator/anyin.go
+++ b/pkg/engine/variables/operator/anyin.go
@@ -117,7 +117,7 @@ func isAnyIn(key []string, value []string) bool {
 	return false
 }
 
-// isAllNotIn checks if all the values in S1 are not in S2
+// isAnyNotIn checks if any of the values in S1 are not in S2
 func isAnyNotIn(key []string, value []string) bool {
 	found := 0
 	for _, valKey := range key {

--- a/pkg/engine/variables/operator/anynotin.go
+++ b/pkg/engine/variables/operator/anynotin.go
@@ -9,7 +9,7 @@ import (
 
 //NewAnyNotInHandler returns handler to manage AnyNotIn operations
 func NewAnyNotInHandler(log logr.Logger, ctx context.EvalInterface) OperatorHandler {
-	return NotInHandler{
+	return AnyNotInHandler{
 		ctx: ctx,
 		log: log,
 	}


### PR DESCRIPTION
## Related issue
From the conversation in the [PR](https://github.com/kyverno/kyverno/pull/2543#issuecomment-954322817)
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.6.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
> /kind cleanup
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
The operators can now accept multiple key items and single string value item. AllNotIn operator is now corrected.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
```
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  # initContainers:
  # - name: jimmy
  #   image: defdasdabian:923
  #   command: ["/bin/sh", "-c", "sleep infinity"]
  #   securityContext:
  #     capabilities:
  #       drop:
  #       - XXXNET_RAWYYY
  #       - SETUID
  containers:
  - name: test
    image: defdasdabian:923
    command: ["/bin/sh", "-c", "sleep infinity"]
    securityContext:
      capabilities:
        drop:
        - orange
        # - green
        - blue
        - green
  # - name: asdf
  #   image: defdasdabian:923
  #   command: ["/bin/sh", "-c", "sleep infinity"]
  #   securityContext:
  #     capabilities:
  #       drop:
  #       - CAP_SOMETHING

```
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: drop-cap-net-raw
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: drop-cap-net-raw
    match:
      resources:
        kinds:
        - Pod
    validate:
      deny:
        conditions:
          any:
          - key: "{{ request.object.spec.[containers, initContainers][].securityContext.capabilities.drop[] }}"
            operator: AnyNotIn
            value: green
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
