### PR TITLE
Handle operations with keys having empty string and numeric condition operator

### DIFF
--- a/pkg/engine/variables/operator/numeric.go
+++ b/pkg/engine/variables/operator/numeric.go
@@ -178,7 +178,14 @@ func (noh NumericOperatorHandler) validateValueWithStringPattern(key string, val
 	resourceKey, err := resource.ParseQuantity(key)
 	if err == nil {
 		if quant, err := resource.ParseQuantity(fmt.Sprint(value)); err == nil {
-			if quant.Format == resource.BinarySI {
+			// int64QuantityExpectedBytes is the expected width in bytes of the canonical string representation
+			// of most Quantity values.
+			const int64QuantityExpectedBytes = 18
+
+			cb := make([]byte, int64QuantityExpectedBytes)
+			_, suffix := quant.CanonicalizeBytes(cb)
+
+			if string(suffix) != "" {
 				return noh.validateValueWithResourcePattern(resourceKey, value)
 			}
 		}

--- a/pkg/engine/variables/operator/numeric.go
+++ b/pkg/engine/variables/operator/numeric.go
@@ -177,8 +177,10 @@ func (noh NumericOperatorHandler) validateValueWithStringPattern(key string, val
 	// attempt to extract resource quantity from string
 	resourceKey, err := resource.ParseQuantity(key)
 	if err == nil {
-		if _, err := resource.ParseQuantity(fmt.Sprint(value)); err == nil {
-			return noh.validateValueWithResourcePattern(resourceKey, value)
+		if quant, err := resource.ParseQuantity(fmt.Sprint(value)); err == nil {
+			if quant.Format == resource.BinarySI {
+				return noh.validateValueWithResourcePattern(resourceKey, value)
+			}
 		}
 	}
 	// extracting float64 from the string key

--- a/test/e2e/mutate/config.go
+++ b/test/e2e/mutate/config.go
@@ -96,6 +96,16 @@ var tests = []struct {
 		ResourceRaw:        kyverno_2971_resource,
 		ExpectedPatternRaw: kyverno_2971_pattern,
 	},
+	{
+		TestDescription:    "checks that preconditions having empty string as key with a numeric condition operator are handled properly",
+		PolicyName:         "add-default-resources",
+		PolicyRaw:          kyverno_3075_policy,
+		ResourceName:       "nginx",
+		ResourceNamespace:  "test-mutate",
+		ResourceGVR:        podGVR,
+		ResourceRaw:        kyverno_3075_resource,
+		ExpectedPatternRaw: kyverno_3075_pattern,
+	},
 }
 
 var ingressTests = struct {


### PR DESCRIPTION
Signed-off-by: Abhinav Sinha <abhinav@nirmata.com>

## Related issue
Closes #3075 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
`/milestone 1.6.1`
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
`/kind bug`
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
* Added a conditional for converting `key` with empty string to `"0"` in `func (noh NumericOperatorHandler) validateValueWithStringPattern(key string, value interface{}) bool`
* Reordered parsing of resource quantity from string for higher precedence over parsing of scalars from string
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Manifests picked and tested directly from the related issue:

#### ClusterPolicy
```yaml
apiVersion : kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: add-default-resources
spec:
  background: false
  rules:
  - name: add-default-requests-memory
    match:
      resources:
        kinds:
        - Pod
    preconditions:
      all:
      - key: "{{request.operation}}"
        operator: In
        value:
        - CREATE
        - UPDATE
    mutate:
      foreach:
      - list: "request.object.spec.containers"
        preconditions:
          all:
          - key: "{{ element.resources.requests.memory || '' }}"
            operator: LessThan
            value: 100Mi
        patchStrategicMerge:
          spec:
            containers:
            - name: "{{ element.name }}"
              resources:
                requests:
                  memory: 100Mi
```

#### Resource
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx
  labels:
    app: myapp
  annotations:
    iam.amazonaws.com/role: cert-manager_mycluster  
spec:
  containers:
  - name: nginx
    image: docker.io/nginx
```

#### Patched Resource Spec
```yaml
spec:
  containers:
  - image: docker.io/nginx
    imagePullPolicy: Always
    name: nginx
    resources:
      requests:
        memory: 100Mi
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
