### PR TITLE
Added Mac ARM64 build to Krew config

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -30,6 +30,17 @@ spec:
       bin: kyverno
     - selector:
         matchLabels:
+          os: darwin
+          arch: arm64
+      {{addURIAndSha "https://github.com/kyverno/kyverno/releases/download/{{ .TagName }}/kyverno-cli_{{ .TagName }}_darwin_arm64.tar.gz" .TagName | indent 6 }}
+      files:
+        - from: kyverno
+          to: .
+        - from: LICENSE
+          to: .
+      bin: kyverno
+    - selector:
+        matchLabels:
           os: windows
           arch: amd64
       {{addURIAndSha "https://github.com/kyverno/kyverno/releases/download/{{ .TagName }}/kyverno-cli_{{ .TagName }}_windows_x86_64.zip" .TagName | indent 6 }}


### PR DESCRIPTION
## Related issue

N/A

## Milestone of this PR

N/A

## What type of PR is this

/kind feature

## Proposed Changes

Adds ARM64 binary to Krew plugin config. 

### Proof Manifests

N/A

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

:warning: **Note**: Requires a new version of Kyverno to be released with the latest goreleaser-action so the binary is built and uploaded to the GitHub release.