### PR TITLE
Increase Kyverno memory request and limit

### DIFF
--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -83,10 +83,10 @@ extraArgs: []
 
 resources:
   limits:
-    memory: 256Mi
+    memory: 384Mi
   requests:
     cpu: 100m
-    memory: 50Mi
+    memory: 128Mi
 
 initResources:
   limits:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -7785,10 +7785,10 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            memory: 256Mi
+            memory: 384Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/manifest/deployment.yaml
+++ b/config/manifest/deployment.yaml
@@ -103,10 +103,10 @@ spec:
                 - all
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "100m"
+              memory: 128Mi
+              cpu: 100m
             limits:
-              memory: "384Mi"
+              memory: 384Mi
           livenessProbe:
             httpGet:
               path: /health/liveness

--- a/config/manifest/deployment.yaml
+++ b/config/manifest/deployment.yaml
@@ -103,10 +103,10 @@ spec:
                 - all
           resources:
             requests:
-              memory: "50Mi"
+              memory: "128Mi"
               cpu: "100m"
             limits:
-              memory: "256Mi"
+              memory: "384Mi"
           livenessProbe:
             httpGet:
               path: /health/liveness


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Related issue

Based on the memory measurement for different sets of resources, captured in [this](https://docs.google.com/spreadsheets/d/1cCQfCtCQn6aMs7IbxXc48SnhuVxAbnBmEZ-gxxboUXw/edit?usp=sharing.) sheet by @siddharthlal25 (thank you Siddharthlal!), and a few other user's [feedback](https://kubernetes.slack.com/archives/CLGR9BJU9/p1639659703367900?thread_ts=1639616500.355300&cid=CLGR9BJU9),  `256Mi` of memory limit seems to cause OOM issue.

This PR bumps the memory request and limit based on the above observation, to 128Mi and 384Mi.
