### PR TITLE
Fix any_all wildcard issue

### DIFF
--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -255,27 +255,35 @@ func Validate(policy *kyverno.ClusterPolicy, client *dclient.Client, mock bool, 
 		match := rule.MatchResources
 		exclude := rule.ExcludeResources
 		for _, value := range match.Any {
-			err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
-			if err != nil {
-				return errors.Wrapf(err, "the kind defined in the any match resource is invalid")
+			if !utils.ContainsString(value.ResourceDescription.Kinds, "*") {
+				err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
+				if err != nil {
+					return errors.Wrapf(err, "the kind defined in the any match resource is invalid")
+				}
 			}
 		}
 		for _, value := range match.All {
-			err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
-			if err != nil {
-				return errors.Wrapf(err, "the kind defined in the all match resource is invalid")
+			if !utils.ContainsString(value.ResourceDescription.Kinds, "*") {
+				err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
+				if err != nil {
+					return errors.Wrapf(err, "the kind defined in the all match resource is invalid")
+				}
 			}
 		}
 		for _, value := range exclude.Any {
-			err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
-			if err != nil {
-				return errors.Wrapf(err, "the kind defined in the any exclude resource is invalid")
+			if !utils.ContainsString(value.ResourceDescription.Kinds, "*") {
+				err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
+				if err != nil {
+					return errors.Wrapf(err, "the kind defined in the any exclude resource is invalid")
+				}
 			}
 		}
 		for _, value := range exclude.All {
-			err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
-			if err != nil {
-				return errors.Wrapf(err, "the kind defined in the all exclude resource is invalid")
+			if !utils.ContainsString(value.ResourceDescription.Kinds, "*") {
+				err := validateKinds(value.ResourceDescription.Kinds, mock, client, *policy)
+				if err != nil {
+					return errors.Wrapf(err, "the kind defined in the all exclude resource is invalid")
+				}
 			}
 		}
 		if !utils.ContainsString(rule.MatchResources.Kinds, "*") {

--- a/test/cli/test/any-all-wildcard/kyverno-test.yaml
+++ b/test/cli/test/any-all-wildcard/kyverno-test.yaml
@@ -1,4 +1,3 @@
----
 name: disallow-protected-namespaces
 policies:
   - policy.yaml

--- a/test/cli/test/any-all-wildcard/policy.yaml
+++ b/test/cli/test/any-all-wildcard/policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-protected-namespaces
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: disallow
+    match:
+      all:
+      - resources:
+          kinds:
+          - "*"
+          namespaces:
+          - "namespace1"
+          - "namespace2"
+    validate:
+      message: "This resource is protected and changes are not allowed."
+      deny: {}

--- a/test/cli/test/any-all-wildcard/resource.yaml
+++ b/test/cli/test/any-all-wildcard/resource.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test1
+  namespace: namespace1
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test2
+  namespace: namespace2
+spec: 
+  containers:
+  - name: nginx
+    image: nginx
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test3
+  namespace: namespace3
+spec: 
+  containers:
+  - name: nginx
+    image: nginx

--- a/test/cli/test/any-all-wildcard/test.yaml
+++ b/test/cli/test/any-all-wildcard/test.yaml
@@ -1,0 +1,25 @@
+---
+name: disallow-protected-namespaces
+policies:
+  - policy.yaml
+resources:
+  - resource.yaml
+results:
+  - policy: disallow-protected-namespaces
+    rule: disallow
+    resource: test1
+    kind: Pod
+    namespace: namespace1
+    result: fail
+  - policy: disallow-protected-namespaces
+    rule: disallow
+    resource: test2
+    kind: Pod
+    namespace: namespace2
+    result: fail
+  - policy: disallow-protected-namespaces
+    rule: disallow
+    resource: test3
+    kind: Pod
+    namespace: namespace3
+    result: skip


### PR DESCRIPTION
Signed-off-by: Vyankatesh vyankateshkd@gmail.com
closes : https://github.com/kyverno/kyverno/issues/3340

## Milestone of this PR
/milestone 1.6.2

## What type of PR is this
 /kind bug

### Proof Manifests
1. Create this policy.
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-protected-namespaces
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: disallow
    match:
      all:
      - resources:
          kinds:
          - "*"
          namespaces:
          - "namespace1"
          - "namespace2"
    validate:
      message: "This resource is protected and changes are not allowed."
      deny: {}
```

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-protected-namespaces
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: disallow
    match:
      any:
      - resources:
          kinds:
          - "*"
          namespaces:
          - "namespace1"
          - "namespace2"
    validate:
      message: "This resource is protected and changes are not allowed."
      deny: {}
```

`Policy is created regardless with  wildcard matching kind is under `any` or `all`.`


Result for testcases
```
Executing disallow-protected-namespaces...
applying 1 policy to 3 resources... 

│───│───────────────────────────────│──────────│──────────────────────│────────│
│ # │ POLICY                        │ RULE     │ RESOURCE             │ RESULT │
│───│───────────────────────────────│──────────│──────────────────────│────────│
│ 1 │ disallow-protected-namespaces │ disallow │ namespace1/Pod/test1 │ Pass   │
│ 2 │ disallow-protected-namespaces │ disallow │ namespace2/Pod/test2 │ Pass   │
│ 3 │ disallow-protected-namespaces │ disallow │ namespace3/Pod/test3 │ Pass   │
│───│───────────────────────────────│──────────│──────────────────────│────────│
```

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->



<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
