### PR TITLE
Fix autogen issue with cronjob generator and foreach pod generator

### DIFF
--- a/pkg/policymutation/cronjob.go
+++ b/pkg/policymutation/cronjob.go
@@ -122,7 +122,7 @@ func generateCronJobRule(rule kyverno.Rule, controllers string, log logr.Logger)
 
 		var newForeachMutation []*kyverno.ForEachMutation
 
-		for _, foreach := range rule.Mutation.ForEachMutation {
+		for _, foreach := range jobRule.Mutation.ForEachMutation {
 			newForeachMutation = append(newForeachMutation, &kyverno.ForEachMutation{
 				List:             foreach.List,
 				Context:          foreach.Context,

--- a/pkg/policymutation/policymutation.go
+++ b/pkg/policymutation/policymutation.go
@@ -618,6 +618,7 @@ func generateRuleForControllers(rule kyverno.Rule, controllers string, log logr.
 		for _, foreach := range rule.Mutation.ForEachMutation {
 			newForeachMutation = append(newForeachMutation, &kyverno.ForEachMutation{
 				List:             foreach.List,
+				Context:          foreach.Context,
 				AnyAllConditions: foreach.AnyAllConditions,
 				PatchStrategicMerge: map[string]interface{}{
 					"spec": map[string]interface{}{

--- a/test/policy/mutate/policy_mutate_pod_foreach_with_context.yaml
+++ b/test/policy/mutate/policy_mutate_pod_foreach_with_context.yaml
@@ -1,0 +1,34 @@
+apiVersion : kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: resolve-image
+spec:
+  background: false
+  rules:
+  - name: resolve-image-containers
+    match:
+      resources:
+        kinds:
+        - Pod
+    preconditions:
+      all:
+      - key: "{{request.operation}}"
+        operator: In
+        value:
+        - CREATE
+        - UPDATE
+    mutate:
+      foreach:
+      - list: "request.object.spec.containers"
+        context:
+          - name: dictionary
+            configMap:
+              # Name of the ConfigMap which will be looked up
+              name: some-config-map
+              # Namespace in which this ConfigMap is stored
+              namespace: some-namespace 
+        patchStrategicMerge:
+          spec:
+            containers:
+            - name: "{{ element.name }}"           
+              image: "{{ dictionary.data.image }}"


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <sambhavs.email@gmail.com>

## Related issue
Closes #2988

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

/milestone 1.6.0
## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

```yaml
apiVersion : kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: resolve-image
spec:
  background: false
  rules:
  - name: resolve-image-containers
    match:
      resources:
        kinds:
        - Pod
    preconditions:
      all:
      - key: "{{request.operation}}"
        operator: In
        value:
        - CREATE
        - UPDATE
    mutate:
      foreach:
      - list: "request.object.spec.containers"
        context:
          - name: dictionary
            configMap:
              # Name of the ConfigMap which will be looked up
              name: some-config-map
              # Namespace in which this ConfigMap is stored
              namespace: some-namespace 
        patchStrategicMerge:
          spec:
            containers:
            - name: "{{ element.name }}"           
              image: "{{ dictionary.data.image }}"
```

Applying the above with `kubectl apply -f policy.yaml --dry-run=server -oyaml` it should output the correct set of rules instead of erroring out like it currently does.

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"annotations":{},"name":"resolve-image"},"spec":{"background":false,"rules":[{"match":{"resources":{"kinds":["Pod"]}},"mutate":{"foreach":[{"context":[{"configMap":{"name":"some-config-map","namespace":"some-namespace"},"name":"dictionary"}],"list":"request.object.spec.containers","patchStrategicMerge":{"spec":{"containers":[{"image":"{{ dictionary.data.resolvedImage }}","name":"{{ element.name }}"}]}}}]},"name":"resolve-image-containers","preconditions":{"all":[{"key":"{{request.operation}}","operator":"In","value":["CREATE","UPDATE"]}]}}]}}
    pod-policies.kyverno.io/autogen-controllers: DaemonSet,Deployment,Job,StatefulSet,CronJob
  creationTimestamp: "2022-01-15T09:15:31Z"
  generation: 1
  name: resolve-image
  uid: 87a34877-dd50-4c6e-8803-30b63661d540
spec:
  background: false
  failurePolicy: Fail
  rules:
  - match:
      resources:
        kinds:
        - Pod
    mutate:
      foreach:
      - context:
        - configMap:
            name: some-config-map
            namespace: some-namespace
          name: dictionary
        list: request.object.spec.containers
        patchStrategicMerge:
          spec:
            containers:
            - image: '{{ dictionary.data.resolvedImage }}'
              name: '{{ element.name }}'
    name: resolve-image-containers
    preconditions:
      all:
      - key: '{{request.operation}}'
        operator: In
        value:
        - CREATE
        - UPDATE
  - match:
      resources:
        kinds:
        - DaemonSet
        - Deployment
        - Job
        - StatefulSet
    mutate:
      foreach:
      - context:
        - configMap:
            name: some-config-map
            namespace: some-namespace
          name: dictionary
        list: request.object.spec.template.spec.containers
        patchStrategicMerge:
          spec:
            template:
              spec:
                containers:
                - image: '{{ dictionary.data.resolvedImage }}'
                  name: '{{ element.name }}'
    name: autogen-resolve-image-containers
    preconditions:
      all:
      - key: '{{request.operation}}'
        operator: In
        value:
        - CREATE
        - UPDATE
  - match:
      resources:
        kinds:
        - CronJob
    mutate:
      foreach:
      - context:
        - configMap:
            name: some-config-map
            namespace: some-namespace
          name: dictionary
        list: request.object.spec.jobTemplate.spec.template.spec.containers
        patchStrategicMerge:
          spec:
            jobTemplate:
              spec:
                template:
                  spec:
                    containers:
                    - image: '{{ dictionary.data.resolvedImage }}'
                      name: '{{ element.name }}'
    name: autogen-cronjob-resolve-image-containers
    preconditions:
      all:
      - key: '{{request.operation}}'
        operator: In
        value:
        - CREATE
        - UPDATE
  validationFailureAction: audit
```

This is the new and correct output.
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
