### PR TITLE
e2e test for mutate policy

### DIFF
--- a/test/e2e/mutate/config.go
+++ b/test/e2e/mutate/config.go
@@ -109,6 +109,16 @@ var tests = []struct {
 		ExpectedPatternRaw: kyverno_2971_pattern,
 	},
 	{
+		TestDescription:    "checks if the imagePullSecrets is set or not",
+		PolicyName:         "set-image-pull-secret",
+		PolicyRaw:          setImagePullSecret,
+		ResourceName:       "nginx",
+		ResourceNamespace:  "test-run",
+		ResourceGVR:        podGVR,
+		ResourceRaw:        podWithNoSecrets,
+		ExpectedPatternRaw: podWithNoSecretPattern,
+	},
+	{
 		TestDescription:    "checks the global anchor variables for emptyDir",
 		PolicyName:         "add-safe-to-evict",
 		PolicyRaw:          annotate_host_path_policy,

--- a/test/e2e/mutate/mutate_test.go
+++ b/test/e2e/mutate/mutate_test.go
@@ -112,7 +112,7 @@ func Test_Mutate_Sets(t *testing.T) {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cmRes.GetLabels()["kyverno.key/copy-me"]).To(Equal("sample-value"))
 
-		//CleanUp Resources
+		// CleanUp Resources
 		e2eClient.CleanClusterPolicies(policyGVR)
 
 		// Clear Namespace

--- a/test/e2e/mutate/resources.go
+++ b/test/e2e/mutate/resources.go
@@ -625,6 +625,56 @@ spec:
               <(path): "*"
 `)
 
+var setImagePullSecret = []byte(`
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: set-image-pull-secret
+spec:
+  background: false
+  rules:
+  - name: set-image-pull-secret
+    match:
+      resources:
+        kinds:
+          - Pod
+    mutate:
+      patchStrategicMerge:
+        spec:
+          containers:
+            # match images that are from our registry
+            - <(image): "registry.corp.com/*"
+              # set the imagePullSecrets
+          imagePullSecrets:
+            - name: regcred
+`)
+
+var podWithNoSecrets = []byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  namespace: test-run
+spec:
+  containers:
+  - name: nginx
+    image: registry.corp.com/nginx:1.14.2
+`)
+
+var podWithNoSecretPattern = []byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  namespace: test-run
+spec:
+  containers:
+  - name: nginx
+    image: registry.corp.com/nginx:1.14.2
+  imagePullSecrets:
+    - name: regcred
+`)
+
 var podWithEmptyDirAsVolume = []byte(`
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
Signed-off-by: slayer321 <sachin.maurya7666@gmail.com>

## Related issue
closes https://github.com/kyverno/kyverno/issues/2358
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Added e2e test to set-image-pull-secret
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
cc @chipzoller