### PR TITLE
Dynamically create and use caches for Policy API calls

### DIFF
--- a/api/kyverno/v1/utils.go
+++ b/api/kyverno/v1/utils.go
@@ -102,6 +102,48 @@ func (r Rule) HasGenerate() bool {
 	return !reflect.DeepEqual(r.Generation, Generation{})
 }
 
+func (p *ClusterPolicy) HasFinalizer(finalizer string) bool {
+	for _, f := range p.GetFinalizers() {
+		if f == finalizer {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *ClusterPolicy) RemoveFinalizer(finalizer string) {
+	for i, f := range p.GetFinalizers() {
+		if f == finalizer {
+			p.Finalizers[i] = p.Finalizers[len(p.Finalizers)-1]
+			p.Finalizers = p.Finalizers[:len(p.Finalizers)-1]
+			return
+		}
+	}
+}
+
+func (np *Policy) HasFinalizer(finalizer string) bool {
+	return (*ClusterPolicy)(np).HasFinalizer(finalizer)
+}
+
+func (np *Policy) RemoveFinalizer(finalizer string) {
+	(*ClusterPolicy)(np).RemoveFinalizer(finalizer)
+}
+
+func (p *ClusterPolicy) HasAPICall() bool {
+	for _, rule := range p.Spec.Rules {
+		for _, entry := range rule.Context {
+			if entry.APICall != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (np *Policy) HasAPICall() bool {
+	return (*ClusterPolicy)(np).HasAPICall()
+}
+
 // MatchKinds returns a slice of all kinds to match
 func (r Rule) MatchKinds() []string {
 	matchKinds := r.MatchResources.ResourceDescription.Kinds

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,8 @@ const (
 	PolicyMutatingWebhookConfigurationDebugName = "kyverno-policy-mutating-webhook-cfg-debug"
 	//PolicyMutatingWebhookName default policy mutating webhook name
 	PolicyMutatingWebhookName = "mutate-policy.kyverno.svc"
+	//PilcyConfigManagerFinalizer finalizer key for the webhook configmanager
+	PolicyConfigManagerFinalizer = "finalizer.kyverno.io/configmanager"
 
 	// Due to kubernetes issue, we must use next literal constants instead of deployment TypeMeta fields
 	// Issue: https://github.com/kubernetes/kubernetes/pull/63972

--- a/pkg/engine/apiPath.go
+++ b/pkg/engine/apiPath.go
@@ -83,7 +83,7 @@ func NewAPIPath(path string) (*APIPath, error) {
 		return &APIPath{
 			Root:         paths[0],
 			Group:        paths[1],
-			Version:      paths[1] + "/" + paths[2],
+			Version:      paths[2],
 			ResourceType: paths[3],
 		}, nil
 	}
@@ -93,7 +93,7 @@ func NewAPIPath(path string) (*APIPath, error) {
 		return &APIPath{
 			Root:         paths[0],
 			Group:        paths[1],
-			Version:      paths[1] + "/" + paths[2],
+			Version:      paths[2],
 			ResourceType: paths[3],
 			Name:         paths[4],
 		}, nil
@@ -104,7 +104,7 @@ func NewAPIPath(path string) (*APIPath, error) {
 		return &APIPath{
 			Root:         paths[0],
 			Group:        paths[1],
-			Version:      paths[1] + "/" + paths[2],
+			Version:      paths[2],
 			Namespace:    paths[4],
 			ResourceType: paths[5],
 		}, nil
@@ -115,7 +115,7 @@ func NewAPIPath(path string) (*APIPath, error) {
 		return &APIPath{
 			Root:         paths[0],
 			Group:        paths[1],
-			Version:      paths[1] + "/" + paths[2],
+			Version:      paths[2],
 			Namespace:    paths[4],
 			ResourceType: paths[5],
 			Name:         paths[6],

--- a/pkg/engine/apiPath.go
+++ b/pkg/engine/apiPath.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"fmt"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type APIPath struct {
@@ -38,7 +40,7 @@ func NewAPIPath(path string) (*APIPath, error) {
 		if len(paths) == 3 {
 			return &APIPath{
 				Root:         paths[0],
-				Group:        paths[1],
+				Version:      paths[1],
 				ResourceType: paths[2],
 			}, nil
 		}
@@ -47,7 +49,7 @@ func NewAPIPath(path string) (*APIPath, error) {
 		if len(paths) == 4 {
 			return &APIPath{
 				Root:         paths[0],
-				Group:        paths[1],
+				Version:      paths[1],
 				ResourceType: paths[2],
 				Name:         paths[3],
 			}, nil
@@ -57,7 +59,7 @@ func NewAPIPath(path string) (*APIPath, error) {
 		if len(paths) == 5 {
 			return &APIPath{
 				Root:         paths[0],
-				Group:        paths[1],
+				Version:      paths[1],
 				Namespace:    paths[3],
 				ResourceType: paths[4],
 			}, nil
@@ -66,7 +68,7 @@ func NewAPIPath(path string) (*APIPath, error) {
 		if len(paths) == 6 {
 			return &APIPath{
 				Root:         paths[0],
-				Group:        paths[1],
+				Version:      paths[1],
 				Namespace:    paths[3],
 				ResourceType: paths[4],
 				Name:         paths[5],
@@ -123,6 +125,21 @@ func NewAPIPath(path string) (*APIPath, error) {
 	return nil, fmt.Errorf("invalid API path %s", path)
 }
 
+func (a *APIPath) ToGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    a.Group,
+		Version:  a.Version,
+		Resource: a.ResourceType,
+	}
+}
+
+func (a *APIPath) ToGVRString() string {
+	if a.Group == "" {
+		return fmt.Sprintf("%s/%s", a.Version, a.ResourceType)
+	}
+	return fmt.Sprintf("%s/%s/%s", a.Group, a.Version, a.ResourceType)
+}
+
 func (a *APIPath) String() string {
 	var paths []string
 	if a.Root == "apis" {
@@ -142,15 +159,15 @@ func (a *APIPath) String() string {
 	} else {
 		if a.Namespace != "" {
 			if a.Name == "" {
-				paths = []string{a.Root, a.Group, "namespaces", a.Namespace, a.ResourceType}
+				paths = []string{a.Root, a.Version, "namespaces", a.Namespace, a.ResourceType}
 			} else {
-				paths = []string{a.Root, a.Group, "namespaces", a.Namespace, a.ResourceType, a.Name}
+				paths = []string{a.Root, a.Version, "namespaces", a.Namespace, a.ResourceType, a.Name}
 			}
 		} else {
 			if a.Name != "" {
-				paths = []string{a.Root, a.Group, a.ResourceType, a.Name}
+				paths = []string{a.Root, a.Version, a.ResourceType, a.Name}
 			} else {
-				paths = []string{a.Root, a.Group, a.ResourceType}
+				paths = []string{a.Root, a.Version, a.ResourceType}
 			}
 		}
 	}

--- a/pkg/engine/jsonContext.go
+++ b/pkg/engine/jsonContext.go
@@ -168,8 +168,9 @@ func loadResourceList(logger logr.Logger, ctx *PolicyContext, p *APIPath) ([]byt
 	}
 
 	if cache, ok := ctx.ResourceCache.GetGVRCache(p.ToGVRString()); ok {
-		logger.V(4).Info("Loading resource list from cache", "gvr", p.ToGVRString())
-		rList, err := cache.Lister().List(labels.Everything())
+		logger.V(4).Info("Loading resource list from cache", "gvr", p.ToGVRString(), "namespace", p.Namespace)
+
+		rList, err := cache.NamespacedLister(p.Namespace).List(labels.Everything())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/event/controller.go
+++ b/pkg/event/controller.go
@@ -232,7 +232,7 @@ func (gen *Generator) syncHandler(key Info) error {
 func (gen *Generator) getResource(key Info) (obj *unstructured.Unstructured, err error) {
 	lister, ok := gen.resCache.GetGVRCache(key.Kind)
 	if !ok {
-		if lister, err = gen.resCache.CreateGVKInformer(key.Kind); err != nil {
+		if lister, err = gen.resCache.CreateGVKInformer(key.Kind, eventsWorkerUID); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/event/util.go
+++ b/pkg/event/util.go
@@ -4,6 +4,8 @@ const eventWorkQueueName = "kyverno-events"
 
 const workQueueRetryLimit = 10
 
+const eventsWorkerUID string = "events-worker"
+
 //Info defines the event details
 type Info struct {
 	Kind      string

--- a/pkg/policy/common.go
+++ b/pkg/policy/common.go
@@ -17,6 +17,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const (
+	policyWorkerUID string = "policy-worker"
+)
+
 func buildPolicyLabel(policyName string) (labels.Selector, error) {
 	policyLabelmap := map[string]string{"policy": policyName}
 	//NOt using a field selector, as the match function will have to cast the runtime.object

--- a/pkg/policy/existing.go
+++ b/pkg/policy/existing.go
@@ -37,7 +37,7 @@ func (pc *PolicyController) processExistingResources(policy *kyverno.ClusterPoli
 func (pc *PolicyController) registerResource(gvk string) (err error) {
 	genericCache, ok := pc.resCache.GetGVRCache(gvk)
 	if !ok {
-		if genericCache, err = pc.resCache.CreateGVKInformer(gvk); err != nil {
+		if genericCache, err = pc.resCache.CreateGVKInformer(gvk, policyWorkerUID); err != nil {
 			return fmt.Errorf("failed to create informer for %s: %v", gvk, err)
 		}
 	}

--- a/pkg/resourcecache/common.go
+++ b/pkg/resourcecache/common.go
@@ -1,0 +1,5 @@
+package resourcecache
+
+const (
+	rescacheWorkerUID string = "resourcecache-worker"
+)

--- a/pkg/resourcecache/main.go
+++ b/pkg/resourcecache/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-logr/logr"
 	dclient "github.com/kyverno/kyverno/pkg/dclient"
 	cmap "github.com/orcaman/concurrent-map"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 )
 
@@ -16,9 +17,11 @@ import (
 // - kind
 type ResourceCache interface {
 	CreateInformers(gvks ...string) []error
-	CreateGVKInformer(gvk string) (GenericCache, error)
-	StopResourceInformer(gvk string)
+	CreateGVKInformer(gvk string, workerUID string) (GenericCache, error)
+	CreateGVRInformer(gvr schema.GroupVersionResource, namespaced bool, cacheKey string, workerUID string) (GenericCache, error)
+	StopResourceInformer(gvk string, workerUID string)
 	GetGVRCache(gvk string) (GenericCache, bool)
+	GetGVRCachesForWorker(workerUID string) map[string]GenericCache
 }
 
 type resourceCache struct {

--- a/pkg/resourcecache/resourcecache.go
+++ b/pkg/resourcecache/resourcecache.go
@@ -1,16 +1,19 @@
 package resourcecache
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/kyverno/kyverno/pkg/common"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // CreateInformers ...
 func (resc *resourceCache) CreateInformers(resources ...string) []error {
 	var errs []error
 	for _, resource := range resources {
-		if _, err := resc.CreateGVKInformer(resource); err != nil {
+		if _, err := resc.CreateGVKInformer(resource, rescacheWorkerUID); err != nil {
 			errs = append(errs, fmt.Errorf("failed to create informer for %s: %v", resource, err))
 		}
 	}
@@ -18,13 +21,17 @@ func (resc *resourceCache) CreateInformers(resources ...string) []error {
 }
 
 // StopResourceInformer - delete the given resource information from ResourceCache and stop watching for the given resource
-func (resc *resourceCache) StopResourceInformer(resource string) {
+func (resc *resourceCache) StopResourceInformer(resource string, workerUID string) {
 	res, ok := resc.GetGVRCache(resource)
 	if ok {
-		resc.gvrCache.Remove(resource)
-		resc.log.V(4).Info("deleted resource from gvr cache", "name", resource)
-		res.StopInformer()
-		resc.log.V(4).Info("closed informer for resource", "name", resource)
+		res.RemoveCacheWorker(workerUID)
+		resc.log.V(4).Info("Stopping cache informer", "resource", resource, "workerUID", workerUID, "cache", res, "workerCount", len(res.GetCacheWorkers()))
+		if len(res.GetCacheWorkers()) == 0 {
+			resc.gvrCache.Remove(resource)
+			resc.log.V(4).Info("Deleted resource from gvr cache", "name", resource)
+			res.StopInformer()
+			resc.log.V(4).Info("Closed informer for resource", "name", resource)
+		}
 	}
 }
 
@@ -38,28 +45,56 @@ func (resc *resourceCache) GetGVRCache(resource string) (GenericCache, bool) {
 	return nil, false
 }
 
-// CreateGVKInformer creates informer for the given gvk
-func (resc *resourceCache) CreateGVKInformer(gvk string) (GenericCache, error) {
-	gc, ok := resc.GetGVRCache(gvk)
-	if ok {
-		return gc, nil
+// GetGVRCachesForWorker - get the GVRCaches locked for the worker
+func (resc *resourceCache) GetGVRCachesForWorker(workerUID string) map[string]GenericCache {
+	caches := make(map[string]GenericCache)
+
+	resCaches := resc.gvrCache.Items()
+	for key, item := range resCaches {
+		if cache, ok := item.(*genericCache); ok {
+			if _, ok := cache.GetCacheWorker(workerUID); ok {
+				caches[key] = cache
+			}
+		}
 	}
+	return caches
+}
+
+// CreateGVKInformer creates informer for the given gvk
+func (resc *resourceCache) CreateGVKInformer(gvk string, workerUID string) (GenericCache, error) {
 	gv, k := common.GetKindFromGVK(gvk)
 	apiResource, gvr, err := resc.dclient.DiscoveryClient.FindResource(gv, k)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find API resource %s", gvk)
 	}
 
+	return resc.CreateGVRInformer(gvr, apiResource.Namespaced, gvk, workerUID)
+}
+
+// CreateGVRInformer creates informer for the given gvr
+func (resc *resourceCache) CreateGVRInformer(gvr schema.GroupVersionResource, namespaced bool, cacheKey string, workerUID string) (GenericCache, error) {
+	gc, ok := resc.GetGVRCache(cacheKey)
+	if ok {
+		gc.AddCacheWorker(workerUID)
+		return gc, nil
+	}
+
+	if _, err := resc.dclient.GetDynamicInterface().Resource(gvr).List(context.TODO(), v1.ListOptions{}); err != nil {
+		resc.log.V(4).Info("Error listing resource before creating cache", "error", err)
+		return nil, err
+	}
+
 	stopCh := make(chan struct{})
 	genInformer := resc.dinformer.ForResource(gvr)
-	gvrIface := NewGVRCache(gvr, apiResource.Namespaced, stopCh, genInformer)
+	gvrIface := NewGVRCache(gvr, namespaced, stopCh, genInformer, resc.log)
 
-	resc.gvrCache.Set(gvk, gvrIface)
+	resc.gvrCache.Set(cacheKey, gvrIface)
 	resc.dinformer.Start(stopCh)
 
 	if synced := resc.dinformer.WaitForCacheSync(stopCh); !synced[gvr] {
 		return nil, fmt.Errorf("informer for %s hasn't synced", gvr)
 	}
 
+	gvrIface.AddCacheWorker(workerUID)
 	return gvrIface, nil
 }

--- a/pkg/webhookconfig/common.go
+++ b/pkg/webhookconfig/common.go
@@ -15,6 +15,10 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
+const (
+	webhookConfigWorkerUID string = "webhook-config-worker"
+)
+
 func (wrc *Register) readCaData() []byte {
 	logger := wrc.log.WithName("readCaData")
 	var caData []byte


### PR DESCRIPTION
## Related issue
None

## What type of PR is this
> /kind feature

## Proposed Changes

This PR adds the functionality for the kyverno operator to dynamically create and tear down informers when Policies with an `apiCall` are created, modified, and deleted. The informers are then used during context building so that for each resource validated against the policy, the cache is used for the lookup rather than direct calls against the apiserver. This can have a large impact on list calls for validated resources that are numerous, such as pods, services, etc.

Implementation details:
	Res caches are now keyed on the GVR string, rather than the kind, and locked by cache workers via a cache worker UID. Each cache worker, be it a controller workload in the operator, or one dynamically created by a policy, must lock the res cache with it's UID, and stop (unlock) the res cache with it's UID. When a res cache is stopped and no longer has any workers locking it, the underlying informer is stopped and the res cache deleted.

### Proof Manifests

A test manifest I used during development:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  annotations:
    pod-policies.kyverno.io/autogen-controllers: none
  name: test-apicall-cache-limit-pods
  namespace: test
spec:
  background: false
  failurePolicy: Fail
  rules:
  - context:
    - apiCall:
        jmesPath: items
        urlPath: /api/v1/namespaces/{{request.namespace}}/pods
      name: numPods
    match:
      resources:
        kinds:
        - Pod
    preconditions:
      all:
      - key: '{{request.operation}}'
        operator: In
        value:
        - CREATE
    validate:
      deny:
        conditions:
        - key: '{{numPods | length(@)}}'
          operator: GreaterThan
          value: 5
```

**With log level >= 4 the following logs are produced indicating that the cache is created, used, and removed:**
- Cache created:
```
I1109 23:49:43.604223       1 configmanager.go:514] WebhookConfigManager/resCache "msg"="Creating new informer" "policy"=" test-apicall-cache-limit-pods" "cacheKey"="v1/pods" "gvr"={"Group":"","Version":"v1","Resource":"pods"}
```
- Cache used:
```
I1109 23:55:09.081417       1 jsonContext.go:171] EngineValidate "msg"="Loading resource list from cache" "kind"="Pod" "name"="test-pod" "policy"=" test-apicall-cache-limit-pods" "rule"="" "gvr"="v1/pods" "namespace"="test"
```
- Cache cleanup:
```
I1110 00:01:46.189138       1 resourcecache.go:28] resourcecache "msg"="Stopping cache informer"  "cache"={} "resource"="v1/pods" "workerCount"=0 "workerUID"="af02ef47-f798-4cb5-b7f0-6653564c2eb6"
I1110 00:01:46.188949       1 configmanager.go:487] WebhookConfigManager/resCache "msg"="Deleting caches" "policy"="test-apicall-cache-limit-pods" "caches"={"v1/pods":{}} "policy uid"="af02ef47-f798-4cb5-b7f0-6653564c2eb6"
I1110 00:01:46.189085       1 configmanager.go:489] WebhookConfigManager/resCache "msg"="Deleting cache for worker" "policy"="test-apicall-cache-limit-pods" "cache"="v1/pods"
```
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
