### PR TITLE
Add path_canonicalize custom JMESPath function

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -50,6 +51,7 @@ var (
 	base64Decode           = "base64_decode"
 	base64Encode           = "base64_encode"
 	timeSince              = "time_since"
+	pathCanonicalize       = "path_canonicalize"
 )
 
 const errorPrefix = "JMESPath function '%s': "
@@ -230,6 +232,13 @@ func getFunctions() []*gojmespath.FunctionEntry {
 				{Types: []JpType{JpString}},
 			},
 			Handler: jpTimeSince,
+		},
+		{
+			Name: pathCanonicalize,
+			Arguments: []ArgSpec{
+				{Types: []JpType{JpString}},
+			},
+			Handler: jpPathCanonicalize,
 		},
 	}
 
@@ -626,6 +635,16 @@ func jpTimeSince(arguments []interface{}) (interface{}, error) {
 	}
 
 	return t2.Sub(t1).String(), nil
+}
+
+func jpPathCanonicalize(arguments []interface{}) (interface{}, error) {
+	var err error
+	str, err := validateArg(pathCanonicalize, arguments, 0, reflect.String)
+	if err != nil {
+		return nil, err
+	}
+
+	return filepath.Join("", str.String()), nil
 }
 
 // InterfaceToString casts an interface to a string type

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -559,3 +559,57 @@ func Test_TimeSince(t *testing.T) {
 		})
 	}
 }
+
+func Test_PathCanonicalize(t *testing.T) {
+	testCases := []struct {
+		jmesPath       string
+		expectedResult string
+	}{
+		{
+			jmesPath:       "path_canonicalize('///')",
+			expectedResult: "/",
+		},
+		{
+			jmesPath:       "path_canonicalize('///var/run/containerd/containerd.sock')",
+			expectedResult: "/var/run/containerd/containerd.sock",
+		},
+		{
+			jmesPath:       "path_canonicalize('/var/run///containerd/containerd.sock')",
+			expectedResult: "/var/run/containerd/containerd.sock",
+		},
+		{
+			jmesPath:       "path_canonicalize('/var/run///containerd////')",
+			expectedResult: "/var/run/containerd",
+		},
+		{
+			jmesPath:       "path_canonicalize('/run///')",
+			expectedResult: "/run",
+		},
+		{
+			jmesPath:       "path_canonicalize('/run/../etc')",
+			expectedResult: "/etc",
+		},
+		{
+			jmesPath:       "path_canonicalize('///etc*')",
+			expectedResult: "/etc*",
+		},
+		{
+			jmesPath:       "path_canonicalize('/../../')",
+			expectedResult: "/",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.jmesPath, func(t *testing.T) {
+			jp, err := New(tc.jmesPath)
+			assert.NilError(t, err)
+
+			result, err := jp.Search("")
+			assert.NilError(t, err)
+
+			res, ok := result.(string)
+			assert.Assert(t, ok)
+			assert.Equal(t, res, tc.expectedResult)
+		})
+	}
+}

--- a/pkg/openapi/crdSync.go
+++ b/pkg/openapi/crdSync.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/googleapis/gnostic/compiler"
 	openapiv2 "github.com/googleapis/gnostic/openapiv2"

--- a/test/cli/test/custom-functions/policy.yaml
+++ b/test/cli/test/custom-functions/policy.yaml
@@ -39,3 +39,34 @@ spec:
               - key: "{{pattern_match('prefix-*', request.object.metadata.labels.value)}}"
                 operator: Equals
                 value: false
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: path-canonicalize
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: disallow-mount-containerd-sock
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      foreach:
+      - list: "request.object.spec.volumes[]"
+        preconditions:
+          all:
+          - key: "{{ element.hostPath.path }}"
+            operator: NotEquals
+            value: ""
+        deny:
+          conditions:
+            any:
+            - key: "{{ path_canonicalize(element.hostPath.path) }}"
+              operator: Equals
+              value: "/var/run/containerd/containerd.sock"
+            - key: "{{ path_canonicalize(element.hostPath.path) }}"
+              operator: Equals
+              value: "/run/containerd/containerd.sock"

--- a/test/cli/test/custom-functions/resources.yaml
+++ b/test/cli/test/custom-functions/resources.yaml
@@ -31,3 +31,23 @@ metadata:
   name: pattern-match-test-no-match
   labels:
     value: test
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mount-containerd-sock
+spec:
+  volumes:
+  - name: test
+    emptyDir: {}
+  - name: sock
+    hostPath:
+      path: ///var/run/containerd///containerd.sock
+  containers:
+  - name: mount-containerd-sock
+    image: nginx
+    volumeMounts:
+    - name: sock
+      mountPath: /sock
+    - name: test
+      mountPath: /test 

--- a/test/cli/test/custom-functions/test.yaml
+++ b/test/cli/test/custom-functions/test.yaml
@@ -24,3 +24,8 @@ results:
     resource: pattern-match-test-no-match
     kind: Namespace
     status: fail
+  - policy: path-canonicalize
+    rule: disallow-mount-containerd-sock
+    resource: mount-containerd-sock
+    kind: Pod
+    status: fail


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

#2273 

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind feature

## Proposed Changes
Add a custom JMESPath function path_canonicalize to prevent bypassing the path validation.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

To test this PR's behavior, create `disallow-container-sock-mounts.yaml`:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-container-sock-mounts
  annotations:
    policies.kyverno.io/title: Disallow CRI socket mounts
    policies.kyverno.io/category: Best Practices
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod
    policies.kyverno.io/description: >-
      Container daemon socket bind mounts allows access to the container engine on the
      node. This access can be used for privilege escalation and to manage containers
      outside of Kubernetes, and hence should not be allowed. This policy validates that
      the sockets used for Containerd are not used.
spec:
  validationFailureAction: enforce
  background: true
  rules:
  - name: validate-containerd-sock-mount
    match:
      resources:
        kinds:
        - Pod
    validate:
      message: >-
        Use of the Containerd Unix socket is not allowed.
      foreach:
      - list: "request.object.spec.volumes[]"
        preconditions:
          all:
          - key: "{{ element.hostPath.path }}"
            operator: NotEquals
            value: ""
        deny:
          conditions:
            any:
            - key: "{{ path_canonicalize(element.hostPath.path) }}"
              operator: Equals
              value: "/var/run/containerd/containerd.sock"
            - key: "{{ path_canonicalize(element.hostPath.path) }}"
              operator: Equals
              value: "/run/containerd/containerd.sock"
```
create `mount-containerd-sock.yaml`:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: mount-containerd-sock
spec:
  volumes:
  - name: test
    emptyDir: {}
  - name: sock
    hostPath:
      path: ///var/run/containerd///containerd.sock
  containers:
  - name: test-normal-mount-sock
    image: debian:8
    command: ["/bin/sh", "-ec", "while :; do echo '.'; sleep 10 ; done"]
    volumeMounts:
    - name: sock
      mountPath: /sock
    - name: test
      mountPath: /test
```
The creation request of mount-containerd-sock should be denied.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [x] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
