### PR TITLE
Remove `resourceCache` from engine

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -310,7 +310,6 @@ func main() {
 		prgen,
 		kubeInformer.Core().V1().Namespaces(),
 		log.Log.WithName("PolicyController"),
-		rCache,
 		policyControllerResyncPeriod,
 		promConfig,
 	)
@@ -335,7 +334,6 @@ func main() {
 		kubedynamicInformer,
 		log.Log.WithName("GenerateController"),
 		configData,
-		rCache,
 	)
 	if err != nil {
 		setupLog.Error(err, "Failed to create generate controller")
@@ -373,7 +371,6 @@ func main() {
 		kubeInformer.Core().V1().Namespaces(),
 		log.Log.WithName("ValidateAuditHandler"),
 		configData,
-		rCache,
 		client,
 		promConfig,
 	)
@@ -469,7 +466,6 @@ func main() {
 		cleanUp,
 		log.Log.WithName("WebhookServer"),
 		openAPIController,
-		rCache,
 		grc,
 		promConfig,
 	)

--- a/pkg/engine/generation.go
+++ b/pkg/engine/generation.go
@@ -70,7 +70,6 @@ func filterRule(rule kyverno.Rule, policyContext *PolicyContext) *response.RuleR
 	oldResource := policyContext.OldResource
 	admissionInfo := policyContext.AdmissionInfo
 	ctx := policyContext.JSONContext
-	resCache := policyContext.ResourceCache
 	excludeGroupRole := policyContext.ExcludeGroupRole
 	namespaceLabels := policyContext.NamespaceLabels
 
@@ -98,7 +97,7 @@ func filterRule(rule kyverno.Rule, policyContext *PolicyContext) *response.RuleR
 	policyContext.JSONContext.Checkpoint()
 	defer policyContext.JSONContext.Restore()
 
-	if err = LoadContext(logger, rule.Context, resCache, policyContext, rule.Name); err != nil {
+	if err = LoadContext(logger, rule.Context, policyContext, rule.Name); err != nil {
 		logger.V(4).Info("cannot add external data to the context", "reason", err.Error())
 		return nil
 	}

--- a/pkg/engine/imageVerify.go
+++ b/pkg/engine/imageVerify.go
@@ -60,7 +60,7 @@ func VerifyAndPatchImages(policyContext *PolicyContext) (resp *response.EngineRe
 
 		policyContext.JSONContext.Restore()
 
-		if err := LoadContext(logger, rule.Context, policyContext.ResourceCache, policyContext, rule.Name); err != nil {
+		if err := LoadContext(logger, rule.Context, policyContext, rule.Name); err != nil {
 			appendError(resp, rule, fmt.Sprintf("failed to load context: %s", err.Error()), response.RuleStatusError)
 			continue
 		}

--- a/pkg/engine/mutation.go
+++ b/pkg/engine/mutation.go
@@ -35,7 +35,6 @@ func Mutate(policyContext *PolicyContext) (resp *response.EngineResponse) {
 	ctx := policyContext.JSONContext
 	var name []string
 
-	resCache := policyContext.ResourceCache
 	logger := log.Log.WithName("EngineMutate").WithValues("policy", policy.Name, "kind", patchedResource.GetKind(),
 		"namespace", patchedResource.GetNamespace(), "name", patchedResource.GetName())
 
@@ -78,7 +77,7 @@ func Mutate(policyContext *PolicyContext) (resp *response.EngineResponse) {
 			logger.Error(err, "failed to query resource object")
 		}
 
-		if err := LoadContext(logger, rule.Context, resCache, policyContext, rule.Name); err != nil {
+		if err := LoadContext(logger, rule.Context, policyContext, rule.Name); err != nil {
 			if _, ok := err.(gojmespath.NotFoundError); ok {
 				logger.V(3).Info("failed to load context", "reason", err.Error())
 			} else {
@@ -144,7 +143,7 @@ func mutateForEach(rule *kyverno.Rule, ctx *PolicyContext, resource unstructured
 	allPatches := make([][]byte, 0)
 
 	for _, foreach := range foreachList {
-		if err := LoadContext(logger, rule.Context, ctx.ResourceCache, ctx, rule.Name); err != nil {
+		if err := LoadContext(logger, rule.Context, ctx, rule.Name); err != nil {
 			logger.Error(err, "failed to load context")
 			return ruleError(rule, utils.Mutation, "failed to load context", err), resource
 		}
@@ -202,7 +201,7 @@ func mutateElements(name string, foreach *kyverno.ForEachMutation, ctx *PolicyCo
 			return mutateError(err, fmt.Sprintf("failed to add element to mutate.foreach[%d].context", i))
 		}
 
-		if err := LoadContext(logger, foreach.Context, ctx.ResourceCache, ctx, name); err != nil {
+		if err := LoadContext(logger, foreach.Context, ctx, name); err != nil {
 			return mutateError(err, fmt.Sprintf("failed to load to mutate.foreach[%d].context", i))
 		}
 

--- a/pkg/engine/policyContext.go
+++ b/pkg/engine/policyContext.go
@@ -4,7 +4,6 @@ import (
 	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
 	client "github.com/kyverno/kyverno/pkg/dclient"
 	"github.com/kyverno/kyverno/pkg/engine/context"
-	"github.com/kyverno/kyverno/pkg/resourcecache"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -34,9 +33,6 @@ type PolicyContext struct {
 
 	ExcludeResourceFunc func(kind, namespace, name string) bool
 
-	// ResourceCache provides listers to resources. Currently Supports Configmap
-	ResourceCache resourcecache.ResourceCache
-
 	// JSONContext is the variable context
 	JSONContext *context.Context
 
@@ -53,7 +49,6 @@ func (pc *PolicyContext) Copy() *PolicyContext {
 		Client:              pc.Client,
 		ExcludeGroupRole:    pc.ExcludeGroupRole,
 		ExcludeResourceFunc: pc.ExcludeResourceFunc,
-		ResourceCache:       pc.ResourceCache,
 		JSONContext:         pc.JSONContext,
 		NamespaceLabels:     pc.NamespaceLabels,
 	}

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -307,7 +307,7 @@ func addElementToContext(ctx *PolicyContext, e interface{}, elementIndex int, el
 }
 
 func (v *validator) loadContext() error {
-	if err := LoadContext(v.log, v.contextEntries, v.ctx.ResourceCache, v.ctx, v.rule.Name); err != nil {
+	if err := LoadContext(v.log, v.contextEntries, v.ctx, v.rule.Name); err != nil {
 		if _, ok := err.(gojmespath.NotFoundError); ok {
 			v.log.V(3).Info("failed to load context", "reason", err.Error())
 		} else {

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -194,7 +194,6 @@ func (c *Controller) applyGenerate(resource unstructured.Unstructured, gr kyvern
 		AdmissionInfo:       gr.Spec.Context.UserRequestInfo,
 		ExcludeGroupRole:    c.Config.GetExcludeGroupRole(),
 		ExcludeResourceFunc: c.Config.ToFilter,
-		ResourceCache:       c.resCache,
 		JSONContext:         ctx,
 		NamespaceLabels:     namespaceLabels,
 		Client:              c.client,
@@ -256,7 +255,6 @@ func (c *Controller) applyGeneratePolicy(log logr.Logger, policyContext *engine.
 	policy := policyContext.Policy
 	resource := policyContext.NewResource
 
-	resCache := policyContext.ResourceCache
 	jsonContext := policyContext.JSONContext
 	// To manage existing resources, we compare the creation time for the default resource to be generated and policy creation time
 
@@ -284,7 +282,7 @@ func (c *Controller) applyGeneratePolicy(log logr.Logger, policyContext *engine.
 		}
 
 		// add configmap json data to context
-		if err := engine.LoadContext(log, rule.Context, resCache, policyContext, rule.Name); err != nil {
+		if err := engine.LoadContext(log, rule.Context, policyContext, rule.Name); err != nil {
 			log.Error(err, "cannot add configmaps to context")
 			return nil, processExisting, err
 		}

--- a/pkg/generate/generate_controller.go
+++ b/pkg/generate/generate_controller.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/config"
 	dclient "github.com/kyverno/kyverno/pkg/dclient"
 	"github.com/kyverno/kyverno/pkg/event"
-	"github.com/kyverno/kyverno/pkg/resourcecache"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -68,8 +67,7 @@ type Controller struct {
 	nsInformer informers.GenericInformer
 	log        logr.Logger
 
-	Config   config.Interface
-	resCache resourcecache.ResourceCache
+	Config config.Interface
 }
 
 //NewController returns an instance of the Generate-Request Controller
@@ -83,7 +81,6 @@ func NewController(
 	dynamicInformer dynamicinformer.DynamicSharedInformerFactory,
 	log logr.Logger,
 	dynamicConfig config.Interface,
-	resourceCache resourcecache.ResourceCache,
 ) (*Controller, error) {
 
 	c := Controller{
@@ -95,7 +92,6 @@ func NewController(
 		dynamicInformer: dynamicInformer,
 		log:             log,
 		Config:          dynamicConfig,
-		resCache:        resourceCache,
 	}
 
 	c.statusControl = StatusControl{client: kyvernoClient}

--- a/pkg/policy/apply.go
+++ b/pkg/policy/apply.go
@@ -14,14 +14,13 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine"
 	"github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/engine/response"
-	"github.com/kyverno/kyverno/pkg/resourcecache"
 	"github.com/kyverno/kyverno/pkg/utils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // applyPolicy applies policy on a resource
 func applyPolicy(policy kyverno.ClusterPolicy, resource unstructured.Unstructured,
-	logger logr.Logger, excludeGroupRole []string, resCache resourcecache.ResourceCache,
+	logger logr.Logger, excludeGroupRole []string,
 	client *client.Client, namespaceLabels map[string]string) (responses []*response.EngineResponse) {
 
 	startTime := time.Now()
@@ -54,7 +53,7 @@ func applyPolicy(policy kyverno.ClusterPolicy, resource unstructured.Unstructure
 		logger.Error(err, "unable to add image info to variables context")
 	}
 
-	engineResponseMutation, err = mutation(policy, resource, logger, resCache, ctx, namespaceLabels)
+	engineResponseMutation, err = mutation(policy, resource, logger, ctx, namespaceLabels)
 	if err != nil {
 		logger.Error(err, "failed to process mutation rule")
 	}
@@ -63,7 +62,6 @@ func applyPolicy(policy kyverno.ClusterPolicy, resource unstructured.Unstructure
 		Policy:           policy,
 		NewResource:      resource,
 		ExcludeGroupRole: excludeGroupRole,
-		ResourceCache:    resCache,
 		JSONContext:      ctx,
 		Client:           client,
 		NamespaceLabels:  namespaceLabels,
@@ -75,12 +73,11 @@ func applyPolicy(policy kyverno.ClusterPolicy, resource unstructured.Unstructure
 	return engineResponses
 }
 
-func mutation(policy kyverno.ClusterPolicy, resource unstructured.Unstructured, log logr.Logger, resCache resourcecache.ResourceCache, jsonContext *context.Context, namespaceLabels map[string]string) (*response.EngineResponse, error) {
+func mutation(policy kyverno.ClusterPolicy, resource unstructured.Unstructured, log logr.Logger, jsonContext *context.Context, namespaceLabels map[string]string) (*response.EngineResponse, error) {
 
 	policyContext := &engine.PolicyContext{
 		Policy:          policy,
 		NewResource:     resource,
-		ResourceCache:   resCache,
 		JSONContext:     jsonContext,
 		NamespaceLabels: namespaceLabels,
 	}

--- a/pkg/policy/common.go
+++ b/pkg/policy/common.go
@@ -144,32 +144,6 @@ func GetAllNamespaces(nslister listerv1.NamespaceLister, log logr.Logger) []stri
 }
 
 func (pc *PolicyController) getResourceList(kind, namespace string, labelSelector *metav1.LabelSelector, log logr.Logger) interface{} {
-	list, err := func() (list []*unstructured.Unstructured, err error) {
-		var selector labels.Selector
-		if labelSelector == nil {
-			selector = labels.Everything()
-		} else {
-			if selector, err = metav1.LabelSelectorAsSelector(labelSelector); err != nil {
-				return nil, err
-			}
-		}
-
-		genericCache, _ := pc.resCache.GetGVRCache(kind)
-
-		if namespace != "" {
-			list, err = genericCache.NamespacedLister(namespace).List(selector)
-		} else {
-			list, err = genericCache.Lister().List(selector)
-		}
-		return list, err
-	}()
-
-	if err != nil {
-		log.V(3).Info("failed to list resource using lister, try to query from the API server", "err", err.Error())
-	} else {
-		return list
-	}
-
 	resourceList, err := pc.client.ListResource("", kind, namespace, labelSelector)
 	if err != nil {
 		log.Error(err, "failed to list resources", "kind", kind, "namespace", namespace)

--- a/pkg/policy/existing.go
+++ b/pkg/policy/existing.go
@@ -2,7 +2,6 @@ package policy
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -32,17 +31,6 @@ func (pc *PolicyController) processExistingResources(policy *kyverno.ClusterPoli
 		matchKinds := rule.MatchKinds()
 		pc.processExistingKinds(matchKinds, policy, rule, logger)
 	}
-}
-
-func (pc *PolicyController) registerResource(gvk string) (err error) {
-	genericCache, ok := pc.resCache.GetGVRCache(gvk)
-	if !ok {
-		if genericCache, err = pc.resCache.CreateGVKInformer(gvk); err != nil {
-			return fmt.Errorf("failed to create informer for %s: %v", gvk, err)
-		}
-	}
-	pc.rm.RegisterScope(gvk, genericCache.IsNamespaced())
-	return nil
 }
 
 func (pc *PolicyController) applyAndReportPerNamespace(policy *kyverno.ClusterPolicy, kind string, ns string, rule kyverno.Rule, logger logr.Logger, metricAlreadyRegistered *bool) {
@@ -217,11 +205,13 @@ func (pc *PolicyController) processExistingKinds(kind []string, policy *kyverno.
 		logger = logger.WithValues("rule", rule.Name, "kind", k)
 		namespaced, err := pc.rm.GetScope(k)
 		if err != nil {
-			if err := pc.registerResource(k); err != nil {
+			resourceSchema, _, err := pc.client.DiscoveryClient.FindResource("", k)
+			if err != nil {
 				logger.Error(err, "failed to find resource", "kind", k)
 				continue
 			}
-			namespaced, _ = pc.rm.GetScope(k)
+			namespaced = resourceSchema.Namespaced
+			pc.rm.RegisterScope(k, namespaced)
 		}
 
 		// this tracker would help to ensure that even for multiple namespaces, duplicate metric are not generated
@@ -231,6 +221,7 @@ func (pc *PolicyController) processExistingKinds(kind []string, policy *kyverno.
 			pc.applyAndReportPerNamespace(policy, k, "", rule, logger.WithValues("kind", k), &metricRegisteredTracker)
 			continue
 		}
+
 		namespaces := pc.getNamespacesForRule(&rule, logger.WithValues("kind", k))
 		for _, ns := range namespaces {
 			// for kind: Policy, consider only the namespace which the policy belongs to.

--- a/pkg/policy/existing.go
+++ b/pkg/policy/existing.go
@@ -78,7 +78,7 @@ func (pc *PolicyController) applyPolicy(policy *kyverno.ClusterPolicy, resource 
 	}
 
 	namespaceLabels := common.GetNamespaceSelectorsFromNamespaceLister(resource.GetKind(), resource.GetNamespace(), pc.nsLister, logger)
-	engineResponse := applyPolicy(*policy, resource, logger, pc.configHandler.GetExcludeGroupRole(), pc.resCache, pc.client, namespaceLabels)
+	engineResponse := applyPolicy(*policy, resource, logger, pc.configHandler.GetExcludeGroupRole(), pc.client, namespaceLabels)
 	engineResponses = append(engineResponses, engineResponse...)
 
 	// post-processing, register the resource as processed

--- a/pkg/policy/generate/validate.go
+++ b/pkg/policy/generate/validate.go
@@ -89,7 +89,7 @@ func (g *Generate) validateClone(c kyverno.CloneFrom, kind string) (string, erro
 			return "", err
 		}
 		if !ok {
-			return "", fmt.Errorf("kyverno does not have permissions to 'get' resource %s/%s. Update permissions in ClusterRole 'kyverno:generatecontroller'", kind, namespace)
+			return "", fmt.Errorf("kyverno does not have permissions to 'get' resource %s/%s. Update permissions in ClusterRole 'kyverno:generate'", kind, namespace)
 		}
 	} else {
 		g.log.V(4).Info("name & namespace uses variables, so cannot be resolved. Skipping Auth Checks.")
@@ -109,7 +109,7 @@ func (g *Generate) canIGenerate(kind, namespace string) error {
 			return err
 		}
 		if !ok {
-			return fmt.Errorf("kyverno does not have permissions to 'create' resource %s/%s. Update permissions in ClusterRole 'kyverno:generatecontroller'", kind, namespace)
+			return fmt.Errorf("kyverno does not have permissions to 'create' resource %s/%s. Update permissions in ClusterRole 'kyverno:generate'", kind, namespace)
 		}
 		// UPDATE
 		ok, err = authCheck.CanIUpdate(kind, namespace)
@@ -118,7 +118,7 @@ func (g *Generate) canIGenerate(kind, namespace string) error {
 			return err
 		}
 		if !ok {
-			return fmt.Errorf("kyverno does not have permissions to 'update' resource %s/%s. Update permissions in ClusterRole 'kyverno:generatecontroller'", kind, namespace)
+			return fmt.Errorf("kyverno does not have permissions to 'update' resource %s/%s. Update permissions in ClusterRole 'kyverno:generate'", kind, namespace)
 		}
 		// GET
 		ok, err = authCheck.CanIGet(kind, namespace)
@@ -127,7 +127,7 @@ func (g *Generate) canIGenerate(kind, namespace string) error {
 			return err
 		}
 		if !ok {
-			return fmt.Errorf("kyverno does not have permissions to 'get' resource %s/%s. Update permissions in ClusterRole 'kyverno:generatecontroller'", kind, namespace)
+			return fmt.Errorf("kyverno does not have permissions to 'get' resource %s/%s. Update permissions in ClusterRole 'kyverno:generate'", kind, namespace)
 		}
 
 		// DELETE
@@ -137,7 +137,7 @@ func (g *Generate) canIGenerate(kind, namespace string) error {
 			return err
 		}
 		if !ok {
-			return fmt.Errorf("kyverno does not have permissions to 'delete' resource %s/%s. Update permissions in ClusterRole 'kyverno:generatecontroller'", kind, namespace)
+			return fmt.Errorf("kyverno does not have permissions to 'delete' resource %s/%s. Update permissions in ClusterRole 'kyverno:generate'", kind, namespace)
 		}
 
 	} else {

--- a/pkg/policy/policy_controller.go
+++ b/pkg/policy/policy_controller.go
@@ -23,7 +23,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/metrics"
 	pm "github.com/kyverno/kyverno/pkg/policymutation"
 	"github.com/kyverno/kyverno/pkg/policyreport"
-	"github.com/kyverno/kyverno/pkg/resourcecache"
 	"github.com/kyverno/kyverno/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -99,9 +98,6 @@ type PolicyController struct {
 
 	policyReportEraser policyreport.PolicyReportEraser
 
-	// resCache - controls creation and fetching of resource informer cache
-	resCache resourcecache.ResourceCache
-
 	reconcilePeriod time.Duration
 
 	log logr.Logger
@@ -123,7 +119,6 @@ func NewPolicyController(
 	policyReportEraser policyreport.PolicyReportEraser,
 	namespaces informers.NamespaceInformer,
 	log logr.Logger,
-	resCache resourcecache.ResourceCache,
 	reconcilePeriod time.Duration,
 	promConfig *metrics.PromConfig) (*PolicyController, error) {
 
@@ -147,7 +142,6 @@ func NewPolicyController(
 		configHandler:      configHandler,
 		prGenerator:        prGenerator,
 		policyReportEraser: policyReportEraser,
-		resCache:           resCache,
 		reconcilePeriod:    reconcilePeriod,
 		promConfig:         promConfig,
 		log:                log,

--- a/pkg/policy/policy_controller.go
+++ b/pkg/policy/policy_controller.go
@@ -82,12 +82,6 @@ type PolicyController struct {
 	// npListerSynced returns true if the namespace policy store has been synced at least once
 	npListerSynced cache.InformerSynced
 
-	// pvListerSynced returns true if the cluster policy violation store has been synced at least once
-	cpvListerSynced cache.InformerSynced
-
-	// pvListerSynced returns true if the policy violation store has been synced at least once
-	nspvListerSynced cache.InformerSynced
-
 	// nsListerSynced returns true if the namespace store has been synced at least once
 	nsListerSynced cache.InformerSynced
 

--- a/pkg/webhooks/generation.go
+++ b/pkg/webhooks/generation.go
@@ -73,7 +73,6 @@ func (ws *WebhookServer) handleGenerate(
 			AdmissionInfo:       userRequestInfo,
 			ExcludeGroupRole:    dynamicConfig.GetExcludeGroupRole(),
 			ExcludeResourceFunc: ws.configHandler.ToFilter,
-			ResourceCache:       ws.resCache,
 			JSONContext:         ctx,
 			Client:              ws.client,
 		}

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -29,7 +29,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/openapi"
 	"github.com/kyverno/kyverno/pkg/policycache"
 	"github.com/kyverno/kyverno/pkg/policyreport"
-	"github.com/kyverno/kyverno/pkg/resourcecache"
 	tlsutils "github.com/kyverno/kyverno/pkg/tls"
 	"github.com/kyverno/kyverno/pkg/userinfo"
 	"github.com/kyverno/kyverno/pkg/utils"
@@ -122,9 +121,6 @@ type WebhookServer struct {
 
 	openAPIController *openapi.Controller
 
-	// resCache - controls creation and fetching of resource informer cache
-	resCache resourcecache.ResourceCache
-
 	grController *generate.Controller
 
 	promConfig *metrics.PromConfig
@@ -154,7 +150,6 @@ func NewWebhookServer(
 	cleanUp chan<- struct{},
 	log logr.Logger,
 	openAPIController *openapi.Controller,
-	resCache resourcecache.ResourceCache,
 	grc *generate.Controller,
 	promConfig *metrics.PromConfig,
 ) (*WebhookServer, error) {
@@ -200,7 +195,6 @@ func NewWebhookServer(
 		auditHandler:      auditHandler,
 		log:               log,
 		openAPIController: openAPIController,
-		resCache:          resCache,
 		promConfig:        promConfig,
 	}
 
@@ -385,7 +379,6 @@ func (ws *WebhookServer) buildPolicyContext(request *v1beta1.AdmissionRequest, a
 		AdmissionInfo:       userRequestInfo,
 		ExcludeGroupRole:    ws.configHandler.GetExcludeGroupRole(),
 		ExcludeResourceFunc: ws.configHandler.ToFilter,
-		ResourceCache:       ws.resCache,
 		JSONContext:         ctx,
 		Client:              ws.client,
 	}
@@ -551,7 +544,6 @@ func (ws *WebhookServer) resourceValidation(request *v1beta1.AdmissionRequest) *
 		AdmissionInfo:       userRequestInfo,
 		ExcludeGroupRole:    ws.configHandler.GetExcludeGroupRole(),
 		ExcludeResourceFunc: ws.configHandler.ToFilter,
-		ResourceCache:       ws.resCache,
 		JSONContext:         ctx,
 		Client:              ws.client,
 	}

--- a/pkg/webhooks/validate_audit.go
+++ b/pkg/webhooks/validate_audit.go
@@ -19,7 +19,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/metrics"
 	"github.com/kyverno/kyverno/pkg/policycache"
 	"github.com/kyverno/kyverno/pkg/policyreport"
-	"github.com/kyverno/kyverno/pkg/resourcecache"
 	"github.com/kyverno/kyverno/pkg/userinfo"
 	"k8s.io/api/admission/v1beta1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -62,7 +61,6 @@ type auditHandler struct {
 
 	log           logr.Logger
 	configHandler config.Interface
-	resCache      resourcecache.ResourceCache
 	promConfig    *metrics.PromConfig
 }
 
@@ -75,7 +73,6 @@ func NewValidateAuditHandler(pCache policycache.Interface,
 	namespaces informers.NamespaceInformer,
 	log logr.Logger,
 	dynamicConfig config.Interface,
-	resCache resourcecache.ResourceCache,
 	client *client.Client,
 	promConfig *metrics.PromConfig) AuditHandler {
 
@@ -92,7 +89,6 @@ func NewValidateAuditHandler(pCache policycache.Interface,
 		log:            log,
 		prGenerator:    prGenerator,
 		configHandler:  dynamicConfig,
-		resCache:       resCache,
 		client:         client,
 		promConfig:     promConfig,
 	}
@@ -195,7 +191,6 @@ func (h *auditHandler) process(request *v1beta1.AdmissionRequest) error {
 		AdmissionInfo:       userRequestInfo,
 		ExcludeGroupRole:    h.configHandler.GetExcludeGroupRole(),
 		ExcludeResourceFunc: h.configHandler.ToFilter,
-		ResourceCache:       h.resCache,
 		JSONContext:         ctx,
 		Client:              h.client,
 	}


### PR DESCRIPTION
## Related issue

Fixes https://github.com/kyverno/kyverno/issues/3012.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.6.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/enhancement
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
This PR removes `resourceCache` from the background controller, generate controller, and the webhook server. With the change, the configmap lookup is now using the client call to fetch the given configmap.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Tested the configmap lookup with the following policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: mutate-env-label
spec:
    background: false
    rules:
    - name: mutate-env-label
      context:
      - name: dictionary
        configMap:
          name: datastore
          namespace: default
      match:
        resources:
          kinds:
          - Deployment
      mutate:
        patchStrategicMerge:
          metadata:
            annotations:
              kyverno.io/created-by: "{{ request.userInfo.username }}"
            labels:
              my-environment-name: "{{ dictionary.data.env }}"
```

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: datastore
data:
  env: staging
```

Create Deployments and see the labels are added:
```yaml
✗ k get deploy --show-labels
NAME              READY   UP-TO-DATE   AVAILABLE   AGE   LABELS
nginx             1/1     1            1           8s    app=nginx,my-environment-name=staging
nginx-protected   1/1     1            1           8s    app=nginx,my-environment-name=staging,protected=true
```

2. Tested the policy report generation, with `disallow_sysctls` validate policy installed the report is generated successfully:
```yaml
✗ k get polr
NAME              PASS   FAIL   WARN   ERROR   SKIP   AGE
polr-ns-default   2      0      0      0       0      89m
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
