### PR TITLE
Fix TLS inconsitency in HA

### DIFF
--- a/pkg/tls/certRenewer.go
+++ b/pkg/tls/certRenewer.go
@@ -160,7 +160,7 @@ func (c *CertRenewer) WriteCACertToSecret(caPEM *PemPair, props CertificateProps
 	}
 
 	if err != nil && strings.HasSuffix(err.Error(), "not found") {
-		_, err := c.client.CreateResource("", "Secret", props.Namespace, secret, false)
+		_, err = c.client.CreateResource("", "Secret", props.Namespace, secret, false)
 		if err == nil {
 			logger.Info("secret created", "name", name, "namespace", props.Namespace)
 		}
@@ -180,7 +180,7 @@ func (c *CertRenewer) WriteCACertToSecret(caPEM *PemPair, props CertificateProps
 	dataMap := map[string]interface{}{
 		RootCAKey: base64.StdEncoding.EncodeToString(caPEM.Certificate)}
 
-	if err := unstructured.SetNestedMap(secretUnstr.Object, dataMap, "data"); err != nil {
+	if err = unstructured.SetNestedMap(secretUnstr.Object, dataMap, "data"); err != nil {
 		return err
 	}
 

--- a/pkg/tls/reader.go
+++ b/pkg/tls/reader.go
@@ -22,10 +22,28 @@ func ReadRootCASecret(restConfig *rest.Config, client *client.Client) (result []
 		return nil, errors.Wrap(err, "failed to get TLS Cert Properties")
 	}
 
+	depl, err := client.GetResource("", "Deployment", certProps.Namespace, config.KyvernoDeploymentName)
+
+	deplHash := ""
+	if err == nil {
+		deplHash = fmt.Sprintf("%v", depl.GetUID())
+	}
+
+	var deplHashSec string = "default"
+	var ok, managedByKyverno bool
+
 	sname := generateRootCASecretName(certProps)
 	stlsca, err := client.GetResource("", "Secret", certProps.Namespace, sname)
 	if err != nil {
 		return nil, err
+	}
+
+	if label, ok := stlsca.GetLabels()[ManagedByLabel]; ok {
+		managedByKyverno = label == "kyverno"
+	}
+	deplHashSec, ok = stlsca.GetAnnotations()[MasterDeploymentUID]
+	if managedByKyverno && (!ok || deplHashSec != deplHash) {
+		return nil, fmt.Errorf("outdated secret")
 	}
 
 	tlsca, err := convertToSecret(stlsca)
@@ -48,10 +66,27 @@ func ReadTLSPair(restConfig *rest.Config, client *client.Client) (*PemPair, erro
 		return nil, errors.Wrap(err, "failed to get TLS Cert Properties")
 	}
 
+	depl, err := client.GetResource("", "Deployment", certProps.Namespace, config.KyvernoDeploymentName)
+
+	deplHash := ""
+	if err == nil {
+		deplHash = fmt.Sprintf("%v", depl.GetUID())
+	}
+
+	var deplHashSec string = "default"
+	var ok, managedByKyverno bool
+
 	sname := generateTLSPairSecretName(certProps)
 	unstrSecret, err := client.GetResource("", "Secret", certProps.Namespace, sname)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret %s/%s: %v", certProps.Namespace, sname, err)
+	}
+	if label, ok := unstrSecret.GetLabels()[ManagedByLabel]; ok {
+		managedByKyverno = label == "kyverno"
+	}
+	deplHashSec, ok = unstrSecret.GetAnnotations()[MasterDeploymentUID]
+	if managedByKyverno && (!ok || deplHashSec != deplHash) {
+		return nil, fmt.Errorf("outdated secret")
 	}
 
 	// If secret contains annotation 'self-signed-cert', then it's created using helper scripts to setup self-signed certificates.

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -248,10 +248,9 @@ func (wrc *Register) cleanupKyvernoResource() bool {
 	logger := wrc.log.WithName("cleanupKyvernoResource")
 	deploy, err := wrc.client.GetResource("", "Deployment", deployNamespace, deployName)
 	if err != nil {
-		logger.Error(err, "failed to get deployment, cleanup kyverno resources anyway")
-		return true
+		logger.Error(err, "failed to get deployment, not cleaning up kyverno resources")
+		return false
 	}
-
 	if deploy.GetDeletionTimestamp() != nil {
 		logger.Info("Kyverno is terminating, cleanup Kyverno resources")
 		return true


### PR DESCRIPTION
Signed-off-by: Kumar Mallikarjuna <kumar@nirmata.com>

cc - @realshuting 

## Related issue
Closes #2805 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.5.3
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
- Disable auto-cleanup of Kyverno secrets on pod deletion
- Annotate CA Secret and verify consistency with current Deployment UID
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
- Test as described [here](https://github.com/kyverno/kyverno/issues/2805#issue-1074434002).
- Upgrade test from 1.5.2
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
