### PR TITLE
Fixed rounding down for quants in JMESPath divide func

### DIFF
--- a/pkg/engine/jmespath/arithmetic.go
+++ b/pkg/engine/jmespath/arithmetic.go
@@ -230,10 +230,11 @@ func (op1 Quantity) Divide(op2 interface{}) (interface{}, error) {
 		if v.ToDec().AsApproximateFloat64() == 0 {
 			return nil, fmt.Errorf(zeroDivisionError, divide)
 		}
+
 		var quo inf.Dec
-		scale := inf.Scale(math.Max(float64(op1.AsDec().Scale()), float64(v.AsDec().Scale())))
-		quo.QuoRound(op1.AsDec(), v.AsDec(), scale, inf.RoundDown)
+		quo.QuoExact(op1.AsDec(), v.AsDec())
 		return strconv.ParseFloat(quo.String(), 64)
+
 	case Scalar:
 		if v.float64 == 0 {
 			return nil, fmt.Errorf(zeroDivisionError, divide)
@@ -244,8 +245,7 @@ func (op1 Quantity) Divide(op2 interface{}) (interface{}, error) {
 		}
 
 		var quo inf.Dec
-		scale := inf.Scale(math.Max(float64(op1.AsDec().Scale()), float64(q.AsDec().Scale())))
-		quo.QuoRound(op1.AsDec(), q.AsDec(), scale, inf.RoundDown)
+		quo.QuoExact(op1.AsDec(), q.AsDec())
 		return resource.NewDecimalQuantity(quo, op1.Quantity.Format).String(), nil
 	}
 
@@ -298,9 +298,7 @@ func (op1 Scalar) Divide(op2 interface{}) (interface{}, error) {
 		}
 
 		var quo inf.Dec
-		scale := inf.Scale(math.Max(float64(q.AsDec().Scale()), float64(v.AsDec().Scale())))
-		quo.QuoRound(q.AsDec(), v.AsDec(), scale, inf.RoundDown)
-
+		quo.QuoExact(q.AsDec(), v.AsDec())
 		return resource.NewDecimalQuantity(quo, v.Format).String(), nil
 	case Duration:
 		var quo float64


### PR DESCRIPTION
Signed-off-by: Abhinav Sinha <abhinav@nirmata.com>

## Related issue
Closes #3168 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.7.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.
-->
## What type of PR is this
`/kind bug`
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Fixed rounding down of decimal values in case of quants, and instead return the exact value.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
#### cpol.yaml
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: kyverno-resource-quota-usage-over-limit
spec:
  validationFailureAction: enforce
  background: true
  rules:
  - name: validate-numOfTerminatingPodsQuotaUsageOverLimit
    exclude:
      resources:
        namespaces: ["openshift*", "kube*", "open-cluster-management*", "*dev"]
    match:
      resources:
        kinds:
        - ResourceQuota
        namespaces: ["*"]
    preconditions:
      all:
      - key: "{{ request.object.spec.scopes[0] }}"
        operator: Equals
        value: Terminating
    validate:
      message: "Denied"
      deny:
        conditions:
          any:
            - key: "{{ divide('20','25') }}"
              operator: NotEquals
              value: 0.8 
```
#### res.yaml
```yaml
apiVersion: v1
kind: ResourceQuota
metadata:
  name: num-of-terminating-pods-usage-over-limit
spec:
  hard:
    pods: "25"
  scopes:
  - Terminating
status:
  hard:
    pods: "25"
  used:
    pods: "10"
```
#### Log
```logtalk
I0209 13:56:09.648300       1 vars.go:378] EngineValidate "msg"="variable substituted" "kind"="ResourceQuota" "name"="num-of-terminating-pods-usage-over-limit" "namespace"="default" "policy"="kyverno-resource-quota-usage-over-limit" "rule"="validate-numOfTerminatingPodsQuotaUsageOverLimit" "path"="/any/0/key" "value"=0.8 "variable"="{{ divide('20','25') }}"
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the doc update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
