### PR TITLE
Add `pattern_match` custom JMESPath function analogous to `regex_match`

### DIFF
--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -268,6 +268,30 @@ func Test_RegexMatchWithNumber(t *testing.T) {
 	assert.Equal(t, true, result)
 }
 
+func Test_PatternMatch(t *testing.T) {
+	data := make(map[string]interface{})
+	data["foo"] = "prefix-foo"
+
+	query, err := New("pattern_match('prefix-*', foo)")
+	assert.NilError(t, err)
+
+	result, err := query.Search(data)
+	assert.NilError(t, err)
+	assert.Equal(t, true, result)
+}
+
+func Test_PatternMatchWithNumber(t *testing.T) {
+	data := make(map[string]interface{})
+	data["foo"] = -12.0
+
+	query, err := New("pattern_match('12*', abs(foo))")
+	assert.NilError(t, err)
+
+	result, err := query.Search(data)
+	assert.NilError(t, err)
+	assert.Equal(t, true, result)
+}
+
 func Test_RegexReplaceAll(t *testing.T) {
 	resourceRaw := []byte(`
 	{

--- a/test/cli/test/custom-functions/policy.yaml
+++ b/test/cli/test/custom-functions/policy.yaml
@@ -17,3 +17,25 @@ spec:
         - key: "{{base64_decode(request.object.data.value)}}"
           operator: NotEquals
           value: "{{request.object.metadata.labels.value}}"
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: pattern-match
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+    - match:
+        all:
+          - resources:
+              kinds:
+                - Namespace
+      name: label-must-match-pattern
+      validate:
+        deny:
+          conditions:
+            all:
+              - key: "{{pattern_match('prefix-*', request.object.metadata.labels.value)}}"
+                operator: Equals
+                value: false

--- a/test/cli/test/custom-functions/resources.yaml
+++ b/test/cli/test/custom-functions/resources.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-match
+  name: base64-test-match
   labels:
     value: hello
 type: Opaque
@@ -11,9 +11,23 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-no-match
+  name: base64-test-no-match
   labels:
     value: hello
 type: Opaque
 data:
   value: Z29vZGJ5ZQ==
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pattern-match-test-match
+  labels:
+    value: prefix-test
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pattern-match-test-no-match
+  labels:
+    value: test

--- a/test/cli/test/custom-functions/test.yaml
+++ b/test/cli/test/custom-functions/test.yaml
@@ -6,11 +6,21 @@ resources:
 results:
   - policy: base64
     rule: secret-value-must-match-label
-    resource: test-match
+    resource: base64-test-match
     kind: Secret
     status: pass
   - policy: base64
     rule: secret-value-must-match-label
-    resource: test-no-match
+    resource: base64-test-no-match
     kind: Secret
+    status: fail
+  - policy: pattern-match
+    rule: label-must-match-pattern
+    resource: pattern-match-test-match
+    kind: Namespace
+    status: pass
+  - policy: pattern-match
+    rule: label-must-match-pattern
+    resource: pattern-match-test-no-match
+    kind: Namespace
     status: fail


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind feature

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

- Add a custom JMESPath function `pattern_match` analogous to `regex_match`. \
  Pattern match is implemented using the same [wildcard library](https://pkg.go.dev/github.com/minio/pkg@v1.1.3/wildcard) as the rest of Kyverno.

### Proof Manifests

To test use the pod.yaml

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: myapp
  labels:
    customLabel: prefix-example
spec:
  containers:
    - name: my-container
      image: nginx
```

when the policy pol.yaml

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: validate-pod-metadata
spec:
  validationFailureAction: enforce
  background: false
  rules:
    - match:
        all:
          - resources:
              kinds:
                - Pod
      name: validate-labels
      validate:
        deny:
          conditions:
            all:
              - key: '{{pattern_match(`"prefix-*"`, `"{{request.object.metadata.labels.customLabel}}"`)}}'
                operator: Equals
                value: true
        message: 'Validation failed'
```

is applied, the request is denied.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [x] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  https://github.com/kyverno/website/pull/391
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
