### PR TITLE
add `semver_compare` JMESPath function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 )
 
 require (
+	github.com/aquilax/truncate v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	gopkg.in/inf.v0 v0.9.1
 )

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 
 require (
 	github.com/aquilax/truncate v1.0.0 // indirect
+	github.com/blang/semver/v4 v4.0.0
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	gopkg.in/inf.v0 v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDw
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
 github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30/go.mod h1:4AJxUpXUhv4N+ziTvIcWWXgeorXpxPZOfk9HdEVr96M=
+github.com/aquilax/truncate v1.0.0 h1:UgIGS8U/aZ4JyOJ2h3xcF5cSQ06+gGBnjxH2RUHJe0U=
+github.com/aquilax/truncate v1.0.0/go.mod h1:BeMESIDMlvlS3bmg4BVvBbbZUNwWtS8uzYPAKXwwhLw=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,7 @@ github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAw
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=

--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	trunc "github.com/aquilax/truncate"
 	gojmespath "github.com/jmespath/go-jmespath"
 	"github.com/minio/pkg/wildcard"
 )
@@ -53,6 +54,7 @@ var (
 	base64Encode           = "base64_encode"
 	timeSince              = "time_since"
 	pathCanonicalize       = "path_canonicalize"
+	truncate               = "truncate"
 )
 
 const errorPrefix = "JMESPath function '%s': "
@@ -241,6 +243,14 @@ func getFunctions() []*gojmespath.FunctionEntry {
 				{Types: []JpType{JpString}},
 			},
 			Handler: jpPathCanonicalize,
+		},
+		{
+			Name: truncate,
+			Arguments: []ArgSpec{
+				{Types: []JpType{JpString}},
+				{Types: []JpType{JpNumber}},
+			},
+			Handler: jpTruncate,
 		},
 	}
 
@@ -598,6 +608,20 @@ func jpPathCanonicalize(arguments []interface{}) (interface{}, error) {
 	}
 
 	return filepath.Join(str.String()), nil
+}
+
+func jpTruncate(arguments []interface{}) (interface{}, error) {
+	var err error
+	str, err := validateArg(truncate, arguments, 0, reflect.String)
+	if err != nil {
+		return nil, err
+	}
+	length, err := validateArg(truncate, arguments, 1, reflect.Float64)
+	if err != nil {
+		return nil, err
+	}
+
+	return trunc.Truncator(str.String(), int(length.Float()), trunc.CutStrategy{}), nil
 }
 
 // InterfaceToString casts an interface to a string type

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -1011,3 +1011,40 @@ func Test_Truncate(t *testing.T) {
 		})
 	}
 }
+
+func Test_SemverCompare(t *testing.T) {
+	testCases := []struct {
+		jmesPath       string
+		expectedResult bool
+	}{
+		{
+			jmesPath:       "semver_compare('4.1.3','>=4.1.x')",
+			expectedResult: true,
+		},
+		{
+			jmesPath:       "semver_compare('4.1.3','!4.x.x')",
+			expectedResult: false,
+		},
+		{
+			jmesPath:       "semver_compare('1.8.6','>1.0.0 <2.0.0')", // >1.0.0 AND <2.0.0
+			expectedResult: true,
+		},
+		{
+			jmesPath:       "semver_compare('2.1.5','<2.0.0 || >=3.0.0')", // <2.0.0 OR >=3.0.0
+			expectedResult: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.jmesPath, func(t *testing.T) {
+			jp, err := New(tc.jmesPath)
+			assert.NilError(t, err)
+
+			result, err := jp.Search("")
+			assert.NilError(t, err)
+
+			res, ok := result.(bool)
+			assert.Assert(t, ok)
+			assert.Equal(t, res, tc.expectedResult)
+		})
+	}
+}

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -972,3 +972,42 @@ func Test_PathCanonicalize(t *testing.T) {
 		})
 	}
 }
+
+func Test_Truncate(t *testing.T) {
+	// Can't use integer literals due to
+	// https://github.com/jmespath/go-jmespath/issues/27
+	//
+	// TODO: fix this in https://github.com/kyverno/go-jmespath
+
+	testCases := []struct {
+		jmesPath       string
+		expectedResult string
+	}{
+		{
+			jmesPath:       "truncate('Lorem ipsum dolor sit amet', `5`)",
+			expectedResult: "Lorem",
+		},
+		{
+			jmesPath:       "truncate('Lorem ipsum ipsum ipsum dolor sit amet', `11`)",
+			expectedResult: "Lorem ipsum",
+		},
+		{
+			jmesPath:       "truncate('Lorem ipsum ipsum ipsum dolor sit amet', `40`)",
+			expectedResult: "Lorem ipsum ipsum ipsum dolor sit amet",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.jmesPath, func(t *testing.T) {
+			jp, err := New(tc.jmesPath)
+			assert.NilError(t, err)
+
+			result, err := jp.Search("")
+			assert.NilError(t, err)
+
+			res, ok := result.(string)
+			assert.Assert(t, ok)
+			assert.Equal(t, res, tc.expectedResult)
+		})
+	}
+}

--- a/pkg/engine/variables/evaluate_test.go
+++ b/pkg/engine/variables/evaluate_test.go
@@ -51,6 +51,9 @@ func TestEvaluate(t *testing.T) {
 		{kyverno.Condition{Key: []interface{}{map[string]string{"foo": "bar"}}, Operator: kyverno.Equals, Value: []interface{}{map[string]string{"bar": "foo"}}}, false},
 		{kyverno.Condition{Key: "1h", Operator: kyverno.Equals, Value: 3600}, true},
 		{kyverno.Condition{Key: "2h", Operator: kyverno.Equals, Value: 3600}, false},
+		{kyverno.Condition{Key: "1.5.2", Operator: kyverno.Equals, Value: "1.5.2"}, true},
+		{kyverno.Condition{Key: "1.5.2", Operator: kyverno.Equals, Value: "1.5.*"}, true},
+		{kyverno.Condition{Key: "1.5.0", Operator: kyverno.Equals, Value: "1.5.5"}, false},
 
 		// Not Equals
 		{kyverno.Condition{Key: "string", Operator: kyverno.NotEquals, Value: "string"}, false},
@@ -88,6 +91,9 @@ func TestEvaluate(t *testing.T) {
 		{kyverno.Condition{Key: []interface{}{map[string]string{"foo": "bar"}}, Operator: kyverno.NotEquals, Value: []interface{}{map[string]string{"bar": "foo"}}}, true},
 		{kyverno.Condition{Key: "1h", Operator: kyverno.NotEquals, Value: 3600}, false},
 		{kyverno.Condition{Key: "2h", Operator: kyverno.NotEquals, Value: 3600}, true},
+		{kyverno.Condition{Key: "1.5.2", Operator: kyverno.NotEquals, Value: "1.5.5"}, true},
+		{kyverno.Condition{Key: "1.5.2", Operator: kyverno.NotEquals, Value: "1.5.*"}, false},
+		{kyverno.Condition{Key: "1.5.0", Operator: kyverno.NotEquals, Value: "1.5.0"}, false},
 
 		// Greater Than
 		{kyverno.Condition{Key: 10, Operator: kyverno.GreaterThan, Value: 1}, true},
@@ -129,6 +135,8 @@ func TestEvaluate(t *testing.T) {
 		{kyverno.Condition{Key: -5, Operator: kyverno.GreaterThan, Value: 1}, false},
 		{kyverno.Condition{Key: -5, Operator: kyverno.GreaterThan, Value: -10}, true},
 		{kyverno.Condition{Key: 1, Operator: kyverno.GreaterThan, Value: -10}, true},
+		{kyverno.Condition{Key: "1.5.5", Operator: kyverno.GreaterThan, Value: "1.5.0"}, true},
+		{kyverno.Condition{Key: "1.5.0", Operator: kyverno.GreaterThan, Value: "1.5.5"}, false},
 
 		// Less Than
 		{kyverno.Condition{Key: 10, Operator: kyverno.LessThan, Value: 1}, false},
@@ -170,6 +178,8 @@ func TestEvaluate(t *testing.T) {
 		{kyverno.Condition{Key: -5, Operator: kyverno.LessThan, Value: 1}, true},
 		{kyverno.Condition{Key: -5, Operator: kyverno.LessThan, Value: -10}, false},
 		{kyverno.Condition{Key: 1, Operator: kyverno.LessThan, Value: -10}, false},
+		{kyverno.Condition{Key: "1.5.5", Operator: kyverno.LessThan, Value: "1.5.0"}, false},
+		{kyverno.Condition{Key: "1.5.0", Operator: kyverno.LessThan, Value: "1.5.5"}, true},
 
 		// Greater Than or Equal
 		{kyverno.Condition{Key: 10, Operator: kyverno.GreaterThanOrEquals, Value: 1}, true},
@@ -206,6 +216,9 @@ func TestEvaluate(t *testing.T) {
 		{kyverno.Condition{Key: 1, Operator: kyverno.GreaterThanOrEquals, Value: int64(1)}, true},
 		{kyverno.Condition{Key: 10, Operator: kyverno.GreaterThanOrEquals, Value: int64(1)}, true},
 		{kyverno.Condition{Key: 1, Operator: kyverno.GreaterThanOrEquals, Value: int64(10)}, false},
+		{kyverno.Condition{Key: "1.5.5", Operator: kyverno.GreaterThanOrEquals, Value: "1.5.5"}, true},
+		{kyverno.Condition{Key: "1.5.5", Operator: kyverno.GreaterThanOrEquals, Value: "1.5.0"}, true},
+		{kyverno.Condition{Key: "1.5.0", Operator: kyverno.GreaterThanOrEquals, Value: "1.5.5"}, false},
 
 		// Less Than or Equal
 		{kyverno.Condition{Key: 10, Operator: kyverno.LessThanOrEquals, Value: 1}, false},
@@ -242,6 +255,9 @@ func TestEvaluate(t *testing.T) {
 		{kyverno.Condition{Key: 1, Operator: kyverno.LessThanOrEquals, Value: int64(1)}, true},
 		{kyverno.Condition{Key: 10, Operator: kyverno.LessThanOrEquals, Value: int64(1)}, false},
 		{kyverno.Condition{Key: 1, Operator: kyverno.LessThanOrEquals, Value: int64(10)}, true},
+		{kyverno.Condition{Key: "1.5.5", Operator: kyverno.LessThanOrEquals, Value: "1.5.5"}, true},
+		{kyverno.Condition{Key: "1.5.0", Operator: kyverno.LessThanOrEquals, Value: "1.5.5"}, true},
+		{kyverno.Condition{Key: "1.5.5", Operator: kyverno.LessThanOrEquals, Value: "1.5.0"}, false},
 
 		// In
 		{kyverno.Condition{Key: 1, Operator: kyverno.In, Value: []interface{}{1, 2, 3}}, true},

--- a/pkg/engine/variables/operator/numeric.go
+++ b/pkg/engine/variables/operator/numeric.go
@@ -38,14 +38,6 @@ func compareByCondition(key float64, value float64, op kyverno.ConditionOperator
 		return key <= value
 	case kyverno.LessThan:
 		return key < value
-	// case kyverno.Equals:
-	// 	return key == value
-	// case kyverno.Equal:
-	// 	return key == value
-	// case kyverno.NotEquals:
-	// 	return key != value
-	// case kyverno.NotEqual:
-	// 	return key != value
 	default:
 		(*log).Info(fmt.Sprintf("Expected operator, one of [GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, Equals, NotEquals], found %s", op))
 		return false

--- a/pkg/engine/variables/operator/numeric.go
+++ b/pkg/engine/variables/operator/numeric.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
 	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/engine/context"
@@ -37,14 +38,30 @@ func compareByCondition(key float64, value float64, op kyverno.ConditionOperator
 		return key <= value
 	case kyverno.LessThan:
 		return key < value
-	case kyverno.Equals:
-		return key == value
-	case kyverno.Equal:
-		return key == value
-	case kyverno.NotEquals:
-		return key != value
-	case kyverno.NotEqual:
-		return key != value
+	// case kyverno.Equals:
+	// 	return key == value
+	// case kyverno.Equal:
+	// 	return key == value
+	// case kyverno.NotEquals:
+	// 	return key != value
+	// case kyverno.NotEqual:
+	// 	return key != value
+	default:
+		(*log).Info(fmt.Sprintf("Expected operator, one of [GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, Equals, NotEquals], found %s", op))
+		return false
+	}
+}
+
+func compareVersionByCondition(key semver.Version, value semver.Version, op kyverno.ConditionOperator, log *logr.Logger) bool {
+	switch op {
+	case kyverno.GreaterThanOrEquals:
+		return key.GTE(value)
+	case kyverno.GreaterThan:
+		return key.GT(value)
+	case kyverno.LessThanOrEquals:
+		return key.LTE(value)
+	case kyverno.LessThan:
+		return key.LT(value)
 	default:
 		(*log).Info(fmt.Sprintf("Expected operator, one of [GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, Equals, NotEquals], found %s", op))
 		return false
@@ -141,6 +158,21 @@ func (noh NumericOperatorHandler) validateValueWithResourcePattern(key resource.
 	}
 }
 
+func (noh NumericOperatorHandler) validateValueWithVersionPattern(key semver.Version, value interface{}) bool {
+	switch typedValue := value.(type) {
+	case string:
+		versionValue, err := semver.Parse(typedValue)
+		if err != nil {
+			noh.log.Error(fmt.Errorf("parse error: "), "Failed to parse value type doesn't match key type")
+			return false
+		}
+		return compareVersionByCondition(key, versionValue, noh.condition, &noh.log)
+	default:
+		noh.log.Info("Expected type string", "value", value, "type", fmt.Sprintf("%T", value))
+		return false
+	}
+}
+
 func (noh NumericOperatorHandler) validateValueWithStringPattern(key string, value interface{}) bool {
 	// We need to check duration first as it's the only type that can be compared to a different type
 	durationKey, durationValue, err := parseDuration(key, value)
@@ -161,6 +193,11 @@ func (noh NumericOperatorHandler) validateValueWithStringPattern(key string, val
 	resourceKey, err := resource.ParseQuantity(key)
 	if err == nil {
 		return noh.validateValueWithResourcePattern(resourceKey, value)
+	}
+	// attempt to extract version from string
+	versionKey, err := semver.Parse(key)
+	if err == nil {
+		return noh.validateValueWithVersionPattern(versionKey, value)
 	}
 
 	noh.log.Error(err, "Failed to parse from the string key, value is not float, int nor resource quantity")

--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -161,7 +161,7 @@ func Command() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(&fileName, "file-name", "f", "test.yaml", "test filename")
+	cmd.Flags().StringVarP(&fileName, "file-name", "f", "kyverno-test.yaml", "test filename")
 	return cmd
 }
 
@@ -222,6 +222,7 @@ func testCommandExecute(dirPath []string, valuesFile string, fileName string) (r
 	fs := memfs.New()
 	rc = &resultCounts{}
 	var testYamlCount int
+	var testYamlNameCount int
 
 	if len(dirPath) == 0 {
 		return rc, sanitizederror.NewWithError(fmt.Sprintf("a directory is required"), err)
@@ -267,8 +268,11 @@ func testCommandExecute(dirPath []string, valuesFile string, fileName string) (r
 				continue
 			}
 
-			if strings.Contains(file.Name(), fileName) {
+			if strings.Contains(file.Name(), fileName) || strings.Contains(file.Name(), "test.yaml") {
 				testYamlCount++
+				if strings.Contains(file.Name(), "test.yaml") {
+					testYamlNameCount++
+				}
 				policyresoucePath := strings.Trim(yamlFilePath, fileName)
 				bytes, err := ioutil.ReadAll(file)
 				if err != nil {
@@ -290,6 +294,9 @@ func testCommandExecute(dirPath []string, valuesFile string, fileName string) (r
 
 		if testYamlCount == 0 {
 			fmt.Printf("\n No test yamls available \n")
+		}
+		if testYamlNameCount > 0 {
+			fmt.Printf("\n Note : test.yaml file name is deprecated in 1.6.0 release. Please provide test yaml file as kyverno-test.yaml \n")
 		}
 
 	} else {
@@ -314,6 +321,8 @@ func testCommandExecute(dirPath []string, valuesFile string, fileName string) (r
 
 func getLocalDirTestFiles(fs billy.Filesystem, path, fileName, valuesFile string, rc *resultCounts) []error {
 	var errors []error
+	var count int
+	var dirTestYamlNameCount int
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		return []error{fmt.Errorf("failed to read %v: %v", path, err.Error())}
@@ -323,7 +332,11 @@ func getLocalDirTestFiles(fs billy.Filesystem, path, fileName, valuesFile string
 			getLocalDirTestFiles(fs, filepath.Join(path, file.Name()), fileName, valuesFile, rc)
 			continue
 		}
-		if strings.Contains(file.Name(), fileName) {
+		if strings.Contains(file.Name(), fileName) || strings.Contains(file.Name(), "test.yaml") {
+			count++
+			if strings.Contains(file.Name(), "test.yaml") {
+				dirTestYamlNameCount++
+			}
 			// We accept the risk of including files here as we read the test dir only.
 			yamlFile, err := ioutil.ReadFile(filepath.Join(path, file.Name())) // #nosec G304
 			if err != nil {
@@ -340,6 +353,12 @@ func getLocalDirTestFiles(fs billy.Filesystem, path, fileName, valuesFile string
 				continue
 			}
 		}
+	}
+	if count == 0 {
+		fmt.Printf("\n No test yamls found. Please provide test yaml file as kyverno-test.yaml \n")
+	}
+	if dirTestYamlNameCount > 0 {
+		fmt.Printf("\n Note: test.yaml file name is deprecated in 1.6.0 release. Please provide test yaml file as kyverno-test.yaml \n")
 	}
 	return errors
 }


### PR DESCRIPTION
## Related issue
#2837 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.6.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Add a custom JMESPath function semver_compare to prevent bypassing the version validation.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
SBOM fragment used for testing: https://github.com/kyverno/kyverno/pull/2846#issuecomment-997671084

policy
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: attest-sbom
spec:
  validationFailureAction: enforce
  background: false
  webhookTimeoutSeconds: 30
  failurePolicy: Fail
  rules:
    - name: check-sbom
      match:
        resources:
          kinds:
            - Pod
      verifyImages:
      - image: "ghcr.io/namanl2001/kyverno:*"
        key: |-
          -----BEGIN PUBLIC KEY-----
          MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtS69SctDWseJdFcQnpJGh3Yq3WfM
          EpLCSBfCcCyTotqkFCsGjhAFiSblvmX8vn51dbnZ7cdtiahat/eehymyJg==
          -----END PUBLIC KEY-----
        attestations:
        - predicateType: https://example.com/CycloneDX/v1
          conditions:
            - all:
              - key: "{{ components[?name == 'failureaccess'].version | [0] }}"
                operator: GreaterThanOrEquals
                value: "1.0.1"
              - key: "{{ semver_compare( '{{ components[?name == 'httpclient'].version | [0] }}', '>4.4.x') }}"
                operator: Equals
                value: true
```
resource
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
spec:
  containers:
  - name: kyverno
    image: ghcr.io/namanl2001/kyverno:v1
```

for any typo in the key, getting error:
```err
attest-sbom:
  check-sbom: attestation checks failed for ghcr.io/namanl2001/kyverno:v1 and predicate
    https://example.com/CycloneDX/v1
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [x] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is: https://github.com/kyverno/website/issues/428
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) 
    <!-- - [ ] and followed the process including adding proof manifests to this PR. -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
