### PR TITLE
fix for cosign image verification in v1.5.4

### DIFF
--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -83,7 +83,11 @@ func VerifySignature(imageRef string, key []byte, repository string, log logr.Lo
 	}
 
 	if key != nil {
-		cosignOpts.SigVerifier, err = sigs.PublicKeyFromKeyRef(ctx, string(key))
+		if strings.HasPrefix(string(key), "-----BEGIN PUBLIC KEY-----") {
+			cosignOpts.SigVerifier, err = decodePEM([]byte(string(key)))
+		} else {
+			cosignOpts.SigVerifier, err = sigs.PublicKeyFromKeyRef(ctx, string(key))
+		}
 	}
 
 	if err != nil {

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -84,7 +84,7 @@ func VerifySignature(imageRef string, key []byte, repository string, log logr.Lo
 
 	if key != nil {
 		if strings.HasPrefix(string(key), "-----BEGIN PUBLIC KEY-----") {
-			cosignOpts.SigVerifier, err = decodePEM([]byte(string(key)))
+			cosignOpts.SigVerifier, err = decodePEM(key)
 		} else {
 			cosignOpts.SigVerifier, err = sigs.PublicKeyFromKeyRef(ctx, string(key))
 		}
@@ -136,9 +136,16 @@ func FetchAttestations(imageRef string, key []byte, repository string) ([]map[st
 	var pubKey signature.Verifier
 	var err error
 
-	pubKey, err = decodePEM([]byte(key))
-	if err != nil {
-		return nil, errors.Wrap(err, "decode pem")
+	if strings.HasPrefix(string(key), "-----BEGIN PUBLIC KEY-----") {
+		pubKey, err = decodePEM(key)
+		if err != nil {
+			return nil, errors.Wrap(err, "decode pem")
+		}
+	} else {
+		pubKey, err = sigs.PublicKeyFromKeyRef(ctx, string(key))
+		if err != nil {
+			return nil, errors.Wrap(err, "loading public key")
+		}
 	}
 
 	var opts []remote.Option


### PR DESCRIPTION
closes:
- https://github.com/kyverno/kyverno/issues/3014 verified my changes for this locally
- https://github.com/kyverno/kyverno/issues/3017 needs to be verified by the user as it requires an image signed by a GCP KMS key, and Kyverno needs to have GCP credentials configured