### PR TITLE
validate and block policy based on the matched kind cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,9 @@ require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20211215200129-69c85dc22db6
 	github.com/blang/semver/v4 v4.0.0
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220119192733-fe33c00cee21
+	github.com/evanphx/json-patch v4.12.0+incompatible
 	github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20220125170349-50dfc2733d10
+	github.com/gorilla/mux v1.8.0
 	gopkg.in/inf.v0 v0.9.1
 )
 
@@ -118,7 +120,6 @@ require (
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
-	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-errors/errors v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1030,6 +1030,7 @@ github.com/goreleaser/nfpm v1.2.1/go.mod h1:TtWrABZozuLOttX2uDlYyECfQX7x5XYkVxhj
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=

--- a/pkg/policy/validate_test.go
+++ b/pkg/policy/validate_test.go
@@ -1555,6 +1555,6 @@ func Test_patchesJson6902_Policy(t *testing.T) {
 	assert.NilError(t, err)
 
 	openAPIController, _ := openapi.NewOpenAPIController()
-	err = Validate(policy, nil, false, openAPIController)
+	err = Validate(policy, nil, true, openAPIController)
 	assert.NilError(t, err)
 }


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Related issue

fixes:#3139

## Milestone of this PR

 `/milestone 1.6.1`.

## What type of PR is this

> /kind bug


## Proposed Changes
- Validate the policy creation based on the in-memory cached matched Kind
- With this change policy will be block  while applying if matched resource not found in cache.

```sh
$ kubectl create -f policy.yaml 
Error from server: error when creating "policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: the kind defined in the any match resource is invalid, err: unable to convert GVK to GVR, [Provisioner], err: kind 'Provisioner' not found in apiVersion ''
```


### Proof Manifests

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: add-karpenter-aws-provider
  annotations:
    policies.kyverno.io/description: >-
      Mutates Karpenter Provisioner resources to add the required AWS provider attributes.
      We do this in kyverno because it can handle interpolation within the resource fields of the CRD.
spec:
  background: false
  validationFailureAction: enforce
  rules:
    - name: add-karpenter-aws-provider
      context:
      - name: clusterMetadata
        configMap:
          name: cluster-metadata
          namespace: default
      match:
        any:
        - resources:
            kinds:
            - Provisioner
      mutate:
        patchStrategicMerge:
          spec:
            provider:
              instanceProfile: '{{clusterMetadata.data.karpenterInstanceProfile}}'
              subnetSelector:
                Tier: eks-workload
                Env: '{{clusterMetadata.data.clusterEnv}}'
              securityGroupSelector:
                aws:eks:cluster-name: '{{clusterMetadata.data.clusterName}}'

```

```sh
$ kubectl create -f policy.yaml 
Error from server: error when creating "policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: the kind defined in the any match resource is invalid, err: unable to convert GVK to GVR, [Provisioner], err: kind 'Provisioner' not found in apiVersion ''

```
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
