### PR TITLE
fix PodExecOptions issue

### DIFF
--- a/pkg/autogen/rule.go
+++ b/pkg/autogen/rule.go
@@ -77,8 +77,8 @@ func generateRuleForControllers(rule kyverno.Rule, controllers string, log logr.
 	matchResourceDescriptionsKinds := rule.MatchKinds()
 	excludeResourceDescriptionsKinds := rule.ExcludeKinds()
 
-	if !utils.ContainsPod(matchResourceDescriptionsKinds, "Pod") ||
-		(len(excludeResourceDescriptionsKinds) != 0 && !utils.ContainsPod(excludeResourceDescriptionsKinds, "Pod")) {
+	if !utils.ContainsKind(matchResourceDescriptionsKinds, "Pod") ||
+		(len(excludeResourceDescriptionsKinds) != 0 && !utils.ContainsKind(excludeResourceDescriptionsKinds, "Pod")) {
 		return nil
 	}
 

--- a/pkg/autogen/utils.go
+++ b/pkg/autogen/utils.go
@@ -8,7 +8,7 @@ import (
 )
 
 func isKindOtherthanPod(kinds []string) bool {
-	if len(kinds) > 1 && utils.ContainsPod(kinds, "Pod") {
+	if len(kinds) > 1 && utils.ContainsKind(kinds, "Pod") {
 		return true
 	}
 	return false
@@ -39,7 +39,7 @@ func validateAnyPattern(anyPatterns []interface{}) []interface{} {
 func getAnyAllAutogenRule(v kyverno.ResourceFilters, controllers string) kyverno.ResourceFilters {
 	anyKind := v.DeepCopy()
 	for i, value := range v {
-		if utils.ContainsPod(value.Kinds, "Pod") {
+		if utils.ContainsKind(value.Kinds, "Pod") {
 			anyKind[i].Kinds = strings.Split(controllers, ",")
 		}
 	}
@@ -65,7 +65,7 @@ func stripCronJob(controllers string) string {
 func cronJobAnyAllAutogenRule(v kyverno.ResourceFilters) kyverno.ResourceFilters {
 	anyKind := v.DeepCopy()
 	for i, value := range v {
-		if utils.ContainsPod(value.Kinds, "Job") {
+		if utils.ContainsKind(value.Kinds, "Job") {
 			anyKind[i].Kinds = []string{PodControllerCronJob}
 		}
 	}

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -1506,7 +1506,7 @@ func validateKinds(kinds []string, mock bool, client *dclient.Client, p kyverno.
 			return fmt.Errorf("kind and match resource kind should not be the same")
 		}
 
-		if !mock {
+		if !mock && !utils.SkipSubResources(k) {
 			_, _, err := client.DiscoveryClient.FindResource(gv, k)
 			if err != nil {
 				return fmt.Errorf("unable to convert GVK to GVR, %s, err: %s", kinds, err)

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -36,7 +36,7 @@ func contains(list []string, element string, fn func(string, string) bool) bool 
 	return false
 }
 
-func ContainsPod(list []string, element string) bool {
+func ContainsKind(list []string, element string) bool {
 	for _, e := range list {
 		_, k := common.GetKindFromGVK(e)
 		if k == element {
@@ -44,6 +44,11 @@ func ContainsPod(list []string, element string) bool {
 		}
 	}
 	return false
+}
+
+func SkipSubResources(kind string) bool {
+	s := []string{"PodExecOptions", "PodAttachOptions", "PodProxyOptions", "ServiceProxyOptions", "NodeProxyOptions"}
+	return ContainsKind(s, kind)
 }
 
 // ContainsNamepace check if namespace satisfies any list of pattern(regex)

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -46,6 +46,7 @@ func ContainsKind(list []string, element string) bool {
 	return false
 }
 
+// note:  check to skip list of resources which don't have group.
 func SkipSubResources(kind string) bool {
 	s := []string{"PodExecOptions", "PodAttachOptions", "PodProxyOptions", "ServiceProxyOptions", "NodeProxyOptions"}
 	return ContainsKind(s, kind)

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -46,7 +46,7 @@ func ContainsKind(list []string, element string) bool {
 	return false
 }
 
-// note:  check to skip list of resources which don't have group.
+// SkipSubResources check to skip list of resources which don't have group.
 func SkipSubResources(kind string) bool {
 	s := []string{"PodExecOptions", "PodAttachOptions", "PodProxyOptions", "ServiceProxyOptions", "NodeProxyOptions"}
 	return ContainsKind(s, kind)


### PR DESCRIPTION
Signed-off-by: Vyankatesh vyankateshkd@gmail.com
closes : https://github.com/kyverno/kyverno/issues/3370

## Milestone of this PR
/milestone 1.6.2

## What type of PR is this
 /kind bug

### Proof Manifests
1. Create this policy.
```yaml
---
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: deny-exec-to-pod
  annotations:
    policies.kyverno.io/title: Block Pod Exec
    policies.kyverno.io/category: Sample
    policies.kyverno.io/minversion: 1.4.2
    policies.kyverno.io/subject: Pod
    policies.kyverno.io/description: >-
      The `exec` command may be used to gain shell access, or run other commands, in a Pod's container. While this can
      be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
spec:
  validationFailureAction: enforce
  background: false
  rules:
    - name: deny-pod-exec
      match:
        resources:
          kinds:
            - PodExecOptions
      preconditions:
        all:
          - key: "{{ request.operation }}"
            operator: Equals
            value: CONNECT
      validate:
        message: Containers can't be exec'd into in production.
        deny: {}
```

`Policy is created.`



<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->



<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
