### PR TITLE
by default request.operation  globally set to CREATE

### DIFF
--- a/pkg/kyverno/test/test_command.go
+++ b/pkg/kyverno/test/test_command.go
@@ -742,6 +742,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, valuesFile s
 
 		matches := common.HasVariables(policy)
 		variable := common.RemoveDuplicateAndObjectVariables(matches)
+		possible_variables := matches
 
 		if len(variable) > 0 {
 			if len(variables) == 0 {
@@ -749,6 +750,18 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, valuesFile s
 				if valuesFile == "" || valuesMap[policy.Name] == nil {
 					fmt.Printf("test skipped for policy  %v  (as required variables are not provided by the users) \n \n", policy.Name)
 				}
+			}
+		}
+
+		// check request.operation variable present in the policy
+		for _, vars := range possible_variables {
+			vari := strings.Join(vars, " ")
+			if strings.Contains(vari, "request.operation") {
+				globalValMap = make(map[string]string)
+				// set globally, request.operation to CREATE
+				globalValMap["request.operation"] = "CREATE"
+				log.Log.V(3).Info("variable request.operation found in policy, by default globally set to CREATE.")
+				break
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: viveksahu26 <vivekkumarsahu650@gmail.com>

## Related issue 
#2653 

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
1.6.2
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
If the policy contains variable `request.operation` then it's value by default set to `CREATE`.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests


Creating tests for [this policy](https://github.com/kyverno/policies/tree/main/psp-migration/check_supplemental_groups).
Create kyverno-test.yaml
```
name: psp-check-supplemental-groups
policies:
  - check-supplemental-groups.yaml
resources:
  - resource.yaml
# variables: variables.yaml
results:
  - policy: psp-check-supplemental-groups
    rule: supplementalgroup-ranges
    resource: badpod01
    kind: Pod
    result: fail
  - policy: psp-check-supplemental-groups
    rule: supplementalgroup-ranges
    resource: goodpod01
    kind: Pod
    result: pass
```
Leave the variables line commented out.

Create `resource.yaml`
```
apiVersion: v1
kind: Pod
metadata:
  name: badpod01
spec:
  containers:
  - name: container01
    image: dummyimagename
  securityContext:
    supplementalGroups:
    - 0
---
apiVersion: v1
kind: Pod
metadata:
  name: goodpod01
spec:
  containers:
  - name: container01
    image: dummyimagename
  securityContext:
    supplementalGroups:
    - 100
```
```
$ go run cmd/cli/kubectl-kyverno/main.go  test ../policies/psp-migration/check_supplemental_groups/ 

Executing psp-check-supplemental-groups...
applying 1 policy to 2 resources... 

│───│───────────────────────────────│──────────────────────────│───────────────────────│────────│
│ # │ POLICY                        │ RULE                     │ RESOURCE              │ RESULT │
│───│───────────────────────────────│──────────────────────────│───────────────────────│────────│
│ 1 │ psp-check-supplemental-groups │ supplementalgroup-ranges │ default/Pod/badpod01  │ Pass   │
│ 2 │ psp-check-supplemental-groups │ supplementalgroup-ranges │ default/Pod/goodpod01 │ Pass   │
│───│───────────────────────────────│──────────────────────────│───────────────────────│────────│

Test Summary: 2 tests passed and 0 tests failed
```
$ go run cmd/cli/kubectl-kyverno/main.go  test ../policies/psp-migration/check_supplemental_groups/ -v=3
```
applying 1 policy to 2 resources... 
I0305 01:47:52.420259 3944788 logr.go:252]  "msg"="variable substituted"  "path"="/preconditions/all/0/key" "value"=null "variable"="{{ request.operation }}"
I0305 01:47:52.421207 3944788 logr.go:252]  "msg"="variable substituted"  "path"="/preconditions/all/0/key" "value"=null "variable"="{{ request.operation }}"
I0305 01:47:52.421893 3944788 logr.go:252]  "msg"="variable substituted"  "path"="/preconditions/all/0/key" "value"=null "variable"="{{ request.operation }}"
I0305 01:47:52.422938 3944788 logr.go:252]  "msg"="variable request.operation found in policy, by default globally set to CREATE."  
I0305 01:47:52.422959 3944788 logr.go:252]  "msg"="applying policy on resource"  "policy"="psp-check-supplemental-groups" "resource"="default/Pod/badpod01"
I0305 01:47:52.423551 3944788 validation.go:101] EngineValidate "msg"="matched validate rule" "kind"="Pod" "name"="badpod01" "namespace"="default" "policy"="psp-check-supplemental-groups" "rule"="supplementalgroup-ranges" 
I0305 01:47:52.423807 3944788 vars.go:378] EngineValidate "msg"="variable substituted" "kind"="Pod" "name"="badpod01" "namespace"="default" "policy"="psp-check-supplemental-groups" "rule"="supplementalgroup-ranges" "path"="/all/0/key" "value"="CREATE" "variable"="{{ request.operation }}"
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
