### PR TITLE
added issuer check

### DIFF
--- a/api/kyverno/v1/policy_types.go
+++ b/api/kyverno/v1/policy_types.go
@@ -551,7 +551,7 @@ type ImageVerification struct {
 	// Subject is the verified identity used for keyless signing, for example the email address
 	Subject string `json:"subject,omitempty" yaml:"subject,omitempty"`
 
-	// Issuer is the verified identity used for keyless signing.
+	// Issuer is the certificate issuer used for keyless signing.
 	Issuer string `json:"issuer,omitempty" yaml:"issuer,omitempty"`
 
 	// Repository is an optional alternate OCI repository to use for image signatures that match this rule.

--- a/api/kyverno/v1/policy_types.go
+++ b/api/kyverno/v1/policy_types.go
@@ -551,6 +551,9 @@ type ImageVerification struct {
 	// Subject is the verified identity used for keyless signing, for example the email address
 	Subject string `json:"subject,omitempty" yaml:"subject,omitempty"`
 
+	// Issuer is the verified identity used for keyless signing.
+	Issuer string `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+
 	// Repository is an optional alternate OCI repository to use for image signatures that match this rule.
 	// If specified Repository will override the default OCI image repository configured for the installation.
 	Repository string `json:"repository,omitempty" yaml:"repository,omitempty"`

--- a/go.sum
+++ b/go.sum
@@ -1393,6 +1393,7 @@ github.com/prometheus/common v0.28.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+
 github.com/prometheus/common v0.29.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
 github.com/prometheus/common v0.31.1 h1:d18hG4PkHnNAKNMOmFuXFaiY8Us0nird/2m60uS1AMs=
 github.com/prometheus/common v0.31.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
+github.com/prometheus/common v0.32.1 h1:hWIdL3N2HoUx3B8j3YN9mWor0qhY/NlEKZEaXxuIRh4=
 github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -145,13 +145,13 @@ func VerifySignature(opts Options) (digest string, err error) {
 		return "", errors.Wrap(err, "failed to get payload")
 	}
 
-	issuer, _ := extractIssuer(opts.ImageRef, payload, log)
-	if issuer != "" && (issuer != opts.Issuer) {
+	issuer, err := extractIssuer(opts.ImageRef, payload, log)
+	if err == nil && (issuer != opts.Issuer) {
 		return "", errors.Wrap(err, "issuer mismatch")
 	}
 
-	subject, _ := extractSubject(opts.ImageRef, payload, log)
-	if subject != "" && wildcard.Match(opts.Subject, subject) {
+	subject, err := extractSubject(opts.ImageRef, payload, log)
+	if err == nil && wildcard.Match(opts.Subject, subject) {
 		return "", errors.Wrap(err, "subject mismatch")
 	}
 

--- a/pkg/cosign/cosign_test.go
+++ b/pkg/cosign/cosign_test.go
@@ -40,13 +40,17 @@ func TestCosignPayload(t *testing.T) {
 	var log logr.Logger = logr.DiscardLogger{}
 	image := "registry-v2.nirmata.io/pause"
 	signedPayloads := cosign.SignedPayload{Payload: []byte(cosignPayload)}
-	d, err := extractDigest(image, []oci.Signature{&sig{cosignPayload: signedPayloads}}, log)
+	p, err := extractPayload(image, []oci.Signature{&sig{cosignPayload: signedPayloads}}, log)
+	assert.NilError(t, err)
+	d, err := extractDigest(image, p, log)
 	assert.NilError(t, err)
 	assert.Equal(t, d, "sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108")
 
 	image2 := "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop"
 	signedPayloads2 := cosign.SignedPayload{Payload: []byte(tektonPayload)}
-	d2, err := extractDigest(image2, []oci.Signature{&sig{cosignPayload: signedPayloads2}}, log)
+	p2, err := extractPayload(image2, []oci.Signature{&sig{cosignPayload: signedPayloads2}}, log)
+	assert.NilError(t, err)
+	d2, err := extractDigest(image2, p2, log)
 	assert.NilError(t, err)
 	assert.Equal(t, d2, "sha256:6a037d5ba27d9c6be32a9038bfe676fb67d2e4145b4f53e9c61fb3e69f06e816")
 }

--- a/pkg/cosign/cosign_test.go
+++ b/pkg/cosign/cosign_test.go
@@ -54,10 +54,10 @@ func TestCosignPayload(t *testing.T) {
 	signedPayloads2 := cosign.SignedPayload{Payload: []byte(tektonPayload)}
 	p2, err := extractPayload(image2, []oci.Signature{&sig{cosignPayload: signedPayloads2}}, log)
 	assert.NilError(t, err)
-	i2, err := extractIssuer(image2, p, log)
+	i2, err := extractIssuer(image2, p2, log)
 	assert.NilError(t, err)
 	assert.Equal(t, i2, "https://github.com/login/oauth")
-	s2, err := extractSubject(image2, p, log)
+	s2, err := extractSubject(image2, p2, log)
 	assert.NilError(t, err)
 	assert.Assert(t, wildcard.Match("https://github.com/mycompany/*/.github/workflows/*.yml@refs/heads/main", s2))
 	d2, err := extractDigest(image2, p2, log)

--- a/pkg/cosign/cosign_test.go
+++ b/pkg/cosign/cosign_test.go
@@ -35,7 +35,7 @@ const tektonPayload = `{
     "Type": "Tekton container signature"
   },
   "Optional": {
-	  "Issuer": "https://github.com/login/oauth"
+	  "Issuer": "https://github.com/login/oauth",
 	  "Subject": "https://github.com/mycompany/demo/.github/workflows/ci.yml@refs/heads/main"
   }
 }`

--- a/pkg/cosign/cosign_test.go
+++ b/pkg/cosign/cosign_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sigstore/cosign/pkg/oci"
 
 	"github.com/go-logr/logr"
+	"github.com/minio/pkg/wildcard"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"gotest.tools/assert"
 )
@@ -33,7 +34,10 @@ const tektonPayload = `{
     },
     "Type": "Tekton container signature"
   },
-  "Optional": {}
+  "Optional": {
+	  "Issuer": "https://github.com/login/oauth"
+	  "Subject": "https://github.com/mycompany/demo/.github/workflows/ci.yml@refs/heads/main"
+  }
 }`
 
 func TestCosignPayload(t *testing.T) {
@@ -50,6 +54,12 @@ func TestCosignPayload(t *testing.T) {
 	signedPayloads2 := cosign.SignedPayload{Payload: []byte(tektonPayload)}
 	p2, err := extractPayload(image2, []oci.Signature{&sig{cosignPayload: signedPayloads2}}, log)
 	assert.NilError(t, err)
+	i2, err := extractIssuer(image2, p, log)
+	assert.NilError(t, err)
+	assert.Equal(t, i2, "https://github.com/login/oauth")
+	s2, err := extractSubject(image2, p, log)
+	assert.NilError(t, err)
+	assert.Assert(t, wildcard.Match("https://github.com/mycompany/*/.github/workflows/*.yml@refs/heads/main", s2))
 	d2, err := extractDigest(image2, p2, log)
 	assert.NilError(t, err)
 	assert.Equal(t, d2, "sha256:6a037d5ba27d9c6be32a9038bfe676fb67d2e4145b4f53e9c61fb3e69f06e816")


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

## Related issue
https://github.com/kyverno/kyverno/issues/2591
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

- adding a new field `Issuer` to the policy declaration.
- using this field to add issuer check in `cosign.go`

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
