### PR TITLE
Disable autogen for policies without Pod

### DIFF
--- a/pkg/policymutation/policymutation.go
+++ b/pkg/policymutation/policymutation.go
@@ -291,6 +291,7 @@ func GeneratePodControllerRule(policy kyverno.ClusterPolicy, log logr.Logger) (p
 // - "none" if:
 //          - name or selector is defined
 //          - mixed kinds (Pod + pod controller) is defined
+//          - Pod is not defined
 //          - mutate.Patches/mutate.PatchesJSON6902/validate.deny/generate rule is defined
 // - otherwise it returns all pod controllers
 func CanAutoGen(policy *kyverno.ClusterPolicy, log logr.Logger) (applyAutoGen bool, controllers string) {
@@ -359,7 +360,7 @@ func isKindOtherthanPod(kinds []string) bool {
 	if len(kinds) > 1 && utils.ContainsPod(kinds, "Pod") {
 		return true
 	}
-	return false
+	return len(kinds) > 0 && !utils.ContainsPod(kinds, "Pod")
 }
 
 func createRuleMap(rules []kyverno.Rule) map[string]kyvernoRule {

--- a/pkg/policymutation/policymutation.go
+++ b/pkg/policymutation/policymutation.go
@@ -291,7 +291,7 @@ func GeneratePodControllerRule(policy kyverno.ClusterPolicy, log logr.Logger) (p
 // - "none" if:
 //          - name or selector is defined
 //          - mixed kinds (Pod + pod controller) is defined
-//          - Pod is not defined
+//          - Pod and PodControllers are not defined
 //          - mutate.Patches/mutate.PatchesJSON6902/validate.deny/generate rule is defined
 // - otherwise it returns all pod controllers
 func CanAutoGen(policy *kyverno.ClusterPolicy, log logr.Logger) (applyAutoGen bool, controllers string) {

--- a/pkg/policymutation/policymutation.go
+++ b/pkg/policymutation/policymutation.go
@@ -385,7 +385,6 @@ func isKindOtherthanPod(kinds []string) bool {
 }
 
 func hasAutogenKinds(kind []string) bool {
-	fmt.Println(kind)
 	for _, v := range kind {
 		if v == "Pod" || strings.Contains(engine.PodControllers, v) {
 			return true

--- a/pkg/policymutation/policymutation_test.go
+++ b/pkg/policymutation/policymutation_test.go
@@ -351,7 +351,10 @@ func Test_getControllers(t *testing.T) {
 		err := json.Unmarshal(test.policy, &policy)
 		assert.NilError(t, err)
 
-		_, controllers := CanAutoGen(&policy, log.Log)
+		applyAutoGen, controllers := CanAutoGen(&policy, log.Log)
+		if !applyAutoGen {
+			controllers = "none"
+		}
 		assert.Equal(t, test.expectedControllers, controllers, fmt.Sprintf("test %s failed", test.name))
 	}
 }

--- a/pkg/policymutation/policymutation_test.go
+++ b/pkg/policymutation/policymutation_test.go
@@ -341,7 +341,7 @@ func Test_getControllers(t *testing.T) {
 		},
 		{
 			name:                "rule-with-only-predefined-valid-controllers",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"set-service-labels-env"},"annotations":null,"pod-policies.kyverno.io/autogen-controllers":"none","spec":{"background":false,"rules":[{"name":"set-service-label","match":{"resources":{"kinds":["DaemonSet","Deployment"]}},"mutate":{"patchStrategicMerge":{"metadata":{"labels":{"+(service)":"{{request.object.spec.template.metadata.labels.app}}"}}}}}]}}`),
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"set-service-labels-env"},"annotations":null,"pod-policies.kyverno.io/autogen-controllers":"none","spec":{"background":false,"rules":[{"name":"set-service-label","match":{"resources":{"kinds":["Namespace"]}},"mutate":{"patchStrategicMerge":{"metadata":{"labels":{"+(service)":"{{request.object.spec.template.metadata.labels.app}}"}}}}}]}}`),
 			expectedControllers: "none",
 		},
 	}

--- a/pkg/policymutation/policymutation_test.go
+++ b/pkg/policymutation/policymutation_test.go
@@ -339,6 +339,11 @@ func Test_getControllers(t *testing.T) {
 			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"set-service-labels-env"},"annotations":null,"pod-policies.kyverno.io/autogen-controllers":"none","spec":{"background":false,"rules":[{"name":"set-service-label","match":{"resources":{"kinds":["Pod","Deployment"]}},"mutate":{"patchStrategicMerge":{"metadata":{"labels":{"+(service)":"{{request.object.spec.template.metadata.labels.app}}"}}}}}]}}`),
 			expectedControllers: "none",
 		},
+		{
+			name:                "rule-with-only-predefined-valid-controllers",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"set-service-labels-env"},"annotations":null,"pod-policies.kyverno.io/autogen-controllers":"none","spec":{"background":false,"rules":[{"name":"set-service-label","match":{"resources":{"kinds":["DaemonSet","Deployment"]}},"mutate":{"patchStrategicMerge":{"metadata":{"labels":{"+(service)":"{{request.object.spec.template.metadata.labels.app}}"}}}}}]}}`),
+			expectedControllers: "none",
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/webhooks/policymutation_test.go
+++ b/pkg/webhooks/policymutation_test.go
@@ -46,7 +46,7 @@ func TestGeneratePodControllerRule_NilAnnotation(t *testing.T) {
 		"metadata": {
 		  "name": "add-safe-to-evict",
 		  "annotations": {
-			"pod-policies.kyverno.io/autogen-controllers": "DaemonSet,Deployment,Job,StatefulSet,CronJob"
+			"pod-policies.kyverno.io/autogen-controllers": "none"
 		  }
 		}
 	  }`)
@@ -69,7 +69,7 @@ func TestGeneratePodControllerRule_PredefinedAnnotation(t *testing.T) {
 	assert.Assert(t, json.Unmarshal(policyRaw, &policy))
 	patches, errs := policymutation.GeneratePodControllerRule(policy, log.Log)
 	assert.Assert(t, len(errs) == 0)
-	assert.Assert(t, len(patches) == 0)
+	assert.Assert(t, len(patches) == 1)
 }
 
 func TestGeneratePodControllerRule_DisableFeature(t *testing.T) {
@@ -315,7 +315,7 @@ func TestGeneratePodControllerRule_ExistOtherAnnotation(t *testing.T) {
 		"metadata": {
 		  "name": "add-safe-to-evict",
 		  "annotations": {
-			"pod-policies.kyverno.io/autogen-controllers": "DaemonSet,Deployment,Job,StatefulSet,CronJob",
+			"pod-policies.kyverno.io/autogen-controllers": "none",
 			"test": "annotation"
 		  }
 		}


### PR DESCRIPTION
Signed-off-by: Kumar Mallikarjuna <kumarmallikarjuna1@gmail.com>

## Related issue
Closes #2751
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.6.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
[missingAutogenRules()](https://github.com/kyverno/kyverno/blob/5c16ee738af04cfeb41b0fc4557d06762d268651/pkg/policy/policy_controller.go#L575) updates `spec.rules` when policy doesn't mention Pod. Setting `autogen-controller` annotation to `none` by default in such a case solves the issue.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Policy
```yaml
apiVersion : kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: restrict-image-registries
spec:
  validationFailureAction: enforce
  rules:
  - name: validate-registries
    match:
      resources:
        kinds:
        - Namespace
    validate:
      message: "Images may only come from our internal enterprise registry."
      pattern:
        metadata:
          name: test-ns
```
CLI
```bash
$ k get cpol restrict-image-registries -o yaml --show-managed-fields=true
```
`autogen-controllers` annotation is added with default `none` and `spec.rules` is not updated.
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
