### PR TITLE
Background controller: list resources once per policy 

### DIFF
--- a/pkg/policy/common.go
+++ b/pkg/policy/common.go
@@ -153,7 +153,10 @@ func (pc *PolicyController) getResourceList(kind, namespace string, labelSelecto
 	return resourceList
 }
 
-// GetResourcesPerNamespace ...
+// GetResourcesPerNamespace returns
+// - Namespaced resources across all namespaces if namespace is set to empty "", for Namespaced Kind
+// - Namespaced resources in the given namespace
+// - Cluster-wide resources for Cluster-wide Kind
 func (pc *PolicyController) getResourcesPerNamespace(kind string, namespace string, rule kyverno.Rule, log logr.Logger) map[string]unstructured.Unstructured {
 	resourceMap := map[string]unstructured.Unstructured{}
 

--- a/pkg/policy/report.go
+++ b/pkg/policy/report.go
@@ -32,9 +32,11 @@ func (pc *PolicyController) report(engineResponses []*response.EngineResponse, l
 
 	// as engineResponses holds the results for all matched resources in one namespace
 	// we can merge pvInfos into a single object to reduce update frequency (throttling request) on RCR
-	info := mergePvInfos(pvInfos)
-	pc.prGenerator.Add(info)
-	logger.V(4).Info("added a request to RCR generator", "key", info.ToKey())
+	infos := mergePvInfos(pvInfos)
+	for _, info := range infos {
+		pc.prGenerator.Add(info)
+		logger.V(4).Info("added a request to RCR generator", "key", info.ToKey())
+	}
 }
 
 // forceReconciliation forces a background scan by adding all policies to the workqueue
@@ -264,21 +266,25 @@ func generateFailEventsPerEr(log logr.Logger, er *response.EngineResponse) []eve
 	return eventInfos
 }
 
-func mergePvInfos(infos []policyreport.Info) policyreport.Info {
-	aggregatedInfo := policyreport.Info{}
+func mergePvInfos(infos []policyreport.Info) []policyreport.Info {
+	aggregatedInfo := []policyreport.Info{}
 	if len(infos) == 0 {
-		return aggregatedInfo
+		return nil
 	}
 
-	var results []policyreport.EngineResponseResult
+	aggregatedInfoPerNamespace := make(map[string]policyreport.Info)
 	for _, info := range infos {
-		for _, res := range info.Results {
-			results = append(results, res)
+		if tmpInfo, ok := aggregatedInfoPerNamespace[info.Namespace]; !ok {
+			aggregatedInfoPerNamespace[info.Namespace] = info
+		} else {
+			tmpInfo.Results = append(tmpInfo.Results, info.Results...)
+			aggregatedInfoPerNamespace[info.Namespace] = tmpInfo
 		}
+
 	}
 
-	aggregatedInfo.PolicyName = infos[0].PolicyName
-	aggregatedInfo.Namespace = infos[0].Namespace
-	aggregatedInfo.Results = results
+	for _, i := range aggregatedInfoPerNamespace {
+		aggregatedInfo = append(aggregatedInfo, i)
+	}
 	return aggregatedInfo
 }


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Related issue
https://github.com/kyverno/kyverno/issues/2793.
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.6.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/enhancement
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Previously with M policies and N namespaces, Kyverno lists matching resources M*N times in the background controller. After this change, Kyerno lists resources M times in order to reduce throttling requests.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Verified reports are generated successfully and correctly: results are the same for the same setup before and after the change.

2. With 80 Cronjobs, 10k ConfigMaps, best-practices policies in place, here's the Kyverno Memory usage 
- for 1.5.2-xxx Kyverno:

```
root@da-m3-large-x86-02:~# kubectl -n kyverno top pod
NAME                       CPU(cores)   MEMORY(bytes)
kyverno-5d496f9bc9-55f7h   227m         414Mi
```

- with the latest change (remove dynamic informers):
```
root@da-m3-large-x86-02:~# kubectl -n kyverno top pod
NAME                       CPU(cores)   MEMORY(bytes)
kyverno-7d6455b484-fp678   119m         252Mi
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
