### PR TITLE
Add a parse_yaml function

### DIFF
--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -101,6 +101,82 @@ func Test_ParseJsonComplex(t *testing.T) {
 	}
 }
 
+func Test_ParseYAML(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output interface{}
+	}{
+		{
+			input: `a: b`,
+			output: map[string]interface{}{
+				"a": "b",
+			},
+		},
+		{
+			input: `
+- 1
+- 2
+- 3
+- a: b`,
+			output: []interface{}{
+				1.0,
+				2.0,
+				3.0,
+				map[string]interface{}{
+					"a": "b",
+				},
+			},
+		},
+		{
+			input: `
+spec:
+  test: 1
+  test2:
+    - 2
+    - 3
+`,
+			output: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"test":  1.0,
+					"test2": []interface{}{2.0, 3.0},
+				},
+			},
+		},
+		{
+			input: `
+bar: >
+  this is not a normal string it
+  spans more than
+  one line
+  see?`,
+			output: map[string]interface{}{
+				"bar": "this is not a normal string it spans more than one line see?",
+			},
+		},
+		{
+			input: `
+---
+foo: ~
+bar: null
+`,
+			output: map[string]interface{}{
+				"bar": nil,
+				"foo": nil,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			jp, err := New(fmt.Sprintf(`parse_yaml('%s')`, tc.input))
+			assert.NilError(t, err)
+			result, err := jp.Search("")
+			assert.NilError(t, err)
+			assert.DeepEqual(t, result, tc.output)
+		})
+	}
+}
+
 func Test_EqualFold(t *testing.T) {
 	testCases := []struct {
 		jmesPath       string

--- a/test/cli/test/custom-functions/kyverno-test.yaml
+++ b/test/cli/test/custom-functions/kyverno-test.yaml
@@ -39,3 +39,23 @@ results:
     resource: invalid-test
     kind: ConfigMap
     result: fail
+  - policy: test-parse-yaml
+    rule: test-yaml-parsing-jmespath
+    resource: valid-yaml-test
+    kind: ConfigMap
+    result: pass
+  - policy: test-parse-yaml
+    rule: test-yaml-parsing-jmespath
+    resource: invalid-yaml-test
+    kind: ConfigMap
+    result: fail
+  - policy: test-parse-yaml-array
+    rule: test-yaml-parsing-jmespath
+    resource: valid-yaml-test
+    kind: ConfigMap
+    result: pass
+  - policy: test-parse-yaml-array
+    rule: test-yaml-parsing-jmespath
+    resource: invalid-yaml-test
+    kind: ConfigMap
+    result: fail

--- a/test/cli/test/custom-functions/policy.yaml
+++ b/test/cli/test/custom-functions/policy.yaml
@@ -95,3 +95,45 @@ spec:
         - key: "{{request.object.metadata.annotations.test | parse_json(@).a }}"
           operator: NotEquals
           value: b
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: test-parse-yaml
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: test-yaml-parsing-jmespath
+    match:
+      resources:
+        kinds:
+         - ConfigMap
+    validate:
+      message: "Test JMESPath"
+      deny:
+        conditions:
+        - key: "{{request.object.metadata.annotations.test | parse_yaml(@).value }}"
+          operator: NotEquals
+          value: "a"
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: test-parse-yaml-array
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: test-yaml-parsing-jmespath
+    match:
+      resources:
+        kinds:
+         - ConfigMap
+    validate:
+      message: "Test JMESPath"
+      deny:
+        conditions:
+        - key: a
+          operator: NotIn
+          value: "{{request.object.metadata.annotations.test | parse_yaml(@).array }}"

--- a/test/cli/test/custom-functions/resources.yaml
+++ b/test/cli/test/custom-functions/resources.yaml
@@ -67,3 +67,28 @@ metadata:
   annotations:
     test: |
       {"a": "not-b"}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: valid-yaml-test
+  annotations:
+    test: |
+      value: a
+      array:
+        - a
+        - b
+        - c 
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: invalid-yaml-test
+  annotations:
+    test: |
+      value: b
+      array:
+        - d
+        - e
+        - f
+


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <sambhavs.email@gmail.com>

Fixes #2998 
Fixes #2693 

This PR adds a `parse_yaml` function that does the following - 

- Convert YAML string to JSON string: This is necessary since YAML is a superset of JSON in terms of the types you can define (for eg. things like `Inf`, `Nan` etc.). We first convert YAML to a JSON serializable string if possible. If it is not possible, the rule will throw an appropriate error describing the error in conversion.
- Deserialize JSON string to an object: We then take the output JSON string and convert it to an object so that it can be queried using JMESPath.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
/milestone 1.6.0

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind feature
## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

---
Policy to validate some keys inside a YAML string

<details>
<summary>policy</summary>

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: test-parse-yaml
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: test-yaml-parsing-jmespath
    match:
      resources:
        kinds:
         - ConfigMap
    validate:
      message: "Test JMESPath"
      deny:
        conditions:
        - key: "{{request.object.metadata.annotations.test | parse_yaml(@).value }}"
          operator: NotEquals
          value: "a"
```

</details>

<details>
<summary>resource</summary>

```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: valid-yaml-test
  annotations:
    test: |
      value: a
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: invalid-yaml-test
  annotations:
    test: |
      value: b
```

</details>
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [x] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
