### PR TITLE
changing git command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 ##################################
 # DEFAULTS
 ##################################
-GIT_VERSION := $(shell git describe --match "v[0-9]*")
+GIT_VERSION := $(shell git tag --list --sort=-version:refname "v[0-9]*" | head -n 1)
 GIT_VERSION_DEV := $(shell git describe --match "[0-9].[0-9]-dev*")
 GIT_BRANCH := $(shell git branch | grep \* | cut -d ' ' -f2)
 GIT_HASH := $(GIT_BRANCH)/$(shell git log -1 --pretty=format:"%H")


### PR DESCRIPTION
`BuildVersion` for `1.6.1-rc2` should be `v1.6.1-rc2` and not `v1.6.1-rc1-14-g5d17bbcfd` 

ref: https://github.com/kyverno/kyverno/runs/5365196710?check_suite_focus=true#step:19:226