### PR TITLE
Adds jmesPath validation for its expression

### DIFF
--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -418,14 +418,17 @@ func hasVariables(policy *kyverno.ClusterPolicy) [][]string {
 	return matches
 }
 
-func validateJMESPath(policy *ClusterPolicy) bool {
+func validateJMESPath(policy *kyverno.ClusterPolicy) bool {
 	for _, rule := range policy.Spec.Rules {
 		for _, context := range rule.Context {
-			if context.apiCall.Type == "jmesPath" {
-				if strings.HasPrefix(context.ApiCall.Expression, "{{") && strings.HasSuffix(context.ApiCall.Expression, "}}") {
+			if context.APICall.JMESPath == "jmesPath" {
+				if strings.HasPrefix(context.APICall.JMESPath, "{{") && strings.HasSuffix(context.APICall.JMESPath, "}}") {
 					return true
 				}
 			}
+		}
+	}
+	return false
 }
 
 func jsonPatchPathHasVariables(patch string) error {


### PR DESCRIPTION
Signed-off-by: afzal442 <afzal442@gmail.com>

## Related issue
Fix #2699 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind api-change
## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:
-->
# Kubernetes resource

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: deny-exec-by-namespace-label
  annotations:
    policies.kyverno.io/title: Block Pod Exec by Namespace Label
    policies.kyverno.io/category: Sample
    policies.kyverno.io/minversion: 1.4.2
    policies.kyverno.io/subject: Pod
    policies.kyverno.io/description: >-
      The `exec` command may be used to gain shell access, or run other commands, in a Pod's container. While this can
      be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
      This policy blocks Pod exec commands based upon a Namespace label `exec=false`.      
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: deny-exec-by-ns-label
    match:
      resources:
        kinds:
        - PodExecOptions
    context:
    - name: nslabelexec
      apiCall:
        urlPath: "/api/v1/namespaces/{{request.namespace}}"
        jmesPath: "metadata.labels.exec"
    preconditions:
    - key: "{{ request.operation }}"
      operator: Equals
      value: CONNECT
    validate:
      message: Executing a command in a container is forbidden for Pods running in Namespaces protected with the label "exec=false".
      deny:
        conditions:
          - key: "{{ nslabelexec }}"
            operator: Equals
            value: "false"

```
```
./main test testcases/

Executing deny-exec-by-namespace-label...
applying 1 policy to 1 resource... 
E0131 17:02:59.909749   19563 test_command.go:696]  "msg"="skipping invalid policy" "error"="JMESPath is not valid"  "name"="deny-exec-by-namespace-label"
```
<!--
# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
