### PR TITLE
feat: support background mode configuration in kyverno-policies chart

### DIFF
--- a/charts/kyverno-policies/templates/baseline/disallow-capabilities.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-capabilities.yaml
@@ -22,7 +22,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: adding-capabilities
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.yaml
@@ -23,7 +23,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: host-namespaces
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-host-path.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-path.yaml
@@ -22,7 +22,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: host-path
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-host-ports.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-ports.yaml
@@ -22,7 +22,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: host-ports-none
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-host-process.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-process.yaml
@@ -23,7 +23,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: host-process-containers
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.yaml
@@ -21,7 +21,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: privileged-containers
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-proc-mount.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-proc-mount.yaml
@@ -23,7 +23,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: check-proc-mount
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-selinux.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-selinux.yaml
@@ -21,7 +21,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: selinux-type
       match:

--- a/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
@@ -24,7 +24,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: app-armor
       match:

--- a/charts/kyverno-policies/templates/baseline/restrict-seccomp.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-seccomp.yaml
@@ -18,7 +18,7 @@ metadata:
       requiring Kubernetes v1.19 or later, ensures that seccomp is unset or 
       set to `RuntimeDefault` or `Localhost`.
 spec:
-  background: true
+  background: {{ .Values.background }}
   validationFailureAction: {{ .Values.validationFailureAction }}
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}

--- a/charts/kyverno-policies/templates/baseline/restrict-sysctls.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-sysctls.yaml
@@ -25,7 +25,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: check-sysctls
       match:

--- a/charts/kyverno-policies/templates/other/require-non-root-groups.yaml
+++ b/charts/kyverno-policies/templates/other/require-non-root-groups.yaml
@@ -23,7 +23,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: check-runasgroup
       match:

--- a/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.yaml
@@ -23,7 +23,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: require-drop-all
       match:

--- a/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.yaml
@@ -21,7 +21,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: privilege-escalation
       match:

--- a/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
@@ -21,7 +21,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: run-as-non-root-user
       match:

--- a/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
@@ -22,7 +22,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: run-as-non-root
       match:

--- a/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.yaml
@@ -20,7 +20,7 @@ metadata:
       set to `RuntimeDefault` or `Localhost`. A known issue prevents a policy such as this
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
 spec:
-  background: true
+  background: {{ .Values.background }}
   validationFailureAction: {{ .Values.validationFailureAction }}
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}

--- a/charts/kyverno-policies/templates/restricted/restrict-volume-types.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-volume-types.yaml
@@ -24,7 +24,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
-  background: true
+  background: {{ .Values.background }}
   rules:
     - name: restricted-volumes
       match:

--- a/charts/kyverno-policies/values.yaml
+++ b/charts/kyverno-policies/values.yaml
@@ -52,3 +52,5 @@ policyExclude: {}
 nameOverride:
 # -- Additional labels
 customLabels: {}
+# Policies background mode
+background: true


### PR DESCRIPTION
This PR adds support for background mode configuration in kyverno-policies chart.
This is useful when configuring exclusion based on infos that are not available in background mode.

Else, the following message is triggered:
```
Error: release kyverno-policies failed, and has been uninstalled due to atomic being set: admission webhook "validate-policy.kyverno.svc" denied the request: only select variables are allowed in background mode. Set spec.background=false to disable background mode for this policy rule: invalid variable used at path: spec/rules[0]/exclude/all[0]/subjects 
```