### PR TITLE
Fix for GVK not working for existing resources policy

### DIFF
--- a/pkg/policy/existing.go
+++ b/pkg/policy/existing.go
@@ -205,7 +205,8 @@ func (pc *PolicyController) processExistingKinds(kind []string, policy *kyverno.
 		logger = logger.WithValues("rule", rule.Name, "kind", k)
 		_, err := pc.rm.GetScope(k)
 		if err != nil {
-			resourceSchema, _, err := pc.client.DiscoveryClient.FindResource("", k)
+			gv, k := common.GetKindFromGVK(k)
+			resourceSchema, _, err := pc.client.DiscoveryClient.FindResource(gv, k)
 			if err != nil {
 				logger.Error(err, "failed to find resource", "kind", k)
 				continue

--- a/pkg/policy/validate_test.go
+++ b/pkg/policy/validate_test.go
@@ -1606,3 +1606,48 @@ func Test_deny_exec(t *testing.T) {
 	err = Validate(policy, nil, true, openAPIController)
 	assert.NilError(t, err)
 }
+
+func Test_existing_resource_policy(t *testing.T) {
+	var err error
+	rawPolicy := []byte(`{
+		"apiVersion": "kyverno.io/v1",
+		"kind": "ClusterPolicy",
+		"metadata": {
+		  "name": "np-test-1"
+		},
+		"spec": {
+		  "validationFailureAction": "audit",
+		  "rules": [
+			{
+			  "name": "no-LoadBalancer",
+			  "match": {
+				"any": [
+				  {
+					"resources": {
+					  "kinds": [
+						"networking.k8s.io/v1/NetworkPolicy"
+					  ]
+					}
+				  }
+				]
+			  },
+			  "validate": {
+				"message": "np-test",
+				"pattern": {
+				  "metadata": {
+					"name": "?*"
+				  }
+				}
+			  }
+			}
+		  ]
+		}
+	  }`)
+	var policy *kyverno.ClusterPolicy
+	err = json.Unmarshal(rawPolicy, &policy)
+	assert.NilError(t, err)
+
+	openAPIController, _ := openapi.NewOpenAPIController()
+	err = Validate(policy, nil, true, openAPIController)
+	assert.NilError(t, err)
+}


### PR DESCRIPTION
Signed-off-by: Vyankatesh vyankateshkd@gmail.com
closes : https://github.com/kyverno/kyverno/issues/3349

## Milestone of this PR
/milestone 1.6.2

## What type of PR is this
 /kind bug

### Proof Manifests
1. create NetworkPolicy
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: test-network-policy
  namespace: default
spec:
  podSelector:
    matchLabels:
      role: db
  policyTypes:
  - Ingress
  - Egress
```

2 . Create this policy.
```yaml
---
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: np-test
spec:
  validationFailureAction: audit
  rules:
  - name: no-LoadBalancer
    match:
      any:
      - resources:
          kinds:
          - networking.k8s.io/v1/NetworkPolicy
    validate:
      message: "np-test"
      pattern:
        metadata:
          name: "?*"
```

`The error mention  the issue of **policyController "msg"="failed to find resource" "error"="kind 'networking.k8s.io/v1/NetworkPolicy'**   Fixed with changes.`



<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->



<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
