### PR TITLE
fix: cosign command in github action workflows

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -42,7 +42,8 @@ jobs:
       - name: Sign image
         env:
           COSIGN_EXPERIMENTAL: "true"
-        run: cosign sign \ 
+        run: |
+          cosign sign \ 
           -a "repo=${{ github.repository }}" \
           -a "workflow=${{ github.workflow }}" \
           -a "ref=${{ github.sha }}" \
@@ -84,7 +85,8 @@ jobs:
       - name: Sign image
         env:
           COSIGN_EXPERIMENTAL: "true"
-        run: cosign sign \ 
+        run: |
+          cosign sign \ 
           -a "repo=${{ github.repository }}" \
           -a "workflow=${{ github.workflow }}" \
           -a "ref=${{ github.sha }}" \
@@ -126,7 +128,8 @@ jobs:
       - name: Sign image
         env:
           COSIGN_EXPERIMENTAL: "true"
-        run: cosign sign \ 
+        run: |
+          cosign sign \ 
           -a "repo=${{ github.repository }}" \
           -a "workflow=${{ github.workflow }}" \
           -a "ref=${{ github.sha }}" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,8 @@ jobs:
       - name: Sign image
         env:
           COSIGN_EXPERIMENTAL: "true"
-        run: cosign sign \ 
+        run: |
+          cosign sign \ 
           -a "repo=${{ github.repository }}" \
           -a "workflow=${{ github.workflow }}" \
           -a "ref=${{ github.sha }}" \
@@ -130,7 +131,8 @@ jobs:
       - name: Sign image and SBOM
         env:
           COSIGN_EXPERIMENTAL: "true"
-        run: cosign sign \ 
+        run: |
+          cosign sign \ 
           -a "repo=${{ github.repository }}" \
           -a "workflow=${{ github.workflow }}" \
           -a "ref=${{ github.sha }}" \
@@ -200,7 +202,8 @@ jobs:
       - name: Sign image
         env:
           COSIGN_EXPERIMENTAL: "true"
-        run: cosign sign \ 
+        run: |
+          cosign sign \ 
           -a "repo=${{ github.repository }}" \
           -a "workflow=${{ github.workflow }}" \
           -a "ref=${{ github.sha }}" \


### PR DESCRIPTION
added missing `|` character which was leading the workflows to fail with this error: https://github.com/kyverno/kyverno/runs/4704334691?check_suite_focus=true#step:9:1

cc: @JimBugwadia 