### PR TITLE
Cherry-pick #3264 to 1.6.1

### DIFF
--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -38,98 +38,95 @@ import (
 )
 
 var longHelp = `
-The test command provides a facility to test resources against policies by comparing expected results, declared ahead of time in a test.yaml file, to actual results reported by Kyverno. Users provide the path to the folder containing a test.yaml file where the location could be on a local filesystem or a remote git repository
+The test command provides a facility to test resources against policies by comparing expected results, declared ahead of time in a test manifest file, to actual results reported by Kyverno. Users provide the path to the folder containing a kyverno-test.yaml file where the location could be on a local filesystem or a remote git repository.
 `
 var exampleHelp = `
+# Test a git repository containing Kyverno test cases.
 kyverno test https://github.com/kyverno/policies/pod-security --git-branch main
-    <snip>
+<snip>
 
-    Executing require-non-root-groups...
-    applying 1 policy to 2 resources...
+Executing require-non-root-groups...
+applying 1 policy to 2 resources...
 
-    │───│─────────────────────────│──────────────────────────│──────────────────────────────────│────────│
-    │ # │ POLICY                  │ RULE                     │ RESOURCE                         │ RESULT │
-    │───│─────────────────────────│──────────────────────────│──────────────────────────────────│────────│
-    │ 1 │ require-non-root-groups │ check-runasgroup         │ default/Pod/fs-group0            │ Pass   │
-    │ 2 │ require-non-root-groups │ check-supplementalGroups │ default/Pod/fs-group0            │ Pass   │
-    │ 3 │ require-non-root-groups │ check-fsGroup            │ default/Pod/fs-group0            │ Pass   │
-    │ 4 │ require-non-root-groups │ check-supplementalGroups │ default/Pod/supplemental-groups0 │ Pass   │
-    │ 5 │ require-non-root-groups │ check-fsGroup            │ default/Pod/supplemental-groups0 │ Pass   │
-    │ 6 │ require-non-root-groups │ check-runasgroup         │ default/Pod/supplemental-groups0 │ Pass   │
-    │───│─────────────────────────│──────────────────────────│──────────────────────────────────│────────│
-    <snip>
+│───│─────────────────────────│──────────────────────────│──────────────────────────────────│────────│
+│ # │ POLICY                  │ RULE                     │ RESOURCE                         │ RESULT │
+│───│─────────────────────────│──────────────────────────│──────────────────────────────────│────────│
+│ 1 │ require-non-root-groups │ check-runasgroup         │ default/Pod/fs-group0            │ Pass   │
+│ 2 │ require-non-root-groups │ check-supplementalGroups │ default/Pod/fs-group0            │ Pass   │
+│ 3 │ require-non-root-groups │ check-fsGroup            │ default/Pod/fs-group0            │ Pass   │
+│ 4 │ require-non-root-groups │ check-supplementalGroups │ default/Pod/supplemental-groups0 │ Pass   │
+│ 5 │ require-non-root-groups │ check-fsGroup            │ default/Pod/supplemental-groups0 │ Pass   │
+│ 6 │ require-non-root-groups │ check-runasgroup         │ default/Pod/supplemental-groups0 │ Pass   │
+│───│─────────────────────────│──────────────────────────│──────────────────────────────────│────────│
+<snip>
+
+# Test a local folder containing test cases.
+kyverno test .
+
+Executing limit-containers-per-pod...
+applying 1 policy to 4 resources... 
+
+│───│──────────────────────────│──────────────────────────────────────│─────────────────────────────│────────│
+│ # │ POLICY                   │ RULE                                 │ RESOURCE                    │ RESULT │
+│───│──────────────────────────│──────────────────────────────────────│─────────────────────────────│────────│
+│ 1 │ limit-containers-per-pod │ limit-containers-per-pod-bare        │ default/Pod/myapp-pod-1     │ Pass   │
+│ 2 │ limit-containers-per-pod │ limit-containers-per-pod-bare        │ default/Pod/myapp-pod-2     │ Pass   │
+│ 3 │ limit-containers-per-pod │ limit-containers-per-pod-controllers │ default/Deployment/mydeploy │ Pass   │
+│ 4 │ limit-containers-per-pod │ limit-containers-per-pod-cronjob     │ default/CronJob/mycronjob   │ Pass   │
+│───│──────────────────────────│──────────────────────────────────────│─────────────────────────────│────────│
+
+Test Summary: 4 tests passed and 0 tests failed
 
 
-Test file structure:
+**TEST FILE STRUCTURE**:
 
-The test.yaml has four parts:
-    "policies"   --> List of policies which are applied.
-    "resources"  --> List of resources on which the policies are applied.
-    "variables"  --> Variable file path (optional).
-    "results"    --> List of results expected after applying the policies on the resources.
+The kyverno-test.yaml has four parts:
+	"policies"   --> List of policies which are applied.
+	"resources"  --> List of resources on which the policies are applied.
+	"variables"  --> Variable file path containing variables referenced in the policy (OPTIONAL).
+	"results"    --> List of results expected after applying the policies to the resources.
 
-Test file format:
+** TEST FILE FORMAT**:
 
-For validate policies
+name: <test_name>
+policies:
+- <path/to/policy1.yaml>
+- <path/to/policy2.yaml>
+resources:
+- <path/to/resource1.yaml>
+- <path/to/resource2.yaml>
+variables: <variable_file> (OPTIONAL)
+results:
+- policy: <name> (For Namespaced [Policy] files, format is <policy_namespace>/<policy_name>)
+  rule: <name>
+  resource: <name>
+  namespace: <name> (OPTIONAL)
+  kind: <name>
+  patchedResource: <path/to/patched/resource.yaml> (For mutate policies/rules only)
+  result: <pass|fail|skip>
 
-- name: test-1
-  policies:
-  - <path>
-  - <path>
+**VARIABLES FILE FORMAT**:
+
+policies:
+- name: <policy_name>
+  rules:
+  - name: <rule_name>
+    # Global variable values
+    values:
+      foo: bar
   resources:
-  - <path>
-  - <path>
-  results:
-  - policy: <name>
-    rule: <name>
-    resource: <name>
-    namespace: <name> (OPTIONAL)
-    kind: <name>
-    result: <pass|fail|skip>
+  - name: <resource_name_1>
+    # Resource-specific variable values
+    values:
+      foo: baz
+  - name: <resource_name_2>
+    values:
+      foo: bin
 
+**RESULT DESCRIPTIONS**:
 
-For mutate policies
-
-Policy (Namespaced)
-
-- name: test-1
-  policies:
-  - <path>
-  - <path>
-  resources:
-  - <path>
-  - <path>
-  results:
-  - policy: <policy_namespace>/<policy_name>
-    rule: <name>
-    resource: <name>
-    namespace: <name> (OPTIONAL)
-        kind: <name>
-    patchedResource: <path>
-    result: <pass|fail|skip>
-
-ClusterPolicy (Cluster-wide)
-
-- name: test-1
-  policies:
-  - <path>
-  - <path>
-  resources:
-  - <path>
-  - <path>
-  results:
-  - policy: <name>
-    rule: <name>
-    resource: <name>
-    namespace: <name> (OPTIONAL)
-    kind: <name>
-    patchedResource: <path>
-    result: <pass|fail|skip>
-
-Result descriptions:
-
-pass  --> The patched resource generated by Kyverno equals the patched resource provided by the user.
-fail  --> The patched resource generated by Kyverno is not equal to the patched resource provided by the user.
+pass  --> The resource is either validated by the policy or, if a mutation, equals the state of the patched resource.
+fail  --> The resource fails validation or the patched resource generated by Kyverno is not equal to the input resource provided by the user.
 skip  --> The rule is not applied.
 
 For more information visit https://kyverno.io/docs/kyverno-cli/#test
@@ -138,10 +135,11 @@ For more information visit https://kyverno.io/docs/kyverno-cli/#test
 // Command returns version command
 func Command() *cobra.Command {
 	var cmd *cobra.Command
+	var testFile []byte
 	var valuesFile, fileName, gitBranch string
 	cmd = &cobra.Command{
-		Use:     "test <path_to_folder_Containing_test.yamls> [flags]\n  kyverno test <path_to_gitRepository_with_dir> --git-branch <branchName>",
-		Args:    cobra.ExactArgs(1),
+		Use: "test <path_to_folder_Containing_test.yamls> [flags]\n  kyverno test <path_to_gitRepository_with_dir> --git-branch <branchName>\n  kyverno test --manifest-mutate > kyverno-test.yaml\n  kyverno test --manifest-validate > kyverno-test.yaml",
+		// Args:    cobra.ExactArgs(1),
 		Short:   "run tests from directory",
 		Long:    longHelp,
 		Example: exampleHelp,
@@ -155,6 +153,48 @@ func Command() *cobra.Command {
 				}
 			}()
 
+			mStatus, _ := cmd.Flags().GetBool("manifest-mutate")
+			vStatus, _ := cmd.Flags().GetBool("manifest-validate")
+			if mStatus {
+				testFile = []byte(`name: <test_name>
+policies:
+- <path/to/policy1.yaml>
+- <path/to/policy2.yaml>
+resources:
+- <path/to/resource1.yaml>
+- <path/to/resource2.yaml>
+variables: <variable_file> (OPTIONAL)
+results:
+- policy: <name> (For Namespaced [Policy] files, format is <policy_namespace>/<policy_name>)
+  rule: <name>
+  resource: <name>
+  namespace: <name> (OPTIONAL)
+  kind: <name>
+  patchedResource: <path/to/patched/resource.yaml>
+  result: <pass|fail|skip>`)
+				fmt.Println(string(testFile))
+				return nil
+			}
+			if vStatus {
+				testFile = []byte(`name: <test_name>
+policies:
+- <path/to/policy1.yaml>
+- <path/to/policy2.yaml>
+resources:
+- <path/to/resource1.yaml>
+- <path/to/resource2.yaml>
+variables: <variable_file> (OPTIONAL)
+results:
+- policy: <name> (For Namespaced [Policy] files, format is <policy_namespace>/<policy_name>)
+  rule: <name>
+  resource: <name>
+  namespace: <name> (OPTIONAL)
+  kind: <name>
+  result: <pass|fail|skip>`)
+				fmt.Println(string(testFile))
+				return nil
+			}
+
 			_, err = testCommandExecute(dirPath, valuesFile, fileName, gitBranch)
 			if err != nil {
 				log.Log.V(3).Info("a directory is required")
@@ -166,6 +206,9 @@ func Command() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&fileName, "file-name", "f", "kyverno-test.yaml", "test filename")
 	cmd.Flags().StringVarP(&gitBranch, "git-branch", "b", "", "test github repository branch")
+
+	cmd.Flags().BoolP("manifest-mutate", "", false, "prints out a template test manifest for a mutate policy")
+	cmd.Flags().BoolP("manifest-validate", "", false, "prints out a template test manifest for a validate policy")
 	return cmd
 }
 

--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -155,9 +155,9 @@ func Command() *cobra.Command {
 
 			mStatus, _ := cmd.Flags().GetBool("manifest-mutate")
 			vStatus, _ := cmd.Flags().GetBool("manifest-validate")
-      
+
 			if mStatus {
-        testFile = []byte(`name: <test_name>
+				testFile = []byte(`name: <test_name>
 policies:
 - <path/to/policy1.yaml>
 - <path/to/policy2.yaml>
@@ -176,7 +176,7 @@ results:
 				fmt.Println(string(testFile))
 				return nil
 			}
-      
+
 			if vStatus {
 				testFile = []byte(`name: <test_name>
 policies:


### PR DESCRIPTION
## Related issue
Cherry-pick PR #3264  for issue #3212 #3214 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
