### PR TITLE
Allow use of "pods/binding" subresource

### DIFF
--- a/pkg/webhookconfig/configmanager.go
+++ b/pkg/webhookconfig/configmanager.go
@@ -690,6 +690,8 @@ func (m *webhookConfigManager) mergeWebhook(dst *webhook, policy *kyverno.Cluste
 			// note: webhook stores GVR in its rules while policy stores GVK in its rules definition
 			gv, k := common.GetKindFromGVK(gvk)
 			switch k {
+			case "Binding":
+				gvrList = append(gvrList, schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods/binding"})
 			case "NodeProxyOptions":
 				gvrList = append(gvrList, schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes/proxy"})
 			case "PodAttachOptions":


### PR DESCRIPTION
# Proposed Changes

For cases where a policy matches the _Bindings_ kind in the "core/v1" API group and version, adjust the pertinent Webhook configuration rule to use the "pods/binding" subresource.

Doing so allows observing and reacting to the Kubernetes scheduler (and its "extenders") assigning pods to nodes, before any other system actors observe that assignment. This is an opportune moment in between the pod' creation and a kubelet starting it running.

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

# Further Comments

Kyverno's code base was already "aware" of the _v1/Binding_ kind; we include it in the known API schema, and block this kind in the default filter set supplied via the "kyverno" container's `--filterK8sResources` command-line flag. Writing policies that target this kind requires editing that filter set to remove the `[Binding,*,*]` entry.

/kind feature
