### PR TITLE
Don't check for Prom Operator apiVersion

### DIFF
--- a/charts/kyverno/templates/servicemonitor.yaml
+++ b/charts/kyverno/templates/servicemonitor.yaml
@@ -1,9 +1,4 @@
 {{- if .Values.serviceMonitor.enabled }}
-
-{{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
-    {{- fail "Prometheus is not installed" }}
-{{ end }}
-
 apiVersion: "monitoring.coreos.com/v1"
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
## Related issue

None.

## Milestone of this PR

Up for chart maintainer.

## What type of PR is this

/kind feature

## Proposed Changes

`.Capabilities.APIVersions.Has` function has limitations when running with `helm template`, which is common step in multiple CD tools. In order to properly resolve `Capabilities.APIVersions` `helm template` has to run with `--validate` option and connect to cluster that has Prom Operator CRDs installed.

As this template is opt-in and user has to set value to enable this, apiVersion check doesn't provide much value and can be removed.

### Proof Manifests

Not applicable.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

None.
