### PR TITLE
Adding tests for cosign keyless image verification

### DIFF
--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -347,10 +347,10 @@ func matchSubjectAndIssuer(signatures []oci.Signature, subject, issuer string) e
 	if subject == "" && issuer == "" {
 		return nil
 	}
-
+	var s string
 	for _, sig := range signatures {
 		cert, err := sig.Cert()
-		if err == nil {
+		if err != nil {
 			return errors.Wrap(err, "failed to read certificate")
 		}
 
@@ -358,18 +358,18 @@ func matchSubjectAndIssuer(signatures []oci.Signature, subject, issuer string) e
 			return errors.Wrap(err, "certificate not found")
 		}
 
-		s := sigs.CertSubject(cert)
+		s = sigs.CertSubject(cert)
 		i := sigs.CertIssuerExtension(cert)
 		if subject == "" || wildcard.Match(subject, s) {
 			if issuer == "" || (issuer == i) {
 				return nil
 			} else {
-				return fmt.Errorf("issuer mismatch")
+				return fmt.Errorf("issuer mismatch: expected %s, got %s", i, issuer)
 			}
 		}
 	}
 
-	return fmt.Errorf("subject mismatch")
+	return fmt.Errorf("subject mismatch: expected %s, got %s", s, subject)
 }
 
 func checkAnnotations(payload []payload.SimpleContainerImage, annotations map[string]string) error {

--- a/pkg/cosign/cosign_test.go
+++ b/pkg/cosign/cosign_test.go
@@ -65,3 +65,25 @@ func TestCosignPayload(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, d2, "sha256:6a037d5ba27d9c6be32a9038bfe676fb67d2e4145b4f53e9c61fb3e69f06e816")
 }
+
+func TestCosignKeyless(t *testing.T) {
+	var log logr.Logger = logr.Discard()
+	opts := Options{
+		ImageRef: "ghcr.io/jimbugwadia/pause2",
+		Issuer:   "https://github.com/",
+		Subject:  "jim",
+		Log:      log,
+	}
+
+	_, err := VerifySignature(opts)
+	assert.Error(t, err, "subject mismatch: expected jim@nirmata.com, got jim")
+
+	opts.Subject = "jim@nirmata.com"
+	_, err = VerifySignature(opts)
+	assert.Error(t, err, "issuer mismatch: expected https://github.com/login/oauth, got https://github.com/")
+
+	opts.Issuer = "https://github.com/login/oauth"
+	_, err = VerifySignature(opts)
+	assert.NilError(t, err)
+
+}


### PR DESCRIPTION
adding tests for cosign keyless image verification feature along with a small fix which does not make issuer and subject mismatch to work