### PR TITLE
added support for --git-branch flag and directory in git path for kyverno test cmd

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'release*'
     paths-ignore:
       - 'README.md'
       - 'docs/**'
@@ -10,6 +11,7 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'release*'
     paths-ignore:
       - 'README.md'
       - 'docs/**'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,7 +48,24 @@ jobs:
 
       - name: Test Policy
         run: |
-          make test-cmd
+          if [[ ${{ github.event_name }} == "push" ]]
+          then
+            GIT_BRANCH=${GITHUB_REF##*/}
+          elif [[ ${{ github.event_name }} == "pull_request" ]]
+          then
+            GIT_BRANCH=${{ github.event.pull_request.base.ref }}
+          fi
+
+          CLI_PATH=cmd/cli/kubectl-kyverno
+
+          go run $PWD/$CLI_PATH/main.go test https://github.com/kyverno/policies/$GIT_BRANCH
+          go run $PWD/$CLI_PATH/main.go test https://github.com/kyverno/policies --git-branch $GIT_BRANCH
+          go run $PWD/$CLI_PATH/main.go test https://github.com/kyverno/policies/pod-security/restricted -b $GIT_BRANCH
+          go run $PWD/$CLI_PATH/main.go test ./test/cli/test-mutate
+          go run $PWD/$CLI_PATH/main.go test ./test/cli/test
+          go run $PWD/$CLI_PATH/main.go test ./test/cli/test-fail/missing-policy && exit 1 || exit 0
+          go run $PWD/$CLI_PATH/main.go test ./test/cli/test-fail/missing-rule && exit 1 || exit 0
+          go run $PWD/$CLI_PATH/main.go test ./test/cli/test-fail/missing-resource && exit 1 || exit 0
       
       - name: gofmt check
         run: |

--- a/Makefile
+++ b/Makefile
@@ -269,9 +269,9 @@ test-e2e-local:
 
 #Test TestCmd Policy
 test-cmd: cli
-	$(PWD)/$(CLI_PATH)/kyverno test https://github.com/kyverno/policies/main
-	$(PWD)/$(CLI_PATH)/kyverno test https://github.com/kyverno/policies --git-branch main
-	$(PWD)/$(CLI_PATH)/kyverno test https://github.com/kyverno/policies/pod-security/restricted -b main
+	$(PWD)/$(CLI_PATH)/kyverno test https://github.com/kyverno/policies/$(GIT_BRANCH)
+	$(PWD)/$(CLI_PATH)/kyverno test https://github.com/kyverno/policies --git-branch $(GIT_BRANCH)
+	$(PWD)/$(CLI_PATH)/kyverno test https://github.com/kyverno/policies/pod-security/restricted -b $(GIT_BRANCH)
 	$(PWD)/$(CLI_PATH)/kyverno test ./test/cli/test-mutate
 	$(PWD)/$(CLI_PATH)/kyverno test ./test/cli/test
 	$(PWD)/$(CLI_PATH)/kyverno test ./test/cli/test-fail/missing-policy && exit 1 || exit 0

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ $(GO_ACC):
 # go-acc merges the result for pks so that it be used by
 # go tool cover for reporting
 
-test: test-clean test-unit test-e2e test-cmd
+test: test-clean test-unit test-e2e
 
 test-clean:
 	@echo "	cleaning test cache"
@@ -266,17 +266,6 @@ test-e2e-local:
 	go test ./test/e2e/generate -v
 	kill  $!
 	$(eval export E2E="")
-
-#Test TestCmd Policy
-test-cmd: cli
-	$(PWD)/$(CLI_PATH)/kyverno test https://github.com/kyverno/policies/$(GIT_BRANCH)
-	$(PWD)/$(CLI_PATH)/kyverno test https://github.com/kyverno/policies --git-branch $(GIT_BRANCH)
-	$(PWD)/$(CLI_PATH)/kyverno test https://github.com/kyverno/policies/pod-security/restricted -b $(GIT_BRANCH)
-	$(PWD)/$(CLI_PATH)/kyverno test ./test/cli/test-mutate
-	$(PWD)/$(CLI_PATH)/kyverno test ./test/cli/test
-	$(PWD)/$(CLI_PATH)/kyverno test ./test/cli/test-fail/missing-policy && exit 1 || exit 0
-	$(PWD)/$(CLI_PATH)/kyverno test ./test/cli/test-fail/missing-rule && exit 1 || exit 0
-	$(PWD)/$(CLI_PATH)/kyverno test ./test/cli/test-fail/missing-resource && exit 1 || exit 0
 
 # godownloader create downloading script for kyverno-cli
 godownloader:

--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,8 @@ test-e2e-local:
 #Test TestCmd Policy
 test-cmd: cli
 	$(PWD)/$(CLI_PATH)/kyverno test https://github.com/kyverno/policies/main
+	$(PWD)/$(CLI_PATH)/kyverno test https://github.com/kyverno/policies --git-branch main
+	$(PWD)/$(CLI_PATH)/kyverno test https://github.com/kyverno/policies/pod-security/restricted -b main
 	$(PWD)/$(CLI_PATH)/kyverno test ./test/cli/test-mutate
 	$(PWD)/$(CLI_PATH)/kyverno test ./test/cli/test
 	$(PWD)/$(CLI_PATH)/kyverno test ./test/cli/test-fail/missing-policy && exit 1 || exit 0

--- a/pkg/kyverno/test/git.go
+++ b/pkg/kyverno/test/git.go
@@ -22,11 +22,17 @@ func clone(path string, fs billy.Filesystem, branch string) (*git.Repository, er
 
 func listYAMLs(fs billy.Filesystem, path string) ([]string, error) {
 	path = filepath.Clean(path)
+
+	if _, err := fs.Stat(path); err != nil {
+		return nil, err
+	}
+
 	fis, err := fs.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
 	yamls := make([]string, 0)
+
 	for _, fi := range fis {
 		name := filepath.Join(path, fi.Name())
 		if fi.IsDir() {

--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -42,18 +42,22 @@ var longHelp = `
 The test command provides a facility to test resources against policies by comparing expected results, declared ahead of time in a test.yaml file, to actual results reported by Kyverno. Users provide the path to the folder containing a test.yaml file where the location could be on a local filesystem or a remote git repository
 `
 var exampleHelp = `
-kyverno test https://github.com/kyverno/policies/main
+kyverno test https://github.com/kyverno/policies/pod-security --git-branch main
     <snip>
 
-    Executing disallow-cri-sock-mount...
-    applying 1 policy to 1 resource...
-    │───│────────────────────────────────│────────────────────────────────│────────────────────────────│────────│
-    │ # │ POLICY                         │ RULE                           │ RESOURCE                   │ RESULT │
-    │───│────────────────────────────────│────────────────────────────────│────────────────────────────│────────│
-    │ 1 │ disallow-container-sock-mounts │ validate-docker-sock-mount     │ pod-with-docker-sock-mount │ Pass   │
-    │ 2 │ disallow-container-sock-mounts │ validate-containerd-sock-mount │ pod-with-docker-sock-mount │ Pass   │
-    │ 3 │ disallow-container-sock-mounts │ validate-crio-sock-mount       │ pod-with-docker-sock-mount │ Pass   │
-    │───│────────────────────────────────│────────────────────────────────│────────────────────────────│────────│
+    Executing require-non-root-groups...
+    applying 1 policy to 2 resources... 
+
+    │───│─────────────────────────│──────────────────────────│──────────────────────────────────│────────│
+    │ # │ POLICY                  │ RULE                     │ RESOURCE                         │ RESULT │
+    │───│─────────────────────────│──────────────────────────│──────────────────────────────────│────────│
+    │ 1 │ require-non-root-groups │ check-runasgroup         │ default/Pod/fs-group0            │ Pass   │
+    │ 2 │ require-non-root-groups │ check-supplementalGroups │ default/Pod/fs-group0            │ Pass   │
+    │ 3 │ require-non-root-groups │ check-fsGroup            │ default/Pod/fs-group0            │ Pass   │
+    │ 4 │ require-non-root-groups │ check-supplementalGroups │ default/Pod/supplemental-groups0 │ Pass   │
+    │ 5 │ require-non-root-groups │ check-fsGroup            │ default/Pod/supplemental-groups0 │ Pass   │
+    │ 6 │ require-non-root-groups │ check-runasgroup         │ default/Pod/supplemental-groups0 │ Pass   │
+    │───│─────────────────────────│──────────────────────────│──────────────────────────────────│────────│
     <snip>
 
 
@@ -135,9 +139,9 @@ For more information visit https://kyverno.io/docs/kyverno-cli/#test
 // Command returns version command
 func Command() *cobra.Command {
 	var cmd *cobra.Command
-	var valuesFile, fileName string
+	var valuesFile, fileName, gitBranch string
 	cmd = &cobra.Command{
-		Use:     "test <path_to_folder_Containing_test.yamls> [flags]\n  kyverno test <path_to_gitRepository>",
+		Use:     "test <path_to_folder_Containing_test.yamls> [flags]\n  kyverno test <path_to_gitRepository_with_dir> --git-branch <branchName>",
 		Args:    cobra.ExactArgs(1),
 		Short:   "run tests from directory",
 		Long:    longHelp,
@@ -152,7 +156,7 @@ func Command() *cobra.Command {
 				}
 			}()
 
-			_, err = testCommandExecute(dirPath, valuesFile, fileName)
+			_, err = testCommandExecute(dirPath, valuesFile, fileName, gitBranch)
 			if err != nil {
 				log.Log.V(3).Info("a directory is required")
 				return err
@@ -162,6 +166,7 @@ func Command() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&fileName, "file-name", "f", "kyverno-test.yaml", "test filename")
+	cmd.Flags().StringVarP(&gitBranch, "git-branch", "b", "", "test github repository branch")
 	return cmd
 }
 
@@ -217,7 +222,7 @@ type resultCounts struct {
 	Fail int
 }
 
-func testCommandExecute(dirPath []string, valuesFile string, fileName string) (rc *resultCounts, err error) {
+func testCommandExecute(dirPath []string, valuesFile string, fileName string, gitBranch string) (rc *resultCounts, err error) {
 	var errors []error
 	fs := memfs.New()
 	rc = &resultCounts{}
@@ -236,26 +241,45 @@ func testCommandExecute(dirPath []string, valuesFile string, fileName string) (r
 
 		pathElems := strings.Split(gitURL.Path[1:], "/")
 		if len(pathElems) <= 1 {
-			err := fmt.Errorf("invalid URL path %s - expected https://github.com/:owner/:repository/:branch", gitURL.Path)
+			err := fmt.Errorf("invalid URL path %s - expected https://github.com/:owner/:repository/:branch (without --git-branch flag) OR https://github.com/:owner/:repository/:directory (with --git-branch flag)", gitURL.Path)
 			fmt.Printf("Error: failed to parse URL \nCause: %s\n", err)
 			os.Exit(1)
 		}
 
 		gitURL.Path = strings.Join([]string{pathElems[0], pathElems[1]}, "/")
 		repoURL := gitURL.String()
-		branch := strings.ReplaceAll(dirPath[0], repoURL+"/", "")
-		if branch == "" {
-			branch = "main"
+
+		var gitPathToYamls string
+		if gitBranch == "" {
+			gitPathToYamls = "/"
+
+			if string(dirPath[0][len(dirPath[0])-1]) == "/" {
+				gitBranch = strings.ReplaceAll(dirPath[0], repoURL+"/", "")
+			} else {
+				gitBranch = strings.ReplaceAll(dirPath[0], repoURL, "")
+			}
+
+			if gitBranch == "" {
+				gitBranch = "main"
+			} else if string(gitBranch[0]) == "/" {
+				gitBranch = gitBranch[1:]
+			}
+		} else {
+			if string(dirPath[0][len(dirPath[0])-1]) == "/" {
+				gitPathToYamls = strings.ReplaceAll(dirPath[0], repoURL+"/", "/")
+			} else {
+				gitPathToYamls = strings.ReplaceAll(dirPath[0], repoURL, "/")
+			}
 		}
 
-		_, cloneErr := clone(repoURL, fs, branch)
+		_, cloneErr := clone(repoURL, fs, gitBranch)
 		if cloneErr != nil {
 			fmt.Printf("Error: failed to clone repository \nCause: %s\n", cloneErr)
 			log.Log.V(3).Info(fmt.Sprintf("failed to clone repository  %v as it is not valid", repoURL), "error", cloneErr)
 			os.Exit(1)
 		}
 
-		policyYamls, err := listYAMLs(fs, "/")
+		policyYamls, err := listYAMLs(fs, gitPathToYamls)
 		if err != nil {
 			return rc, sanitizederror.NewWithError("failed to list YAMLs in repository", err)
 		}


### PR DESCRIPTION
Signed-off-by: Abhinav Sinha <zeborg3@gmail.com>

## Related issue
Closes #2746
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.6.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
* Added `--git-branch` _(shorthand `-b`)_ flag for specifying the branch for the git path mentioned in `kyverno test` command.
* Added support for specifying the directory in git path having the policies which the user wants to test.
* Supported git path syntaxes for `kyverno test` following this PR:
  * `kyverno test https://github.com/{owner}/{repo}/{branch}`
  _(same as the old syntax for backwards compatibility; uses `main` as default branch in the absence of `{branch}`; does not support testing a specific directory in git path)_
    * Example:
    `kyverno test https://github.com/kyverno/policies/release-1.5`
    
  * `kyverno test https://github.com/{owner}/{repo}/{directory} --git-branch {branch}`
    * Example:
    `kyverno test https://github.com/kyverno/policies/pod-security/restricted --git-branch release-1.5`
    
  * `kyverno test https://github.com/{owner}/{repo}/{directory} -b {branch}`
    * Example:
    `kyverno test https://github.com/kyverno/policies/pod-security/restricted -b release-1.5`
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proofs
* `kyverno test https://github.com/kyverno/policies/pod-security/restricted --git-branch release-1.5`
Here, owner=`kyverno`, repo=`policies`, directory=`/pod-security/restricted`, branch=`release-1.5`
Output:
```
Enumerating objects: 2737, done.
Counting objects: 100% (1554/1554), done.
Compressing objects: 100% (763/763), done.
Total 2737 (delta 948), reused 1299 (delta 791), pack-reused 1183

Executing deny-privilege-escalation...
applying 1 policy to 1 resource... 

│───│───────────────────────────│───────────────────────────│────────────────────────│────────│
│ # │ POLICY                    │ RULE                      │ RESOURCE               │ RESULT │
│───│───────────────────────────│───────────────────────────│────────────────────────│────────│
│ 1 │ deny-privilege-escalation │ deny-privilege-escalation │ default/Pod/privileged │ Pass   │
│───│───────────────────────────│───────────────────────────│────────────────────────│────────│

Executing require-non-root-groups...
applying 1 policy to 2 resources... 

│───│─────────────────────────│──────────────────────────│──────────────────────────────────│────────│
│ # │ POLICY                  │ RULE                     │ RESOURCE                         │ RESULT │
│───│─────────────────────────│──────────────────────────│──────────────────────────────────│────────│
│ 1 │ require-non-root-groups │ check-runasgroup         │ default/Pod/fs-group0            │ Pass   │
│ 2 │ require-non-root-groups │ check-supplementalGroups │ default/Pod/fs-group0            │ Pass   │
│ 3 │ require-non-root-groups │ check-fsGroup            │ default/Pod/fs-group0            │ Pass   │
│ 4 │ require-non-root-groups │ check-supplementalGroups │ default/Pod/supplemental-groups0 │ Pass   │
│ 5 │ require-non-root-groups │ check-fsGroup            │ default/Pod/supplemental-groups0 │ Pass   │
│ 6 │ require-non-root-groups │ check-runasgroup         │ default/Pod/supplemental-groups0 │ Pass   │
│───│─────────────────────────│──────────────────────────│──────────────────────────────────│────────│

Executing require-run-as-non-root...
applying 1 policy to 2 resources... 

│───│─────────────────────────│──────────────────│─────────────────────────│────────│
│ # │ POLICY                  │ RULE             │ RESOURCE                │ RESULT │
│───│─────────────────────────│──────────────────│─────────────────────────│────────│
│ 1 │ require-run-as-non-root │ check-containers │ default/Pod/nonroot-pod │ Pass   │
│ 2 │ require-run-as-non-root │ check-containers │ default/Pod/root-pod    │ Pass   │
│───│─────────────────────────│──────────────────│─────────────────────────│────────│

Executing restrict-seccomp...
applying 1 policy to 13 resources... 

│─────────│──────────────────│──────────────────│───────────────────────────────────────────────────│────────│
│ # (13)  │ POLICY           │ RULE             │ RESOURCE                                          │ RESULT │
│─────────│──────────────────│──────────────────│───────────────────────────────────────────────────│────────│
│       1 │ restrict-seccomp │ restrict-seccomp │ default/Pod/seccomp-pod-spec-undefined            │ Pass   │
│       2 │ restrict-seccomp │ restrict-seccomp │ default/Pod/seccomp-pod-spec-unconfined           │ Pass   │
│       3 │ restrict-seccomp │ restrict-seccomp │ default/Pod/seccomp-pod-cont1-unconfined          │ Pass   │
│       4 │ restrict-seccomp │ restrict-seccomp │ default/Pod/seccomp-pod-cont2-inconsistent        │ Pass   │
│       5 │ restrict-seccomp │ restrict-seccomp │ default/Pod/seccomp-pod-cont2-inconsistent1       │ Pass   │
│       6 │ restrict-seccomp │ restrict-seccomp │ default/Pod/seccomp-pod-initcont-undefined        │ Pass   │
│       7 │ restrict-seccomp │ restrict-seccomp │ default/Pod/seccomp-pod-initcont-unconfined       │ Pass   │
│       8 │ restrict-seccomp │ restrict-seccomp │ default/Pod/seccomp-good-pod                      │ Pass   │
│       9 │ restrict-seccomp │ restrict-seccomp │ default/Pod/seccomp-good-pod-localhost            │ Pass   │
│      10 │ restrict-seccomp │ restrict-seccomp │ default/Pod/seccomp-good-pod-cont1-runtimedefault │ Pass   │
│      11 │ restrict-seccomp │ restrict-seccomp │ default/Pod/seccomp-good-pod-cont2-runtimedefault │ Pass   │
│      12 │ restrict-seccomp │ restrict-seccomp │ default/Pod/seccomp-good-pod-initcont             │ Pass   │
│      13 │ restrict-seccomp │ restrict-seccomp │ default/Pod/seccomp-good-pod-initcont1            │ Pass   │
│─────────│──────────────────│──────────────────│───────────────────────────────────────────────────│────────│

Executing restrict-volume-types...
applying 1 policy to 1 resource... 

│───│───────────────────────│─────────────────────────────────────│────────────────────│────────│
│ # │ POLICY                │ RULE                                │ RESOURCE           │ RESULT │
│───│───────────────────────│─────────────────────────────────────│────────────────────│────────│
│ 1 │ restrict-volume-types │ restricted-vol-gcePersistentDisk    │ default/Pod/gce-pd │ Pass   │
│ 2 │ restrict-volume-types │ restricted-vol-awsElasticBlockStore │ default/Pod/gce-pd │ Pass   │
│───│───────────────────────│─────────────────────────────────────│────────────────────│────────│
```

* `kyverno test https://github.com/kyverno/policies/pod-security/baseline -b main`
Here, owner=`kyverno`, repo=`policies`, directory=`/pod-security/baseline`, branch=`main`
Output:
```Enumerating objects: 2737, done.
Counting objects: 100% (1554/1554), done.
Compressing objects: 100% (763/763), done.
Total 2737 (delta 948), reused 1299 (delta 791), pack-reused 1183

Executing disallow-add-capabilities...
applying 1 policy to 1 resource... 

│───│───────────────────────────│──────────────│──────────────────────────────────│────────│
│ # │ POLICY                    │ RULE         │ RESOURCE                         │ RESULT │
│───│───────────────────────────│──────────────│──────────────────────────────────│────────│
│ 1 │ disallow-add-capabilities │ capabilities │ default/Pod/add-new-capabilities │ Pass   │
│───│───────────────────────────│──────────────│──────────────────────────────────│────────│

Executing disallow-host-namespaces...
applying 1 policy to 3 resources... 

│───│──────────────────────────│─────────────────│─────────────────────────────────│────────│
│ # │ POLICY                   │ RULE            │ RESOURCE                        │ RESULT │
│───│──────────────────────────│─────────────────│─────────────────────────────────│────────│
│ 1 │ disallow-host-namespaces │ host-namespaces │ default/Pod/host-namespaces-net │ Pass   │
│ 2 │ disallow-host-namespaces │ host-namespaces │ default/Pod/host-namespaces-pid │ Pass   │
│───│──────────────────────────│─────────────────│─────────────────────────────────│────────│

Executing disallow-host-path...
applying 1 policy to 1 resource... 

│───│────────────────────│───────────│───────────────────────│────────│
│ # │ POLICY             │ RULE      │ RESOURCE              │ RESULT │
│───│────────────────────│───────────│───────────────────────│────────│
│ 1 │ disallow-host-path │ host-path │ default/Pod/host-path │ Pass   │
│───│────────────────────│───────────│───────────────────────│────────│

Executing disallow-host-ports...
applying 1 policy to 1 resource... 

│───│─────────────────────│────────────│───────────────────────│────────│
│ # │ POLICY              │ RULE       │ RESOURCE              │ RESULT │
│───│─────────────────────│────────────│───────────────────────│────────│
│ 1 │ disallow-host-ports │ host-ports │ default/Pod/host-port │ Pass   │
│───│─────────────────────│────────────│───────────────────────│────────│

Executing disallow-privileged-containers...
applying 1 policy to 1 resource... 

│───│────────────────────────────────│────────────────────────│──────────────────────────────────│────────│
│ # │ POLICY                         │ RULE                   │ RESOURCE                         │ RESULT │
│───│────────────────────────────────│────────────────────────│──────────────────────────────────│────────│
│ 1 │ disallow-privileged-containers │ priviledged-containers │ default/Pod/check-privileged-cfg │ Pass   │
│───│────────────────────────────────│────────────────────────│──────────────────────────────────│────────│

Executing require-default-proc-mount...
applying 1 policy to 1 resource... 

│───│────────────────────────────│──────────────────│──────────────────────────────│────────│
│ # │ POLICY                     │ RULE             │ RESOURCE                     │ RESULT │
│───│────────────────────────────│──────────────────│──────────────────────────────│────────│
│ 1 │ require-default-proc-mount │ check-proc-mount │ default/Pod/nginx-proc-mount │ Pass   │
│───│────────────────────────────│──────────────────│──────────────────────────────│────────│

Executing disallow-selinux...
applying 1 policy to 1 resource... 

│───│──────────────────│─────────│─────────────────────────────│────────│
│ # │ POLICY           │ RULE    │ RESOURCE                    │ RESULT │
│───│──────────────────│─────────│─────────────────────────────│────────│
│ 1 │ disallow-selinux │ seLinux │ default/Pod/busybox-selinux │ Pass   │
│───│──────────────────│─────────│─────────────────────────────│────────│

Executing restrict-apparmor-profiles...
applying 1 policy to 1 resource... 

│───│────────────────────────────│───────────│──────────────────────│────────│
│ # │ POLICY                     │ RULE      │ RESOURCE             │ RESULT │
│───│────────────────────────────│───────────│──────────────────────│────────│
│ 1 │ restrict-apparmor-profiles │ app-armor │ default/Pod/apparmor │ Pass   │
│───│────────────────────────────│───────────│──────────────────────│────────│

Executing restrict-sysctls...
applying 1 policy to 1 resource... 

│───│──────────────────│─────────│───────────────────│────────│
│ # │ POLICY           │ RULE    │ RESOURCE          │ RESULT │
│───│──────────────────│─────────│───────────────────│────────│
│ 1 │ restrict-sysctls │ sysctls │ default/Pod/nginx │ Pass   │
│───│──────────────────│─────────│───────────────────│────────│
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [x] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
