### PR TITLE
Don't generate policy report on managed pod/job

### DIFF
--- a/pkg/engine/response/response.go
+++ b/pkg/engine/response/response.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -11,6 +12,10 @@ import (
 type EngineResponse struct {
 	// Resource patched with the engine action changes
 	PatchedResource unstructured.Unstructured
+
+	// Original policy
+	Policy *kyverno.ClusterPolicy
+
 	// Policy Response
 	PolicyResponse PolicyResponse
 }

--- a/pkg/engine/utils.go
+++ b/pkg/engine/utils.go
@@ -377,7 +377,7 @@ func copyAnyAllConditions(original kyverno.AnyAllConditions) kyverno.AnyAllCondi
 
 // backwards compatibility
 func copyOldConditions(original []kyverno.Condition) []kyverno.Condition {
-	if original == nil || len(original) == 0 {
+	if len(original) == 0 {
 		return []kyverno.Condition{}
 	}
 

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -64,6 +64,7 @@ func buildResponse(ctx *PolicyContext, resp *response.EngineResponse, startTime 
 		resp.PatchedResource = resource
 	}
 
+	resp.Policy = &ctx.Policy
 	resp.PolicyResponse.Policy.Name = ctx.Policy.GetName()
 	resp.PolicyResponse.Policy.Namespace = ctx.Policy.GetNamespace()
 	resp.PolicyResponse.Resource.Name = resp.PatchedResource.GetName()

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -12,6 +12,7 @@ import (
 	report "github.com/kyverno/kyverno/api/policyreport/v1alpha2"
 	kyvernolister "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/config"
+	"github.com/kyverno/kyverno/pkg/engine"
 	"github.com/kyverno/kyverno/pkg/engine/response"
 	"github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/kyverno/kyverno/pkg/version"
@@ -63,6 +64,10 @@ func GeneratePRsFromEngineResponse(ers []*response.EngineResponse, log logr.Logg
 		}
 
 		if len(er.PolicyResponse.Rules) == 0 {
+			continue
+		}
+
+		if er.Policy != nil && engine.ManagedPodResource(*er.Policy, er.PatchedResource) {
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Related issue

Closes https://github.com/kyverno/kyverno/issues/2330.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.5.3
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/enhancement
/bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
With PR https://github.com/kyverno/kyverno/pull/2648, Kyverno applies policy on all managed pods/jobs to fix the security issue. While duplicate policy results are audited in the reports, for example, when there's a CronJob installed, the report includes results for CronJob, Job, and Pod. If one has enough CronJobs scheduled in the cluster, the report will eventually be flooded and exceed its limit (ResourceExhausted). Furthermore, reportChangeRequests can no longer be merged to policy reports (due to "ResourceExhausted") thus leading to memory increase.

This PR keeps the policy application at managed pods/jobs level, while only reporting the results for top-level owners (CronJob, Deployment, etc). 

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

With 80 CronJobs (across 8 namespaces) and default kyverno-policies chart installed, the total policy report results dropped from ~3000 down to 60, and the memory usage dropped to ~500Mi from ~800Mi.

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments
The policy report seems inconsistent between `main` and `release-1.5` branches. Will cherry-pick and test thoroughly for two versions.

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
