### PR TITLE
Fix dynamic webhook for namespace policies

### DIFF
--- a/pkg/webhookconfig/configmanager.go
+++ b/pkg/webhookconfig/configmanager.go
@@ -429,18 +429,18 @@ func (m *webhookConfigManager) getPolicy(namespace, name string) (*kyverno.Clust
 }
 
 func (m *webhookConfigManager) listPolicies(namespace string) ([]*kyverno.ClusterPolicy, error) {
+	policies := []*kyverno.ClusterPolicy{}
+
 	if namespace != "" {
 		polList, err := m.npLister.Policies(namespace).List(labels.Everything())
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to list Policy")
 		}
 
-		policies := make([]*kyverno.ClusterPolicy, len(polList))
-		for i, pol := range polList {
+		for _, pol := range polList {
 			p := kyverno.ClusterPolicy(*pol)
-			policies[i] = &p
+			policies = append(policies, &p)
 		}
-		return policies, nil
 	}
 
 	cpolList, err := m.pLister.List(labels.Everything())
@@ -448,7 +448,8 @@ func (m *webhookConfigManager) listPolicies(namespace string) ([]*kyverno.Cluste
 		return nil, errors.Wrapf(err, "failed to list ClusterPolicy")
 	}
 
-	return cpolList, nil
+	policies = append(policies, cpolList...)
+	return policies, nil
 }
 
 const (

--- a/pkg/webhookconfig/configmanager.go
+++ b/pkg/webhookconfig/configmanager.go
@@ -9,7 +9,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/go-logr/logr"
 	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernoclient "github.com/kyverno/kyverno/pkg/client/clientset/versioned"
@@ -416,7 +415,7 @@ func (m *webhookConfigManager) listAllPolicies() ([]*kyverno.ClusterPolicy, erro
 
 	namespaces, err := m.nsLister.List(labels.Everything())
 	if err != nil {
-		logger.Error(err, "unabled to list namespaces")
+		m.log.Error(err, "unabled to list namespaces")
 		return nil, err
 	}
 


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Related issue
Fixes https://github.com/kyverno/kyverno/issues/3041.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.6.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
/bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
List cluster policies for Namespaced policy reconciliation.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Tested with the following policy that generates mutate and validate namespace policies for new the namespace.
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-namespace-label
  annotations:
    policies.kyverno.io/title: Require Namespace Labels
    policies.kyverno.io/category: Core
    policies.kyverno.io/severity: high
    policies.kyverno.io/subject: Namespace
    policies.kyverno.io/description: >-
      Namespaces are required to have POC and AppID labels
spec:
  validationFailureAction: enforce
  rules:
    - name: require-labels
      match:
        resources:
          kinds:
            - Namespace
      validate:
        pattern:
          metadata:
            labels:
              example.com/POC: "?*"
              example.com/AppID: "?*"
    - name: add-labels
      match:
        resources:
          kinds:
            - Namespace
      generate:
        apiVersion: kyverno.io/v1
        kind: Policy
        name: add-labels-policy
        synchronize: true
        namespace: "{{request.object.metadata.name}}"
        data:
          spec:
            rules:
            - name: add-labels
              match:
                resources:
                  kinds:
                    - Pod
                    - DaemonSet
                    - Deployment
                    - Job
                    - StatefulSet
                    - CronJob
              mutate:
                patchStrategicMerge:
                  metadata:
                    labels:
                      example.com/AppID: '{{request.object.metadata.labels."example.com/AppID"}}'
                      example.com/POC: '{{request.object.metadata.labels."example.com/POC"}}'
    - name: validate-labels
      match:
        resources:
          kinds:
            - Namespace
      generate:
        apiVersion: kyverno.io/v1
        kind: Policy
        name: validate-labels-policy
        synchronize: true
        namespace: "{{request.object.metadata.name}}"
        data:
          spec:
            rules:
            - name: add-labels
              match:
                resources:
                  kinds:
                    - Pod
                    - DaemonSet
                    - Deployment
                    - Job
                    - StatefulSet
                    - CronJob
              validate:
                pattern:
                  metadata:
                    labels:
                      example.com/AppID: '{{request.object.metadata.labels."example.com/AppID"}}'
                      example.com/POC: '{{request.object.metadata.labels."example.com/POC"}}'
```

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: foo
  labels:
    example.com/POC: foo
    example.com/AppID: bar
```

Both namespace policies were created.
```
✗ k get pol -A
NAMESPACE   NAME                     BACKGROUND   ACTION   READY
foo         add-labels-policy        true         audit    true
foo         validate-labels-policy   true         audit    true
```

And the `validatingwebhookconfigurations` was configured correctly for all matching resources.
```
✗ k get validatingwebhookconfigurations kyverno-resource-validating-webhook-cfg -o yaml | k neat
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  name: kyverno-resource-validating-webhook-cfg
webhooks:
- admissionReviewVersions:
  - v1beta1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM3VENDQWRXZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFZTVJZd0ZBWURWUVFEREEwcUxtdDUKZG1WeWJtOHVjM1pqTUI0WERUSXlNREV5TWpBME5ESXpNbG9YRFRJek1ERXlNakExTkRJek1sb3dHREVXTUJRRwpBMVVFQXd3TktpNXJlWFpsY201dkxuTjJZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBTWtETUtlY2E3QUY4QzhwTmZWNndWNHlxZm9IME0vUWZldDF6R0w5WkxJNVZ2bWFJenQrQThmc29tc0kKOEgrN1U2Ym5rUDYrdEdXakIzUGJKd0pmREFVVDVuQ0hSWEovdytHTXh6QXZ0MHNRbEQ4SWxrZHVjQXM0R2liLwpDSVZCaWtINHpVYlMyOHo1S3BwWXhGbDJ1Z2F6a0ZUaFpCK1V4NE5uRjFHblNXdlNIUi82VlZ1YkpQWDdEKytsCjNWcU5pT2RpWEFyUUtkdXowN2dMdjZCWmJIWDQyR0taRzgzRThzMG1IZjloUGFyWC9pcS83ZjA1KzZ2M3dzdWIKamtqSXFjK0lBR1R4Qk40VUNlaHRCdC94NkU0aHBYdTVLSHliNTR2N1NrTGZOL0REamRtL1ZsZXVLWWFna3hFUwpxVmsxTHZraXNuTHFxRlVkd3lmNUFSNUdQYmNDQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHCkExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkU1eFJjQjlSRGlRL3ozSUVyUWg0bnorQkhDK01BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUFuN1Z6NCswTWZ4eXNsTzF6VTFxeEVnSHlLUWJvYVUvUnlXOE95dlR4eQppWVJsSGw5ZjJvZy9HU1luTkUvTHRQbWVNd1FGYm9YOXRJVlR4ODkwcmhHZWNHYnIwQVlSK1N1MUFUTE41Vk9hCnE1QmU1NHRmRlhjbGZGWHVXVXNRMWs2VDc3eGhsMVRtNDVVdG5QbjNOeDRQUEs4SS9YRFhLV3NuN3ZXVHg2eWUKbGFlREJ1aHoxdktybElUS2w4bFdZK3YvUTNWdU5Nb1lKT0ViSjZJZGxWaFJjYzdUVURvN2o4V2JhZGpDb2dweQp6R1l6QWFyQjdVNUFHWGxDbW1nc3ExbnFGWldlMXJIWldJRk5HZ2J5T2JHUmxNUnRiVDJGL3hzejYwOGVlU0F1CitscTYwbFF4YkJBZDFPUjlDWVpEZ3pjU0E0Qmg3WFFJbUJwcGptUm1vcC85Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    service:
      name: kyverno-svc
      namespace: kyverno
      path: /validate
      port: 443
  failurePolicy: Ignore
  matchPolicy: Equivalent
  name: validate.kyverno.svc-ignore
  sideEffects: NoneOnDryRun
  timeoutSeconds: 10
- admissionReviewVersions:
  - v1beta1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM3VENDQWRXZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFZTVJZd0ZBWURWUVFEREEwcUxtdDUKZG1WeWJtOHVjM1pqTUI0WERUSXlNREV5TWpBME5ESXpNbG9YRFRJek1ERXlNakExTkRJek1sb3dHREVXTUJRRwpBMVVFQXd3TktpNXJlWFpsY201dkxuTjJZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBTWtETUtlY2E3QUY4QzhwTmZWNndWNHlxZm9IME0vUWZldDF6R0w5WkxJNVZ2bWFJenQrQThmc29tc0kKOEgrN1U2Ym5rUDYrdEdXakIzUGJKd0pmREFVVDVuQ0hSWEovdytHTXh6QXZ0MHNRbEQ4SWxrZHVjQXM0R2liLwpDSVZCaWtINHpVYlMyOHo1S3BwWXhGbDJ1Z2F6a0ZUaFpCK1V4NE5uRjFHblNXdlNIUi82VlZ1YkpQWDdEKytsCjNWcU5pT2RpWEFyUUtkdXowN2dMdjZCWmJIWDQyR0taRzgzRThzMG1IZjloUGFyWC9pcS83ZjA1KzZ2M3dzdWIKamtqSXFjK0lBR1R4Qk40VUNlaHRCdC94NkU0aHBYdTVLSHliNTR2N1NrTGZOL0REamRtL1ZsZXVLWWFna3hFUwpxVmsxTHZraXNuTHFxRlVkd3lmNUFSNUdQYmNDQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHCkExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkU1eFJjQjlSRGlRL3ozSUVyUWg0bnorQkhDK01BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUFuN1Z6NCswTWZ4eXNsTzF6VTFxeEVnSHlLUWJvYVUvUnlXOE95dlR4eQppWVJsSGw5ZjJvZy9HU1luTkUvTHRQbWVNd1FGYm9YOXRJVlR4ODkwcmhHZWNHYnIwQVlSK1N1MUFUTE41Vk9hCnE1QmU1NHRmRlhjbGZGWHVXVXNRMWs2VDc3eGhsMVRtNDVVdG5QbjNOeDRQUEs4SS9YRFhLV3NuN3ZXVHg2eWUKbGFlREJ1aHoxdktybElUS2w4bFdZK3YvUTNWdU5Nb1lKT0ViSjZJZGxWaFJjYzdUVURvN2o4V2JhZGpDb2dweQp6R1l6QWFyQjdVNUFHWGxDbW1nc3ExbnFGWldlMXJIWldJRk5HZ2J5T2JHUmxNUnRiVDJGL3hzejYwOGVlU0F1CitscTYwbFF4YkJBZDFPUjlDWVpEZ3pjU0E0Qmg3WFFJbUJwcGptUm1vcC85Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    service:
      name: kyverno-svc
      namespace: kyverno
      path: /validate
      port: 443
  failurePolicy: Fail
  matchPolicy: Equivalent
  name: validate.kyverno.svc-fail
  rules:
  - apiGroups:
    - ""
    - apps
    - batch
    - kyverno.io
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - pods
    - daemonsets
    - deployments
    - jobs
    - statefulsets
    - cronjobs
    - pods/ephemeralcontainers
    - namespaces
    - policies
    scope: '*'
  sideEffects: NoneOnDryRun
  timeoutSeconds: 10
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
