### PR TITLE
chore: bump go version used to build images

### DIFF
--- a/cmd/cli/kubectl-kyverno/Dockerfile
+++ b/cmd/cli/kubectl-kyverno/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage docker build
 # Build stage
-FROM golang:1.17.2 AS builder
+FROM golang:1.17.6 AS builder
 
 LABEL maintainer="Kyverno"
 

--- a/cmd/initContainer/Dockerfile
+++ b/cmd/initContainer/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage docker build
 # Build stage
-FROM golang:1.17.2 AS builder
+FROM golang:1.17.6 AS builder
 
 LABEL maintainer="Kyverno"
 

--- a/cmd/kyverno/Dockerfile
+++ b/cmd/kyverno/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage docker build
 # Build stage
-FROM golang:1.17.2 AS builder
+FROM golang:1.17.6 AS builder
 
 LABEL maintainer="Kyverno"
 


### PR DESCRIPTION
## Related issue

#2967 

## Milestone of this PR

/milestone 1.6.0

## What type of PR is this

/kind cleanup

## Proposed Changes

Update Golang version in Dockerfiles from 1.7.2 to 1.7.6 to inherit bug and security fixes from Go patch releases

### Proof Manifests

Proof can be achieved through the following commands:

```shell
docker build -f cmd/cli/kubectl-kyverno/Dockerfile  .
docker build -f cmd/initContainer/Dockerfile  .
docker build -f cmd/kyverno/Dockerfile  .
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

> Change does not alter Kyverno functionality and does not require new tests or documentation.   Existing tests are sufficient.

## Further Comments

