### PR TITLE
Return warning on admission response when mutating pods

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -12097,7 +12097,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-            - ALL
+            - all
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -12126,7 +12126,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-            - ALL
+            - all
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -12097,7 +12097,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-            - all
+            - ALL
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -12126,7 +12126,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-            - all
+            - ALL
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/pkg/kyverno/apply/apply_command.go
+++ b/pkg/kyverno/apply/apply_command.go
@@ -268,7 +268,7 @@ func applyCommandHelper(resourcePaths []string, cluster bool, policyReport bool,
 	skipInvalidPolicies.invalid = make([]string, 0)
 
 	for _, policy := range mutatedPolicies {
-		err := policy2.Validate(policy, nil, true, openAPIController)
+		_, err := policy2.Validate(policy, nil, true, openAPIController)
 		if err != nil {
 			log.Log.Error(err, "policy validation error")
 			if strings.HasPrefix(err.Error(), "variable 'element.name'") {

--- a/pkg/kyverno/common/fetch.go
+++ b/pkg/kyverno/common/fetch.go
@@ -31,7 +31,7 @@ func GetResources(policies []*v1.ClusterPolicy, resourcePaths []string, dClient 
 	var resourceTypes []string
 
 	for _, policy := range policies {
-		for _, rule := range policy.Spec.Rules {
+		for _, rule := range policy.Spec.GetRules() {
 			resourceTypesInRule := GetKindsFromRule(rule)
 			for resourceKind := range resourceTypesInRule {
 				resourceTypesMap[resourceKind] = true

--- a/pkg/kyverno/common/fetch.go
+++ b/pkg/kyverno/common/fetch.go
@@ -31,8 +31,8 @@ func GetResources(policies []*v1.ClusterPolicy, resourcePaths []string, dClient 
 	var resourceTypes []string
 
 	for _, policy := range policies {
-		for _, rule := range policy.Spec.GetRules() {
-			resourceTypesInRule := getKindsFromPolicy(rule)
+		for _, rule := range policy.Spec.Rules {
+			resourceTypesInRule := GetKindsFromRule(rule)
 			for resourceKind := range resourceTypesInRule {
 				resourceTypesMap[resourceKind] = true
 			}
@@ -286,8 +286,8 @@ func GetPatchedResource(patchResourceBytes []byte) (patchedResource unstructured
 	return patchedResource, nil
 }
 
-// getKindsFromPolicy will return the kinds from policy match block
-func getKindsFromPolicy(rule v1.Rule) map[string]bool {
+// GetKindsFromRule will return the kinds from policy match block
+func GetKindsFromRule(rule v1.Rule) map[string]bool {
 	var resourceTypesMap = make(map[string]bool)
 	for _, kind := range rule.MatchResources.Kinds {
 		if strings.Contains(kind, "/") {

--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -842,7 +842,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, isGit bool, 
 	}
 
 	for _, policy := range mutatedPolicies {
-		err := policy2.Validate(policy, nil, true, openAPIController)
+		_, err := policy2.Validate(policy, nil, true, openAPIController)
 		if err != nil {
 			log.Log.Error(err, "skipping invalid policy", "name", policy.Name)
 			continue

--- a/pkg/kyverno/validate/command.go
+++ b/pkg/kyverno/validate/command.go
@@ -162,7 +162,7 @@ func validatePolicies(policies []*v1.ClusterPolicy, v1crd apiextensions.CustomRe
 		}
 
 		if errorList == nil {
-			err = policy2.Validate(policy, nil, true, openAPIController)
+			_, err = policy2.Validate(policy, nil, true, openAPIController)
 		}
 
 		fmt.Println("----------------------------------------------------------------------")

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -185,7 +185,7 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 		// - Mutate
 		// - Validate
 		// - Generate
-		if err := validateActions(i, &policy.Spec.Rules[i], client, mock); err != nil {
+		if err := validateActions(i, &rules[i], client, mock); err != nil {
 			return nil, err
 		}
 

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -291,7 +291,7 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 			if !utils.ContainsString(value.ResourceDescription.Kinds, "*") {
 				err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
 				if err != nil {
-					return nil errors.Wrapf(err, "the kind defined in the all match resource is invalid")
+					return nil, errors.Wrapf(err, "the kind defined in the all match resource is invalid")
 				}
 			}
 		}

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -280,27 +280,35 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 		match := rule.MatchResources
 		exclude := rule.ExcludeResources
 		for _, value := range match.Any {
-			err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
-			if err != nil {
-				return nil, errors.Wrapf(err, "the kind defined in the any match resource is invalid")
+			if !utils.ContainsString(value.ResourceDescription.Kinds, "*") {
+				err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
+				if err != nil {
+					return nil, errors.Wrapf(err, "the kind defined in the any match resource is invalid")
+				}
 			}
 		}
 		for _, value := range match.All {
-			err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
-			if err != nil {
-				return nil, errors.Wrapf(err, "the kind defined in the all match resource is invalid")
+			if !utils.ContainsString(value.ResourceDescription.Kinds, "*") {
+				err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
+				if err != nil {
+					return nil errors.Wrapf(err, "the kind defined in the all match resource is invalid")
+				}
 			}
 		}
 		for _, value := range exclude.Any {
-			err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
-			if err != nil {
-				return nil, errors.Wrapf(err, "the kind defined in the any exclude resource is invalid")
+			if !utils.ContainsString(value.ResourceDescription.Kinds, "*") {
+				err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
+				if err != nil {
+					return nil, errors.Wrapf(err, "the kind defined in the any exclude resource is invalid")
+				}
 			}
 		}
 		for _, value := range exclude.All {
-			err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
-			if err != nil {
-				return nil, errors.Wrapf(err, "the kind defined in the all exclude resource is invalid")
+			if !utils.ContainsString(value.ResourceDescription.Kinds, "*") {
+				err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
+				if err != nil {
+					return nil, errors.Wrapf(err, "the kind defined in the all exclude resource is invalid")
+				}
 			}
 		}
 		if !utils.ContainsString(rule.MatchResources.Kinds, "*") {

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -150,14 +150,6 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 			}, nil
 		}
 
-		if podControllerAutoGenExclusion(policy) {
-			log.Log.V(1).Info("Pod controllers excluded from autogen require adding of preconditions to also exclude the desired controller(s).")
-			return &v1beta1.AdmissionResponse{
-				Allowed:  true,
-				Warnings: []string{"Pod controllers excluded from autogen require adding of preconditions to also exclude the desired controller(s)."},
-			}, nil
-		}
-
 		// validate resource description
 		if path, err := validateResources(rule); err != nil {
 			return nil, fmt.Errorf("path: spec.rules[%d].%s: %v", i, path, err)
@@ -253,6 +245,14 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 						}
 					}
 				}
+			}
+
+			if podControllerAutoGenExclusion(policy) {
+				log.Log.V(1).Info("Pod controllers excluded from autogen require adding of preconditions to also exclude the desired controller(s).")
+				return &v1beta1.AdmissionResponse{
+					Allowed:  true,
+					Warnings: []string{"Pod controllers excluded from autogen require adding of preconditions to also exclude the desired controller(s)."},
+				}, nil
 			}
 
 			if rule.HasMutate() {

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -143,7 +143,7 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 		}
 
 		if jsonPatchOnPod(rule) {
-			log.Log.V(1).Info("pods managed by workload controllers cannot be mutated using policies, use the auto-gen feature or write policies that match pod controllers")
+			log.Log.V(1).Info("Pods managed by workload controllers cannot be mutated using policies. Use the autogen feature or write policies that match Pod controllers.")
 			return &v1beta1.AdmissionResponse{
 				Allowed:  true,
 				Warnings: []string{"Pods managed by workload controllers cannot be mutated using policies. Use the autogen feature or write policies that match Pod controllers."},

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -269,7 +269,7 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 		var podOnlyMap = make(map[string]bool) //Validate that Kind is only Pod
 		podOnlyMap["Pod"] = true
 		if reflect.DeepEqual(common.GetKindsFromRule(rule), podOnlyMap) && podControllerAutoGenExclusion(policy) {
-			log.Log.V(1).Info("Pod controllers excluded from autogen require adding of preconditions to also exclude the desired controller(s).")
+			log.Log.V(4).Info("Pod controllers excluded from autogen require adding of preconditions to also exclude the desired controller(s).")
 			return &v1beta1.AdmissionResponse{
 				Allowed:  true,
 				Warnings: []string{"Pod controllers excluded from autogen require adding of preconditions to also exclude the desired controller(s)."},

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -148,6 +148,15 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 				Warnings: []string{"pods managed by workload controllers cannot be mutated using policies, use the auto-gen feature or write policies that match pod controllers"},
 			}, nil
 		}
+
+		if policy.HasAutoGenAnnotation() {
+			log.Log.V(1).Info("pod controllers excluded by autogen annotation requires additional work of adding preconditions to exclude the controller as part of the policy")
+			return &v1beta1.AdmissionResponse{
+				Allowed:  true,
+				Warnings: []string{"pod controllers excluded by autogen annotation requires additional work of adding preconditions to exclude the controller as part of the policy"},
+			}, nil
+		}
+
 		// validate resource description
 		if path, err := validateResources(rule); err != nil {
 			return nil, fmt.Errorf("path: spec.rules[%d].%s: %v", i, path, err)

--- a/pkg/policy/validate_test.go
+++ b/pkg/policy/validate_test.go
@@ -594,7 +594,7 @@ func Test_Validate_Policy(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	err = Validate(policy, nil, true, openAPIController)
+	_, err = Validate(policy, nil, true, openAPIController)
 	assert.NilError(t, err)
 }
 
@@ -741,7 +741,7 @@ func Test_Validate_ErrorFormat(t *testing.T) {
 	assert.NilError(t, err)
 
 	openAPIController, _ := openapi.NewOpenAPIController()
-	err = Validate(policy, nil, true, openAPIController)
+	_, err = Validate(policy, nil, true, openAPIController)
 	assert.Assert(t, err != nil)
 }
 
@@ -1281,7 +1281,7 @@ func Test_Validate_Kind(t *testing.T) {
 	assert.NilError(t, err)
 
 	openAPIController, _ := openapi.NewOpenAPIController()
-	err = Validate(policy, nil, true, openAPIController)
+	_, err = Validate(policy, nil, true, openAPIController)
 	assert.Assert(t, err != nil)
 }
 
@@ -1330,7 +1330,7 @@ func Test_Validate_Any_Kind(t *testing.T) {
 	assert.NilError(t, err)
 
 	openAPIController, _ := openapi.NewOpenAPIController()
-	err = Validate(policy, nil, true, openAPIController)
+	_, err = Validate(policy, nil, true, openAPIController)
 	assert.Assert(t, err != nil)
 }
 
@@ -1457,7 +1457,7 @@ func Test_Wildcards_Kind(t *testing.T) {
 	assert.NilError(t, err)
 
 	openAPIController, _ := openapi.NewOpenAPIController()
-	err = Validate(policy, nil, true, openAPIController)
+	_, err = Validate(policy, nil, true, openAPIController)
 	assert.Assert(t, err != nil)
 }
 
@@ -1507,7 +1507,7 @@ func Test_Namespced_Policy(t *testing.T) {
 	assert.NilError(t, err)
 
 	openAPIController, _ := openapi.NewOpenAPIController()
-	err = Validate(policy, nil, true, openAPIController)
+	_, err = Validate(policy, nil, true, openAPIController)
 	assert.Assert(t, err != nil)
 }
 
@@ -1555,7 +1555,7 @@ func Test_patchesJson6902_Policy(t *testing.T) {
 	assert.NilError(t, err)
 
 	openAPIController, _ := openapi.NewOpenAPIController()
-	err = Validate(policy, nil, true, openAPIController)
+	_, err = Validate(policy, nil, false, openAPIController)
 	assert.NilError(t, err)
 }
 

--- a/pkg/policy/validate_test.go
+++ b/pkg/policy/validate_test.go
@@ -1555,7 +1555,7 @@ func Test_patchesJson6902_Policy(t *testing.T) {
 	assert.NilError(t, err)
 
 	openAPIController, _ := openapi.NewOpenAPIController()
-	_, err = Validate(policy, nil, false, openAPIController)
+	_, err = Validate(policy, nil, true, openAPIController)
 	assert.NilError(t, err)
 }
 

--- a/pkg/webhooks/policyvalidation.go
+++ b/pkg/webhooks/policyvalidation.go
@@ -48,7 +48,7 @@ func (ws *WebhookServer) policyValidation(request *v1beta1.AdmissionRequest) *v1
 			},
 		}
 	}
-	if len(response.Warnings) != 0 {
+	if response != nil && len(response.Warnings) != 0 {
 		return response
 	}
 	return &v1beta1.AdmissionResponse{

--- a/pkg/webhooks/policyvalidation.go
+++ b/pkg/webhooks/policyvalidation.go
@@ -38,7 +38,8 @@ func (ws *WebhookServer) policyValidation(request *v1beta1.AdmissionRequest) *v1
 	logger.V(3).Info("start policy change validation")
 	defer logger.V(3).Info("finished policy change validation", "time", time.Since(startTime).String())
 
-	if _, err := policyvalidate.Validate(policy, ws.client, false, ws.openAPIController); err != nil {
+	response, err := policyvalidate.Validate(policy, ws.client, false, ws.openAPIController)
+	if err != nil {
 		logger.Error(err, "policy validation errors")
 		return &v1beta1.AdmissionResponse{
 			Allowed: false,
@@ -47,7 +48,9 @@ func (ws *WebhookServer) policyValidation(request *v1beta1.AdmissionRequest) *v1
 			},
 		}
 	}
-
+	if len(response.Warnings) != 0 {
+		return response
+	}
 	return &v1beta1.AdmissionResponse{
 		Allowed: true,
 	}

--- a/pkg/webhooks/policyvalidation.go
+++ b/pkg/webhooks/policyvalidation.go
@@ -38,7 +38,7 @@ func (ws *WebhookServer) policyValidation(request *v1beta1.AdmissionRequest) *v1
 	logger.V(3).Info("start policy change validation")
 	defer logger.V(3).Info("finished policy change validation", "time", time.Since(startTime).String())
 
-	if err := policyvalidate.Validate(policy, ws.client, false, ws.openAPIController); err != nil {
+	if _, err := policyvalidate.Validate(policy, ws.client, false, ws.openAPIController); err != nil {
 		logger.Error(err, "policy validation errors")
 		return &v1beta1.AdmissionResponse{
 			Allowed: false,


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).


If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

Closes:#1381, #3156 

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind design

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

* Return a warning as part of the admission response when a mutate policy is applied directly to pods using `patchesJson6902`

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

* Applied the below manifest (re: 1381) which is referenced within the issue:

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: add-node-selector
spec:
  rules:
    - name: patch-pod-controllers
      match:
        resources:
          kinds:
            - Pod
      mutate:
        patchesJson6902: |-
          - path: "/spec/nodeSelector"
            op: add
            value: {"node.kubernetes.io/role": "test"}
          - path: "/spec/tolerations/-"
            op: add
            value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}

```

When the above policy is applied, a warning is returned as part of the response:

![image](https://user-images.githubusercontent.com/43758739/155200014-e2f91f4e-b5a2-4a29-b099-385a49e7209c.png)

* Applied the below manifest (re: 3158) to return a warning as part of the admission response when `pod-policies.kyverno.io/autogen-controllers` annotation is being used:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-pod-probes
  annotations:
    pod-policies.kyverno.io/autogen-controllers: DaemonSet,Deployment,StatefulSet
    policies.kyverno.io/title: Require Pod Probes
    policies.kyverno.io/category: Best Practices
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod
    policies.kyverno.io/description: >-
      Liveness and readiness probes need to be configured to correctly manage a Pod's
      lifecycle during deployments, restarts, and upgrades. For each Pod, a periodic
      `livenessProbe` is performed by the kubelet to determine if the Pod's containers
      are running or need to be restarted. A `readinessProbe` is used by Services
      and Deployments to determine if the Pod is ready to receive network traffic.
      This policy validates that all containers have liveness and readiness probes by
      ensuring the `periodSeconds` field is greater than zero.
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: validate-livenessProbe-readinessProbe
    match:
      resources:
        kinds:
        - Pod
    validate:
      message: "Liveness and readiness probes are required."
      pattern:
        spec:
          containers:
          - livenessProbe:
              periodSeconds: ">0"
            readinessProbe:
              periodSeconds: ">0"
```
When the above policy is applied, a warning is returned as part of the response:

![image](https://user-images.githubusercontent.com/43758739/158090384-715a27ff-8369-4301-a002-eb5c90ec09ab.png)


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

In order to not modify/change the existing logic, I have adding another return for admission response and only displaying a warning which solves the current issue. 
