### PR TITLE
Bump chart versions in `main`

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kyverno-policies
-version: v2.1.3
-appVersion: v1.5.1
+version: v2.2.0-rc2
+appVersion: v1.6.0-rc2
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management Policies
 keywords:

--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kyverno
-version: v2.1.3
-appVersion: v1.5.1
+version: v2.2.0-rc2
+appVersion: v1.6.0-rc2
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
 keywords:


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Related issue
This PR bumps Helm charts versions to fix chart testing failure https://github.com/kyverno/kyverno/pull/3126/#issuecomment-1028715938. I will send a separate PR to cherry-pick changes to release-1.6 including Helm changes.

The comparison between `release-1.6` and `main` can be found (you can locate chart changes in `charts/...`) https://github.com/kyverno/kyverno/compare/release-1.6...realshuting:bump_chart_versions.


