### PR TITLE
Fix Foreach JMESPath issue

### DIFF
--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -328,7 +328,6 @@ func substituteVariablesIfAny(log logr.Logger, ctx context.EvalInterface, vr Var
 		vars := RegexVariables.FindAllString(value, -1)
 		for len(vars) > 0 {
 			originalPattern := value
-
 			for _, v := range vars {
 				initial := len(regexVariableInit.FindAllString(v, -1)) > 0
 				old := v
@@ -415,6 +414,9 @@ var regexPathDigit = regexp.MustCompile(`\.?([\d])\.?`)
 // getJMESPath converts path to JMESPath format
 func getJMESPath(rawPath string) string {
 	tokens := strings.Split(rawPath, "/")[3:] // skip "/" + 2 elements (e.g. mutate.overlay | validate.pattern)
+	if strings.Contains(rawPath, "foreach") {
+		tokens = strings.Split(rawPath, "/")[5:] // skip "/" + 4 elements (e.g. mutate.foreach/list/overlay | validate.mutate.foreach/list/pattern)
+	}
 	path := strings.Join(tokens, ".")
 	b := regexPathDigit.ReplaceAll([]byte(path), []byte("[$1]."))
 	result := strings.Trim(string(b), ".")

--- a/pkg/engine/variables/vars_test.go
+++ b/pkg/engine/variables/vars_test.go
@@ -1157,3 +1157,9 @@ func Test_getJMESPath(t *testing.T) {
 	assert.Equal(t, "spec.containers[0].volumes[1]", getJMESPath("/validate/pattern/spec/containers/0/volumes/1"))
 	assert.Equal(t, "[0]", getJMESPath("/mutate/overlay/0"))
 }
+
+func Test_getJMESPathForForeach(t *testing.T) {
+	assert.Equal(t, "spec.containers[0]", getJMESPath("/validate/foreach/0/pattern/spec/containers/0"))
+	assert.Equal(t, "spec.containers[0].volumes[1]", getJMESPath("/validate/foreach/0/pattern/spec/containers/0/volumes/1"))
+	assert.Equal(t, "[0]", getJMESPath("/mutate/foreach/0/overlay/0"))
+}


### PR DESCRIPTION
## Related issue
Signed-off-by: Vyankatesh vyankateshkd@gmail.com

## Related issue
closes https://github.com/kyverno/kyverno/issues/2863

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
milestone 1.6.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/kind bug

## Proof Manifest
Policy.yaml

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: replace-image-registry
  annotations:
    policies.kyverno.io/title: Replace Image Registry
    policies.kyverno.io/category: Sample
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod
    policies.kyverno.io/minversion: 1.3.6
    policies.kyverno.io/description: >-
      Rather than blocking Pods which come from outside registries,
      it is also possible to mutate them so the pulls are directed to
      approved registries. In some cases, those registries may function as
      pull-through proxies and can fetch the image if not cached.
      This policy policy mutates all images either
      in the form 'image:tag' or 'registry.corp.com/image:tag' to be prefaced
      with `myregistry.corp.com/`.      
spec:
  background: false
  rules:
    - name: replace-image-registry
      match:
        resources:
          kinds:
          - Pod
      preconditions:
      - key: "{{ request.operation }}"
        operator: Equals
        value: "CREATE"
      mutate:
        foreach:
          - list: request.object.spec.containers
            patchStrategicMerge:
              spec:
                containers:
                  - name: '{{ element.name }}'
                    image: |-    
                                {{ regex_replace_all('^[^/]+', '{{@}}', 'myregistry.corp.com') }}

```

Resource.yaml

```yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    annotation.corp.com/restrict1: foo1
  labels:
    app: busybox
  name: mypod-23
spec:
  automountServiceAccountToken: false
  containers:
  - name: nginx
    image: ghcr.io/nginx:1.28

```

result
```
spec:
  automountServiceAccountToken: false
  containers:
  - name: nginx
    image: myregistry.corp.com/nginx:1.28
```


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
