### PR TITLE
Fixing the CI job to push images

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -34,10 +34,14 @@ jobs:
           install: true
 
       - name: docker images publish
-        id: push-step
         run: |
           make docker-publish-sigs
           make docker-publish-initContainer-dev
+
+      - name: get digest
+        id: get-step
+        run: |
+          echo "::set-output name=digest::$(make docker-get-initContainer-digest)"
 
       - name: Sign image
         env:
@@ -47,7 +51,7 @@ jobs:
           -a "repo=${{ github.repository }}" \
           -a "workflow=${{ github.workflow }}" \
           -a "ref=${{ github.sha }}" \
-          ghcr.io/kyverno/kyvernopre@${{ steps.push-step.outputs.digest }}
+          ghcr.io/kyverno/kyvernopre@sha256:${{ steps.get-step.outputs.digest }}
 
   push-kyverno:
     runs-on: ubuntu-latest
@@ -78,9 +82,13 @@ jobs:
           install: true
 
       - name: docker images publish
-        id: push-step
         run: |
           make docker-publish-kyverno-dev
+
+      - name: get digest
+        id: get-step
+        run: |
+          echo "::set-output name=digest::$(make docker-get-kyverno-digest)"
 
       - name: Sign image
         env:
@@ -90,7 +98,7 @@ jobs:
           -a "repo=${{ github.repository }}" \
           -a "workflow=${{ github.workflow }}" \
           -a "ref=${{ github.sha }}" \
-          ghcr.io/kyverno/kyverno@${{ steps.push-step.outputs.digest }}
+          ghcr.io/kyverno/kyverno@sha256:${{ steps.get-step.outputs.digest }}
 
   push-kyverno-cli:
     runs-on: ubuntu-latest
@@ -121,9 +129,13 @@ jobs:
           install: true
 
       - name: docker images publish
-        id: push-step
         run: |
           make docker-publish-cli-dev
+
+      - name: get digest
+        id: get-step
+        run: |
+          echo "::set-output name=digest::$(make docker-get-cli-digest)"
 
       - name: Sign image
         env:
@@ -133,4 +145,4 @@ jobs:
           -a "repo=${{ github.repository }}" \
           -a "workflow=${{ github.workflow }}" \
           -a "ref=${{ github.sha }}" \
-          ghcr.io/kyverno/kyverno-cli@${{ steps.push-step.outputs.digest }}
+          ghcr.io/kyverno/kyverno-cli@sha256:${{ steps.get-step.outputs.digest }}

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,8 @@ docker-push-initContainer-dev: docker-buildx-builder
 	@docker buildx build --file $(PWD)/$(INITC_PATH)/Dockerfile --progress plane --push --platform linux/arm64,linux/amd64 --tag $(REPO)/$(INITC_IMAGE):$(IMAGE_TAG_DEV) . --build-arg LD_FLAGS=$(LD_FLAGS_DEV)
 	@docker buildx build --file $(PWD)/$(INITC_PATH)/Dockerfile --progress plane --push --platform linux/arm64,linux/amd64 --tag $(REPO)/$(INITC_IMAGE):$(IMAGE_TAG_LATEST_DEV)-latest . --build-arg LD_FLAGS=$(LD_FLAGS_DEV)
 
+docker-get-initContainer-digest: docker-buildx-builder
+	@docker buildx imagetools inspect --raw $(REPO)/$(INITC_IMAGE):$(IMAGE_TAG_DEV) | perl -pe 'chomp if eof' | openssl dgst -sha256 | sed 's/^.* //'
 ##################################
 # KYVERNO CONTAINER
 ##################################
@@ -155,6 +157,9 @@ docker-publish-kyverno-dev: docker-buildx-builder docker-push-kyverno-dev
 docker-push-kyverno-dev: docker-buildx-builder
 	@docker buildx build --file $(PWD)/$(KYVERNO_PATH)/Dockerfile --progress plane --push --platform linux/arm64,linux/amd64 --tag $(REPO)/$(KYVERNO_IMAGE):$(IMAGE_TAG_DEV) . --build-arg LD_FLAGS=$(LD_FLAGS_DEV) --build-arg TAGS=$(TAGS)
 	@docker buildx build --file $(PWD)/$(KYVERNO_PATH)/Dockerfile --progress plane --push --platform linux/arm64,linux/amd64 --tag $(REPO)/$(KYVERNO_IMAGE):$(IMAGE_TAG_LATEST_DEV)-latest . --build-arg LD_FLAGS=$(LD_FLAGS_DEV) --build-arg TAGS=$(TAGS)
+
+docker-get-kyverno-digest: docker-buildx-builder
+	@docker buildx imagetools inspect --raw $(REPO)/$(KYVERNO_IMAGE):$(IMAGE_TAG_DEV) | perl -pe 'chomp if eof' | openssl dgst -sha256 | sed 's/^.* //'
 ##################################
 
 # Generate Docs for types.go
@@ -191,6 +196,9 @@ docker-publish-cli-dev: docker-buildx-builder docker-push-cli-dev
 docker-push-cli-dev: docker-buildx-builder
 	@docker buildx build --file $(PWD)/$(CLI_PATH)/Dockerfile --progress plane --push --platform linux/arm64,linux/amd64 --tag $(REPO)/$(KYVERNO_CLI_IMAGE):$(IMAGE_TAG_DEV) . --build-arg LD_FLAGS=$(LD_FLAGS_DEV)
 	@docker buildx build --file $(PWD)/$(CLI_PATH)/Dockerfile --progress plane --push --platform linux/arm64,linux/amd64 --tag $(REPO)/$(KYVERNO_CLI_IMAGE):$(IMAGE_TAG_LATEST_DEV)-latest . --build-arg LD_FLAGS=$(LD_FLAGS_DEV)
+
+docker-get-cli-digest: docker-buildx-builder
+	@docker buildx imagetools inspect --raw $(REPO)/$(KYVERNO_CLI_IMAGE):$(IMAGE_TAG_DEV) | perl -pe 'chomp if eof' | openssl dgst -sha256 | sed 's/^.* //'
 
 ##################################
 docker-publish-all: docker-buildx-builder docker-publish-initContainer docker-publish-kyverno docker-publish-cli


### PR DESCRIPTION
fix for #2920 

tested the same workflow in a separate repo https://github.com/Namanl2001/learning-github/blob/master/.github/workflows/cosign.yaml through which I'm successfully able to sign the image but not able write the image back in the registry due to some permission issues (tried multiple ways to resolve it but no help) https://github.com/Namanl2001/learning-github/runs/4727092772?check_suite_focus=true#step:7:13 

I hope changes in this pr should work fine in the kyverno repo 🤞 