### PR TITLE
support RSA, ECDSA and EDDSA public key verification

### DIFF
--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sigstore/cosign/pkg/cosign/attestation"
 	"github.com/sigstore/cosign/pkg/oci"
 	sigs "github.com/sigstore/cosign/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
@@ -310,12 +311,12 @@ func stringToJSONMap(i interface{}) (map[string]interface{}, error) {
 
 func decodePEM(raw []byte) (signature.Verifier, error) {
 	// PEM encoded file.
-	ed, err := cosign.PemToECDSAKey(raw)
+	pubKey, err := cryptoutils.UnmarshalPEMToPublicKey(raw)
 	if err != nil {
-		return nil, errors.Wrap(err, "pem to ecdsa")
+		return nil, errors.Wrap(err, "pem to public key")
 	}
 
-	return signature.LoadECDSAVerifier(ed, crypto.SHA256)
+	return signature.LoadVerifier(pubKey, crypto.SHA256)
 }
 
 func extractPayload(verified []oci.Signature) ([]payload.SimpleContainerImage, error) {


### PR DESCRIPTION
Signed-off-by: Ivan Wallis <iwallis@gmail.com>

## Related issue

When attempting to verify a signed image using RSA you get:

```
kubectl run signed --image=localhost:5000/alpine:latest
Error from server: admission webhook "mutate.kyverno.svc-fail" denied the request: 

resource Pod/default/signed was blocked due to the following policies

check-image:
  check-image: 'image verification failed for localhost:5000/alpine:latest: loading
    credentials: pem to ecdsa: invalid public key: was *rsa.PublicKey, require *ecdsa.PublicKey'
```
## What type of PR is this


/kind feature


## Proposed Changes

Updates signature verification process to support RSA, ECDSA and EDDSA public keys as supported by cosign.

