### PR TITLE
Fix TLS inconsistency in HA

### DIFF
--- a/pkg/tls/certRenewer.go
+++ b/pkg/tls/certRenewer.go
@@ -118,7 +118,7 @@ func (c *CertRenewer) WriteCACertToSecret(caPEM *PemPair, props CertificateProps
 	logger := c.log.WithName("CAcert")
 	name := generateRootCASecretName(props)
 
-	depl, err := c.client.GetResource("", "Deployment", props.Namespace, "kyverno")
+	depl, err := c.client.GetResource("", "Deployment", props.Namespace, config.KyvernoDeploymentName)
 
 	rsHash := ""
 	if err != nil {

--- a/pkg/tls/certRenewer.go
+++ b/pkg/tls/certRenewer.go
@@ -165,7 +165,7 @@ func (c *CertRenewer) WriteCACertToSecret(caPEM *PemPair, props CertificateProps
 		}
 		return err
 	} else if managedByKyverno && (!ok || deplHashSec != deplHash) {
-		c.client.UpdateResource("", "Secret", props.Namespace, secret, false)
+		_, err = c.client.UpdateResource("", "Secret", props.Namespace, secret, false)
 		if err == nil {
 			logger.Info("secret updated", "name", name, "namespace", props.Namespace)
 		}

--- a/pkg/tls/certRenewer.go
+++ b/pkg/tls/certRenewer.go
@@ -120,8 +120,12 @@ func (c *CertRenewer) WriteCACertToSecret(caPEM *PemPair, props CertificateProps
 
 	depl, err := c.client.GetResource("", "Deployment", props.Namespace, "kyverno")
 
-	rsHash := fmt.Sprintf("%v", depl.GetUID())
-	var rsHashSec string
+	rsHash := ""
+	if err != nil {
+		rsHash = fmt.Sprintf("%v", depl.GetUID())
+	}
+
+	var rsHashSec string = "default"
 	var ok bool
 
 	secretUnstr, err := c.client.GetResource("", "Secret", props.Namespace, name)

--- a/pkg/tls/certRenewer.go
+++ b/pkg/tls/certRenewer.go
@@ -118,59 +118,59 @@ func (c *CertRenewer) WriteCACertToSecret(caPEM *PemPair, props CertificateProps
 	logger := c.log.WithName("CAcert")
 	name := generateRootCASecretName(props)
 
-	depl, err := c.client.GetResource("", "Deployment", props.Namespace, config.KyvernoDeploymentName)
+	// depl, err := c.client.GetResource("", "Deployment", props.Namespace, config.KyvernoDeploymentName)
 
-	deplHash := ""
-	if err == nil {
-		deplHash = fmt.Sprintf("%v", depl.GetUID())
-	}
+	// deplHash := ""
+	// if err == nil {
+	// 	deplHash = fmt.Sprintf("%v", depl.GetUID())
+	// }
 
-	var deplHashSec string = "default"
-	var ok, managedByKyverno bool
+	//	var deplHashSec string = "default"
+	//	var ok, managedByKyverno bool
 
 	secretUnstr, err := c.client.GetResource("", "Secret", props.Namespace, name)
-	if err == nil {
-		if label, ok := secretUnstr.GetLabels()[ManagedByLabel]; ok {
-			managedByKyverno = label == "kyverno"
-		}
-		deplHashSec, ok = secretUnstr.GetAnnotations()[MasterDeploymentUID]
-	}
-
-	secret := &v1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: props.Namespace,
-			Annotations: map[string]string{
-				SelfSignedAnnotation: "true",
-				MasterDeploymentUID:  deplHash,
-			},
-			Labels: map[string]string{
-				ManagedByLabel: "kyverno",
-			},
-		},
-		Data: map[string][]byte{
-			RootCAKey: caPEM.Certificate,
-		},
-		Type: v1.SecretTypeOpaque,
-	}
+	//	if err == nil {
+	//		if label, ok := secretUnstr.GetLabels()[ManagedByLabel]; ok {
+	//			managedByKyverno = label == "kyverno"
+	//		}
+	//		deplHashSec, ok = secretUnstr.GetAnnotations()[MasterDeploymentUID]
+	//	}
 
 	if err != nil {
+		secret := &v1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: props.Namespace,
+				Annotations: map[string]string{
+					SelfSignedAnnotation: "true",
+					//			MasterDeploymentUID:  deplHash,
+				},
+				Labels: map[string]string{
+					ManagedByLabel: "kyverno",
+				},
+			},
+			Data: map[string][]byte{
+				RootCAKey: caPEM.Certificate,
+			},
+			Type: v1.SecretTypeOpaque,
+		}
 		_, err := c.client.CreateResource("", "Secret", props.Namespace, secret, false)
 		if err == nil {
 			logger.Info("secret created", "name", name, "namespace", props.Namespace)
 		}
 		return err
-	} else if managedByKyverno && (!ok || deplHashSec != deplHash) {
-		_, err = c.client.UpdateResource("", "Secret", props.Namespace, secret, false)
-		if err == nil {
-			logger.Info("secret updated", "name", name, "namespace", props.Namespace)
-		}
-		return err
 	}
+	//	else if managedByKyverno && (!ok || deplHashSec != deplHash) {
+	//		_, err = c.client.UpdateResource("", "Secret", props.Namespace, secret, false)
+	//		if err == nil {
+	//			logger.Info("secret updated", "name", name, "namespace", props.Namespace)
+	//		}
+	//		return err
+	//	}
 
 	if _, ok := secretUnstr.GetAnnotations()[SelfSignedAnnotation]; !ok {
 		secretUnstr.SetAnnotations(map[string]string{SelfSignedAnnotation: "true"})
@@ -198,59 +198,59 @@ func (c *CertRenewer) WriteTLSPairToSecret(props CertificateProps, pemPair *PemP
 
 	name := generateTLSPairSecretName(props)
 
-	depl, err := c.client.GetResource("", "Deployment", props.Namespace, config.KyvernoDeploymentName)
-
-	deplHash := ""
-	if err == nil {
-		deplHash = fmt.Sprintf("%v", depl.GetUID())
-	}
-
-	var deplHashSec string = "default"
-	var ok, managedByKyverno bool
+	//	depl, err := c.client.GetResource("", "Deployment", props.Namespace, config.KyvernoDeploymentName)
+	//
+	//	deplHash := ""
+	//	if err == nil {
+	//		deplHash = fmt.Sprintf("%v", depl.GetUID())
+	//	}
+	//
+	//	var deplHashSec string = "default"
+	//	var ok, managedByKyverno bool
 
 	secretUnstr, err := c.client.GetResource("", "Secret", props.Namespace, name)
-	if err == nil {
-		if label, ok := secretUnstr.GetLabels()[ManagedByLabel]; ok {
-			managedByKyverno = label == "kyverno"
-		}
-		deplHashSec, ok = secretUnstr.GetAnnotations()[MasterDeploymentUID]
-	}
-
-	secretPtr := &v1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: props.Namespace,
-			Annotations: map[string]string{
-				MasterDeploymentUID: deplHash,
-			},
-			Labels: map[string]string{
-				ManagedByLabel: "kyverno",
-			},
-		},
-		Data: map[string][]byte{
-			v1.TLSCertKey:       pemPair.Certificate,
-			v1.TLSPrivateKeyKey: pemPair.PrivateKey,
-		},
-		Type: v1.SecretTypeTLS,
-	}
+	//	if err == nil {
+	//		if label, ok := secretUnstr.GetLabels()[ManagedByLabel]; ok {
+	//			managedByKyverno = label == "kyverno"
+	//		}
+	//		deplHashSec, ok = secretUnstr.GetAnnotations()[MasterDeploymentUID]
+	//	}
 
 	if err != nil {
+		secretPtr := &v1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: props.Namespace,
+				//			Annotations: map[string]string{
+				//				MasterDeploymentUID: deplHash,
+				//			},
+				Labels: map[string]string{
+					ManagedByLabel: "kyverno",
+				},
+			},
+			Data: map[string][]byte{
+				v1.TLSCertKey:       pemPair.Certificate,
+				v1.TLSPrivateKeyKey: pemPair.PrivateKey,
+			},
+			Type: v1.SecretTypeTLS,
+		}
 		_, err := c.client.CreateResource("", "Secret", props.Namespace, secretPtr, false)
 		if err == nil {
 			logger.Info("secret created", "name", name, "namespace", props.Namespace)
 		}
 		return err
-	} else if managedByKyverno && (!ok || deplHashSec != deplHash) {
-		_, err := c.client.UpdateResource("", "Secret", props.Namespace, secretPtr, false)
-		if err == nil {
-			logger.Info("secret updated", "name", name, "namespace", props.Namespace)
-		}
-		return err
 	}
+	//else if managedByKyverno && (!ok || deplHashSec != deplHash) {
+	//	_, err := c.client.UpdateResource("", "Secret", props.Namespace, secretPtr, false)
+	//	if err == nil {
+	//		logger.Info("secret updated", "name", name, "namespace", props.Namespace)
+	//	}
+	//	return err
+	//}
 
 	dataMap := map[string][]byte{
 		v1.TLSCertKey:       pemPair.Certificate,

--- a/pkg/tls/reader.go
+++ b/pkg/tls/reader.go
@@ -43,7 +43,7 @@ func ReadRootCASecret(restConfig *rest.Config, client *client.Client) (result []
 	}
 	deplHashSec, ok = stlsca.GetAnnotations()[MasterDeploymentUID]
 	if managedByKyverno && (!ok || deplHashSec != deplHash) {
-		return nil, fmt.Errorf("Outdated Secret")
+		return nil, fmt.Errorf("outdated secret")
 	}
 
 	tlsca, err := convertToSecret(stlsca)
@@ -81,14 +81,12 @@ func ReadTLSPair(restConfig *rest.Config, client *client.Client) (*PemPair, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret %s/%s: %v", certProps.Namespace, sname, err)
 	}
-	if err == nil {
-		if label, ok := unstrSecret.GetLabels()[ManagedByLabel]; ok {
-			managedByKyverno = label == "kyverno"
-		}
-		deplHashSec, ok = unstrSecret.GetAnnotations()[MasterDeploymentUID]
+	if label, ok := unstrSecret.GetLabels()[ManagedByLabel]; ok {
+		managedByKyverno = label == "kyverno"
 	}
+	deplHashSec, ok = unstrSecret.GetAnnotations()[MasterDeploymentUID]
 	if managedByKyverno && (!ok || deplHashSec != deplHash) {
-		return nil, fmt.Errorf("Outdated Secret")
+		return nil, fmt.Errorf("outdated secret")
 	}
 
 	// If secret contains annotation 'self-signed-cert', then it's created using helper scripts to setup self-signed certificates.

--- a/pkg/tls/reader.go
+++ b/pkg/tls/reader.go
@@ -22,15 +22,15 @@ func ReadRootCASecret(restConfig *rest.Config, client *client.Client) (result []
 		return nil, errors.Wrap(err, "failed to get TLS Cert Properties")
 	}
 
-	depl, err := client.GetResource("", "Deployment", certProps.Namespace, config.KyvernoDeploymentName)
+	// depl, err := client.GetResource("", "Deployment", certProps.Namespace, config.KyvernoDeploymentName)
 
-	deplHash := ""
-	if err == nil {
-		deplHash = fmt.Sprintf("%v", depl.GetUID())
-	}
+	// deplHash := ""
+	// if err == nil {
+	// 	deplHash = fmt.Sprintf("%v", depl.GetUID())
+	// }
 
-	var deplHashSec string = "default"
-	var ok, managedByKyverno bool
+	// var deplHashSec string = "default"
+	// var ok, managedByKyverno bool
 
 	sname := generateRootCASecretName(certProps)
 	stlsca, err := client.GetResource("", "Secret", certProps.Namespace, sname)
@@ -38,13 +38,13 @@ func ReadRootCASecret(restConfig *rest.Config, client *client.Client) (result []
 		return nil, err
 	}
 
-	if label, ok := stlsca.GetLabels()[ManagedByLabel]; ok {
-		managedByKyverno = label == "kyverno"
-	}
-	deplHashSec, ok = stlsca.GetAnnotations()[MasterDeploymentUID]
-	if managedByKyverno && (!ok || deplHashSec != deplHash) {
-		return nil, fmt.Errorf("outdated secret")
-	}
+	// if label, ok := stlsca.GetLabels()[ManagedByLabel]; ok {
+	// 	managedByKyverno = label == "kyverno"
+	// }
+	// deplHashSec, ok = stlsca.GetAnnotations()[MasterDeploymentUID]
+	// if managedByKyverno && (!ok || deplHashSec != deplHash) {
+	// 	return nil, fmt.Errorf("outdated secret")
+	// }
 
 	tlsca, err := convertToSecret(stlsca)
 	if err != nil {
@@ -66,27 +66,20 @@ func ReadTLSPair(restConfig *rest.Config, client *client.Client) (*PemPair, erro
 		return nil, errors.Wrap(err, "failed to get TLS Cert Properties")
 	}
 
-	depl, err := client.GetResource("", "Deployment", certProps.Namespace, config.KyvernoDeploymentName)
+	// depl, err := client.GetResource("", "Deployment", certProps.Namespace, config.KyvernoDeploymentName)
 
-	deplHash := ""
-	if err == nil {
-		deplHash = fmt.Sprintf("%v", depl.GetUID())
-	}
+	// deplHash := ""
+	// if err == nil {
+	// 	deplHash = fmt.Sprintf("%v", depl.GetUID())
+	// }
 
-	var deplHashSec string = "default"
-	var ok, managedByKyverno bool
+	// var deplHashSec string = "default"
+	// var ok, managedByKyverno bool
 
 	sname := generateTLSPairSecretName(certProps)
 	unstrSecret, err := client.GetResource("", "Secret", certProps.Namespace, sname)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret %s/%s: %v", certProps.Namespace, sname, err)
-	}
-	if label, ok := unstrSecret.GetLabels()[ManagedByLabel]; ok {
-		managedByKyverno = label == "kyverno"
-	}
-	deplHashSec, ok = unstrSecret.GetAnnotations()[MasterDeploymentUID]
-	if managedByKyverno && (!ok || deplHashSec != deplHash) {
-		return nil, fmt.Errorf("outdated secret")
 	}
 
 	// If secret contains annotation 'self-signed-cert', then it's created using helper scripts to setup self-signed certificates.
@@ -99,6 +92,15 @@ func ReadTLSPair(restConfig *rest.Config, client *client.Client) (*PemPair, erro
 			return nil, fmt.Errorf("rootCA secret is required while using self-signed certificate TLS pair, defaulting to generating new TLS pair  %s/%s", certProps.Namespace, sname)
 		}
 	}
+
+	// if label, ok := unstrSecret.GetLabels()[ManagedByLabel]; ok {
+	// 	managedByKyverno = label == "kyverno"
+	// }
+	// deplHashSec, ok = unstrSecret.GetAnnotations()[MasterDeploymentUID]
+	// if managedByKyverno && (!ok || deplHashSec != deplHash) {
+	// 	return nil, fmt.Errorf("outdated secret")
+	// }
+
 	secret, err := convertToSecret(unstrSecret)
 	if err != nil {
 		return nil, err

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -167,7 +167,7 @@ func (wrc *Register) Remove(cleanUp chan<- struct{}) {
 	}
 
 	wrc.removeWebhookConfigurations()
-	// wrc.removeSecrets()
+	wrc.removeSecrets()
 	err := wrc.client.DeleteResource("coordination.k8s.io/v1", "Lease", config.KyvernoNamespace, "kyvernopre-lock", false)
 	if err != nil && errorsapi.IsNotFound(err) {
 		wrc.log.WithName("cleanup").Error(err, "failed to clean up Lease lock")
@@ -246,11 +246,6 @@ func (wrc *Register) ValidateWebhookConfigurations(namespace, name string) error
 func (wrc *Register) cleanupKyvernoResource() bool {
 	logger := wrc.log.WithName("cleanupKyvernoResource")
 	deploy, err := wrc.client.GetResource("", "Deployment", deployNamespace, deployName)
-	if err != nil {
-		logger.Error(err, "failed to get deployment, cleanup kyverno resources anyway")
-		return true
-	}
-
 	if deploy.GetDeletionTimestamp() != nil {
 		logger.Info("Kyverno is terminating, cleanup Kyverno resources")
 		return true

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -247,8 +247,8 @@ func (wrc *Register) cleanupKyvernoResource() bool {
 	logger := wrc.log.WithName("cleanupKyvernoResource")
 	deploy, err := wrc.client.GetResource("", "Deployment", deployNamespace, deployName)
 	if err != nil {
-		logger.Error(err, "failed to get deployment, not cleaning up kyverno resources")
-		return false
+		logger.Error(err, "failed to get deployment, cleanup kyverno resources anyway")
+		return true
 	}
 	if deploy.GetDeletionTimestamp() != nil {
 		logger.Info("Kyverno is terminating, cleanup Kyverno resources")

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -246,6 +246,10 @@ func (wrc *Register) ValidateWebhookConfigurations(namespace, name string) error
 func (wrc *Register) cleanupKyvernoResource() bool {
 	logger := wrc.log.WithName("cleanupKyvernoResource")
 	deploy, err := wrc.client.GetResource("", "Deployment", deployNamespace, deployName)
+	if err != nil {
+		logger.Error(err, "failed to get deployment, not cleaning up kyverno resources")
+		return false
+	}
 	if deploy.GetDeletionTimestamp() != nil {
 		logger.Info("Kyverno is terminating, cleanup Kyverno resources")
 		return true

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -167,7 +167,7 @@ func (wrc *Register) Remove(cleanUp chan<- struct{}) {
 	}
 
 	wrc.removeWebhookConfigurations()
-	wrc.removeSecrets()
+	// wrc.removeSecrets()
 	err := wrc.client.DeleteResource("coordination.k8s.io/v1", "Lease", config.KyvernoNamespace, "kyvernopre-lock", false)
 	if err != nil && errorsapi.IsNotFound(err) {
 		wrc.log.WithName("cleanup").Error(err, "failed to clean up Lease lock")


### PR DESCRIPTION
Signed-off-by: Kumar Mallikarjuna <kumar@nirmata.com>

cc - @realshuting 

## Related issue
Closes #2805 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.5.3
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
- Disable auto-cleanup of Kyverno secrets on pod deletion
- Annotate CA Secret and verify consistency with current Deployment UID
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
