### PR TITLE
Update division for same units

### DIFF
--- a/pkg/engine/jmespath/arithmetic.go
+++ b/pkg/engine/jmespath/arithmetic.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strconv"
 	"time"
 
 	"gopkg.in/inf.v0"
@@ -229,7 +230,7 @@ func (op1 Quantity) Divide(op2 interface{}) (interface{}, error) {
 		var quo inf.Dec
 		scale := inf.Scale(math.Max(float64(op1.AsDec().Scale()), float64(v.AsDec().Scale())))
 		quo.QuoRound(op1.AsDec(), v.AsDec(), scale, inf.RoundDown)
-		return resource.NewDecimalQuantity(quo, v.Quantity.Format).String(), nil
+		return strconv.ParseFloat(quo.String(), 64)
 	case Scalar:
 		q, err := resource.ParseQuantity(fmt.Sprintf("%v", v.float64))
 		if err != nil {
@@ -255,20 +256,22 @@ func (op1 Duration) Divide(op2 interface{}) (interface{}, error) {
 		}
 
 		quo = op1.Seconds() / v.Seconds()
+		return quo, nil
 	case Scalar:
 		if v.float64 == 0 {
 			return nil, fmt.Errorf(undefinedQuoError, divide)
 		}
 
 		quo = op1.Seconds() / v.float64
+		res, err := time.ParseDuration(fmt.Sprintf("%.9fs", quo))
+		if err != nil {
+			return nil, err
+		}
+
+		return res.String(), nil
 	}
 
-	res, err := time.ParseDuration(fmt.Sprintf("%.9fs", quo))
-	if err != nil {
-		return nil, err
-	}
-
-	return res.String(), nil
+	return nil, nil
 }
 
 func (op1 Scalar) Divide(op2 interface{}) (interface{}, error) {
@@ -315,7 +318,13 @@ func (op1 Quantity) Modulo(op2 interface{}) (interface{}, error) {
 		return nil, err
 	}
 
-	x, err := resource.ParseQuantity(quo.(string))
+	var x resource.Quantity
+	switch y := quo.(type) {
+	case float64:
+		x, err = resource.ParseQuantity(fmt.Sprintf("%.9f", y))
+	case string:
+		x, err = resource.ParseQuantity(y)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +348,13 @@ func (op1 Duration) Modulo(op2 interface{}) (interface{}, error) {
 		return nil, err
 	}
 
-	x, err := time.ParseDuration(quo.(string))
+	var x time.Duration
+	switch y := quo.(type) {
+	case float64:
+		x, err = time.ParseDuration(fmt.Sprintf("%.9fs", y))
+	case string:
+		x, err = time.ParseDuration(y)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -815,7 +815,8 @@ func Test_Divide(t *testing.T) {
 		},
 		{
 			test:           "divide('25m0s', '2s')",
-			expectedResult: `12m30s`,
+			expectedResult: 750.0,
+			retFloat:       true,
 		},
 		{
 			test:           "divide(`360`, '-2s')",
@@ -827,7 +828,8 @@ func Test_Divide(t *testing.T) {
 		},
 		{
 			test:           "divide('26Gi', '13Ki')",
-			expectedResult: `2Mi`,
+			expectedResult: 2097152.0,
+			retFloat:       true,
 		},
 		{
 			test:           "divide('500m', `2`)",


### PR DESCRIPTION
Signed-off-by: Kumar Mallikarjuna <kumar@nirmata.com>

cc - @chipzoller, @realshuting 

## Related issue
Closes #2985
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.6.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/kind design
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Make division output unitless incase both dividend and divisor have the same base unit
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Policy
```yaml
apiVersion : kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: requests-limits
spec:
  validationFailureAction: enforce
  # schemaValidation: false
  rules:
  - name: check-requests-limits
    match:
      resources:
        kinds:
        - Pod
    validate:
      message: Limits may not exceed 2.5x the requests.
      foreach:
      - list: "request.object.spec.containers"
        deny:
          conditions:
            any:
            - key: "{{ divide('{{ element.resources.limits.memory }}', '{{ element.resources.requests.memory }}') }}"
              operator: GreaterThan
              value: 2.5
```

Pod
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: busybox
spec:
  containers:
  - image: asdfsasdffs:1.28
    name: busybox0
    args:
    - "sleep"
    - "9999"
    resources:
      requests:
        cpu: 100m
        memory: 100Mi
      limits: 
        cpu: 800m
        memory: 1.2Gi
```

```bash
$ k apply -f pod.yaml
Error from server: error when creating "pod.yaml": admission webhook "validate.kyverno.svc-fail" denied the request:

resource Pod/default/busybox was blocked due to the following policies

requests-limits:
  check-requests-limits: validation failed in foreach rule for Limits may not exceed
    2.5x the requests.
```

Logs (-v=4)
```yaml
I0121 09:15:47.523174       1 vars.go:378] EngineValidate "msg"="variable substituted" "kind"="Pod" "name"="busybox" "namespace"="default" "policy"="requests-limits" "rule"="check-request
s-limits" "path"="/any/0/key" "value"=12.288 "variable"="{{ divide('1288490188800m', '100Mi') }}"
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
