### PR TITLE
Add parse_json function the decode json strings

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -2,6 +2,7 @@ package jmespath
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -57,6 +58,7 @@ var (
 	pathCanonicalize       = "path_canonicalize"
 	truncate               = "truncate"
 	semverCompare          = "semver_compare"
+	parseJson              = "parse_json"
 )
 
 const errorPrefix = "JMESPath function '%s': "
@@ -261,6 +263,13 @@ func getFunctions() []*gojmespath.FunctionEntry {
 				{Types: []JpType{JpString}},
 			},
 			Handler: jpSemverCompare,
+		},
+		{
+			Name: parseJson,
+			Arguments: []ArgSpec{
+				{Types: []JpType{JpString}},
+			},
+			Handler: jpParseJson,
 		},
 	}
 
@@ -665,6 +674,16 @@ func jpSemverCompare(arguments []interface{}) (interface{}, error) {
 	return false, nil
 }
 
+func jpParseJson(arguments []interface{}) (interface{}, error) {
+	input, err := validateArg(parseJson, arguments, 0, reflect.String)
+	if err != nil {
+		return nil, err
+	}
+	var output interface{}
+	err = json.Unmarshal([]byte(input.String()), &output)
+	return output, err
+}
+
 // InterfaceToString casts an interface to a string type
 func ifaceToString(iface interface{}) (string, error) {
 	switch i := iface.(type) {
@@ -686,7 +705,7 @@ func ifaceToString(iface interface{}) (string, error) {
 func validateArg(f string, arguments []interface{}, index int, expectedType reflect.Kind) (reflect.Value, error) {
 	arg := reflect.ValueOf(arguments[index])
 	if arg.Type().Kind() != expectedType {
-		return reflect.Value{}, fmt.Errorf(invalidArgumentTypeError, equalFold, index+1, expectedType.String())
+		return reflect.Value{}, fmt.Errorf(invalidArgumentTypeError, f, index+1, expectedType.String())
 	}
 
 	return arg, nil

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -43,6 +43,68 @@ func Test_Compare(t *testing.T) {
 	}
 }
 
+func Test_ParseJsonSerde(t *testing.T) {
+	testCases := []string{
+		`{"a":"b"}`,
+		`true`,
+		`[1,2,3,{"a":"b"}]`,
+		`null`,
+		`[]`,
+		`{}`,
+		`0`,
+		`1.2`,
+		`[1.2,true,{"a":{"a":"b"}}]`,
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			jp, err := New(fmt.Sprintf(`to_string(parse_json('%s'))`, tc))
+			fmt.Println(err)
+			assert.NilError(t, err)
+
+			result, err := jp.Search("")
+			fmt.Println(err)
+			assert.NilError(t, err)
+
+			assert.Equal(t, result, tc)
+		})
+	}
+}
+
+func Test_ParseJsonComplex(t *testing.T) {
+	testCases := []struct {
+		input          string
+		expectedResult interface{}
+	}{
+		{
+			input:          `parse_json('{"a": "b"}').a`,
+			expectedResult: "b",
+		},
+		{
+			input:          `parse_json('{"a": [1, 2, 3, 4]}').a[0]`,
+			expectedResult: 1.0,
+		},
+		{
+			input:          `parse_json('[1, 2, {"a": {"b": {"c": [1, 2]}}}]')[2].a.b.c[1]`,
+			expectedResult: 2.0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			jp, err := New(tc.input)
+			fmt.Println(err)
+			assert.NilError(t, err)
+
+			result, err := jp.Search("")
+			fmt.Println(err)
+			assert.NilError(t, err)
+
+			assert.Equal(t, result, tc.expectedResult)
+		})
+	}
+}
+
 func Test_EqualFold(t *testing.T) {
 	testCases := []struct {
 		jmesPath       string

--- a/test/cli/test/custom-functions/policy.yaml
+++ b/test/cli/test/custom-functions/policy.yaml
@@ -74,3 +74,24 @@ spec:
             - key: "{{ path_canonicalize(element.hostPath.path) }}"
               operator: Equals
               value: "\\var\\run\\containerd\\containerd.sock"
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: test-parse-json
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: test-json-parsing-jmespath
+    match:
+      resources:
+        kinds:
+         - ConfigMap
+    validate:
+      message: "Test JMESPath"
+      deny:
+        conditions:
+        - key: "{{request.object.metadata.annotations.test | parse_json(@).a }}"
+          operator: NotEquals
+          value: b

--- a/test/cli/test/custom-functions/resources.yaml
+++ b/test/cli/test/custom-functions/resources.yaml
@@ -51,3 +51,19 @@ spec:
       mountPath: /sock
     - name: test
       mountPath: /test 
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: valid-test
+  annotations:
+    test: |
+      {"a": "b"}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: invalid-test
+  annotations:
+    test: |
+      {"a": "not-b"}

--- a/test/cli/test/custom-functions/test.yaml
+++ b/test/cli/test/custom-functions/test.yaml
@@ -29,3 +29,13 @@ results:
     resource: mount-containerd-sock
     kind: Pod
     status: fail
+  - policy: test-parse-json
+    rule: test-json-parsing-jmespath
+    resource: valid-test
+    kind: ConfigMap
+    result: pass
+  - policy: test-parse-json
+    rule: test-json-parsing-jmespath
+    resource: invalid-test
+    kind: ConfigMap
+    result: fail


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <sambhavs.email@gmail.com>

## Related issue
Fixes #2940
This PR  adds a parse_json JMESPath function which complements the upstream to_string JMESPath function. More details around usage in the attached issue.
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
/milestone 1.6.0
## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind feature
## Proposed Changes

This change adds a `parse_json` JMESPath function that is capable of parsing arbitrary json strings to correct objects. Examples noted below. Related docs PR https://github.com/kyverno/website/pull/433

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Note - They have also been added to CLI tests.

cf.yaml

```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: valid-test
  annotations:
    test: |
      {"a": "b"}
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: invalid-test
  annotations:
    test: |
      {"a": "not-b"}
```

policy.yaml

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: test-parse-json
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: test-json-parsing-jmespath
    match:
      resources:
        kinds:
         - ConfigMap
    validate:
      message: "Test JMESPath"
      deny:
        conditions:
        - key: "{{request.object.metadata.annotations.test | parse_json(@).a }}"
          operator: NotEquals
          value: b
```

kyverno-test.yaml

```yaml
name: mytests
policies:
  - policy.yaml
resources:
  - cf.yaml
results:
- policy: test-parse-json
  rule: test-json-parsing-jmespath
  resource: valid-test
  kind: ConfigMap
  result: pass
- policy: test-parse-json
  rule: test-json-parsing-jmespath
  resource: invalid-test
  kind: ConfigMap
  result: fail
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [] CLI support should be added my PR doesn't contain that functionality.
  - [x] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is: https://github.com/kyverno/website/pull/433
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
