### PR TITLE
fix hardcoded clusterrole name issue

### DIFF
--- a/charts/kyverno/templates/clusterrole.yaml
+++ b/charts/kyverno/templates/clusterrole.yaml
@@ -69,6 +69,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "kyverno.fullname" . }}:userinfo
   labels: {{ include "kyverno.labels" . | nindent 4 }}
+    app.kubernetes.io/ownerreference: "true"
     app: kyverno
 rules:
 # get the roleRef for incoming api-request user

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -7278,6 +7278,7 @@ metadata:
     app.kubernetes.io/name: kyverno
     app.kubernetes.io/part-of: kyverno
     app.kubernetes.io/version: v1.5.2-rc1
+    app.kubernetes.io/ownerreference: "true"
   name: kyverno:webhook
 rules:
 - apiGroups:

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -7163,6 +7163,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: kyverno
+    app.kubernetes.io/ownerreference: "true"
   name: kyverno:webhook
 rules:
 - apiGroups:

--- a/definitions/k8s-resource/clusterroles.yaml
+++ b/definitions/k8s-resource/clusterroles.yaml
@@ -22,6 +22,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: kyverno
+    app.kubernetes.io/ownerreference: "true"
   name: kyverno:webhook
 rules:
 # Dynamic creation of webhooks, events & certs

--- a/definitions/release/install.yaml
+++ b/definitions/release/install.yaml
@@ -7278,6 +7278,7 @@ metadata:
     app.kubernetes.io/name: kyverno
     app.kubernetes.io/part-of: kyverno
     app.kubernetes.io/version: v1.5.2-rc1
+    app.kubernetes.io/ownerreference: "true"
   name: kyverno:webhook
 rules:
 - apiGroups:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,9 +63,6 @@ const (
 
 	// ClusterRoleKind define the default clusterrole resource kind
 	ClusterRoleKind = "ClusterRole"
-
-	// ClusterRoleName define the default name of clusterrole
-	ClusterRoleName = "kyverno:webhook"
 )
 
 var (

--- a/pkg/webhookconfig/common.go
+++ b/pkg/webhookconfig/common.go
@@ -57,27 +57,27 @@ func extractCA(config *rest.Config) (result []byte) {
 func (wrc *Register) constructOwner() v1.OwnerReference {
 	logger := wrc.log
 
-	kubeClusterRole, err := wrc.GetKubePolicyClusterRole()
+	kubeClusterRoleName, err := wrc.GetKubePolicyClusterRoleName()
 	if err != nil {
-		logger.Error(err, "failed to construct OwnerReference")
+		logger.Error(err, "failed to get cluster role")
 		return v1.OwnerReference{}
 	}
 
 	return v1.OwnerReference{
 		APIVersion: config.ClusterRoleAPIVersion,
 		Kind:       config.ClusterRoleKind,
-		Name:       config.ClusterRoleName,
-		UID:        kubeClusterRole.GetUID(),
+		Name:       kubeClusterRoleName.GetName(),
+		UID:        kubeClusterRoleName.GetUID(),
 	}
 }
 
-func (wrc *Register) GetKubePolicyClusterRole() (*unstructured.Unstructured, error) {
-	kubeNamespace, err := wrc.client.GetResource(config.ClusterRoleAPIVersion, config.ClusterRoleKind, "", config.ClusterRoleName)
+func (wrc *Register) GetKubePolicyClusterRoleName() (*unstructured.Unstructured, error) {
+	clusterRole, err := wrc.client.ListResource(config.ClusterRoleAPIVersion, config.ClusterRoleKind, "", &v1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/ownerreference": "true"}})
 	if err != nil {
 		return nil, err
 	}
 
-	return kubeNamespace, nil
+	return &clusterRole.Items[0], nil
 }
 
 // GetKubePolicyDeployment gets Kyverno deployment using the resource cache


### PR DESCRIPTION
## Related issue
Signed-off-by: Vyankatesh vyankateshkd@gmail.com

## Related issue
closes https://github.com/kyverno/kyverno/issues/2713

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
milestone 1.5.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

Install Kyverno using local changes
Kyverno Pod coming  state
Unistall Kyverno

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
