### PR TITLE
truncate custom jmespath function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 )
 
 require (
+	github.com/aquilax/truncate v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	gopkg.in/inf.v0 v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDw
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
 github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30/go.mod h1:4AJxUpXUhv4N+ziTvIcWWXgeorXpxPZOfk9HdEVr96M=
+github.com/aquilax/truncate v1.0.0 h1:UgIGS8U/aZ4JyOJ2h3xcF5cSQ06+gGBnjxH2RUHJe0U=
+github.com/aquilax/truncate v1.0.0/go.mod h1:BeMESIDMlvlS3bmg4BVvBbbZUNwWtS8uzYPAKXwwhLw=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aquilax/truncate"
 	gojmespath "github.com/jmespath/go-jmespath"
 	"github.com/minio/pkg/wildcard"
-	"github.com/aquilax/truncate"
 )
 
 var (

--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -13,6 +13,7 @@ import (
 
 	gojmespath "github.com/jmespath/go-jmespath"
 	"github.com/minio/pkg/wildcard"
+	"github.com/aquilax/truncate"
 )
 
 var (
@@ -53,6 +54,7 @@ var (
 	base64Encode           = "base64_encode"
 	timeSince              = "time_since"
 	pathCanonicalize       = "path_canonicalize"
+	stringTruncate         = "truncate"
 )
 
 const errorPrefix = "JMESPath function '%s': "
@@ -241,6 +243,14 @@ func getFunctions() []*gojmespath.FunctionEntry {
 				{Types: []JpType{JpString}},
 			},
 			Handler: jpPathCanonicalize,
+		},
+		{
+			Name: stringTruncate,
+			Arguments: []ArgSpec{
+				{Types: []JpType{JpString}},
+				{Types: []JpType{JpNumber}},
+			},
+			Handler: jpStringTruncate,
 		},
 	}
 
@@ -598,6 +608,20 @@ func jpPathCanonicalize(arguments []interface{}) (interface{}, error) {
 	}
 
 	return filepath.Join(str.String()), nil
+}
+
+func jpStringTruncate(arguments []interface{}) (interface{}, error) {
+	var err error
+	str, err := validateArg(stringTruncate, arguments, 0, reflect.String)
+	if err != nil {
+		return nil, err
+	}
+	length, err := validateArg(stringTruncate, arguments, 1, reflect.Float64)
+	if err != nil {
+		return nil, err
+	}
+
+	return truncate.Truncator(str.String(), int(length.Float()), truncate.CutStrategy{}), nil
 }
 
 // InterfaceToString casts an interface to a string type

--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aquilax/truncate"
+	trunc "github.com/aquilax/truncate"
 	gojmespath "github.com/jmespath/go-jmespath"
 	"github.com/minio/pkg/wildcard"
 )
@@ -54,7 +54,7 @@ var (
 	base64Encode           = "base64_encode"
 	timeSince              = "time_since"
 	pathCanonicalize       = "path_canonicalize"
-	stringTruncate         = "truncate"
+	truncate               = "truncate"
 )
 
 const errorPrefix = "JMESPath function '%s': "
@@ -245,12 +245,12 @@ func getFunctions() []*gojmespath.FunctionEntry {
 			Handler: jpPathCanonicalize,
 		},
 		{
-			Name: stringTruncate,
+			Name: truncate,
 			Arguments: []ArgSpec{
 				{Types: []JpType{JpString}},
 				{Types: []JpType{JpNumber}},
 			},
-			Handler: jpStringTruncate,
+			Handler: jpTruncate,
 		},
 	}
 
@@ -610,18 +610,18 @@ func jpPathCanonicalize(arguments []interface{}) (interface{}, error) {
 	return filepath.Join(str.String()), nil
 }
 
-func jpStringTruncate(arguments []interface{}) (interface{}, error) {
+func jpTruncate(arguments []interface{}) (interface{}, error) {
 	var err error
-	str, err := validateArg(stringTruncate, arguments, 0, reflect.String)
+	str, err := validateArg(truncate, arguments, 0, reflect.String)
 	if err != nil {
 		return nil, err
 	}
-	length, err := validateArg(stringTruncate, arguments, 1, reflect.Float64)
+	length, err := validateArg(truncate, arguments, 1, reflect.Float64)
 	if err != nil {
 		return nil, err
 	}
 
-	return truncate.Truncator(str.String(), int(length.Float()), truncate.CutStrategy{}), nil
+	return trunc.Truncator(str.String(), int(length.Float()), trunc.CutStrategy{}), nil
 }
 
 // InterfaceToString casts an interface to a string type

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -972,3 +972,42 @@ func Test_PathCanonicalize(t *testing.T) {
 		})
 	}
 }
+
+func Test_StringTruncate(t *testing.T) {
+	// Can't use integer literals due to
+	// https://github.com/jmespath/go-jmespath/issues/27
+	//
+	// TODO: fix this in https://github.com/kyverno/go-jmespath
+
+	testCases := []struct {
+		jmesPath       string
+		expectedResult string
+	}{
+		{
+			jmesPath:       "truncate('Lorem ipsum dolor sit amet', `5`)",
+			expectedResult: "Lorem",
+		},
+		{
+			jmesPath:       "truncate('Lorem ipsum ipsum ipsum dolor sit amet', `11`)",
+			expectedResult: "Lorem ipsum",
+		},
+		{
+			jmesPath:       "truncate('Lorem ipsum ipsum ipsum dolor sit amet', `40`)",
+			expectedResult: "Lorem ipsum ipsum ipsum dolor sit amet",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.jmesPath, func(t *testing.T) {
+			jp, err := New(tc.jmesPath)
+			assert.NilError(t, err)
+
+			result, err := jp.Search("")
+			assert.NilError(t, err)
+
+			res, ok := result.(string)
+			assert.Assert(t, ok)
+			assert.Equal(t, res, tc.expectedResult)
+		})
+	}
+}

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -973,7 +973,7 @@ func Test_PathCanonicalize(t *testing.T) {
 	}
 }
 
-func Test_StringTruncate(t *testing.T) {
+func Test_Truncate(t *testing.T) {
 	// Can't use integer literals due to
 	// https://github.com/jmespath/go-jmespath/issues/27
 	//


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind feature
## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

This PR adds a `truncate` custom jmespath function that receives a string and length(integer) and returns a new string with only the length(integer) bytes.

This is useful for policies, where some fields are populated from the source resource but may need to be truncated to a certain length due to field size restrictions.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: test
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

# Kubernetes resource

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: test-very-long-name
```

# Policy

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: test-truncate
spec:
  rules:
  - name: test-truncate
    match:
      resources:
        kinds:
        - v1/ServiceAccount
    mutate:
      patchStrategicMerge:
        metadata:
          labels:
            truncated-name: "{{request.object.metadata.name | truncate(@, `9`)}}"
```

# Mutated resource

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  annotations:
    policies.kyverno.io/last-applied-patches: |
      test-truncate.test-truncate.kyverno.io: added /metadata/labels
  labels:
    truncated-name: test-very
  name: test-very-long-name
  namespace: default
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [X] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is: https://github.com/kyverno/website/issues/422
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [X] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
