### PR TITLE
Fix variable substitution for foreach preconditions

### DIFF
--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -83,12 +83,19 @@ func SubstituteAll(log logr.Logger, ctx context.EvalInterface, document interfac
 }
 
 func SubstituteAllInPreconditions(log logr.Logger, ctx context.EvalInterface, document interface{}) (_ interface{}, err error) {
-	return substituteAll(log, ctx, document, newPreconditionsVariableResolver(log))
+	// We must convert all incoming conditions to JSON data i.e.
+	// string, []interface{}, map[string]interface{}
+	// we cannot use structs otherwise json traverse doesn't work
+	untypedDoc, err := DocumentToUntyped(document)
+	if err != nil {
+		return document, err
+	}
+	return substituteAll(log, ctx, untypedDoc, newPreconditionsVariableResolver(log))
 }
 
 func SubstituteAllInRule(log logr.Logger, ctx context.EvalInterface, typedRule kyverno.Rule) (_ kyverno.Rule, err error) {
 	var rule interface{}
-	rule, err = RuleToUntyped(typedRule)
+	rule, err = DocumentToUntyped(typedRule)
 	if err != nil {
 		return typedRule, err
 	}
@@ -101,14 +108,14 @@ func SubstituteAllInRule(log logr.Logger, ctx context.EvalInterface, typedRule k
 	return UntypedToRule(rule)
 }
 
-func RuleToUntyped(rule kyverno.Rule) (interface{}, error) {
-	jsonRule, err := json.Marshal(rule)
+func DocumentToUntyped(doc interface{}) (interface{}, error) {
+	jsonDoc, err := json.Marshal(doc)
 	if err != nil {
 		return nil, err
 	}
 
 	var untyped interface{}
-	err = json.Unmarshal(jsonRule, &untyped)
+	err = json.Unmarshal(jsonDoc, &untyped)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +192,7 @@ func substituteAll(log logr.Logger, ctx context.EvalInterface, document interfac
 func SubstituteAllForceMutate(log logr.Logger, ctx *context.Context, typedRule kyverno.Rule) (_ kyverno.Rule, err error) {
 	var rule interface{}
 
-	rule, err = RuleToUntyped(typedRule)
+	rule, err = DocumentToUntyped(typedRule)
 	if err != nil {
 		return kyverno.Rule{}, err
 	}

--- a/test/e2e/mutate/config.go
+++ b/test/e2e/mutate/config.go
@@ -86,6 +86,16 @@ var tests = []struct {
 		ResourceRaw:        kyverno_2316_resource,
 		ExpectedPatternRaw: kyverno_2316_pattern,
 	},
+	{
+		TestDescription:    "checks that preconditions are substituted correctly",
+		PolicyName:         "replace-docker-hub",
+		PolicyRaw:          kyverno_2971_policy,
+		ResourceName:       "nginx",
+		ResourceNamespace:  "test-mutate",
+		ResourceGVR:        podGVR,
+		ResourceRaw:        kyverno_2971_resource,
+		ExpectedPatternRaw: kyverno_2971_pattern,
+	},
 }
 
 var ingressTests = struct {


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <sambhavs.email@gmail.com>

Fixes #2971

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
/milestone 1.6.0

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind bug
## Proposed Changes

This was a very subtle bug where preconditions for rules get var subs. correctly but not for foreach preconditions. The issue was that the json traversal method used for var substitution relies on the input document being a json document and not a struct. foreach preconditions (AnyAllConditions) are of a different type than rule preconditions(apiextensions.JSON). The latter is compatible with the traversal method, the former isn't. The fix involved converting the foreach precondition to an untyped object (map like) which allows the json traversal to work properly.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

An E2E test has been added to replicate the behavior described at https://github.com/kyverno/kyverno/issues/2971 which is now fixed.
Policy
```yaml
apiVersion : kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: replace-docker-hub
spec:
  rules:
  - name: replace-docker-hub
    match:
      resources:
        kinds:
        - Pod
    preconditions:
      all:
      - key: "{{request.operation}}"
        operator: In
        value:
        - CREATE
        - UPDATE
    mutate:
      foreach:
      - list: "request.object.spec.containers"
        preconditions:
          all:
            - key: '{{images.containers."{{element.name}}".registry}}'
              operator: Equals
              value: 'docker.io'
        patchStrategicMerge:
          spec:
            containers:
            - name: "{{ element.name }}"           
              image: 'my-private-registry/{{images.containers."{{element.name}}".path}}:{{images.containers."{{element.name}}".tag}}'
```

Resource
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
  - name: nginx
    image: nginx:1.14.2
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
