### PR TITLE
fix: incorrect path in helm-test workflow

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -2,11 +2,11 @@ name: helm-test
 on:
   pull_request:
     branches:
-      - 'main'
-      - 'release*'
+      - main
+      - release*
     paths:
-      - 'charts/kyverno/**'
-      - '.github/workflows/helm-test.yaml'
+      - charts/**
+      - .github/workflows/helm-test.yaml
 
 permissions: read-all
 


### PR DESCRIPTION
This PR fixes an incorrect path in helm-test workflow.
It checks only the `kyverno` chart but ignores the `kyverno-policies` one.