### PR TITLE
fix signature

### DIFF
--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -25,7 +25,6 @@ import (
 	"github.com/sigstore/cosign/pkg/oci"
 	sigs "github.com/sigstore/cosign/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature"
-	"github.com/sigstore/sigstore/pkg/signature/dsse"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -177,7 +176,7 @@ func FetchAttestations(imageRef string, key string, repository string, log logr.
 
 	cosignOpts := &cosign.CheckOpts{
 		ClaimVerifier:      cosign.IntotoSubjectClaimVerifier,
-		SigVerifier:        dsse.WrapVerifier(pubKey),
+		SigVerifier:        pubKey,
 		RegistryClientOpts: opts,
 	}
 


### PR DESCRIPTION
Signed-off-by: Jim Bugwadia <jim@nirmata.com>

## Related issue

https://github.com/kyverno/kyverno/issues/2739

## Milestone of this PR

1.5.2

## What type of PR is this

/kind bug


## Proposed Changes

Fix signature construction.


### Proof Manifests

With this change, using an invalid key returns:

```sh

❯ kubectl run test --image=ghcr.io/jimbugwadia/pause2
Error from server: admission webhook "mutate.kyverno.svc-fail" denied the request:

resource Pod/default/test was blocked due to the following policies

attest-code-review:
  attest: |-
    failed to fetch attestations for ghcr.io/jimbugwadia/pause2:latest: no matching signatures:
    failed to verify signature

```


-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
