### PR TITLE
jmespath truncate - handle negative input value

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -612,6 +612,7 @@ func jpPathCanonicalize(arguments []interface{}) (interface{}, error) {
 
 func jpTruncate(arguments []interface{}) (interface{}, error) {
 	var err error
+	var normalizedLength float64
 	str, err := validateArg(truncate, arguments, 0, reflect.String)
 	if err != nil {
 		return nil, err
@@ -621,7 +622,13 @@ func jpTruncate(arguments []interface{}) (interface{}, error) {
 		return nil, err
 	}
 
-	return trunc.Truncator(str.String(), int(length.Float()), trunc.CutStrategy{}), nil
+	if length.Float() < 0 {
+		normalizedLength = float64(0)
+	} else {
+		normalizedLength = length.Float()
+	}
+
+	return trunc.Truncator(str.String(), int(normalizedLength), trunc.CutStrategy{}), nil
 }
 
 // InterfaceToString casts an interface to a string type

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -995,6 +995,18 @@ func Test_Truncate(t *testing.T) {
 			jmesPath:       "truncate('Lorem ipsum ipsum ipsum dolor sit amet', `40`)",
 			expectedResult: "Lorem ipsum ipsum ipsum dolor sit amet",
 		},
+		{
+			jmesPath:       "truncate('Lorem ipsum', `2.6`)",
+			expectedResult: "Lo",
+		},
+		{
+			jmesPath:       "truncate('Lorem ipsum', `0`)",
+			expectedResult: "",
+		},
+		{
+			jmesPath:       "truncate('Lorem ipsum', `-1`)",
+			expectedResult: "",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

#2836 

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

/milestone 1.6.0

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

Fixes handling of negative length input value in the JMESPath custom truncate function

## Proof Manifests

### Kubernetes resource

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: test-very-long-name
  namespace: default
```

### Policy

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: test-truncate
spec:
  rules:
  - name: test-truncate
    match:
      resources:
        kinds:
        - v1/ServiceAccount
    mutate:
      patchStrategicMerge:
        metadata:
          labels:
            truncated-name: "{{request.object.metadata.name | truncate(@, `-1`)}}"
```

### Mutated resource
```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  annotations:
    policies.kyverno.io/last-applied-patches: |
      test-truncate.test-truncate.kyverno.io: added /metadata/labels
  labels:
    truncated-name: ""
  name: test-very-long-name
  namespace: default
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [X] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is: https://github.com/kyverno/website/issues/422
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [X] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

follow-up on #2836 to address https://github.com/kyverno/kyverno/pull/2836#issuecomment-994824094