### PR TITLE
Add a kyverno jp command to test jmespath expressions

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -26,6 +26,7 @@ var (
 	JpArray       = gojmespath.JpArray
 	JpArrayString = gojmespath.JpArrayString
 	JpAny         = gojmespath.JpAny
+	JpBool        = gojmespath.JpType("bool")
 )
 
 type (
@@ -70,215 +71,301 @@ const zeroDivisionError = errorPrefix + "Zero divisor passed"
 const undefinedQuoError = errorPrefix + "Undefined quotient"
 const nonIntModuloError = errorPrefix + "Non-integer argument(s) passed for modulo"
 
-func getFunctions() []*gojmespath.FunctionEntry {
-	return []*gojmespath.FunctionEntry{
+type FunctionEntry struct {
+	Entry      *gojmespath.FunctionEntry
+	Note       string
+	ReturnType []JpType
+}
+
+func (f *FunctionEntry) String() string {
+	args := []string{}
+	for _, a := range f.Entry.Arguments {
+		aTypes := []string{}
+		for _, t := range a.Types {
+			aTypes = append(aTypes, string(t))
+		}
+		args = append(args, strings.Join(aTypes, "|"))
+	}
+	returnArgs := []string{}
+	for _, ra := range f.ReturnType {
+		returnArgs = append(returnArgs, string(ra))
+	}
+	output := fmt.Sprintf("%s(%s) %s", f.Entry.Name, strings.Join(args, ", "), strings.Join(returnArgs, ","))
+	if f.Note != "" {
+		output += fmt.Sprintf(" (%s)", f.Note)
+	}
+	return output
+}
+
+func GetFunctions() []*FunctionEntry {
+	return []*FunctionEntry{
 		{
-			Name: compare,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: compare,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpfCompare,
 			},
-			Handler: jpfCompare,
+			ReturnType: []JpType{JpBool},
 		},
 		{
-			Name: equalFold,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: equalFold,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpfEqualFold,
 			},
-			Handler: jpfEqualFold,
+			ReturnType: []JpType{JpBool},
 		},
 		{
-			Name: replace,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpNumber}},
+			Entry: &gojmespath.FunctionEntry{Name: replace,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpNumber}},
+				},
+				Handler: jpfReplace,
 			},
-			Handler: jpfReplace,
+			ReturnType: []JpType{JpString},
 		},
 		{
-			Name: replaceAll,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: replaceAll,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpfReplaceAll,
 			},
-			Handler: jpfReplaceAll,
+			ReturnType: []JpType{JpString},
 		},
 		{
-			Name: toUpper,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: toUpper,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpfToUpper,
 			},
-			Handler: jpfToUpper,
+			ReturnType: []JpType{JpString},
 		},
 		{
-			Name: toLower,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: toLower,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpfToLower,
 			},
-			Handler: jpfToLower,
+			ReturnType: []JpType{JpString},
 		},
 		{
-			Name: trim,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: trim,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpfTrim,
 			},
-			Handler: jpfTrim,
+			ReturnType: []JpType{JpString},
 		},
 		{
-			Name: split,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: split,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpfSplit,
 			},
-			Handler: jpfSplit,
+			ReturnType: []JpType{JpArrayString},
 		},
 		{
-			Name: regexReplaceAll,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString, JpNumber}},
-				{Types: []JpType{JpString, JpNumber}},
+			Entry: &gojmespath.FunctionEntry{Name: regexReplaceAll,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString, JpNumber}},
+					{Types: []JpType{JpString, JpNumber}},
+				},
+				Handler: jpRegexReplaceAll,
 			},
-			Handler: jpRegexReplaceAll,
+			ReturnType: []JpType{JpString},
+			Note:       "converts all parameters to string",
 		},
 		{
-			Name: regexReplaceAllLiteral,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString, JpNumber}},
-				{Types: []JpType{JpString, JpNumber}},
+			Entry: &gojmespath.FunctionEntry{Name: regexReplaceAllLiteral,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString, JpNumber}},
+					{Types: []JpType{JpString, JpNumber}},
+				},
+				Handler: jpRegexReplaceAllLiteral,
 			},
-			Handler: jpRegexReplaceAllLiteral,
+			ReturnType: []JpType{JpString},
+			Note:       "converts all parameters to string",
 		},
 		{
-			Name: regexMatch,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString, JpNumber}},
+			Entry: &gojmespath.FunctionEntry{Name: regexMatch,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString, JpNumber}},
+				},
+				Handler: jpRegexMatch,
 			},
-			Handler: jpRegexMatch,
 		},
 		{
-			Name: patternMatch,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString, JpNumber}},
+			Entry: &gojmespath.FunctionEntry{Name: patternMatch,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString, JpNumber}},
+				},
+				Handler: jpPatternMatch,
 			},
-			Handler: jpPatternMatch,
+			ReturnType: []JpType{JpBool},
+			Note:       "'*' matches zero or more alphanumeric characters, '?' matches a single alphanumeric character",
 		},
 		{
 			// Validates if label (param1) would match pod/host/etc labels (param2)
-			Name: labelMatch,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpObject}},
-				{Types: []JpType{JpObject}},
+			Entry: &gojmespath.FunctionEntry{Name: labelMatch,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpObject}},
+					{Types: []JpType{JpObject}},
+				},
+				Handler: jpLabelMatch,
 			},
-			Handler: jpLabelMatch,
+			ReturnType: []JpType{JpBool},
+			Note:       "object arguments must be enclosed in backticks; ex. `{{request.object.spec.template.metadata.labels}}`",
 		},
 		{
-			Name: add,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpAny}},
-				{Types: []JpType{JpAny}},
+			Entry: &gojmespath.FunctionEntry{Name: add,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpAny}},
+					{Types: []JpType{JpAny}},
+				},
+				Handler: jpAdd,
 			},
-			Handler: jpAdd,
+			ReturnType: []JpType{JpAny},
 		},
 		{
-			Name: subtract,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpAny}},
-				{Types: []JpType{JpAny}},
+			Entry: &gojmespath.FunctionEntry{Name: subtract,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpAny}},
+					{Types: []JpType{JpAny}},
+				},
+				Handler: jpSubtract,
 			},
-			Handler: jpSubtract,
+			ReturnType: []JpType{JpAny},
 		},
 		{
-			Name: multiply,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpAny}},
-				{Types: []JpType{JpAny}},
+			Entry: &gojmespath.FunctionEntry{Name: multiply,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpAny}},
+					{Types: []JpType{JpAny}},
+				},
+				Handler: jpMultiply,
 			},
-			Handler: jpMultiply,
+			ReturnType: []JpType{JpAny},
 		},
 		{
-			Name: divide,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpAny}},
-				{Types: []JpType{JpAny}},
+			Entry: &gojmespath.FunctionEntry{Name: divide,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpAny}},
+					{Types: []JpType{JpAny}},
+				},
+				Handler: jpDivide,
 			},
-			Handler: jpDivide,
+			ReturnType: []JpType{JpAny},
+			Note:       "divisor must be non zero",
 		},
 		{
-			Name: modulo,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpAny}},
-				{Types: []JpType{JpAny}},
+			Entry: &gojmespath.FunctionEntry{Name: modulo,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpAny}},
+					{Types: []JpType{JpAny}},
+				},
+				Handler: jpModulo,
 			},
-			Handler: jpModulo,
+			ReturnType: []JpType{JpAny},
+			Note:       "divisor must be non-zero, arguments must be integers",
 		},
 		{
-			Name: base64Decode,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: base64Decode,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpBase64Decode,
 			},
-			Handler: jpBase64Decode,
+			ReturnType: []JpType{JpString},
 		},
 		{
-			Name: base64Encode,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: base64Encode,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpBase64Encode,
 			},
-			Handler: jpBase64Encode,
+			ReturnType: []JpType{JpString},
 		},
 		{
-			Name: timeSince,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: timeSince,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpTimeSince,
 			},
-			Handler: jpTimeSince,
+			ReturnType: []JpType{JpString},
 		},
 		{
-			Name: pathCanonicalize,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: pathCanonicalize,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpPathCanonicalize,
 			},
-			Handler: jpPathCanonicalize,
+			ReturnType: []JpType{JpString},
 		},
 		{
-			Name: truncate,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpNumber}},
+			Entry: &gojmespath.FunctionEntry{Name: truncate,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpNumber}},
+				},
+				Handler: jpTruncate,
 			},
-			Handler: jpTruncate,
+			ReturnType: []JpType{JpString},
+			Note:       "length argument must be enclosed in backticks; ex. \"{{request.object.metadata.name | truncate(@, `9`)}}\"",
 		},
 		{
-			Name: semverCompare,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: semverCompare,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpSemverCompare,
 			},
-			Handler: jpSemverCompare,
+			ReturnType: []JpType{JpBool},
 		},
 		{
-			Name: parseJson,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: parseJson,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpParseJson,
 			},
-			Handler: jpParseJson,
+			ReturnType: []JpType{JpAny},
+			Note:       "decodes a valid JSON encoded string to the appropriate type. Opposite of `to_string` function",
 		},
 		{
-			Name: parseYAML,
-			Arguments: []ArgSpec{
-				{Types: []JpType{JpString}},
+			Entry: &gojmespath.FunctionEntry{Name: parseYAML,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpParseYAML,
 			},
-			Handler: jpParseYAML,
+			ReturnType: []JpType{JpAny},
+			Note:       "decodes a valid YAML encoded string to the appropriate type provided it can be represented as JSON",
 		},
 	}
 

--- a/pkg/engine/jmespath/new.go
+++ b/pkg/engine/jmespath/new.go
@@ -10,8 +10,8 @@ func New(query string) (*gojmespath.JMESPath, error) {
 		return nil, err
 	}
 
-	for _, function := range getFunctions() {
-		jp.Register(function)
+	for _, function := range GetFunctions() {
+		jp.Register(function.Entry)
 	}
 
 	return jp, nil

--- a/pkg/kyverno/jp/jp_command.go
+++ b/pkg/kyverno/jp/jp_command.go
@@ -1,0 +1,109 @@
+package jp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	gojmespath "github.com/jmespath/go-jmespath"
+	jmespath "github.com/kyverno/kyverno/pkg/engine/jmespath"
+	"github.com/spf13/cobra"
+)
+
+var shortHelp = `provides a command-line interface to JMESPath, enhanced with Kyverno specific custom functions`
+
+// Command returns jp command
+func Command() *cobra.Command {
+	var compact, unquoted, ast bool
+	var filename, exprFile string
+	cmd := &cobra.Command{
+		Use:          "jp",
+		Short:        shortHelp,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// The following function has been adapted from
+			// https://github.com/jmespath/jp/blob/54882e03bd277fc4475a677fab1d35eaa478b839/jp.go
+			var expression string
+			if exprFile != "" {
+				byteExpr, err := ioutil.ReadFile(exprFile)
+				if err != nil {
+					return fmt.Errorf("Error opening expression file: %s", err)
+				}
+				expression = string(byteExpr)
+			} else {
+				if len(args) == 0 {
+					return fmt.Errorf("Must provide at least one argument.")
+				}
+				expression = args[0]
+			}
+			if ast {
+				parser := gojmespath.NewParser()
+				parsed, err := parser.Parse(expression)
+				if err != nil {
+					if syntaxError, ok := err.(gojmespath.SyntaxError); ok {
+						return fmt.Errorf("%s\n%s\n",
+							syntaxError,
+							syntaxError.HighlightLocation())
+					}
+					return fmt.Errorf("%s", err)
+				}
+				fmt.Println("")
+				fmt.Printf("%s\n", parsed)
+				return nil
+			}
+			var input interface{}
+			var jsonParser *json.Decoder
+			if filename != "" {
+				f, err := os.Open(filename)
+				defer f.Close()
+				if err != nil {
+					return fmt.Errorf("Error opening input file: %s", err)
+				}
+				jsonParser = json.NewDecoder(f)
+
+			} else {
+				jsonParser = json.NewDecoder(os.Stdin)
+			}
+			if err := jsonParser.Decode(&input); err != nil {
+				return fmt.Errorf("Error parsing input json: %s\n", err)
+			}
+			jp, err := jmespath.New(expression)
+			if err != nil {
+				return fmt.Errorf("failed to compile JMESPath: %s, error: %v", expression, err)
+			}
+			result, err := jp.Search(input)
+			if err != nil {
+				if syntaxError, ok := err.(gojmespath.SyntaxError); ok {
+					return fmt.Errorf("%s\n%s\n",
+						syntaxError,
+						syntaxError.HighlightLocation())
+				}
+				return fmt.Errorf("Error evaluating JMESPath expression: %s", err)
+			}
+			converted, isString := result.(string)
+			if unquoted && isString {
+				os.Stdout.WriteString(converted)
+			} else {
+				var toJSON []byte
+				if compact {
+					toJSON, err = json.Marshal(result)
+				} else {
+					toJSON, err = json.MarshalIndent(result, "", "  ")
+				}
+				if err != nil {
+					return fmt.Errorf("Error marshalling result to JSON: %s\n", err)
+				}
+				os.Stdout.Write(toJSON)
+			}
+			os.Stdout.WriteString("\n")
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&compact, "compact", "c", false, "Produce compact JSON output that omits nonessential whitespace")
+	cmd.Flags().BoolVarP(&unquoted, "unquoted", "u", false, "If the final result is a string, it will be printed without quotes")
+	cmd.Flags().BoolVar(&ast, "ast", false, "Only print the AST of the parsed expression.  Do not rely on this output, only useful for debugging purposes")
+	cmd.Flags().StringVarP(&exprFile, "expr-file", "e", "", "Read JMESPath expression from the specified file")
+	cmd.Flags().StringVarP(&filename, "filename", "f", "", "Read input JSON from a file instead of stdin")
+	return cmd
+}

--- a/pkg/kyverno/main.go
+++ b/pkg/kyverno/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/kyverno/kyverno/pkg/kyverno/apply"
+	"github.com/kyverno/kyverno/pkg/kyverno/jp"
 	"github.com/kyverno/kyverno/pkg/kyverno/test"
 	"github.com/kyverno/kyverno/pkg/kyverno/validate"
 	"github.com/kyverno/kyverno/pkg/kyverno/version"
@@ -28,6 +29,7 @@ func CLI() {
 		apply.Command(),
 		validate.Command(),
 		test.Command(),
+		jp.Command(),
 	}
 
 	cli.AddCommand(commands...)


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <sambhavs.email@gmail.com>

Fixes #3167 

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
/milestone 1.6.0
## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind feature
## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->
Adds a `kyverno jp` command to test JMESPath expressions with Kyverno grammar.

### Proof Manifests

```
$ ./cmd/cli/kubectl-kyverno/kyverno jp --help
Provides a command-line interface to JMESPath, enhanced with Kyverno specific custom functions

Usage:
  kyverno jp [flags]

Flags:
      --ast                Only print the AST of the parsed expression.  Do not rely on this output, only useful for debugging purposes
  -c, --compact            Produce compact JSON output that omits nonessential whitespace
  -e, --expr-file string   Read JMESPath expression from the specified file
  -f, --filename string    Read input JSON from a file instead of stdin
  -h, --help               help for jp
  -l, --list-functions     Output a list of custom JMESPath functions in Kyverno
  -u, --unquoted           If the final result is a string, it will be printed without quotes

Global Flags:
      --add_dir_header           If true, adds the file directory to the header of the log messages
      --log_file string          If non-empty, use this log file
      --log_file_max_size uint   Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --one_output               If true, only write logs to their native severity level (vs also writing to each lower severity level)
      --skip_headers             If true, avoid header prefixes in the log messages
      --skip_log_headers         If true, avoid headers when opening log files
  -v, --v Level                  number for the log level verbosity
$ echo '{"test": "TEST"}' | ./cmd/cli/kubectl-kyverno/kyverno jp -u 'to_lower(test)'
test

$ ./cmd/cli/kubectl-kyverno/kyverno jp --ast 'to_lower(test)'

ASTFunctionExpression {
  value: "to_lower"
  children: {
    ASTField {
      value: "test"
    }
}
```


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [x] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is: https://github.com/kyverno/website/issues/463
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
