### PR TITLE
Deprecating `resourceFilters`

### DIFF
--- a/charts/kyverno/templates/configmap.yaml
+++ b/charts/kyverno/templates/configmap.yaml
@@ -7,10 +7,6 @@ metadata:
   name: {{ template "kyverno.configMapName" . }}
   namespace: {{ template "kyverno.namespace" . }}
 data:
-  # resource types to be skipped by kyverno policy engine
-  {{- if .Values.config.resourceFilters }}
-  resourceFilters: {{ join "" .Values.config.resourceFilters | quote }}
-  {{- end -}}
   {{- if .Values.config.excludeGroupRole }}
   excludeGroupRole: {{ join "" .Values.config.excludeGroupRole | quote }}
   {{- end -}}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -144,25 +144,6 @@ generatecontrollerExtraResources:
 # - ResourceB
 
 config:
-  # resource types to be skipped by kyverno policy engine
-  # Make sure to surround each entry in quotes so that it doesn't get parsed
-  # as a nested YAML list. These are joined together without spaces in the configmap
-  resourceFilters:
-  - "[Event,*,*]"
-  - "[*,kube-system,*]"
-  - "[*,kube-public,*]"
-  - "[*,kube-node-lease,*]"
-  - "[Node,*,*]"
-  - "[APIService,*,*]"
-  - "[TokenReview,*,*]"
-  - "[SubjectAccessReview,*,*]"
-  - "[SelfSubjectAccessReview,*,*]"
-  - "[*,kyverno,*]"
-  - "[Binding,*,*]"
-  - "[ReplicaSet,*,*]"
-  - "[ReportChangeRequest,*,*]"
-  - "[ClusterReportChangeRequest,*,*]"
-  # Or give the name of an existing config map (ignores default/provided resourceFilters)
   existingConfig: ''
   excludeGroupRole:
 #  - ""

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -50,7 +50,6 @@ const resyncPeriod = 15 * time.Minute
 var (
 	//TODO: this has been added to backward support command line arguments
 	// will be removed in future and the configuration will be set only via configmaps
-	filterK8sResources           string
 	kubeconfig                   string
 	serverIP                     string
 	excludeGroupRole             string
@@ -74,7 +73,6 @@ var (
 func main() {
 	klog.InitFlags(nil)
 	log.SetLogger(klogr.New())
-	flag.StringVar(&filterK8sResources, "filterK8sResources", "", "Resource in format [kind,namespace,name] where policy is not evaluated by the admission webhook. For example, --filterK8sResources \"[Deployment, kyverno, kyverno],[Events, *, *]\"")
 	flag.StringVar(&excludeGroupRole, "excludeGroupRole", "", "")
 	flag.StringVar(&excludeUsername, "excludeUsername", "", "")
 	flag.IntVar(&webhookTimeout, "webhooktimeout", int(webhookconfig.DefaultWebhookTimeout), "Timeout for webhook configurations. Deprecated and will be removed in 1.6.0.")
@@ -265,7 +263,6 @@ func main() {
 	configData := config.NewConfigData(
 		kubeClient,
 		kubeKyvernoInformer.Core().V1().ConfigMaps(),
-		filterK8sResources,
 		excludeGroupRole,
 		excludeUsername,
 		prgen.ReconcileCh,

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -7720,7 +7720,6 @@ apiVersion: v1
 data:
   excludeGroupRole: system:serviceaccounts:kube-system,system:nodes,system:kube-scheduler
   generateSuccessEvents: "false"
-  resourceFilters: '[Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*][PolicyReport,*,*][ClusterPolicyReport,*,*]'
 kind: ConfigMap
 metadata:
   labels:
@@ -7838,7 +7837,6 @@ spec:
             weight: 1
       containers:
       - args:
-        - --filterK8sResources=[Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][*,kyverno,*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*][PolicyReport,*,*][ClusterPolicyReport,*,*]
         - -v=2
         env:
         - name: INIT_CONFIG

--- a/config/install_debug.yaml
+++ b/config/install_debug.yaml
@@ -7583,7 +7583,6 @@ apiVersion: v1
 data:
   excludeGroupRole: system:serviceaccounts:kube-system,system:nodes,system:kube-scheduler
   generateSuccessEvents: "false"
-  resourceFilters: '[Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*][PolicyReport,*,*][ClusterPolicyReport,*,*]'
 kind: ConfigMap
 metadata:
   labels:

--- a/config/k8s-resource/configmap.yaml
+++ b/config/k8s-resource/configmap.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
 data:
-  resourceFilters: '[Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*][PolicyReport,*,*][ClusterPolicyReport,*,*]'
   excludeGroupRole: 'system:serviceaccounts:kube-system,system:nodes,system:kube-scheduler'
   generateSuccessEvents: 'false'
 kind: ConfigMap

--- a/config/manifest/deployment.yaml
+++ b/config/manifest/deployment.yaml
@@ -67,7 +67,6 @@ spec:
           image: ghcr.io/kyverno/kyverno:latest
           imagePullPolicy: IfNotPresent
           args:
-          - "--filterK8sResources=[Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][*,kyverno,*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*][PolicyReport,*,*][ClusterPolicyReport,*,*]"
           # customize webhook timeout
           #- "--webhookTimeout=4"
           # enable profiling

--- a/pkg/config/dynamicconfig.go
+++ b/pkg/config/dynamicconfig.go
@@ -300,12 +300,6 @@ func (cd *ConfigData) unload(cm v1.ConfigMap) {
 	cd.generateSuccessEvents = false
 }
 
-type k8Resource struct {
-	Kind      string //TODO: as we currently only support one GVK version, we use the kind only. But if we support multiple GVK, then GV need to be added
-	Namespace string
-	Name      string
-}
-
 func parseRbac(list string) []string {
 	return strings.Split(list, ",")
 }

--- a/pkg/engine/generation.go
+++ b/pkg/engine/generation.go
@@ -43,11 +43,6 @@ func filterRules(policyContext *PolicyContext, startTime time.Time) *response.En
 		},
 	}
 
-	if policyContext.ExcludeResourceFunc(kind, namespace, name) {
-		log.Log.WithName("Generate").Info("resource excluded", "kind", kind, "namespace", namespace, "name", name)
-		return resp
-	}
-
 	for _, rule := range policyContext.Policy.Spec.Rules {
 		if ruleResp := filterRule(rule, policyContext); ruleResp != nil {
 			resp.PolicyResponse.Rules = append(resp.PolicyResponse.Rules, *ruleResp)

--- a/pkg/engine/policyContext.go
+++ b/pkg/engine/policyContext.go
@@ -31,8 +31,6 @@ type PolicyContext struct {
 	// Config handler
 	ExcludeGroupRole []string
 
-	ExcludeResourceFunc func(kind, namespace, name string) bool
-
 	// JSONContext is the variable context
 	JSONContext *context.Context
 
@@ -42,14 +40,13 @@ type PolicyContext struct {
 
 func (pc *PolicyContext) Copy() *PolicyContext {
 	return &PolicyContext{
-		Policy:              pc.Policy,
-		NewResource:         pc.NewResource,
-		OldResource:         pc.OldResource,
-		AdmissionInfo:       pc.AdmissionInfo,
-		Client:              pc.Client,
-		ExcludeGroupRole:    pc.ExcludeGroupRole,
-		ExcludeResourceFunc: pc.ExcludeResourceFunc,
-		JSONContext:         pc.JSONContext,
-		NamespaceLabels:     pc.NamespaceLabels,
+		Policy:           pc.Policy,
+		NewResource:      pc.NewResource,
+		OldResource:      pc.OldResource,
+		AdmissionInfo:    pc.AdmissionInfo,
+		Client:           pc.Client,
+		ExcludeGroupRole: pc.ExcludeGroupRole,
+		JSONContext:      pc.JSONContext,
+		NamespaceLabels:  pc.NamespaceLabels,
 	}
 }

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -189,14 +189,13 @@ func (c *Controller) applyGenerate(resource unstructured.Unstructured, gr kyvern
 	}
 
 	policyContext := &engine.PolicyContext{
-		NewResource:         resource,
-		Policy:              *policyObj,
-		AdmissionInfo:       gr.Spec.Context.UserRequestInfo,
-		ExcludeGroupRole:    c.Config.GetExcludeGroupRole(),
-		ExcludeResourceFunc: c.Config.ToFilter,
-		JSONContext:         ctx,
-		NamespaceLabels:     namespaceLabels,
-		Client:              c.client,
+		NewResource:      resource,
+		Policy:           *policyObj,
+		AdmissionInfo:    gr.Spec.Context.UserRequestInfo,
+		ExcludeGroupRole: c.Config.GetExcludeGroupRole(),
+		JSONContext:      ctx,
+		NamespaceLabels:  namespaceLabels,
+		Client:           c.client,
 	}
 
 	// check if the policy still applies to the resource

--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -577,11 +577,8 @@ func ApplyPolicyOnResource(policy *v1.ClusterPolicy, resource *unstructured.Unst
 			NewResource:      *resource,
 			Policy:           *policy,
 			ExcludeGroupRole: []string{},
-			ExcludeResourceFunc: func(s1, s2, s3 string) bool {
-				return false
-			},
-			JSONContext:     context.NewContext(),
-			NamespaceLabels: namespaceLabels,
+			JSONContext:      context.NewContext(),
+			NamespaceLabels:  namespaceLabels,
 		}
 		generateResponse := engine.Generate(policyContext)
 		if generateResponse != nil {

--- a/pkg/testrunner/scenario.go
+++ b/pkg/testrunner/scenario.go
@@ -185,10 +185,7 @@ func runTestCase(t *testing.T, tc TestCase) bool {
 				Policy:           *policy,
 				Client:           client,
 				ExcludeGroupRole: []string{},
-				ExcludeResourceFunc: func(s1, s2, s3 string) bool {
-					return false
-				},
-				JSONContext: context.NewContext(),
+				JSONContext:      context.NewContext(),
 			}
 
 			er = engine.Generate(policyContext)

--- a/pkg/webhooks/generation.go
+++ b/pkg/webhooks/generation.go
@@ -68,13 +68,12 @@ func (ws *WebhookServer) handleGenerate(
 		}
 
 		policyContext := &engine.PolicyContext{
-			NewResource:         new,
-			OldResource:         old,
-			AdmissionInfo:       userRequestInfo,
-			ExcludeGroupRole:    dynamicConfig.GetExcludeGroupRole(),
-			ExcludeResourceFunc: ws.configHandler.ToFilter,
-			JSONContext:         ctx,
-			Client:              ws.client,
+			NewResource:      new,
+			OldResource:      old,
+			AdmissionInfo:    userRequestInfo,
+			ExcludeGroupRole: dynamicConfig.GetExcludeGroupRole(),
+			JSONContext:      ctx,
+			Client:           ws.client,
 		}
 
 		for _, policy := range policies {

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -199,11 +199,11 @@ func NewWebhookServer(
 	}
 
 	mux := httprouter.New()
-	mux.HandlerFunc("POST", config.MutatingWebhookServicePath, ws.handlerFunc(ws.resourceMutation, true))
-	mux.HandlerFunc("POST", config.ValidatingWebhookServicePath, ws.handlerFunc(ws.resourceValidation, true))
-	mux.HandlerFunc("POST", config.PolicyMutatingWebhookServicePath, ws.handlerFunc(ws.policyMutation, true))
-	mux.HandlerFunc("POST", config.PolicyValidatingWebhookServicePath, ws.handlerFunc(ws.policyValidation, true))
-	mux.HandlerFunc("POST", config.VerifyMutatingWebhookServicePath, ws.handlerFunc(ws.verifyHandler, false))
+	mux.HandlerFunc("POST", config.MutatingWebhookServicePath, ws.handlerFunc(ws.resourceMutation))
+	mux.HandlerFunc("POST", config.ValidatingWebhookServicePath, ws.handlerFunc(ws.resourceValidation))
+	mux.HandlerFunc("POST", config.PolicyMutatingWebhookServicePath, ws.handlerFunc(ws.policyMutation))
+	mux.HandlerFunc("POST", config.PolicyValidatingWebhookServicePath, ws.handlerFunc(ws.policyValidation))
+	mux.HandlerFunc("POST", config.VerifyMutatingWebhookServicePath, ws.handlerFunc(ws.verifyHandler))
 
 	// Patch Liveness responds to a Kubernetes Liveness probe
 	// Fail this request if Kubernetes should restart this instance
@@ -235,7 +235,7 @@ func NewWebhookServer(
 	return ws, nil
 }
 
-func (ws *WebhookServer) handlerFunc(handler func(request *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse, filter bool) http.HandlerFunc {
+func (ws *WebhookServer) handlerFunc(handler func(request *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		startTime := time.Now()
 		ws.webhookMonitor.SetTime(startTime)

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -254,13 +254,7 @@ func (ws *WebhookServer) handlerFunc(handler func(request *v1beta1.AdmissionRequ
 			UID:     admissionReview.Request.UID,
 		}
 
-		// Do not process the admission requests for kinds that are in filterKinds for filtering
 		request := admissionReview.Request
-		if filter && ws.configHandler.ToFilter(request.Kind.Kind, request.Namespace, request.Name) {
-			writeResponse(rw, admissionReview)
-			return
-		}
-
 		admissionReview.Response = handler(request)
 		writeResponse(rw, admissionReview)
 		logger.V(4).Info("admission review request processed", "time", time.Since(startTime).String())
@@ -375,12 +369,11 @@ func (ws *WebhookServer) buildPolicyContext(request *v1beta1.AdmissionRequest, a
 	}
 
 	policyContext := &engine.PolicyContext{
-		NewResource:         resource,
-		AdmissionInfo:       userRequestInfo,
-		ExcludeGroupRole:    ws.configHandler.GetExcludeGroupRole(),
-		ExcludeResourceFunc: ws.configHandler.ToFilter,
-		JSONContext:         ctx,
-		Client:              ws.client,
+		NewResource:      resource,
+		AdmissionInfo:    userRequestInfo,
+		ExcludeGroupRole: ws.configHandler.GetExcludeGroupRole(),
+		JSONContext:      ctx,
+		Client:           ws.client,
 	}
 
 	if request.Operation == v1beta1.Update {
@@ -539,13 +532,12 @@ func (ws *WebhookServer) resourceValidation(request *v1beta1.AdmissionRequest) *
 	}
 
 	policyContext := &engine.PolicyContext{
-		NewResource:         newResource,
-		OldResource:         oldResource,
-		AdmissionInfo:       userRequestInfo,
-		ExcludeGroupRole:    ws.configHandler.GetExcludeGroupRole(),
-		ExcludeResourceFunc: ws.configHandler.ToFilter,
-		JSONContext:         ctx,
-		Client:              ws.client,
+		NewResource:      newResource,
+		OldResource:      oldResource,
+		AdmissionInfo:    userRequestInfo,
+		ExcludeGroupRole: ws.configHandler.GetExcludeGroupRole(),
+		JSONContext:      ctx,
+		Client:           ws.client,
 	}
 
 	vh := &validationHandler{

--- a/pkg/webhooks/validate_audit.go
+++ b/pkg/webhooks/validate_audit.go
@@ -186,13 +186,12 @@ func (h *auditHandler) process(request *v1beta1.AdmissionRequest) error {
 	}
 
 	policyContext := &engine.PolicyContext{
-		NewResource:         newResource,
-		OldResource:         oldResource,
-		AdmissionInfo:       userRequestInfo,
-		ExcludeGroupRole:    h.configHandler.GetExcludeGroupRole(),
-		ExcludeResourceFunc: h.configHandler.ToFilter,
-		JSONContext:         ctx,
-		Client:              h.client,
+		NewResource:      newResource,
+		OldResource:      oldResource,
+		AdmissionInfo:    userRequestInfo,
+		ExcludeGroupRole: h.configHandler.GetExcludeGroupRole(),
+		JSONContext:      ctx,
+		Client:           h.client,
 	}
 
 	vh := &validationHandler{


### PR DESCRIPTION
Signed-off-by: Abhinav Sinha <abhinav@nirmata.com>

## Related issue
Closes #2916 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
`/milestone 1.7.0`
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
`/kind enhancement`
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Removing all references to `filterK8sResources` and `resourceFilters`, including related methods and types.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
