### PR TITLE
Fix policy report reconciliation on resource/policy deletion

### DIFF
--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -145,7 +145,7 @@ func (builder *requestBuilder) build(info Info) (req *unstructured.Unstructured,
 		set(req, info)
 	}
 
-	if !setRequestLabels(req, info) {
+	if !setRequestDeletionLabels(req, info) {
 		if len(results) == 0 {
 			// return nil on empty result without a deletion
 			return nil, nil
@@ -206,7 +206,7 @@ func set(obj *unstructured.Unstructured, info Info) {
 	})
 }
 
-func setRequestLabels(req *unstructured.Unstructured, info Info) bool {
+func setRequestDeletionLabels(req *unstructured.Unstructured, info Info) bool {
 	switch {
 	case isResourceDeletion(info):
 		req.SetAnnotations(map[string]string{
@@ -214,26 +214,28 @@ func setRequestLabels(req *unstructured.Unstructured, info Info) bool {
 			deletedAnnotationResourceKind: info.Results[0].Resource.Kind,
 		})
 
-		req.SetLabels(map[string]string{
-			resourceLabelNamespace: info.Results[0].Resource.Namespace,
-		})
+		labels := req.GetLabels()
+		labels[resourceLabelNamespace] = info.Results[0].Resource.Namespace
+		req.SetLabels(labels)
 		return true
 
 	case isPolicyDeletion(info):
 		req.SetKind("ReportChangeRequest")
 		req.SetGenerateName("rcr-")
-		req.SetLabels(map[string]string{
-			deletedLabelPolicy: info.PolicyName},
-		)
+
+		labels := req.GetLabels()
+		labels[deletedLabelPolicy] = info.PolicyName
+		req.SetLabels(labels)
 		return true
 
 	case isRuleDeletion(info):
 		req.SetKind("ReportChangeRequest")
 		req.SetGenerateName("rcr-")
-		req.SetLabels(map[string]string{
-			deletedLabelPolicy: info.PolicyName,
-			deletedLabelRule:   info.Results[0].Rules[0].Name},
-		)
+
+		labels := req.GetLabels()
+		labels[deletedLabelPolicy] = info.PolicyName
+		labels[deletedLabelRule] = info.Results[0].Rules[0].Name
+		req.SetLabels(labels)
 		return true
 	}
 

--- a/pkg/policyreport/reportcontroller.go
+++ b/pkg/policyreport/reportcontroller.go
@@ -319,6 +319,7 @@ func (g *ReportGenerator) syncHandler(key string) (aggregatedRequests interface{
 	g.log.V(4).Info("syncing policy report", "key", key)
 
 	if policy, rule, ok := isDeletedPolicyKey(key); ok {
+		g.log.V(4).Info("sync policy report on policy deletion")
 		return g.removePolicyEntryFromReport(policy, rule)
 	}
 
@@ -332,7 +333,9 @@ func (g *ReportGenerator) syncHandler(key string) (aggregatedRequests interface{
 	if old, err = g.createReportIfNotPresent(namespace, new, aggregatedRequests); err != nil {
 		return aggregatedRequests, err
 	}
+
 	if old == nil {
+		g.log.V(4).Info("no existing policy report is found, clean up related report change requests")
 		g.cleanupReportRequests(aggregatedRequests)
 		return nil, nil
 	}
@@ -629,6 +632,7 @@ func (g *ReportGenerator) updateReport(old interface{}, new *unstructured.Unstru
 		g.log.V(4).Info("empty report to update")
 		return nil
 	}
+	g.log.V(4).Info("reconcile policy report")
 
 	oldUnstructured := make(map[string]interface{})
 
@@ -655,6 +659,7 @@ func (g *ReportGenerator) updateReport(old interface{}, new *unstructured.Unstru
 		new.SetResourceVersion(oldTyped.GetResourceVersion())
 	}
 
+	g.log.V(4).Info("update results entries")
 	obj, _, err := updateResults(oldUnstructured, new.UnstructuredContent(), aggregatedRequests)
 	if err != nil {
 		return fmt.Errorf("failed to update results entry: %v", err)


### PR DESCRIPTION
Cherry-pick https://github.com/kyverno/kyverno/pull/2610 to fix the policy report issue.

Related: https://github.com/kyverno/kyverno/issues/2330:

I am seeing memory increase using Kyverno v1.5.2. 

The memory kept increasing due to the stale results in reports, where the pods were deleted but the results were left in the reports. Test setup: with the best practice policies installed and cronjobs scheduled, the report results weren't cleaned up when the pods were GC-ed. 

Next: will test the fixed version and continue troubleshooting https://github.com/kyverno/kyverno/issues/2330.
