### PR TITLE
chore: gen helm crds from config crds

### DIFF
--- a/charts/kyverno/templates/crds.yaml
+++ b/charts/kyverno/templates/crds.yaml
@@ -1,17 +1,12 @@
 {{- if .Values.installCRDs }}
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-    config.kubernetes.io/index: '1'
   creationTimestamp: null
-  labels:
-    app.kubernetes.io/component: kyverno
-    app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: latest
   name: clusterpolicies.kyverno.io
 spec:
   group: kyverno.io
@@ -41,13 +36,18 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.
+        description: ClusterPolicy declares validation, mutation, and generation behaviors
+          for matching resources.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -55,32 +55,58 @@ spec:
             description: Spec declares policy behaviors.
             properties:
               background:
-                description: Background controls if rules are applied to existing resources during a background scan. Optional. Default value is "true". The value must be set to "false" if the policy rule uses variables that are only available in the admission review request (e.g. user name).
+                description: Background controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
                 type: boolean
               failurePolicy:
-                description: FailurePolicy defines how unrecognized errors from the admission endpoint are handled. Rules within the same policy share the same failure behavior. Allowed values are Ignore or Fail. Defaults to Fail.
+                description: FailurePolicy defines how unrecognized errors from the
+                  admission endpoint are handled. Rules within the same policy share
+                  the same failure behavior. Allowed values are Ignore or Fail. Defaults
+                  to Fail.
                 enum:
                 - Ignore
                 - Fail
                 type: string
               rules:
-                description: Rules is a list of Rule instances. A Policy contains multiple rules and each rule can validate, mutate, or generate resources.
+                description: Rules is a list of Rule instances. A Policy contains
+                  multiple rules and each rule can validate, mutate, or generate resources.
                 items:
-                  description: Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.
+                  description: Rule defines a validation, mutation, or generation
+                    control for matching resources. Each rules contains a match declaration
+                    to select resources, and an optional exclude declaration to specify
+                    which resources to exclude.
                   properties:
                     context:
-                      description: Context defines variables and data sources that can be used during rule execution.
+                      description: Context defines variables and data sources that
+                        can be used during rule execution.
                       items:
-                        description: ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.
+                        description: ContextEntry adds variables and data sources
+                          to a rule Context. Either a ConfigMap reference or a APILookup
+                          must be provided.
                         properties:
                           apiCall:
-                            description: APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.
+                            description: APICall defines an HTTP request to the Kubernetes
+                              API server. The JSON data retrieved is stored in the
+                              context.
                             properties:
                               jmesPath:
-                                description: JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of "items | length(@)" applied to the API server response to the URLPath "/apis/apps/v1/deployments" will return the total count of deployments across all namespaces.
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the JSON response
+                                  returned from the API server. For example a JMESPath
+                                  of "items | length(@)" applied to the API server
+                                  response to the URLPath "/apis/apps/v1/deployments"
+                                  will return the total count of deployments across
+                                  all namespaces.
                                 type: string
                               urlPath:
-                                description: URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments"). The format required is the same format used by the `kubectl get --raw` command.
+                                description: URLPath is the URL path to be used in
+                                  the HTTP GET request to the Kubernetes API server
+                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                  The format required is the same format used by the
+                                  `kubectl get --raw` command.
                                 type: string
                             required:
                             - urlPath
@@ -98,13 +124,17 @@ spec:
                             - name
                             type: object
                           imageRegistry:
-                            description: ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.
+                            description: ImageRegistry defines requests to an OCI/Docker
+                              V2 registry to fetch image details.
                             properties:
                               jmesPath:
-                                description: JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the ImageData struct
+                                  returned as a result of processing the image reference.
                                 type: string
                               reference:
-                                description: 'Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
+                                description: 'Reference is image reference to a container
+                                  image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
                                 type: string
                             required:
                             - reference
@@ -115,25 +145,36 @@ spec:
                         type: object
                       type: array
                     exclude:
-                      description: ExcludeResources defines when this policy rule should not be applied. The exclude criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the name or role.
+                      description: ExcludeResources defines when this policy rule
+                        should not be applied. The exclude criteria can include resource
+                        information (e.g. kind, name, namespace, labels) and admission
+                        review request information like the name or role.
                       properties:
                         all:
-                          description: All allows specifying resources which will be ANDed
+                          description: All allows specifying resources which will
+                            be ANDed
                           items:
-                            description: ResourceFilter allow users to "AND" or "OR" between resources
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -141,29 +182,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -175,30 +246,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -210,31 +311,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -244,22 +366,30 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will be ORed
+                          description: Any allows specifying resources which will
+                            be ORed
                           items:
-                            description: ResourceFilter allow users to "AND" or "OR" between resources
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -267,29 +397,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -301,30 +461,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -336,31 +526,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -370,17 +581,25 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role names for the user.
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about the resource being created or modified. Specifying ResourceDescription directly under exclude is being deprecated. Please specify under "any" or "all" instead.
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Specifying ResourceDescription
+                            directly under exclude is being deprecated. Please specify
+                            under "any" or "all" instead.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -388,29 +607,52 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -422,30 +664,54 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -457,31 +723,51 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names for the user.
+                          description: Roles is the list of namespaced role names
+                            for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
                                 type: string
                             required:
                             - kind
@@ -496,7 +782,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specifies the source resource used to populate each generated resource. At most one of Data or Clone can be specified. If neither are provided, the generated resource will be created with default data only.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -506,7 +795,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource declaration used to populate each generated resource. At most one of Data or Clone must be specified. If neither are provided, the generated resource will be created with default data only.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -518,29 +810,46 @@ spec:
                           description: Namespace specifies resource namespace.
                           type: string
                         synchronize:
-                          description: Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to "true" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to "false" if not specified.
+                          description: Synchronize controls if generated resources
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
+                            Defaults to "false" if not specified.
                           type: boolean
                       type: object
                     match:
-                      description: MatchResources defines when this policy rule should be applied. The match criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the user name or role. At least one kind is required.
+                      description: MatchResources defines when this policy rule should
+                        be applied. The match criteria can include resource information
+                        (e.g. kind, name, namespace, labels) and admission review
+                        request information like the user name or role. At least one
+                        kind is required.
                       properties:
                         all:
-                          description: All allows specifying resources which will be ANDed
+                          description: All allows specifying resources which will
+                            be ANDed
                           items:
-                            description: ResourceFilter allow users to "AND" or "OR" between resources
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -548,29 +857,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -582,30 +921,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -617,31 +986,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -651,22 +1041,30 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will be ORed
+                          description: Any allows specifying resources which will
+                            be ORed
                           items:
-                            description: ResourceFilter allow users to "AND" or "OR" between resources
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -674,29 +1072,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -708,30 +1136,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -743,31 +1201,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -777,17 +1256,26 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role names for the user.
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about the resource being created or modified. Requires at least one tag to be specified when under MatchResources. Specifying ResourceDescription directly under match is being deprecated. Please specify under "any" or "all" instead.
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Requires at least
+                            one tag to be specified when under MatchResources. Specifying
+                            ResourceDescription directly under match is being deprecated.
+                            Please specify under "any" or "all" instead.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -795,29 +1283,52 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -829,30 +1340,54 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -864,31 +1399,51 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names for the user.
+                          description: Roles is the list of namespaced role names
+                            for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
                                 type: string
                             required:
                             - kind
@@ -900,23 +1455,45 @@ spec:
                       description: Mutation is used to modify matching resources.
                       properties:
                         foreach:
-                          description: ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.
+                          description: ForEach applies mutation rules to a list of
+                            sub-elements by creating a context for each entry in the
+                            list and looping over it to apply the specified logic.
                           items:
-                            description: ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.
+                            description: ForEach applies mutation rules to a list
+                              of sub-elements by creating a context for each entry
+                              in the list and looping over it to apply the specified
+                              logic.
                             properties:
                               context:
-                                description: Context defines variables and data sources that can be used during rule execution.
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
                                 items:
-                                  description: ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
                                   properties:
                                     apiCall:
-                                      description: APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
                                       properties:
                                         jmesPath:
-                                          description: JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of "items | length(@)" applied to the API server response to the URLPath "/apis/apps/v1/deployments" will return the total count of deployments across all namespaces.
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
                                           type: string
                                         urlPath:
-                                          description: URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments"). The format required is the same format used by the `kubectl get --raw` command.
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
                                           type: string
                                       required:
                                       - urlPath
@@ -928,19 +1505,27 @@ spec:
                                           description: Name is the ConfigMap name.
                                           type: string
                                         namespace:
-                                          description: Namespace is the ConfigMap namespace.
+                                          description: Namespace is the ConfigMap
+                                            namespace.
                                           type: string
                                       required:
                                       - name
                                       type: object
                                     imageRegistry:
-                                      description: ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
                                       properties:
                                         jmesPath:
-                                          description: JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
                                           type: string
                                         reference:
-                                          description: 'Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
                                           type: string
                                       required:
                                       - reference
@@ -951,27 +1536,49 @@ spec:
                                   type: object
                                 type: array
                               list:
-                                description: List specifies a JMESPath expression that results in one or more elements to which the validation logic is applied.
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
                                 type: string
                               patchStrategicMerge:
-                                description: PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                                description: PatchStrategicMerge is a strategic merge
+                                  patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                  and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
                                 x-kubernetes-preserve-unknown-fields: true
                               patchesJson6902:
-                                description: PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                                description: PatchesJSON6902 is a list of RFC 6902
+                                  JSON Patch declarations used to modify resources.
+                                  See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
                                 type: string
                               preconditions:
-                                description: 'AnyAllConditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
                                 properties:
                                   all:
-                                    description: AllConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, all of the conditions need to pass
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
                                     items:
-                                      description: Condition defines variable-based conditional criteria for rule execution.
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
                                       properties:
                                         key:
-                                          description: Key is the context entry (using JMESPath) for conditional rule evaluation.
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
                                           x-kubernetes-preserve-unknown-fields: true
                                         operator:
-                                          description: 'Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
                                           enum:
                                           - Equals
                                           - NotEquals
@@ -991,20 +1598,36 @@ spec:
                                           - DurationLessThan
                                           type: string
                                         value:
-                                          description: Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using using JMESPath.
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
                                           x-kubernetes-preserve-unknown-fields: true
                                       type: object
                                     type: array
                                   any:
-                                    description: AnyConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, at least one of the conditions need to pass
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
                                     items:
-                                      description: Condition defines variable-based conditional criteria for rule execution.
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
                                       properties:
                                         key:
-                                          description: Key is the context entry (using JMESPath) for conditional rule evaluation.
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
                                           x-kubernetes-preserve-unknown-fields: true
                                         operator:
-                                          description: 'Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
                                           enum:
                                           - Equals
                                           - NotEquals
@@ -1024,7 +1647,10 @@ spec:
                                           - DurationLessThan
                                           type: string
                                         value:
-                                          description: Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using using JMESPath.
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
                                           x-kubernetes-preserve-unknown-fields: true
                                       type: object
                                     type: array
@@ -1033,53 +1659,94 @@ spec:
                             type: object
                           type: array
                         patchStrategicMerge:
-                          description: PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          description: PatchStrategicMerge is a strategic merge patch
+                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
                           x-kubernetes-preserve-unknown-fields: true
                         patchesJson6902:
-                          description: PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON
+                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
                           type: string
                       type: object
                     name:
-                      description: Name is a label to identify the rule, It must be unique within the policy.
+                      description: Name is a label to identify the rule, It must be
+                        unique within the policy.
                       maxLength: 63
                       type: string
                     preconditions:
-                      description: 'Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      description: 'Preconditions are used to determine if a policy
+                        rule should be applied by evaluating a set of conditions.
+                        The declaration can contain nested `any` or `all` statements.
+                        A direct list of conditions (without `any` or `all` statements
+                        is supported for backwards compatibility but will be deprecated
+                        in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
                       x-kubernetes-preserve-unknown-fields: true
                     validate:
                       description: Validation is used to validate matching resources.
                       properties:
                         anyPattern:
-                          description: AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.
+                          description: AnyPattern specifies list of validation patterns.
+                            At least one of the patterns must be satisfied for the
+                            validation rule to succeed.
                           x-kubernetes-preserve-unknown-fields: true
                         deny:
-                          description: Deny defines conditions used to pass or fail a validation rule.
+                          description: Deny defines conditions used to pass or fail
+                            a validation rule.
                           properties:
                             conditions:
-                              description: 'Multiple conditions can be declared under an `any` or `all` statement. A direct list of conditions (without `any` or `all` statements) is also supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              description: 'Multiple conditions can be declared under
+                                an `any` or `all` statement. A direct list of conditions
+                                (without `any` or `all` statements) is also supported
+                                for backwards compatibility but will be deprecated
+                                in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
                               x-kubernetes-preserve-unknown-fields: true
                           type: object
                         foreach:
-                          description: ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.
+                          description: ForEach applies validate rules to a list of
+                            sub-elements by creating a context for each entry in the
+                            list and looping over it to apply the specified logic.
                           items:
-                            description: ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.
+                            description: ForEach applies validate rules to a list
+                              of sub-elements by creating a context for each entry
+                              in the list and looping over it to apply the specified
+                              logic.
                             properties:
                               anyPattern:
-                                description: AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.
+                                description: AnyPattern specifies list of validation
+                                  patterns. At least one of the patterns must be satisfied
+                                  for the validation rule to succeed.
                                 x-kubernetes-preserve-unknown-fields: true
                               context:
-                                description: Context defines variables and data sources that can be used during rule execution.
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
                                 items:
-                                  description: ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
                                   properties:
                                     apiCall:
-                                      description: APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
                                       properties:
                                         jmesPath:
-                                          description: JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of "items | length(@)" applied to the API server response to the URLPath "/apis/apps/v1/deployments" will return the total count of deployments across all namespaces.
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
                                           type: string
                                         urlPath:
-                                          description: URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments"). The format required is the same format used by the `kubectl get --raw` command.
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
                                           type: string
                                       required:
                                       - urlPath
@@ -1091,19 +1758,27 @@ spec:
                                           description: Name is the ConfigMap name.
                                           type: string
                                         namespace:
-                                          description: Namespace is the ConfigMap namespace.
+                                          description: Namespace is the ConfigMap
+                                            namespace.
                                           type: string
                                       required:
                                       - name
                                       type: object
                                     imageRegistry:
-                                      description: ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
                                       properties:
                                         jmesPath:
-                                          description: JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
                                           type: string
                                         reference:
-                                          description: 'Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
                                           type: string
                                       required:
                                       - reference
@@ -1114,34 +1789,64 @@ spec:
                                   type: object
                                 type: array
                               deny:
-                                description: Deny defines conditions used to pass or fail a validation rule.
+                                description: Deny defines conditions used to pass
+                                  or fail a validation rule.
                                 properties:
                                   conditions:
-                                    description: 'Multiple conditions can be declared under an `any` or `all` statement. A direct list of conditions (without `any` or `all` statements) is also supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                    description: 'Multiple conditions can be declared
+                                      under an `any` or `all` statement. A direct
+                                      list of conditions (without `any` or `all` statements)
+                                      is also supported for backwards compatibility
+                                      but will be deprecated in the next major release.
+                                      See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
                                     x-kubernetes-preserve-unknown-fields: true
                                 type: object
                               elementScope:
-                                description: ElementScope specifies whether to use the current list element as the scope for validation. Defaults to "true" if not specified. When set to "false", "request.object" is used as the validation scope within the foreach block to allow referencing other elements in the subtree.
+                                description: ElementScope specifies whether to use
+                                  the current list element as the scope for validation.
+                                  Defaults to "true" if not specified. When set to
+                                  "false", "request.object" is used as the validation
+                                  scope within the foreach block to allow referencing
+                                  other elements in the subtree.
                                 type: boolean
                               list:
-                                description: List specifies a JMESPath expression that results in one or more elements to which the validation logic is applied.
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
                                 type: string
                               pattern:
-                                description: Pattern specifies an overlay-style pattern used to check resources.
+                                description: Pattern specifies an overlay-style pattern
+                                  used to check resources.
                                 x-kubernetes-preserve-unknown-fields: true
                               preconditions:
-                                description: 'AnyAllConditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
                                 properties:
                                   all:
-                                    description: AllConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, all of the conditions need to pass
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
                                     items:
-                                      description: Condition defines variable-based conditional criteria for rule execution.
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
                                       properties:
                                         key:
-                                          description: Key is the context entry (using JMESPath) for conditional rule evaluation.
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
                                           x-kubernetes-preserve-unknown-fields: true
                                         operator:
-                                          description: 'Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
                                           enum:
                                           - Equals
                                           - NotEquals
@@ -1161,20 +1866,36 @@ spec:
                                           - DurationLessThan
                                           type: string
                                         value:
-                                          description: Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using using JMESPath.
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
                                           x-kubernetes-preserve-unknown-fields: true
                                       type: object
                                     type: array
                                   any:
-                                    description: AnyConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, at least one of the conditions need to pass
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
                                     items:
-                                      description: Condition defines variable-based conditional criteria for rule execution.
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
                                       properties:
                                         key:
-                                          description: Key is the context entry (using JMESPath) for conditional rule evaluation.
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
                                           x-kubernetes-preserve-unknown-fields: true
                                         operator:
-                                          description: 'Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
                                           enum:
                                           - Equals
                                           - NotEquals
@@ -1194,7 +1915,10 @@ spec:
                                           - DurationLessThan
                                           type: string
                                         value:
-                                          description: Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using using JMESPath.
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
                                           x-kubernetes-preserve-unknown-fields: true
                                       type: object
                                     type: array
@@ -1203,42 +1927,81 @@ spec:
                             type: object
                           type: array
                         message:
-                          description: Message specifies a custom message to be displayed on failure.
+                          description: Message specifies a custom message to be displayed
+                            on failure.
                           type: string
                         pattern:
-                          description: Pattern specifies an overlay-style pattern used to check resources.
+                          description: Pattern specifies an overlay-style pattern
+                            used to check resources.
                           x-kubernetes-preserve-unknown-fields: true
                       type: object
                     verifyImages:
-                      description: VerifyImages is used to verify image signatures and mutate them to add a digest
+                      description: VerifyImages is used to verify image signatures
+                        and mutate them to add a digest
                       items:
-                        description: ImageVerification validates that images that match the specified pattern are signed with the supplied public key. Once the image is verified it is mutated to include the SHA digest retrieved during the registration.
+                        description: ImageVerification validates that images that
+                          match the specified pattern are signed with the supplied
+                          public key. Once the image is verified it is mutated to
+                          include the SHA digest retrieved during the registration.
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
-                            description: Annotations are used for image verification. Every specified key-value pair must exist and match in the verified payload. The payload may contain other key-value pairs.
+                            description: Annotations are used for image verification.
+                              Every specified key-value pair must exist and match
+                              in the verified payload. The payload may contain other
+                              key-value pairs.
                             type: object
                           attestations:
-                            description: Attestations are optional checks for signed in-toto Statements used to verify the image. See https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the OCI registry and decodes them into a list of Statement declarations.
+                            description: Attestations are optional checks for signed
+                              in-toto Statements used to verify the image. See https://github.com/in-toto/attestation.
+                              Kyverno fetches signed attestations from the OCI registry
+                              and decodes them into a list of Statement declarations.
                             items:
-                              description: Attestation are checks for signed in-toto Statements that are used to verify the image. See https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the OCI registry and decodes them into a list of Statements.
+                              description: Attestation are checks for signed in-toto
+                                Statements that are used to verify the image. See
+                                https://github.com/in-toto/attestation. Kyverno fetches
+                                signed attestations from the OCI registry and decodes
+                                them into a list of Statements.
                               properties:
                                 conditions:
-                                  description: Conditions are used to verify attributes within a Predicate. If no Conditions are specified the attestation check is satisfied as long there are predicates that match the predicate type.
+                                  description: Conditions are used to verify attributes
+                                    within a Predicate. If no Conditions are specified
+                                    the attestation check is satisfied as long there
+                                    are predicates that match the predicate type.
                                   items:
-                                    description: AnyAllConditions consists of conditions wrapped denoting a logical criteria to be fulfilled. AnyConditions get fulfilled when at least one of its sub-conditions passes. AllConditions get fulfilled only when all of its sub-conditions pass.
+                                    description: AnyAllConditions consists of conditions
+                                      wrapped denoting a logical criteria to be fulfilled.
+                                      AnyConditions get fulfilled when at least one
+                                      of its sub-conditions passes. AllConditions
+                                      get fulfilled only when all of its sub-conditions
+                                      pass.
                                     properties:
                                       all:
-                                        description: AllConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, all of the conditions need to pass
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
                                         items:
-                                          description: Condition defines variable-based conditional criteria for rule execution.
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
                                           properties:
                                             key:
-                                              description: Key is the context entry (using JMESPath) for conditional rule evaluation.
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
                                               x-kubernetes-preserve-unknown-fields: true
                                             operator:
-                                              description: 'Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
                                               enum:
                                               - Equals
                                               - NotEquals
@@ -1258,20 +2021,38 @@ spec:
                                               - DurationLessThan
                                               type: string
                                             value:
-                                              description: Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using using JMESPath.
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using using JMESPath.
                                               x-kubernetes-preserve-unknown-fields: true
                                           type: object
                                         type: array
                                       any:
-                                        description: AnyConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, at least one of the conditions need to pass
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
                                         items:
-                                          description: Condition defines variable-based conditional criteria for rule execution.
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
                                           properties:
                                             key:
-                                              description: Key is the context entry (using JMESPath) for conditional rule evaluation.
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
                                               x-kubernetes-preserve-unknown-fields: true
                                             operator:
-                                              description: 'Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
                                               enum:
                                               - Equals
                                               - NotEquals
@@ -1291,50 +2072,70 @@ spec:
                                               - DurationLessThan
                                               type: string
                                             value:
-                                              description: Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using using JMESPath.
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using using JMESPath.
                                               x-kubernetes-preserve-unknown-fields: true
                                           type: object
                                         type: array
                                     type: object
                                   type: array
                                 predicateType:
-                                  description: PredicateType defines the type of Predicate contained within the Statement.
+                                  description: PredicateType defines the type of Predicate
+                                    contained within the Statement.
                                   type: string
                               type: object
                             type: array
                           image:
-                            description: 'Image is the image name consisting of the registry address, repository, image, and tag. Wildcards (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                            description: 'Image is the image name consisting of the
+                              registry address, repository, image, and tag. Wildcards
+                              (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
                             type: string
                           issuer:
-                            description: Issuer is the certificate issuer used for keyless signing.
+                            description: Issuer is the certificate issuer used for
+                              keyless signing.
                             type: string
                           key:
-                            description: Key is the PEM encoded public key that the image or attestation is signed with.
+                            description: Key is the PEM encoded public key that the
+                              image or attestation is signed with.
                             type: string
                           repository:
-                            description: Repository is an optional alternate OCI repository to use for image signatures that match this rule. If specified Repository will override the default OCI image repository configured for the installation.
+                            description: Repository is an optional alternate OCI repository
+                              to use for image signatures that match this rule. If
+                              specified Repository will override the default OCI image
+                              repository configured for the installation.
                             type: string
                           roots:
-                            description: Roots is the PEM encoded Root certificate chain used for keyless signing
+                            description: Roots is the PEM encoded Root certificate
+                              chain used for keyless signing
                             type: string
                           subject:
-                            description: Subject is the verified identity used for keyless signing, for example the email address
+                            description: Subject is the verified identity used for
+                              keyless signing, for example the email address
                             type: string
                         type: object
                       type: array
                   type: object
                 type: array
               schemaValidation:
-                description: SchemaValidation skips policy validation checks. Optional. The default value is set to "true", it must be set to "false" to disable the validation checks.
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
                 type: boolean
               validationFailureAction:
-                description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
+                description: ValidationFailureAction controls if a validation policy
+                  rule failure should disallow the admission review request (enforce),
+                  or allow (audit) the admission review request and report an error
+                  in a policy report. Optional. The default value is "audit".
                 enum:
                 - audit
                 - enforce
                 type: string
               validationFailureActionOverrides:
-                description: ValidationFailureActionOverrides is a Cluster Policy attribute that specifies ValidationFailureAction namespace-wise. It overrides ValidationFailureAction for the specified namespaces.
+                description: ValidationFailureActionOverrides is a Cluster Policy
+                  attribute that specifies ValidationFailureAction namespace-wise.
+                  It overrides ValidationFailureAction for the specified namespaces.
                 items:
                   properties:
                     action:
@@ -1349,15 +2150,91 @@ spec:
                   type: object
                 type: array
               webhookTimeoutSeconds:
-                description: WebhookTimeoutSeconds specifies the maximum time in seconds allowed to apply this policy. After the configured time expires, the admission request may fail, or may simply ignore the policy results, based on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.
+                description: WebhookTimeoutSeconds specifies the maximum time in seconds
+                  allowed to apply this policy. After the configured time expires,
+                  the admission request may fail, or may simply ignore the policy
+                  results, based on the failure policy. The default timeout is 10s,
+                  the value must be between 1 and 30 seconds.
                 format: int32
                 type: integer
             type: object
           status:
             description: Status contains policy runtime data.
             properties:
+              conditions:
+                description: Conditions is a list of conditions that apply to the
+                  policy
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               ready:
-                description: Ready indicates if the policy is ready to serve the admission request
+                description: Ready indicates if the policy is ready to serve the admission
+                  request
                 type: boolean
             required:
             - ready
@@ -1375,512 +2252,14 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-    config.kubernetes.io/index: '2'
   creationTimestamp: null
-  labels:
-    app.kubernetes.io/component: kyverno
-    app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: latest
-  name: clusterpolicyreports.wgpolicyk8s.io
-spec:
-  group: wgpolicyk8s.io
-  names:
-    kind: ClusterPolicyReport
-    listKind: ClusterPolicyReportList
-    plural: clusterpolicyreports
-    shortNames:
-    - cpolr
-    singular: clusterpolicyreport
-  scope: Cluster
-  versions:
-  - additionalPrinterColumns:
-    - jsonPath: .scope.kind
-      name: Kind
-      priority: 1
-      type: string
-    - jsonPath: .scope.name
-      name: Name
-      priority: 1
-      type: string
-    - jsonPath: .summary.pass
-      name: Pass
-      type: integer
-    - jsonPath: .summary.fail
-      name: Fail
-      type: integer
-    - jsonPath: .summary.warn
-      name: Warn
-      type: integer
-    - jsonPath: .summary.error
-      name: Error
-      type: integer
-    - jsonPath: .summary.skip
-      name: Skip
-      type: integer
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ClusterPolicyReport is the Schema for the clusterpolicyreports API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          results:
-            description: PolicyReportResult provides result details
-            items:
-              description: PolicyReportResult provides the result for an individual policy
-              properties:
-                category:
-                  description: Category indicates policy category
-                  type: string
-                data:
-                  additionalProperties:
-                    type: string
-                  description: Data provides additional information for the policy rule
-                  type: object
-                message:
-                  description: Message is a short user friendly description of the policy rule
-                  type: string
-                policy:
-                  description: Policy is the name of the policy
-                  type: string
-                resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
-                  type: object
-                resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
-                  items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  type: array
-                rule:
-                  description: Rule is the name of the policy rule
-                  type: string
-                scored:
-                  description: Scored indicates if this policy rule is scored
-                  type: boolean
-                severity:
-                  description: Severity indicates policy severity
-                  enum:
-                  - high
-                  - low
-                  - medium
-                  type: string
-                status:
-                  description: Status indicates the result of the policy rule check
-                  enum:
-                  - pass
-                  - fail
-                  - warn
-                  - error
-                  - skip
-                  type: string
-              required:
-              - policy
-              type: object
-            type: array
-          scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
-            properties:
-              apiVersion:
-                description: API version of the referent.
-                type: string
-              fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                type: string
-              kind:
-                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
-              name:
-                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                type: string
-              namespace:
-                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                type: string
-              resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                type: string
-              uid:
-                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                type: string
-            type: object
-          scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
-            properties:
-              matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                  properties:
-                    key:
-                      description: key is the label key that the selector applies to.
-                      type: string
-                    operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                      type: string
-                    values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                      items:
-                        type: string
-                      type: array
-                  required:
-                  - key
-                  - operator
-                  type: object
-                type: array
-              matchLabels:
-                additionalProperties:
-                  type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                type: object
-            type: object
-          summary:
-            description: PolicyReportSummary provides a summary of results
-            properties:
-              error:
-                description: Error provides the count of policies that could not be evaluated
-                type: integer
-              fail:
-                description: Fail provides the count of policies whose requirements were not met
-                type: integer
-              pass:
-                description: Pass provides the count of policies whose requirements were met
-                type: integer
-              skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
-                type: integer
-              warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources: {}
-  - additionalPrinterColumns:
-    - jsonPath: .scope.kind
-      name: Kind
-      priority: 1
-      type: string
-    - jsonPath: .scope.name
-      name: Name
-      priority: 1
-      type: string
-    - jsonPath: .summary.pass
-      name: Pass
-      type: integer
-    - jsonPath: .summary.fail
-      name: Fail
-      type: integer
-    - jsonPath: .summary.warn
-      name: Warn
-      type: integer
-    - jsonPath: .summary.error
-      name: Error
-      type: integer
-    - jsonPath: .summary.skip
-      name: Skip
-      type: integer
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        description: ClusterPolicyReport is the Schema for the clusterpolicyreports API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          results:
-            description: PolicyReportResult provides result details
-            items:
-              description: PolicyReportResult provides the result for an individual policy
-              properties:
-                category:
-                  description: Category indicates policy category
-                  type: string
-                message:
-                  description: Message is a short user friendly description of the policy rule
-                  type: string
-                policy:
-                  description: Policy is the name of the policy
-                  type: string
-                properties:
-                  additionalProperties:
-                    type: string
-                  description: Properties provides additional information for the policy rule
-                  type: object
-                resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
-                  type: object
-                resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
-                  items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  type: array
-                result:
-                  description: Result indicates the outcome of the policy rule execution
-                  enum:
-                  - pass
-                  - fail
-                  - warn
-                  - error
-                  - skip
-                  type: string
-                rule:
-                  description: Rule is the name of the policy rule
-                  type: string
-                scored:
-                  description: Scored indicates if this policy rule is scored
-                  type: boolean
-                severity:
-                  description: Severity indicates policy severity
-                  enum:
-                  - high
-                  - low
-                  - medium
-                  type: string
-                source:
-                  description: Source is an identifier for the policy engine that manages this report
-                  type: string
-                timestamp:
-                  description: Timestamp indicates the time the result was found
-                  properties:
-                    nanos:
-                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
-                      format: int32
-                      type: integer
-                    seconds:
-                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
-                      format: int64
-                      type: integer
-                  required:
-                  - nanos
-                  - seconds
-                  type: object
-              required:
-              - policy
-              type: object
-            type: array
-          scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
-            properties:
-              apiVersion:
-                description: API version of the referent.
-                type: string
-              fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                type: string
-              kind:
-                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
-              name:
-                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                type: string
-              namespace:
-                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                type: string
-              resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                type: string
-              uid:
-                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                type: string
-            type: object
-          scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
-            properties:
-              matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                  properties:
-                    key:
-                      description: key is the label key that the selector applies to.
-                      type: string
-                    operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                      type: string
-                    values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                      items:
-                        type: string
-                      type: array
-                  required:
-                  - key
-                  - operator
-                  type: object
-                type: array
-              matchLabels:
-                additionalProperties:
-                  type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                type: object
-            type: object
-          summary:
-            description: PolicyReportSummary provides a summary of results
-            properties:
-              error:
-                description: Error provides the count of policies that could not be evaluated
-                type: integer
-              fail:
-                description: Fail provides the count of policies whose requirements were not met
-                type: integer
-              pass:
-                description: Pass provides the count of policies whose requirements were met
-                type: integer
-              skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
-                type: integer
-              warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
-    config.kubernetes.io/index: '3'
-  creationTimestamp: null
-  labels:
-    app.kubernetes.io/component: kyverno
-    app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: latest
   name: clusterreportchangerequests.kyverno.io
 spec:
   group: kyverno.io
@@ -1923,20 +2302,26 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests API
+        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -1944,30 +2329,46 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy rule
+                  description: Data provides additional information for the policy
+                    rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -1979,19 +2380,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -2003,7 +2443,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -2037,13 +2478,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -2055,28 +2506,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -2088,26 +2550,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -2144,26 +2614,33 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests API
+        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -2171,24 +2648,39 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the policy rule
+                  description: Properties provides additional information for the
+                    policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -2200,19 +2692,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -2224,7 +2755,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -2254,17 +2786,24 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that manages this report
+                  description: Source is an identifier for the policy engine that
+                    manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -2276,13 +2815,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -2294,28 +2843,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -2327,26 +2887,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -2359,20 +2927,14 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-    config.kubernetes.io/index: '4'
   creationTimestamp: null
-  labels:
-    app.kubernetes.io/component: kyverno
-    app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: latest
   name: generaterequests.kyverno.io
 spec:
   group: kyverno.io
@@ -2410,10 +2972,14 @@ spec:
         description: GenerateRequest is a request to process generate rule.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2424,19 +2990,23 @@ spec:
                 description: Context ...
                 properties:
                   admissionRequestInfo:
-                    description: AdmissionRequestInfoObject stores the admission request and operation details
+                    description: AdmissionRequestInfoObject stores the admission request
+                      and operation details
                     properties:
                       admissionRequest:
                         type: string
                       operation:
-                        description: Operation is the type of resource operation being checked for admission control
+                        description: Operation is the type of resource operation being
+                          checked for admission control
                         type: string
                     type: object
                   userInfo:
-                    description: RequestInfo contains permission info carried in an admission request.
+                    description: RequestInfo contains permission info carried in an
+                      admission request.
                     properties:
                       clusterRoles:
-                        description: ClusterRoles is a list of possible clusterRoles send the request.
+                        description: ClusterRoles is a list of possible clusterRoles
+                          send the request.
                         items:
                           type: string
                         nullable: true
@@ -2448,15 +3018,18 @@ spec:
                         nullable: true
                         type: array
                       userInfo:
-                        description: UserInfo is the userInfo carried in the admission request.
+                        description: UserInfo is the userInfo carried in the admission
+                          request.
                         properties:
                           extra:
                             additionalProperties:
-                              description: ExtraValue masks the value so protobuf can generate
+                              description: ExtraValue masks the value so protobuf
+                                can generate
                               items:
                                 type: string
                               type: array
-                            description: Any additional information provided by the authenticator.
+                            description: Any additional information provided by the
+                              authenticator.
                             type: object
                           groups:
                             description: The names of groups this user is a part of.
@@ -2464,10 +3037,14 @@ spec:
                               type: string
                             type: array
                           uid:
-                            description: A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs.
+                            description: A unique value that identifies this user
+                              across time. If this user is deleted and another user
+                              by the same name is added, they will have different
+                              UIDs.
                             type: string
                           username:
-                            description: The name that uniquely identifies this user among all active users.
+                            description: The name that uniquely identifies this user
+                              among all active users.
                             type: string
                         type: object
                     type: object
@@ -2476,7 +3053,8 @@ spec:
                 description: Specifies the name of the policy.
                 type: string
               resource:
-                description: ResourceSpec is the information to identify the generate request.
+                description: ResourceSpec is the information to identify the generate
+                  request.
                 properties:
                   apiVersion:
                     description: APIVersion specifies resource apiVersion.
@@ -2500,7 +3078,8 @@ spec:
             description: Status contains statistics related to generate request.
             properties:
               generatedResources:
-                description: This will track the resources that are generated by the generate Policy. Will be used during clean up resources.
+                description: This will track the resources that are generated by the
+                  generate Policy. Will be used during clean up resources.
                 items:
                   description: ResourceSpec contains information to identify a resource.
                   properties:
@@ -2540,20 +3119,14 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-    config.kubernetes.io/index: '5'
   creationTimestamp: null
-  labels:
-    app.kubernetes.io/component: kyverno
-    app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: latest
   name: policies.kyverno.io
 spec:
   group: kyverno.io
@@ -2583,13 +3156,19 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: 'Policy declares validation, mutation, and generation behaviors for matching resources. See: https://kyverno.io/docs/writing-policies/ for more information.'
+        description: 'Policy declares validation, mutation, and generation behaviors
+          for matching resources. See: https://kyverno.io/docs/writing-policies/ for
+          more information.'
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2597,32 +3176,58 @@ spec:
             description: Spec defines policy behaviors and contains one or more rules.
             properties:
               background:
-                description: Background controls if rules are applied to existing resources during a background scan. Optional. Default value is "true". The value must be set to "false" if the policy rule uses variables that are only available in the admission review request (e.g. user name).
+                description: Background controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
                 type: boolean
               failurePolicy:
-                description: FailurePolicy defines how unrecognized errors from the admission endpoint are handled. Rules within the same policy share the same failure behavior. Allowed values are Ignore or Fail. Defaults to Fail.
+                description: FailurePolicy defines how unrecognized errors from the
+                  admission endpoint are handled. Rules within the same policy share
+                  the same failure behavior. Allowed values are Ignore or Fail. Defaults
+                  to Fail.
                 enum:
                 - Ignore
                 - Fail
                 type: string
               rules:
-                description: Rules is a list of Rule instances. A Policy contains multiple rules and each rule can validate, mutate, or generate resources.
+                description: Rules is a list of Rule instances. A Policy contains
+                  multiple rules and each rule can validate, mutate, or generate resources.
                 items:
-                  description: Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.
+                  description: Rule defines a validation, mutation, or generation
+                    control for matching resources. Each rules contains a match declaration
+                    to select resources, and an optional exclude declaration to specify
+                    which resources to exclude.
                   properties:
                     context:
-                      description: Context defines variables and data sources that can be used during rule execution.
+                      description: Context defines variables and data sources that
+                        can be used during rule execution.
                       items:
-                        description: ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.
+                        description: ContextEntry adds variables and data sources
+                          to a rule Context. Either a ConfigMap reference or a APILookup
+                          must be provided.
                         properties:
                           apiCall:
-                            description: APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.
+                            description: APICall defines an HTTP request to the Kubernetes
+                              API server. The JSON data retrieved is stored in the
+                              context.
                             properties:
                               jmesPath:
-                                description: JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of "items | length(@)" applied to the API server response to the URLPath "/apis/apps/v1/deployments" will return the total count of deployments across all namespaces.
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the JSON response
+                                  returned from the API server. For example a JMESPath
+                                  of "items | length(@)" applied to the API server
+                                  response to the URLPath "/apis/apps/v1/deployments"
+                                  will return the total count of deployments across
+                                  all namespaces.
                                 type: string
                               urlPath:
-                                description: URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments"). The format required is the same format used by the `kubectl get --raw` command.
+                                description: URLPath is the URL path to be used in
+                                  the HTTP GET request to the Kubernetes API server
+                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                  The format required is the same format used by the
+                                  `kubectl get --raw` command.
                                 type: string
                             required:
                             - urlPath
@@ -2640,13 +3245,17 @@ spec:
                             - name
                             type: object
                           imageRegistry:
-                            description: ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.
+                            description: ImageRegistry defines requests to an OCI/Docker
+                              V2 registry to fetch image details.
                             properties:
                               jmesPath:
-                                description: JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the ImageData struct
+                                  returned as a result of processing the image reference.
                                 type: string
                               reference:
-                                description: 'Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
+                                description: 'Reference is image reference to a container
+                                  image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
                                 type: string
                             required:
                             - reference
@@ -2657,25 +3266,36 @@ spec:
                         type: object
                       type: array
                     exclude:
-                      description: ExcludeResources defines when this policy rule should not be applied. The exclude criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the name or role.
+                      description: ExcludeResources defines when this policy rule
+                        should not be applied. The exclude criteria can include resource
+                        information (e.g. kind, name, namespace, labels) and admission
+                        review request information like the name or role.
                       properties:
                         all:
-                          description: All allows specifying resources which will be ANDed
+                          description: All allows specifying resources which will
+                            be ANDed
                           items:
-                            description: ResourceFilter allow users to "AND" or "OR" between resources
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -2683,29 +3303,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2717,30 +3367,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2752,31 +3432,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -2786,22 +3487,30 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will be ORed
+                          description: Any allows specifying resources which will
+                            be ORed
                           items:
-                            description: ResourceFilter allow users to "AND" or "OR" between resources
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -2809,29 +3518,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2843,30 +3582,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2878,31 +3647,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -2912,17 +3702,25 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role names for the user.
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about the resource being created or modified. Specifying ResourceDescription directly under exclude is being deprecated. Please specify under "any" or "all" instead.
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Specifying ResourceDescription
+                            directly under exclude is being deprecated. Please specify
+                            under "any" or "all" instead.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -2930,29 +3728,52 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -2964,30 +3785,54 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -2999,31 +3844,51 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names for the user.
+                          description: Roles is the list of namespaced role names
+                            for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
                                 type: string
                             required:
                             - kind
@@ -3038,7 +3903,10 @@ spec:
                           description: APIVersion specifies resource apiVersion.
                           type: string
                         clone:
-                          description: Clone specifies the source resource used to populate each generated resource. At most one of Data or Clone can be specified. If neither are provided, the generated resource will be created with default data only.
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           properties:
                             name:
                               description: Name specifies name of the resource.
@@ -3048,7 +3916,10 @@ spec:
                               type: string
                           type: object
                         data:
-                          description: Data provides the resource declaration used to populate each generated resource. At most one of Data or Clone must be specified. If neither are provided, the generated resource will be created with default data only.
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
                           x-kubernetes-preserve-unknown-fields: true
                         kind:
                           description: Kind specifies resource kind.
@@ -3060,29 +3931,46 @@ spec:
                           description: Namespace specifies resource namespace.
                           type: string
                         synchronize:
-                          description: Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to "true" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to "false" if not specified.
+                          description: Synchronize controls if generated resources
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
+                            Defaults to "false" if not specified.
                           type: boolean
                       type: object
                     match:
-                      description: MatchResources defines when this policy rule should be applied. The match criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the user name or role. At least one kind is required.
+                      description: MatchResources defines when this policy rule should
+                        be applied. The match criteria can include resource information
+                        (e.g. kind, name, namespace, labels) and admission review
+                        request information like the user name or role. At least one
+                        kind is required.
                       properties:
                         all:
-                          description: All allows specifying resources which will be ANDed
+                          description: All allows specifying resources which will
+                            be ANDed
                           items:
-                            description: ResourceFilter allow users to "AND" or "OR" between resources
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -3090,29 +3978,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3124,30 +4042,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3159,31 +4107,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -3193,22 +4162,30 @@ spec:
                             type: object
                           type: array
                         any:
-                          description: Any allows specifying resources which will be ORed
+                          description: Any allows specifying resources which will
+                            be ORed
                           items:
-                            description: ResourceFilter allow users to "AND" or "OR" between resources
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
                             properties:
                               clusterRoles:
-                                description: ClusterRoles is the list of cluster-wide role names for the user.
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
                                 items:
                                   type: string
                                 type: array
                               resources:
-                                description: ResourceDescription contains information about the resource being created or modified.
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
                                 properties:
                                   annotations:
                                     additionalProperties:
                                       type: string
-                                    description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
                                     type: object
                                   kinds:
                                     description: Kinds is a list of resource kinds.
@@ -3216,29 +4193,59 @@ spec:
                                       type: string
                                     type: array
                                   name:
-                                    description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
                                     type: string
                                   names:
-                                    description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
                                     items:
                                       type: string
                                     type: array
                                   namespaceSelector:
-                                    description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3250,30 +4257,60 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
                                     items:
                                       type: string
                                     type: array
                                   selector:
-                                    description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3285,31 +4322,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                 type: object
                               roles:
-                                description: Roles is the list of namespaced role names for the user.
+                                description: Roles is the list of namespaced role
+                                  names for the user.
                                 items:
                                   type: string
                                 type: array
                               subjects:
-                                description: Subjects is the list of subject names like users, user groups, and service accounts.
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
                                 items:
-                                  description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
                                       type: string
                                     kind:
-                                      description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
                                       type: string
                                     name:
                                       description: Name of the object being referenced.
                                       type: string
                                     namespace:
-                                      description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
                                       type: string
                                   required:
                                   - kind
@@ -3319,17 +4377,26 @@ spec:
                             type: object
                           type: array
                         clusterRoles:
-                          description: ClusterRoles is the list of cluster-wide role names for the user.
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
                           items:
                             type: string
                           type: array
                         resources:
-                          description: ResourceDescription contains information about the resource being created or modified. Requires at least one tag to be specified when under MatchResources. Specifying ResourceDescription directly under match is being deprecated. Please specify under "any" or "all" instead.
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Requires at least
+                            one tag to be specified when under MatchResources. Specifying
+                            ResourceDescription directly under match is being deprecated.
+                            Please specify under "any" or "all" instead.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters "*" (matches zero or many characters) and "?" (matches at least one character).
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
                               type: object
                             kinds:
                               description: Kinds is a list of resource kinds.
@@ -3337,29 +4404,52 @@ spec:
                                 type: string
                               type: array
                             name:
-                              description: Name is the name of the resource. The name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
                               type: string
                             names:
-                              description: 'Names are the names of the resources. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character). NOTE: "Name" is being deprecated in favor of "Names".'
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
                               items:
                                 type: string
                               type: array
                             namespaceSelector:
-                              description: 'NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -3371,30 +4461,54 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
                               items:
                                 type: string
                               type: array
                             selector:
-                              description: 'Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like ["storage.k8s.io/*": "*"]. Note that using ["*" : "*"] matches any key and value but does not match an empty label set.'
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -3406,31 +4520,51 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                           type: object
                         roles:
-                          description: Roles is the list of namespaced role names for the user.
+                          description: Roles is the list of namespaced role names
+                            for the user.
                           items:
                             type: string
                           type: array
                         subjects:
-                          description: Subjects is the list of subject names like users, user groups, and service accounts.
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
                           items:
-                            description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
                             properties:
                               apiGroup:
-                                description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
                                 type: string
                               kind:
-                                description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
                                 type: string
                               name:
                                 description: Name of the object being referenced.
                                 type: string
                               namespace:
-                                description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
                                 type: string
                             required:
                             - kind
@@ -3442,23 +4576,45 @@ spec:
                       description: Mutation is used to modify matching resources.
                       properties:
                         foreach:
-                          description: ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.
+                          description: ForEach applies mutation rules to a list of
+                            sub-elements by creating a context for each entry in the
+                            list and looping over it to apply the specified logic.
                           items:
-                            description: ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.
+                            description: ForEach applies mutation rules to a list
+                              of sub-elements by creating a context for each entry
+                              in the list and looping over it to apply the specified
+                              logic.
                             properties:
                               context:
-                                description: Context defines variables and data sources that can be used during rule execution.
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
                                 items:
-                                  description: ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
                                   properties:
                                     apiCall:
-                                      description: APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
                                       properties:
                                         jmesPath:
-                                          description: JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of "items | length(@)" applied to the API server response to the URLPath "/apis/apps/v1/deployments" will return the total count of deployments across all namespaces.
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
                                           type: string
                                         urlPath:
-                                          description: URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments"). The format required is the same format used by the `kubectl get --raw` command.
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
                                           type: string
                                       required:
                                       - urlPath
@@ -3470,19 +4626,27 @@ spec:
                                           description: Name is the ConfigMap name.
                                           type: string
                                         namespace:
-                                          description: Namespace is the ConfigMap namespace.
+                                          description: Namespace is the ConfigMap
+                                            namespace.
                                           type: string
                                       required:
                                       - name
                                       type: object
                                     imageRegistry:
-                                      description: ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
                                       properties:
                                         jmesPath:
-                                          description: JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
                                           type: string
                                         reference:
-                                          description: 'Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
                                           type: string
                                       required:
                                       - reference
@@ -3493,27 +4657,49 @@ spec:
                                   type: object
                                 type: array
                               list:
-                                description: List specifies a JMESPath expression that results in one or more elements to which the validation logic is applied.
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
                                 type: string
                               patchStrategicMerge:
-                                description: PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                                description: PatchStrategicMerge is a strategic merge
+                                  patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                  and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
                                 x-kubernetes-preserve-unknown-fields: true
                               patchesJson6902:
-                                description: PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                                description: PatchesJSON6902 is a list of RFC 6902
+                                  JSON Patch declarations used to modify resources.
+                                  See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
                                 type: string
                               preconditions:
-                                description: 'AnyAllConditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
                                 properties:
                                   all:
-                                    description: AllConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, all of the conditions need to pass
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
                                     items:
-                                      description: Condition defines variable-based conditional criteria for rule execution.
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
                                       properties:
                                         key:
-                                          description: Key is the context entry (using JMESPath) for conditional rule evaluation.
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
                                           x-kubernetes-preserve-unknown-fields: true
                                         operator:
-                                          description: 'Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
                                           enum:
                                           - Equals
                                           - NotEquals
@@ -3533,20 +4719,36 @@ spec:
                                           - DurationLessThan
                                           type: string
                                         value:
-                                          description: Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using using JMESPath.
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
                                           x-kubernetes-preserve-unknown-fields: true
                                       type: object
                                     type: array
                                   any:
-                                    description: AnyConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, at least one of the conditions need to pass
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
                                     items:
-                                      description: Condition defines variable-based conditional criteria for rule execution.
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
                                       properties:
                                         key:
-                                          description: Key is the context entry (using JMESPath) for conditional rule evaluation.
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
                                           x-kubernetes-preserve-unknown-fields: true
                                         operator:
-                                          description: 'Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
                                           enum:
                                           - Equals
                                           - NotEquals
@@ -3566,7 +4768,10 @@ spec:
                                           - DurationLessThan
                                           type: string
                                         value:
-                                          description: Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using using JMESPath.
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
                                           x-kubernetes-preserve-unknown-fields: true
                                       type: object
                                     type: array
@@ -3575,53 +4780,94 @@ spec:
                             type: object
                           type: array
                         patchStrategicMerge:
-                          description: PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          description: PatchStrategicMerge is a strategic merge patch
+                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
                           x-kubernetes-preserve-unknown-fields: true
                         patchesJson6902:
-                          description: PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON
+                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
                           type: string
                       type: object
                     name:
-                      description: Name is a label to identify the rule, It must be unique within the policy.
+                      description: Name is a label to identify the rule, It must be
+                        unique within the policy.
                       maxLength: 63
                       type: string
                     preconditions:
-                      description: 'Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      description: 'Preconditions are used to determine if a policy
+                        rule should be applied by evaluating a set of conditions.
+                        The declaration can contain nested `any` or `all` statements.
+                        A direct list of conditions (without `any` or `all` statements
+                        is supported for backwards compatibility but will be deprecated
+                        in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
                       x-kubernetes-preserve-unknown-fields: true
                     validate:
                       description: Validation is used to validate matching resources.
                       properties:
                         anyPattern:
-                          description: AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.
+                          description: AnyPattern specifies list of validation patterns.
+                            At least one of the patterns must be satisfied for the
+                            validation rule to succeed.
                           x-kubernetes-preserve-unknown-fields: true
                         deny:
-                          description: Deny defines conditions used to pass or fail a validation rule.
+                          description: Deny defines conditions used to pass or fail
+                            a validation rule.
                           properties:
                             conditions:
-                              description: 'Multiple conditions can be declared under an `any` or `all` statement. A direct list of conditions (without `any` or `all` statements) is also supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              description: 'Multiple conditions can be declared under
+                                an `any` or `all` statement. A direct list of conditions
+                                (without `any` or `all` statements) is also supported
+                                for backwards compatibility but will be deprecated
+                                in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
                               x-kubernetes-preserve-unknown-fields: true
                           type: object
                         foreach:
-                          description: ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.
+                          description: ForEach applies validate rules to a list of
+                            sub-elements by creating a context for each entry in the
+                            list and looping over it to apply the specified logic.
                           items:
-                            description: ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.
+                            description: ForEach applies validate rules to a list
+                              of sub-elements by creating a context for each entry
+                              in the list and looping over it to apply the specified
+                              logic.
                             properties:
                               anyPattern:
-                                description: AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.
+                                description: AnyPattern specifies list of validation
+                                  patterns. At least one of the patterns must be satisfied
+                                  for the validation rule to succeed.
                                 x-kubernetes-preserve-unknown-fields: true
                               context:
-                                description: Context defines variables and data sources that can be used during rule execution.
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
                                 items:
-                                  description: ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
                                   properties:
                                     apiCall:
-                                      description: APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
                                       properties:
                                         jmesPath:
-                                          description: JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of "items | length(@)" applied to the API server response to the URLPath "/apis/apps/v1/deployments" will return the total count of deployments across all namespaces.
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
                                           type: string
                                         urlPath:
-                                          description: URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments"). The format required is the same format used by the `kubectl get --raw` command.
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
                                           type: string
                                       required:
                                       - urlPath
@@ -3633,19 +4879,27 @@ spec:
                                           description: Name is the ConfigMap name.
                                           type: string
                                         namespace:
-                                          description: Namespace is the ConfigMap namespace.
+                                          description: Namespace is the ConfigMap
+                                            namespace.
                                           type: string
                                       required:
                                       - name
                                       type: object
                                     imageRegistry:
-                                      description: ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
                                       properties:
                                         jmesPath:
-                                          description: JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
                                           type: string
                                         reference:
-                                          description: 'Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
                                           type: string
                                       required:
                                       - reference
@@ -3656,34 +4910,64 @@ spec:
                                   type: object
                                 type: array
                               deny:
-                                description: Deny defines conditions used to pass or fail a validation rule.
+                                description: Deny defines conditions used to pass
+                                  or fail a validation rule.
                                 properties:
                                   conditions:
-                                    description: 'Multiple conditions can be declared under an `any` or `all` statement. A direct list of conditions (without `any` or `all` statements) is also supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                    description: 'Multiple conditions can be declared
+                                      under an `any` or `all` statement. A direct
+                                      list of conditions (without `any` or `all` statements)
+                                      is also supported for backwards compatibility
+                                      but will be deprecated in the next major release.
+                                      See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
                                     x-kubernetes-preserve-unknown-fields: true
                                 type: object
                               elementScope:
-                                description: ElementScope specifies whether to use the current list element as the scope for validation. Defaults to "true" if not specified. When set to "false", "request.object" is used as the validation scope within the foreach block to allow referencing other elements in the subtree.
+                                description: ElementScope specifies whether to use
+                                  the current list element as the scope for validation.
+                                  Defaults to "true" if not specified. When set to
+                                  "false", "request.object" is used as the validation
+                                  scope within the foreach block to allow referencing
+                                  other elements in the subtree.
                                 type: boolean
                               list:
-                                description: List specifies a JMESPath expression that results in one or more elements to which the validation logic is applied.
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
                                 type: string
                               pattern:
-                                description: Pattern specifies an overlay-style pattern used to check resources.
+                                description: Pattern specifies an overlay-style pattern
+                                  used to check resources.
                                 x-kubernetes-preserve-unknown-fields: true
                               preconditions:
-                                description: 'AnyAllConditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
                                 properties:
                                   all:
-                                    description: AllConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, all of the conditions need to pass
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
                                     items:
-                                      description: Condition defines variable-based conditional criteria for rule execution.
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
                                       properties:
                                         key:
-                                          description: Key is the context entry (using JMESPath) for conditional rule evaluation.
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
                                           x-kubernetes-preserve-unknown-fields: true
                                         operator:
-                                          description: 'Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
                                           enum:
                                           - Equals
                                           - NotEquals
@@ -3703,20 +4987,36 @@ spec:
                                           - DurationLessThan
                                           type: string
                                         value:
-                                          description: Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using using JMESPath.
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
                                           x-kubernetes-preserve-unknown-fields: true
                                       type: object
                                     type: array
                                   any:
-                                    description: AnyConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, at least one of the conditions need to pass
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
                                     items:
-                                      description: Condition defines variable-based conditional criteria for rule execution.
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
                                       properties:
                                         key:
-                                          description: Key is the context entry (using JMESPath) for conditional rule evaluation.
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
                                           x-kubernetes-preserve-unknown-fields: true
                                         operator:
-                                          description: 'Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
                                           enum:
                                           - Equals
                                           - NotEquals
@@ -3736,7 +5036,10 @@ spec:
                                           - DurationLessThan
                                           type: string
                                         value:
-                                          description: Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using using JMESPath.
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
                                           x-kubernetes-preserve-unknown-fields: true
                                       type: object
                                     type: array
@@ -3745,42 +5048,81 @@ spec:
                             type: object
                           type: array
                         message:
-                          description: Message specifies a custom message to be displayed on failure.
+                          description: Message specifies a custom message to be displayed
+                            on failure.
                           type: string
                         pattern:
-                          description: Pattern specifies an overlay-style pattern used to check resources.
+                          description: Pattern specifies an overlay-style pattern
+                            used to check resources.
                           x-kubernetes-preserve-unknown-fields: true
                       type: object
                     verifyImages:
-                      description: VerifyImages is used to verify image signatures and mutate them to add a digest
+                      description: VerifyImages is used to verify image signatures
+                        and mutate them to add a digest
                       items:
-                        description: ImageVerification validates that images that match the specified pattern are signed with the supplied public key. Once the image is verified it is mutated to include the SHA digest retrieved during the registration.
+                        description: ImageVerification validates that images that
+                          match the specified pattern are signed with the supplied
+                          public key. Once the image is verified it is mutated to
+                          include the SHA digest retrieved during the registration.
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
-                            description: Annotations are used for image verification. Every specified key-value pair must exist and match in the verified payload. The payload may contain other key-value pairs.
+                            description: Annotations are used for image verification.
+                              Every specified key-value pair must exist and match
+                              in the verified payload. The payload may contain other
+                              key-value pairs.
                             type: object
                           attestations:
-                            description: Attestations are optional checks for signed in-toto Statements used to verify the image. See https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the OCI registry and decodes them into a list of Statement declarations.
+                            description: Attestations are optional checks for signed
+                              in-toto Statements used to verify the image. See https://github.com/in-toto/attestation.
+                              Kyverno fetches signed attestations from the OCI registry
+                              and decodes them into a list of Statement declarations.
                             items:
-                              description: Attestation are checks for signed in-toto Statements that are used to verify the image. See https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the OCI registry and decodes them into a list of Statements.
+                              description: Attestation are checks for signed in-toto
+                                Statements that are used to verify the image. See
+                                https://github.com/in-toto/attestation. Kyverno fetches
+                                signed attestations from the OCI registry and decodes
+                                them into a list of Statements.
                               properties:
                                 conditions:
-                                  description: Conditions are used to verify attributes within a Predicate. If no Conditions are specified the attestation check is satisfied as long there are predicates that match the predicate type.
+                                  description: Conditions are used to verify attributes
+                                    within a Predicate. If no Conditions are specified
+                                    the attestation check is satisfied as long there
+                                    are predicates that match the predicate type.
                                   items:
-                                    description: AnyAllConditions consists of conditions wrapped denoting a logical criteria to be fulfilled. AnyConditions get fulfilled when at least one of its sub-conditions passes. AllConditions get fulfilled only when all of its sub-conditions pass.
+                                    description: AnyAllConditions consists of conditions
+                                      wrapped denoting a logical criteria to be fulfilled.
+                                      AnyConditions get fulfilled when at least one
+                                      of its sub-conditions passes. AllConditions
+                                      get fulfilled only when all of its sub-conditions
+                                      pass.
                                     properties:
                                       all:
-                                        description: AllConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, all of the conditions need to pass
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
                                         items:
-                                          description: Condition defines variable-based conditional criteria for rule execution.
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
                                           properties:
                                             key:
-                                              description: Key is the context entry (using JMESPath) for conditional rule evaluation.
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
                                               x-kubernetes-preserve-unknown-fields: true
                                             operator:
-                                              description: 'Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
                                               enum:
                                               - Equals
                                               - NotEquals
@@ -3800,20 +5142,38 @@ spec:
                                               - DurationLessThan
                                               type: string
                                             value:
-                                              description: Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using using JMESPath.
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using using JMESPath.
                                               x-kubernetes-preserve-unknown-fields: true
                                           type: object
                                         type: array
                                       any:
-                                        description: AnyConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, at least one of the conditions need to pass
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
                                         items:
-                                          description: Condition defines variable-based conditional criteria for rule execution.
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
                                           properties:
                                             key:
-                                              description: Key is the context entry (using JMESPath) for conditional rule evaluation.
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
                                               x-kubernetes-preserve-unknown-fields: true
                                             operator:
-                                              description: 'Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
                                               enum:
                                               - Equals
                                               - NotEquals
@@ -3833,50 +5193,70 @@ spec:
                                               - DurationLessThan
                                               type: string
                                             value:
-                                              description: Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using using JMESPath.
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using using JMESPath.
                                               x-kubernetes-preserve-unknown-fields: true
                                           type: object
                                         type: array
                                     type: object
                                   type: array
                                 predicateType:
-                                  description: PredicateType defines the type of Predicate contained within the Statement.
+                                  description: PredicateType defines the type of Predicate
+                                    contained within the Statement.
                                   type: string
                               type: object
                             type: array
                           image:
-                            description: 'Image is the image name consisting of the registry address, repository, image, and tag. Wildcards (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                            description: 'Image is the image name consisting of the
+                              registry address, repository, image, and tag. Wildcards
+                              (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
                             type: string
                           issuer:
-                            description: Issuer is the certificate issuer used for keyless signing.
+                            description: Issuer is the certificate issuer used for
+                              keyless signing.
                             type: string
                           key:
-                            description: Key is the PEM encoded public key that the image or attestation is signed with.
+                            description: Key is the PEM encoded public key that the
+                              image or attestation is signed with.
                             type: string
                           repository:
-                            description: Repository is an optional alternate OCI repository to use for image signatures that match this rule. If specified Repository will override the default OCI image repository configured for the installation.
+                            description: Repository is an optional alternate OCI repository
+                              to use for image signatures that match this rule. If
+                              specified Repository will override the default OCI image
+                              repository configured for the installation.
                             type: string
                           roots:
-                            description: Roots is the PEM encoded Root certificate chain used for keyless signing
+                            description: Roots is the PEM encoded Root certificate
+                              chain used for keyless signing
                             type: string
                           subject:
-                            description: Subject is the verified identity used for keyless signing, for example the email address
+                            description: Subject is the verified identity used for
+                              keyless signing, for example the email address
                             type: string
                         type: object
                       type: array
                   type: object
                 type: array
               schemaValidation:
-                description: SchemaValidation skips policy validation checks. Optional. The default value is set to "true", it must be set to "false" to disable the validation checks.
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
                 type: boolean
               validationFailureAction:
-                description: ValidationFailureAction controls if a validation policy rule failure should disallow the admission review request (enforce), or allow (audit) the admission review request and report an error in a policy report. Optional. The default value is "audit".
+                description: ValidationFailureAction controls if a validation policy
+                  rule failure should disallow the admission review request (enforce),
+                  or allow (audit) the admission review request and report an error
+                  in a policy report. Optional. The default value is "audit".
                 enum:
                 - audit
                 - enforce
                 type: string
               validationFailureActionOverrides:
-                description: ValidationFailureActionOverrides is a Cluster Policy attribute that specifies ValidationFailureAction namespace-wise. It overrides ValidationFailureAction for the specified namespaces.
+                description: ValidationFailureActionOverrides is a Cluster Policy
+                  attribute that specifies ValidationFailureAction namespace-wise.
+                  It overrides ValidationFailureAction for the specified namespaces.
                 items:
                   properties:
                     action:
@@ -3891,15 +5271,92 @@ spec:
                   type: object
                 type: array
               webhookTimeoutSeconds:
-                description: WebhookTimeoutSeconds specifies the maximum time in seconds allowed to apply this policy. After the configured time expires, the admission request may fail, or may simply ignore the policy results, based on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.
+                description: WebhookTimeoutSeconds specifies the maximum time in seconds
+                  allowed to apply this policy. After the configured time expires,
+                  the admission request may fail, or may simply ignore the policy
+                  results, based on the failure policy. The default timeout is 10s,
+                  the value must be between 1 and 30 seconds.
                 format: int32
                 type: integer
             type: object
           status:
-            description: Status contains policy runtime information. Deprecated. Policy metrics are available via the metrics endpoint
+            description: Status contains policy runtime information. Deprecated. Policy
+              metrics are available via the metrics endpoint
             properties:
+              conditions:
+                description: Conditions is a list of conditions that apply to the
+                  policy
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               ready:
-                description: Ready indicates if the policy is ready to serve the admission request
+                description: Ready indicates if the policy is ready to serve the admission
+                  request
                 type: boolean
             required:
             - ready
@@ -3917,20 +5374,1364 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-    config.kubernetes.io/index: '6'
   creationTimestamp: null
-  labels:
-    app.kubernetes.io/component: kyverno
-    app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: latest
+  name: reportchangerequests.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: ReportChangeRequest
+    listKind: ReportChangeRequestList
+    plural: reportchangerequests
+    shortNames:
+    - rcr
+    singular: reportchangerequest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ReportChangeRequest is the Schema for the ReportChangeRequests
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                data:
+                  additionalProperties:
+                    type: string
+                  description: Data provides additional information for the policy
+                    rule
+                  type: object
+                message:
+                  description: Message is a short user friendly description of the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name of the policy
+                  type: string
+                resourceSelector:
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                resources:
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
+                  items:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  type: array
+                rule:
+                  description: Rule is the name of the policy rule
+                  type: string
+                scored:
+                  description: Scored indicates if this policy rule is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy severity
+                  enum:
+                  - high
+                  - low
+                  - medium
+                  type: string
+                status:
+                  description: Status indicates the result of the policy rule check
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ReportChangeRequest is the Schema for the ReportChangeRequests
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                message:
+                  description: Message is a short user friendly description of the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name of the policy
+                  type: string
+                properties:
+                  additionalProperties:
+                    type: string
+                  description: Properties provides additional information for the
+                    policy rule
+                  type: object
+                resourceSelector:
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                resources:
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
+                  items:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  type: array
+                result:
+                  description: Result indicates the outcome of the policy rule execution
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+                rule:
+                  description: Rule is the name of the policy rule
+                  type: string
+                scored:
+                  description: Scored indicates if this policy rule is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy severity
+                  enum:
+                  - high
+                  - low
+                  - medium
+                  type: string
+                source:
+                  description: Source is an identifier for the policy engine that
+                    manages this report
+                  type: string
+                timestamp:
+                  description: Timestamp indicates the time the result was found
+                  properties:
+                    nanos:
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
+                      format: int32
+                      type: integer
+                    seconds:
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
+                      format: int64
+                      type: integer
+                  required:
+                  - nanos
+                  - seconds
+                  type: object
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: clusterpolicyreports.wgpolicyk8s.io
+spec:
+  group: wgpolicyk8s.io
+  names:
+    kind: ClusterPolicyReport
+    listKind: ClusterPolicyReportList
+    plural: clusterpolicyreports
+    shortNames:
+    - cpolr
+    singular: clusterpolicyreport
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterPolicyReport is the Schema for the clusterpolicyreports
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                data:
+                  additionalProperties:
+                    type: string
+                  description: Data provides additional information for the policy
+                    rule
+                  type: object
+                message:
+                  description: Message is a short user friendly description of the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name of the policy
+                  type: string
+                resourceSelector:
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                resources:
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
+                  items:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  type: array
+                rule:
+                  description: Rule is the name of the policy rule
+                  type: string
+                scored:
+                  description: Scored indicates if this policy rule is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy severity
+                  enum:
+                  - high
+                  - low
+                  - medium
+                  type: string
+                status:
+                  description: Status indicates the result of the policy rule check
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ClusterPolicyReport is the Schema for the clusterpolicyreports
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                message:
+                  description: Message is a short user friendly description of the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name of the policy
+                  type: string
+                properties:
+                  additionalProperties:
+                    type: string
+                  description: Properties provides additional information for the
+                    policy rule
+                  type: object
+                resourceSelector:
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                resources:
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
+                  items:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  type: array
+                result:
+                  description: Result indicates the outcome of the policy rule execution
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+                rule:
+                  description: Rule is the name of the policy rule
+                  type: string
+                scored:
+                  description: Scored indicates if this policy rule is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy severity
+                  enum:
+                  - high
+                  - low
+                  - medium
+                  type: string
+                source:
+                  description: Source is an identifier for the policy engine that
+                    manages this report
+                  type: string
+                timestamp:
+                  description: Timestamp indicates the time the result was found
+                  properties:
+                    nanos:
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
+                      format: int32
+                      type: integer
+                    seconds:
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
+                      format: int64
+                      type: integer
+                  required:
+                  - nanos
+                  - seconds
+                  type: object
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
   name: policyreports.wgpolicyk8s.io
 spec:
   group: wgpolicyk8s.io
@@ -3976,17 +6777,22 @@ spec:
         description: PolicyReport is the Schema for the policyreports API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
@@ -3994,30 +6800,46 @@ spec:
                 data:
                   additionalProperties:
                     type: string
-                  description: Data provides additional information for the policy rule
+                  description: Data provides additional information for the policy
+                    rule
                   type: object
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
                   type: string
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -4029,19 +6851,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -4053,7 +6914,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -4087,13 +6949,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -4105,28 +6977,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -4138,26 +7021,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object
@@ -4197,23 +7088,29 @@ spec:
         description: PolicyReport is the Schema for the policyreports API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           results:
             description: PolicyReportResult provides result details
             items:
-              description: PolicyReportResult provides the result for an individual policy
+              description: PolicyReportResult provides the result for an individual
+                policy
               properties:
                 category:
                   description: Category indicates policy category
                   type: string
                 message:
-                  description: Message is a short user friendly description of the policy rule
+                  description: Message is a short user friendly description of the
+                    policy rule
                   type: string
                 policy:
                   description: Policy is the name of the policy
@@ -4221,24 +7118,39 @@ spec:
                 properties:
                   additionalProperties:
                     type: string
-                  description: Properties provides additional information for the policy rule
+                  description: Properties provides additional information for the
+                    policy rule
                   type: object
                 resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -4250,19 +7162,58 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
                   items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -4274,7 +7225,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -4304,17 +7256,24 @@ spec:
                   - medium
                   type: string
                 source:
-                  description: Source is an identifier for the policy engine that manages this report
+                  description: Source is an identifier for the policy engine that
+                    manages this report
                   type: string
                 timestamp:
                   description: Timestamp indicates the time the result was found
                   properties:
                     nanos:
-                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
                       format: int32
                       type: integer
                     seconds:
-                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
                       format: int64
                       type: integer
                   required:
@@ -4326,13 +7285,23 @@ spec:
               type: object
             type: array
           scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
             properties:
               apiVersion:
                 description: API version of the referent.
                 type: string
               fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
                 type: string
               kind:
                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -4344,28 +7313,39 @@ spec:
                 description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                 type: string
               resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                 type: string
               uid:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
           scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
             properties:
               matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
                   properties:
                     key:
-                      description: key is the label key that the selector applies to.
+                      description: key is the label key that the selector applies
+                        to.
                       type: string
                     operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                       type: string
                     values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
                       items:
                         type: string
                       type: array
@@ -4377,518 +7357,34 @@ spec:
               matchLabels:
                 additionalProperties:
                   type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
                 type: object
             type: object
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
               error:
-                description: Error provides the count of policies that could not be evaluated
+                description: Error provides the count of policies that could not be
+                  evaluated
                 type: integer
               fail:
-                description: Fail provides the count of policies whose requirements were not met
+                description: Fail provides the count of policies whose requirements
+                  were not met
                 type: integer
               pass:
-                description: Pass provides the count of policies whose requirements were met
+                description: Pass provides the count of policies whose requirements
+                  were met
                 type: integer
               skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
                 type: integer
               warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
-    config.kubernetes.io/index: '7'
-  creationTimestamp: null
-  labels:
-    app.kubernetes.io/component: kyverno
-    app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: latest
-  name: reportchangerequests.kyverno.io
-spec:
-  group: kyverno.io
-  names:
-    kind: ReportChangeRequest
-    listKind: ReportChangeRequestList
-    plural: reportchangerequests
-    shortNames:
-    - rcr
-    singular: reportchangerequest
-  scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - jsonPath: .scope.kind
-      name: Kind
-      priority: 1
-      type: string
-    - jsonPath: .scope.name
-      name: Name
-      priority: 1
-      type: string
-    - jsonPath: .summary.pass
-      name: Pass
-      type: integer
-    - jsonPath: .summary.fail
-      name: Fail
-      type: integer
-    - jsonPath: .summary.warn
-      name: Warn
-      type: integer
-    - jsonPath: .summary.error
-      name: Error
-      type: integer
-    - jsonPath: .summary.skip
-      name: Skip
-      type: integer
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ReportChangeRequest is the Schema for the ReportChangeRequests API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          results:
-            description: PolicyReportResult provides result details
-            items:
-              description: PolicyReportResult provides the result for an individual policy
-              properties:
-                category:
-                  description: Category indicates policy category
-                  type: string
-                data:
-                  additionalProperties:
-                    type: string
-                  description: Data provides additional information for the policy rule
-                  type: object
-                message:
-                  description: Message is a short user friendly description of the policy rule
-                  type: string
-                policy:
-                  description: Policy is the name of the policy
-                  type: string
-                resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
-                  type: object
-                resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
-                  items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  type: array
-                rule:
-                  description: Rule is the name of the policy rule
-                  type: string
-                scored:
-                  description: Scored indicates if this policy rule is scored
-                  type: boolean
-                severity:
-                  description: Severity indicates policy severity
-                  enum:
-                  - high
-                  - low
-                  - medium
-                  type: string
-                status:
-                  description: Status indicates the result of the policy rule check
-                  enum:
-                  - pass
-                  - fail
-                  - warn
-                  - error
-                  - skip
-                  type: string
-              required:
-              - policy
-              type: object
-            type: array
-          scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
-            properties:
-              apiVersion:
-                description: API version of the referent.
-                type: string
-              fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                type: string
-              kind:
-                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
-              name:
-                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                type: string
-              namespace:
-                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                type: string
-              resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                type: string
-              uid:
-                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                type: string
-            type: object
-          scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
-            properties:
-              matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                  properties:
-                    key:
-                      description: key is the label key that the selector applies to.
-                      type: string
-                    operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                      type: string
-                    values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                      items:
-                        type: string
-                      type: array
-                  required:
-                  - key
-                  - operator
-                  type: object
-                type: array
-              matchLabels:
-                additionalProperties:
-                  type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                type: object
-            type: object
-          summary:
-            description: PolicyReportSummary provides a summary of results
-            properties:
-              error:
-                description: Error provides the count of policies that could not be evaluated
-                type: integer
-              fail:
-                description: Fail provides the count of policies whose requirements were not met
-                type: integer
-              pass:
-                description: Pass provides the count of policies whose requirements were met
-                type: integer
-              skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
-                type: integer
-              warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources: {}
-  - additionalPrinterColumns:
-    - jsonPath: .scope.kind
-      name: Kind
-      priority: 1
-      type: string
-    - jsonPath: .scope.name
-      name: Name
-      priority: 1
-      type: string
-    - jsonPath: .summary.pass
-      name: Pass
-      type: integer
-    - jsonPath: .summary.fail
-      name: Fail
-      type: integer
-    - jsonPath: .summary.warn
-      name: Warn
-      type: integer
-    - jsonPath: .summary.error
-      name: Error
-      type: integer
-    - jsonPath: .summary.skip
-      name: Skip
-      type: integer
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        description: ReportChangeRequest is the Schema for the ReportChangeRequests API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          results:
-            description: PolicyReportResult provides result details
-            items:
-              description: PolicyReportResult provides the result for an individual policy
-              properties:
-                category:
-                  description: Category indicates policy category
-                  type: string
-                message:
-                  description: Message is a short user friendly description of the policy rule
-                  type: string
-                policy:
-                  description: Policy is the name of the policy
-                  type: string
-                properties:
-                  additionalProperties:
-                    type: string
-                  description: Properties provides additional information for the policy rule
-                  type: object
-                resourceSelector:
-                  description: ResourceSelector is an optional selector for policy results that apply to multiple resources. For example, a policy result may apply to all pods that match a label. Either a Resource or a ResourceSelector can be specified. If neither are provided, the result is assumed to be for the policy report scope.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
-                  type: object
-                resources:
-                  description: Resources is an optional reference to the resource checked by the policy and rule
-                  items:
-                    description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  type: array
-                result:
-                  description: Result indicates the outcome of the policy rule execution
-                  enum:
-                  - pass
-                  - fail
-                  - warn
-                  - error
-                  - skip
-                  type: string
-                rule:
-                  description: Rule is the name of the policy rule
-                  type: string
-                scored:
-                  description: Scored indicates if this policy rule is scored
-                  type: boolean
-                severity:
-                  description: Severity indicates policy severity
-                  enum:
-                  - high
-                  - low
-                  - medium
-                  type: string
-                source:
-                  description: Source is an identifier for the policy engine that manages this report
-                  type: string
-                timestamp:
-                  description: Timestamp indicates the time the result was found
-                  properties:
-                    nanos:
-                      description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.
-                      format: int32
-                      type: integer
-                    seconds:
-                      description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
-                      format: int64
-                      type: integer
-                  required:
-                  - nanos
-                  - seconds
-                  type: object
-              required:
-              - policy
-              type: object
-            type: array
-          scope:
-            description: Scope is an optional reference to the report scope (e.g. a Deployment, Namespace, or Node)
-            properties:
-              apiVersion:
-                description: API version of the referent.
-                type: string
-              fieldPath:
-                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                type: string
-              kind:
-                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
-              name:
-                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                type: string
-              namespace:
-                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                type: string
-              resourceVersion:
-                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                type: string
-              uid:
-                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                type: string
-            type: object
-          scopeSelector:
-            description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
-            properties:
-              matchExpressions:
-                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                  properties:
-                    key:
-                      description: key is the label key that the selector applies to.
-                      type: string
-                    operator:
-                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                      type: string
-                    values:
-                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                      items:
-                        type: string
-                      type: array
-                  required:
-                  - key
-                  - operator
-                  type: object
-                type: array
-              matchLabels:
-                additionalProperties:
-                  type: string
-                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                type: object
-            type: object
-          summary:
-            description: PolicyReportSummary provides a summary of results
-            properties:
-              error:
-                description: Error provides the count of policies that could not be evaluated
-                type: integer
-              fail:
-                description: Fail provides the count of policies whose requirements were not met
-                type: integer
-              pass:
-                description: Pass provides the count of policies whose requirements were met
-                type: integer
-              skip:
-                description: Skip indicates the count of policies that were not selected for evaluation
-                type: integer
-              warn:
-                description: Warn provides the count of unscored policies whose requirements were not met
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
                 type: integer
             type: object
         type: object


### PR DESCRIPTION
This PR adds a `Makefile` target to generate helm CRDs template from config ones.
We should verify that they are up to date in CI too, will add that in a follow up PR if this one gets merged.

The changes in the labels should not be an issue, this should be added by Helm automatically I believe.