### PR TITLE
Remove abstraction that doesn't work anyway

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -92,6 +92,7 @@ The following table lists the configurable parameters of the kyverno chart and t
 | `nameOverride` | override the name of the chart | `nil` |
 | `namespace` | namespace the chart deploy to | `nil` |
 | `networkPolicy.enabled` | when true, use a NetworkPolicy to grant access to the webhook. | `false` |
+| `networkPolicy.ingressFrom` | A list of valid from selectors. | `[]` |
 | `nodeAffinity` | node affinities. Empty by default. Can be added for nodeAffinities. | `nil` |
 | `nodeSelector` | node labels for pod assignment | `{}` |
 | `podAffinity` | pod affinities. Empty by default. Can be added for podAffinities. | `nil` |

--- a/charts/kyverno/templates/networkpolicy.yaml
+++ b/charts/kyverno/templates/networkpolicy.yaml
@@ -12,34 +12,11 @@ spec:
       app: kyverno
   policyTypes:
   - Ingress
-  {{- if or .Values.networkPolicy.namespaceExpressions .Values.networkPolicy.namespaceLabels .Values.networkPolicy.podExpressions .Values.networkPolicy.podLabels }}
+  {{- if .Values.networkPolicy.ingressFrom }}
   ingress:
   - from:
-    {{- if or .Values.networkPolicy.namespaceExpressions .Values.networkPolicy.namespaceLabels }}
-      - namespaceSelector:
-        {{- with .Values.networkPolicy.namespaceExpressions }}
-          matchExpressions:
-            {{- toYaml . | nindent 10 }}
-        {{- end }}
-        {{- with .Values.networkPolicy.namespaceLabels }}
-          matchLabels:
-            {{- range $key, $value := . }}
-            {{ $key | quote }}: {{ $value | quote }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
-    {{- if or .Values.networkPolicy.podExpressions .Values.networkPolicy.podLabels }}
-        podSelector:
-          {{- with .Values.networkPolicy.podExpressions }}
-          matchExpressions:
-            {{- toYaml . | nindent 10 }}
-          {{- end }}
-          {{- with .Values.networkPolicy.podLabels }}
-          matchLabels:
-            {{- range $key, $value := . }}
-            {{ $key | quote }}: {{ $value | quote }}
-            {{- end }}
-          {{- end }}
+    {{- with .Values.networkPolicy.ingressFrom }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
     ports:
     - protocol: TCP
@@ -50,6 +27,7 @@ spec:
       port: {{ .Values.metricsService.port }}
   {{- end }}
   {{- else }}
-  ingress: []
+  ingress:
+    - {}
   {{- end }}
 {{- end }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -262,7 +262,5 @@ installCRDs: true
 # policies in a default-deny setup.
 networkPolicy:
   enabled: false
-  namespaceExpressions: []
-  namespaceLabels: {}
-  podExpressions: []
-  podLabels: {}
+# A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies
+  ingressFrom: []


### PR DESCRIPTION
@treydock 

## Related issue
[Slack Thread](https://kubernetes.slack.com/archives/CLGR9BJU9/p1644340884838279)

/kind bug

## Proposed Changes

I've removed the abstraction previously introduced in order to allow the end user to simply pass a list of valid from selectors from their values.yaml. This seems to be the simplest way to achieve a flexible template while maintaining compatibility with official documentation.

Here's the snippet I from values.yaml I tested using helm template:

```
networkPolicy:
  enabled: true
  from:
    - namespaceSelector:
        matchLabels:
          app: foo
      podSelector:
        matchLabels:
          app: foo
```
