### PR TITLE
Fix kyverno panic with `PodSpec.containers` JSON merge patch w/o image

### DIFF
--- a/pkg/engine/context/imageutils.go
+++ b/pkg/engine/context/imageutils.go
@@ -134,8 +134,13 @@ func convertToImageInfo(containers []interface{}, jsonPath string) (images []*Co
 	var index = 0
 	for _, ctr := range containers {
 		if container, ok := ctr.(map[string]interface{}); ok {
-			name := container["name"].(string)
-			image := container["image"].(string)
+			var name, image string
+
+			name = container["name"].(string)
+			if _, ok := container["image"]; ok {
+				image = container["image"].(string)
+			}
+
 			jp := strings.Join([]string{jsonPath, strconv.Itoa(index), "image"}, "/")
 			imageInfo, err := newImageInfo(image, jp)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Abhinav Sinha <abhinav@nirmata.com>

## Related issue
Closes #3141 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
`/milestone 1.6.0`
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this
`/kind bug`
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
* Added non-existence check for `image` key in `container` map before type conversion in `func convertToImageInfo(containers []interface{}, jsonPath string) (images []*ContainerImage, err error)
`
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Follow the steps in this [comment](https://github.com/kyverno/kyverno/issues/3141#issuecomment-1026342495) to reproduce the issue

#### Output before fix:
```logos
2022/01/31 20:42:28 http: panic serving 10.239.125.13:57878: interface conversion: interface {} is nil, not string
goroutine 1714041 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1801 +0xb9
panic({0x1b07ee0, 0xc005489680})
	/usr/local/go/src/runtime/panic.go:1047 +0x266
github.com/kyverno/kyverno/pkg/engine/context.convertToImageInfo({0xc004ebf800, 0x1, 0xb0ea3a}, {0x1db3823, 0x1e})
	/kyverno/pkg/engine/context/imageutils.go:125 +0x534
github.com/kyverno/kyverno/pkg/engine/context.extractImageInfos({0xc004ebf800, 0x1, 0x1}, {0x0, 0x0, 0x0}, {0x1db3823, 0x8}, {0x261edb8, 0xc004e23680})
	/kyverno/pkg/engine/context/imageutils.go:111 +0x6e
github.com/kyverno/kyverno/pkg/engine/context.extractImageInfo(0xc001bf14f8, {0x261edb8, 0xc004e23270})
	/kyverno/pkg/engine/context/imageutils.go:101 +0xa3e
github.com/kyverno/kyverno/pkg/engine/context.(*Context).AddImageInfo(0xc000e12680, 0x13)
	/kyverno/pkg/engine/context/context.go:293 +0x30
github.com/kyverno/kyverno/pkg/webhooks.(*WebhookServer).buildPolicyContext(0xc000d1bb00, 0xc0030b2000, 0x0)
	/kyverno/pkg/webhooks/server.go:377 +0x21b
github.com/kyverno/kyverno/pkg/webhooks.(*WebhookServer).resourceMutation(0xc000d1bb00, 0xc0030b2000)
	/kyverno/pkg/webhooks/server.go:317 +0x9fc
github.com/kyverno/kyverno/pkg/webhooks.(*WebhookServer).handlerFunc.func1({0x25f3060, 0xc0009c09a0}, 0xc000e03100)
	/kyverno/pkg/webhooks/server.go:270 +0x44b
net/http.HandlerFunc.ServeHTTP(0x3458ec464d538613, {0x25f3060, 0xc0009c09a0}, 0x18b1dba)
	/usr/local/go/src/net/http/server.go:2046 +0x2f
github.com/julienschmidt/httprouter.(*Router).Handler.func1({0x25f3060, 0xc0009c09a0}, 0xc004dcdd10, {0x0, 0x781bc54d53a3, 0x3600400})
	/go/pkg/mod/github.com/julienschmidt/httprouter@v1.3.0/router.go:275 +0x2c4
github.com/julienschmidt/httprouter.(*Router).ServeHTTP(0xc00568a720, {0x25f3060, 0xc0009c09a0}, 0xc000e03100)
	/go/pkg/mod/github.com/julienschmidt/httprouter@v1.3.0/router.go:387 +0x84b
net/http.serverHandler.ServeHTTP({0x25e5d20}, {0x25f3060, 0xc0009c09a0}, 0xc000e03100)
	/usr/local/go/src/net/http/server.go:2878 +0x43b
net/http.(*conn).serve(0xc00164a780, {0x25fcd18, 0xc000f6c120})
	/usr/local/go/src/net/http/server.go:1929 +0xb08
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:3033 +0x4e8
```

#### Output after fix:
```
The Deployment "nginx" is invalid: spec.template.spec.containers[0].image: Required value
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
