### PR TITLE
fix(generate): use JSON patch for GenerateRequests status updates 

### DIFF
--- a/pkg/generate/status.go
+++ b/pkg/generate/status.go
@@ -1,13 +1,9 @@
 package generate
 
 import (
-	"context"
-
 	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernoclient "github.com/kyverno/kyverno/pkg/client/clientset/versioned"
-	"github.com/kyverno/kyverno/pkg/config"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -25,29 +21,45 @@ type StatusControl struct {
 
 //Failed sets gr status.state to failed with message
 func (sc StatusControl) Failed(gr kyverno.GenerateRequest, message string, genResources []kyverno.ResourceSpec) error {
-	gr.Status.State = kyverno.Failed
-	gr.Status.Message = message
-	// Update Generated Resources
-	gr.Status.GeneratedResources = genResources
-	_, err := sc.client.KyvernoV1().GenerateRequests(config.KyvernoNamespace).UpdateStatus(context.TODO(), &gr, v1.UpdateOptions{})
+	patch := []PatchOp{
+		{
+			Op:   "replace",
+			Path: "/status",
+			Value: &kyverno.GenerateRequestStatus{
+				State:              kyverno.Failed,
+				Message:            message,
+				GeneratedResources: genResources, // Update Generated Resources
+			},
+		},
+	}
+
+	_, err := PatchGenerateRequest(&gr, patch, sc.client, "status")
 	if err != nil && !errors.IsNotFound(err) {
-		log.Log.Error(err, "failed to update generate request status", "name", gr.Name)
+		log.Log.Error(err, "failed to patch generate request status", "name", gr.Name)
 		return err
 	}
+
 	log.Log.V(3).Info("updated generate request status", "name", gr.Name, "status", string(kyverno.Failed))
 	return nil
 }
 
 // Success sets the gr status.state to completed and clears message
 func (sc StatusControl) Success(gr kyverno.GenerateRequest, genResources []kyverno.ResourceSpec) error {
-	gr.Status.State = kyverno.Completed
-	gr.Status.Message = ""
-	// Update Generated Resources
-	gr.Status.GeneratedResources = genResources
+	patch := []PatchOp{
+		{
+			Op:   "replace",
+			Path: "/status",
+			Value: &kyverno.GenerateRequestStatus{
+				State:              kyverno.Completed,
+				Message:            "",
+				GeneratedResources: genResources, // Update Generated Resources
+			},
+		},
+	}
 
-	_, err := sc.client.KyvernoV1().GenerateRequests(config.KyvernoNamespace).UpdateStatus(context.TODO(), &gr, v1.UpdateOptions{})
+	_, err := PatchGenerateRequest(&gr, patch, sc.client, "status")
 	if err != nil && !errors.IsNotFound(err) {
-		log.Log.Error(err, "failed to update generate request status", "name", gr.Name)
+		log.Log.Error(err, "failed to patch generate request status", "name", gr.Name)
 		return err
 	}
 
@@ -57,14 +69,21 @@ func (sc StatusControl) Success(gr kyverno.GenerateRequest, genResources []kyver
 
 // Success sets the gr status.state to completed and clears message
 func (sc StatusControl) Skip(gr kyverno.GenerateRequest, genResources []kyverno.ResourceSpec) error {
-	gr.Status.State = kyverno.Skip
-	gr.Status.Message = ""
-	// Update Generated Resources
-	gr.Status.GeneratedResources = genResources
+	patch := []PatchOp{
+		{
+			Op:   "replace",
+			Path: "/status",
+			Value: &kyverno.GenerateRequestStatus{
+				State:              kyverno.Skip,
+				Message:            "",
+				GeneratedResources: genResources, // Update Generated Resources
+			},
+		},
+	}
 
-	_, err := sc.client.KyvernoV1().GenerateRequests(config.KyvernoNamespace).UpdateStatus(context.TODO(), &gr, v1.UpdateOptions{})
+	_, err := PatchGenerateRequest(&gr, patch, sc.client, "status")
 	if err != nil && !errors.IsNotFound(err) {
-		log.Log.Error(err, "failed to update generate request status", "name", gr.Name)
+		log.Log.Error(err, "failed to patch generate request status", "name", gr.Name)
 		return err
 	}
 

--- a/pkg/generate/util.go
+++ b/pkg/generate/util.go
@@ -1,0 +1,34 @@
+package generate
+
+import (
+	"context"
+	"encoding/json"
+
+	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
+	kyvernoclient "github.com/kyverno/kyverno/pkg/client/clientset/versioned"
+	"github.com/kyverno/kyverno/pkg/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// PatchOp represents a json patch operation
+type PatchOp struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+// PatchGenerateRequest patches a generate request object
+func PatchGenerateRequest(gr *kyverno.GenerateRequest, patch []PatchOp, client kyvernoclient.Interface, subresources ...string) (*kyverno.GenerateRequest, error) {
+	data, err := json.Marshal(patch)
+	if nil != err {
+		return gr, err
+	}
+
+	newGR, err := client.KyvernoV1().GenerateRequests(config.KyvernoNamespace).Patch(context.TODO(), gr.Name, types.JSONPatchType, data, metav1.PatchOptions{}, subresources...)
+	if err != nil {
+		return gr, err
+	}
+
+	return newGR, nil
+}


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>

## Related issue

fixes:#2547

## Milestone of this PR

/milestone 1.6.0


## What type of PR is this
> /kind bug

## Proposed Changes

This PR addresses the `object has been modified, please apply your changes to the latest version and try again` issue we see a lot in the generate controller logs with success status while updating  GenereteRequest resource. Similar changes can be done with Failed and Skip status update as well.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
N/A
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
