### PR TITLE
Improve E2E test CI timings

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -1,0 +1,63 @@
+name: cli
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release*'
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+      - '.github/config.yml'
+  pull_request:
+    branches:
+      - 'main'
+      - 'release*'
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+      - '.github/config.yml'
+
+permissions: read-all
+
+jobs:
+  cli-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Set up Go 
+        uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
+        with:
+          go-version: 1.17
+
+      - name: Cache Go modules
+        uses: actions/cache@d9747005de0f7240e5d35a68dca96b3f41b8b340 # v1.2.0
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Test Policy
+        run: |
+          if [[ ${{ github.event_name }} == "push" ]]
+          then
+            GIT_BRANCH=${GITHUB_REF##*/}
+          elif [[ ${{ github.event_name }} == "pull_request" ]]
+          then
+            GIT_BRANCH=${{ github.event.pull_request.base.ref }}
+          fi
+          make cli
+          CLI_PATH=$PWD/cmd/cli/kubectl-kyverno/kyverno
+          $CLI_PATH test https://github.com/kyverno/policies/$GIT_BRANCH
+          $CLI_PATH test https://github.com/kyverno/policies --git-branch $GIT_BRANCH
+          $CLI_PATH test https://github.com/kyverno/policies/pod-security/restricted -b $GIT_BRANCH
+          $CLI_PATH test ./test/cli/test-mutate
+          $CLI_PATH test ./test/cli/test
+          $CLI_PATH test ./test/cli/test-fail/missing-policy && exit 1 || exit 0
+          $CLI_PATH test ./test/cli/test-fail/missing-rule && exit 1 || exit 0
+          $CLI_PATH test ./test/cli/test-fail/missing-resource && exit 1 || exit 0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,47 +50,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Test Policy
+      - name :  Create dev images, kind cluster and setup kustomize
         run: |
-          if [[ ${{ github.event_name }} == "push" ]]
-          then
-            GIT_BRANCH=${GITHUB_REF##*/}
-          elif [[ ${{ github.event_name }} == "pull_request" ]]
-          then
-            GIT_BRANCH=${{ github.event.pull_request.base.ref }}
-          fi
-
-          CLI_PATH=cmd/cli/kubectl-kyverno
-
-          go run $PWD/$CLI_PATH/main.go test https://github.com/kyverno/policies/$GIT_BRANCH
-          go run $PWD/$CLI_PATH/main.go test https://github.com/kyverno/policies --git-branch $GIT_BRANCH
-          go run $PWD/$CLI_PATH/main.go test https://github.com/kyverno/policies/pod-security/restricted -b $GIT_BRANCH
-          go run $PWD/$CLI_PATH/main.go test ./test/cli/test-mutate
-          go run $PWD/$CLI_PATH/main.go test ./test/cli/test
-          go run $PWD/$CLI_PATH/main.go test ./test/cli/test-fail/missing-policy && exit 1 || exit 0
-          go run $PWD/$CLI_PATH/main.go test ./test/cli/test-fail/missing-rule && exit 1 || exit 0
-          go run $PWD/$CLI_PATH/main.go test ./test/cli/test-fail/missing-resource && exit 1 || exit 0
-      
-      - name: gofmt check
-        run: |
-         if [ "$(gofmt -s -l . | wc -l)" -ne 0 ] 
-         then
-          echo "The following files were found to be not go formatted:"
-          gofmt -s -l .
-          echo "Please run 'make fmt' to go format the above files."
-          exit 1
-         fi
-
-      - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@02bcf8c1a9febe8620f1ca523b18dd64f82296db # v1.25.0
-
-      - name: docker images build (AMD64)
-        run: |
-          make docker-build-all-amd64
-
-      - name :  Create Kind Cluster and setup kustomize
-        run: |
-          make create-e2e-infrastruture
+          make -j4 create-e2e-infrastruture
 
       - name: e2e testing
         run: |

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -1,10 +1,6 @@
-name: build
+name: image-build
 on:
   push:
-    branches:
-      - 'main'
-      - 'release*'
-  pull_request:
     branches:
       - 'main'
       - 'release*'
@@ -172,31 +168,3 @@ jobs:
       - name: docker images build
         run: |
           make docker-build-cli
-
-  tests:
-    runs-on: ubuntu-latest
-    needs: pre-checks
-    steps:
-      - name: Checkout
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-
-      - name: Set up Go
-        uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
-        with:
-          go-version: 1.17
-
-      - name: Cache Go modules
-        uses: actions/cache@d9747005de0f7240e5d35a68dca96b3f41b8b340 # v1.2.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Kyverno unit test
-        run: |
-          export PROJECT_PATH=$(pwd)
-          make test-unit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,93 @@
+name: tests
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release*'
+  pull_request:
+    branches:
+      - 'main'
+      - 'release*'
+
+permissions: 
+  contents: read
+  packages: write
+  id-token: write 
+
+jobs:
+  pre-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Set up Go
+        uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
+        with:
+          go-version: 1.17
+
+      - name: Cache Go modules
+        uses: actions/cache@d9747005de0f7240e5d35a68dca96b3f41b8b340 # v1.2.0
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: gofmt check
+        run: |
+          if [ "$(gofmt -s -l . | wc -l)" -ne 0 ]
+          then
+           echo "The following files were found to be not go formatted:"
+           gofmt -s -l .
+           echo "Please run 'make fmt' to go format the above files."
+           exit 1
+          fi
+
+      - name: goimports
+        run: |
+          if [ "$(goimports -l . | wc -l)" -ne 0 ]
+          then
+           echo "The following files were found to have import formatting issues:"
+           goimports -l -l .
+           echo "Please run 'make fmt' to go format the above files."
+           exit 1
+          fi
+
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@02bcf8c1a9febe8620f1ca523b18dd64f82296db # v1.25.0
+
+      - name: Checking unused pkgs using go mod tidy
+        run: |
+          make unused-package-check
+
+  tests:
+    runs-on: ubuntu-latest
+    needs: pre-checks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Set up Go
+        uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
+        with:
+          go-version: 1.17
+
+      - name: Cache Go modules
+        uses: actions/cache@d9747005de0f7240e5d35a68dca96b3f41b8b340 # v1.2.0
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Kyverno unit test
+        run: |
+          export PROJECT_PATH=$(pwd)
+          make test-unit

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,8 @@ docker-get-initContainer-digest:
 
 docker-build-initContainer-local:
 	CGO_ENABLED=0 GOOS=linux go build -o $(PWD)/$(INITC_PATH)/kyvernopre -ldflags=$(LD_FLAGS) $(PWD)/$(INITC_PATH)/main.go
-	@docker build -f $(PWD)/$(INITC_PATH)/localDockerfile -t $(REPO)/$(INITC_IMAGE):$(IMAGE_TAG) $(PWD)/$(INITC_PATH)
-	@docker tag $(REPO)/$(INITC_IMAGE):$(IMAGE_TAG) $(REPO)/$(INITC_IMAGE):latest
+	@docker build -f $(PWD)/$(INITC_PATH)/localDockerfile -t $(REPO)/$(INITC_IMAGE):$(IMAGE_TAG_DEV) $(PWD)/$(INITC_PATH)
+	@docker tag $(REPO)/$(INITC_IMAGE):$(IMAGE_TAG_DEV) $(REPO)/$(INITC_IMAGE):latest
 
 docker-publish-initContainer-dev: docker-buildx-builder docker-push-initContainer-dev
 
@@ -187,7 +187,7 @@ docker-build-all-amd64: docker-buildx-builder docker-build-initContainer-amd64 d
 # Create e2e Infrastruture
 ##################################
 
-create-e2e-infrastruture:
+create-e2e-infrastruture: docker-build-initContainer-local docker-build-kyverno-local
 	chmod a+x $(PWD)/scripts/create-e2e-infrastruture.sh
 	$(PWD)/scripts/create-e2e-infrastruture.sh
 


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <sambhavs.email@gmail.com>

Fixes #3003

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
/milestone 1.6.1

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind cleanup
## Proposed Changes

Does a simple change to E2E tests to use local go builds rather than building it inside the container. This should significantly improve CI timings enough to allow us to test against a matrix of K8s version. More PRs can follow to improve CI timings for other workflows like builds.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
