### PR TITLE
fix: update registry credentials on image verify

### DIFF
--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -31,10 +31,20 @@ import (
 var (
 	// ImageSignatureRepository is an alternate signature repository
 	ImageSignatureRepository string
+	Secrets                  []string
+
+	kubeClient            kubernetes.Interface
+	kyvernoNamespace      string
+	kyvernoServiceAccount string
 )
 
 // Initialize loads the image pull secrets and initializes the default auth method for container registry API calls
 func Initialize(client kubernetes.Interface, namespace, serviceAccount string, imagePullSecrets []string) error {
+	kubeClient = client
+	kyvernoNamespace = namespace
+	kyvernoServiceAccount = serviceAccount
+	Secrets = imagePullSecrets
+
 	var kc authn.Keychain
 	kcOpts := &k8schain.Options{
 		Namespace:          namespace,
@@ -48,6 +58,15 @@ func Initialize(client kubernetes.Interface, namespace, serviceAccount string, i
 	}
 
 	authn.DefaultKeychain = kc
+	return nil
+}
+
+// UpdateKeychain reinitializes the image pull secrets and default auth method for container registry API calls
+func UpdateKeychain() error {
+	var err = Initialize(kubeClient, kyvernoNamespace, kyvernoServiceAccount, Secrets)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/engine/imageVerify.go
+++ b/pkg/engine/imageVerify.go
@@ -39,6 +39,14 @@ func VerifyAndPatchImages(policyContext *PolicyContext) (resp *response.EngineRe
 	policyContext.JSONContext.Checkpoint()
 	defer policyContext.JSONContext.Restore()
 
+	// update image registry secrets
+	if len(cosign.Secrets) > 0 {
+		logger.V(4).Info("updating registry credentials", "secrets", cosign.Secrets)
+		if err := cosign.UpdateKeychain(); err != nil {
+			logger.Error(err, "failed to update image pull secrets")
+		}
+	}
+
 	for i := range policyContext.Policy.Spec.Rules {
 		rule := &policyContext.Policy.Spec.Rules[i]
 		if len(rule.VerifyImages) == 0 {


### PR DESCRIPTION
Signed-off-by: Joel Kamp <joel.kamp@invitae.com>

## Related issue

#2790 
@JimBugwadia 

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this

 /kind bug


## Proposed Changes

This PR updates the image registry credentials keychain `authn.DefaultKeychain` on calls to `engine.VerifyAndPatchImages()` to fix registry authentication failures due to short lived access token expiration.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
