### PR TITLE
Fix webhook re-creation error

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -251,7 +251,7 @@ func main() {
 		stopCh,
 		log.Log)
 
-	webhookMonitor, err := webhookconfig.NewMonitor(kubeClient, log.Log.WithName("WebhookMonitor"))
+	webhookMonitor, err := webhookconfig.NewMonitor(kubeClient, log.Log)
 	if err != nil {
 		setupLog.Error(err, "failed to initialize webhookMonitor")
 		os.Exit(1)

--- a/pkg/webhookconfig/monitor.go
+++ b/pkg/webhookconfig/monitor.go
@@ -6,11 +6,13 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/event"
 	"github.com/kyverno/kyverno/pkg/tls"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
+	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 )
 
 //maxRetryCount defines the max deadline count
@@ -39,6 +41,9 @@ const (
 // not compare other details like the webhook settings.
 //
 type Monitor struct {
+	// deployClient is used to manage Kyverno deployment
+	deployClient appsv1.DeploymentInterface
+
 	// lastSeenRequestTime records the timestamp
 	// of the latest received admission request
 	lastSeenRequestTime time.Time
@@ -50,6 +55,7 @@ type Monitor struct {
 // NewMonitor returns a new instance of webhook monitor
 func NewMonitor(kubeClient kubernetes.Interface, log logr.Logger) (*Monitor, error) {
 	monitor := &Monitor{
+		deployClient:        kubeClient.AppsV1().Deployments(config.KyvernoNamespace),
 		lastSeenRequestTime: time.Now(),
 		log:                 log,
 	}
@@ -77,7 +83,7 @@ func (t *Monitor) Run(register *Register, certRenewer *tls.CertRenewer, eventGen
 	logger := t.log.WithName("webhookMonitor")
 
 	logger.V(4).Info("starting webhook monitor", "interval", idleCheckInterval.String())
-	status := newStatusControl(register, eventGen, t.log.WithName("WebhookStatusControl"))
+	status := newStatusControl(t.deployClient, eventGen, logger.WithName("WebhookStatusControl"))
 
 	ticker := time.NewTicker(tickerInterval)
 	defer ticker.Stop()
@@ -108,7 +114,7 @@ func (t *Monitor) Run(register *Register, certRenewer *tls.CertRenewer, eventGen
 
 			// update namespaceSelector every 30 seconds
 			if register.autoUpdateWebhooks {
-				logger.V(3).Info("updating webhook configurations for namespaceSelector with latest kyverno ConfigMap")
+				logger.V(4).Info("updating webhook configurations for namespaceSelector with latest kyverno ConfigMap")
 				register.UpdateWebhookChan <- true
 			}
 
@@ -125,14 +131,16 @@ func (t *Monitor) Run(register *Register, certRenewer *tls.CertRenewer, eventGen
 
 			switch {
 			case timeDiff > idleDeadline:
-				err := fmt.Errorf("admission control configuration error")
-				logger.Error(err, "webhook check failed", "deadline", idleDeadline.String())
+				err := fmt.Errorf("webhook hasn't received requests in %v, updating Kyverno to verify webhook status", idleDeadline.String())
+				logger.Error(err, "webhook check failed", "time", t.Time(), "lastRequestTimestamp", lastRequestTimeFromAnn)
+
+				// update deployment to renew lastSeenRequestTime
 				if err := status.failure(); err != nil {
 					logger.Error(err, "failed to annotate deployment webhook status to failure")
-				}
 
-				if err := register.Register(); err != nil {
-					logger.Error(err, "Failed to register webhooks")
+					if err := register.Register(); err != nil {
+						logger.Error(err, "Failed to register webhooks")
+					}
 				}
 
 			case timeDiff > 2*idleCheckInterval:
@@ -150,7 +158,7 @@ func (t *Monitor) Run(register *Register, certRenewer *tls.CertRenewer, eventGen
 			idleT := time.Since(*lastRequestTimeFromAnn)
 			if idleT > idleCheckInterval {
 				if t.Time().After(*lastRequestTimeFromAnn) {
-					logger.V(3).Info("updating annotation lastRequestTimestamp with the latest in-memory timestamp", "time", t.Time())
+					logger.V(3).Info("updating annotation lastRequestTimestamp with the latest in-memory timestamp", "time", t.Time(), "lastRequestTimestamp", lastRequestTimeFromAnn)
 					if err := status.UpdateLastRequestTimestmap(t.Time()); err != nil {
 						logger.Error(err, "failed to update lastRequestTimestamp annotation")
 					}

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -531,7 +531,7 @@ func (wrc *Register) constructVerifyMutatingWebhookConfig(caData []byte) *admreg
 				true,
 				wrc.timeoutSeconds,
 				admregapi.Rule{
-					Resources:   []string{"deployments/*"},
+					Resources:   []string{"deployments"},
 					APIGroups:   []string{"apps"},
 					APIVersions: []string{"v1"},
 				},
@@ -558,7 +558,7 @@ func (wrc *Register) constructDebugVerifyMutatingWebhookConfig(caData []byte) *a
 				true,
 				wrc.timeoutSeconds,
 				admregapi.Rule{
-					Resources:   []string{"deployments/*"},
+					Resources:   []string{"deployments"},
 					APIGroups:   []string{"apps"},
 					APIVersions: []string{"v1"},
 				},

--- a/pkg/webhookconfig/status.go
+++ b/pkg/webhookconfig/status.go
@@ -17,7 +17,6 @@ var deployName string = config.KyvernoDeploymentName
 var deployNamespace string = config.KyvernoNamespace
 
 const (
-	annCounter         string = "kyverno.io/generationCounter"
 	annWebhookStatus   string = "kyverno.io/webhookActive"
 	annLastRequestTime string = "kyverno.io/last-request-time"
 )

--- a/pkg/webhookconfig/status.go
+++ b/pkg/webhookconfig/status.go
@@ -1,15 +1,16 @@
 package webhookconfig
 
 import (
+	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/event"
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 )
 
 var deployName string = config.KyvernoDeploymentName
@@ -23,9 +24,9 @@ const (
 
 //statusControl controls the webhook status
 type statusControl struct {
-	register *Register
-	eventGen event.Interface
-	log      logr.Logger
+	deployClient appsv1.DeploymentInterface
+	eventGen     event.Interface
+	log          logr.Logger
 }
 
 //success ...
@@ -39,11 +40,11 @@ func (vc statusControl) failure() error {
 }
 
 // NewStatusControl creates a new webhook status control
-func newStatusControl(register *Register, eventGen event.Interface, log logr.Logger) *statusControl {
+func newStatusControl(deployClient appsv1.DeploymentInterface, eventGen event.Interface, log logr.Logger) *statusControl {
 	return &statusControl{
-		register: register,
-		eventGen: eventGen,
-		log:      log,
+		deployClient: deployClient,
+		eventGen:     eventGen,
+		log:          log,
 	}
 }
 
@@ -51,7 +52,7 @@ func (vc statusControl) setStatus(status string) error {
 	logger := vc.log.WithValues("name", deployName, "namespace", deployNamespace)
 	var ann map[string]string
 	var err error
-	deploy, err := vc.register.client.GetResource("", "Deployment", deployNamespace, deployName)
+	deploy, err := vc.deployClient.Get(context.TODO(), deployName, metav1.GetOptions{})
 	if err != nil {
 		logger.Error(err, "failed to get deployment")
 		return err
@@ -71,16 +72,15 @@ func (vc statusControl) setStatus(status string) error {
 		}
 	}
 
-	// set the status
-	logger.Info("updating deployment annotation", "key", annWebhookStatus, "val", status)
 	ann[annWebhookStatus] = status
 	deploy.SetAnnotations(ann)
 
-	// update counter
-	_, err = vc.register.client.UpdateResource("", "Deployment", deployNamespace, deploy, false)
+	_, err = vc.deployClient.Update(context.TODO(), deploy, metav1.UpdateOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "key %s, val %s", annWebhookStatus, status)
 	}
+
+	logger.Info("updated deployment annotation", "key", annWebhookStatus, "val", status)
 
 	// create event on kyverno deployment
 	createStatusUpdateEvent(status, vc.eventGen)
@@ -97,61 +97,15 @@ func createStatusUpdateEvent(status string, eventGen event.Interface) {
 	eventGen.Add(e)
 }
 
-//IncrementAnnotation ...
-func (vc statusControl) IncrementAnnotation() error {
-	logger := vc.log
-	var ann map[string]string
-	var err error
-	deploy, err := vc.register.client.GetResource("", "Deployment", deployNamespace, deployName)
-	if err != nil {
-		logger.Error(err, "failed to find Kyverno", "deployment", deployName, "namespace", deployNamespace)
-		return err
-	}
-
-	ann = deploy.GetAnnotations()
-	if ann == nil {
-		ann = map[string]string{}
-	}
-
-	if ann[annCounter] == "" {
-		ann[annCounter] = "0"
-	}
-
-	counter, err := strconv.Atoi(ann[annCounter])
-	if err != nil {
-		logger.Error(err, "Failed to parse string", "name", annCounter, "value", ann[annCounter])
-		return err
-	}
-
-	// increment counter
-	counter++
-	ann[annCounter] = strconv.Itoa(counter)
-
-	logger.V(3).Info("updating webhook test annotation", "key", annCounter, "value", counter, "deployment", deployName, "namespace", deployNamespace)
-	deploy.SetAnnotations(ann)
-
-	// update counter
-	_, err = vc.register.client.UpdateResource("", "Deployment", deployNamespace, deploy, false)
-	if err != nil {
-		logger.Error(err, fmt.Sprintf("failed to update annotation %s for deployment %s in namespace %s", annCounter, deployName, deployNamespace))
-		return err
-	}
-
-	return nil
-}
-
 func (vc statusControl) UpdateLastRequestTimestmap(new time.Time) error {
-	_, deploy, err := vc.register.GetKubePolicyDeployment()
+	deploy, err := vc.deployClient.Get(context.TODO(), deployName, metav1.GetOptions{})
 	if err != nil {
-		return errors.Wrap(err, "unable to get Kyverno deployment")
+		vc.log.WithName("UpdateLastRequestTimestmap").Error(err, "failed to get deployment")
+		return err
 	}
 
-	annotation, ok, err := unstructured.NestedStringMap(deploy.UnstructuredContent(), "metadata", "annotations")
-	if err != nil {
-		return errors.Wrap(err, "unable to get annotation")
-	}
-
-	if !ok {
+	annotation := deploy.GetAnnotations()
+	if annotation == nil {
 		annotation = make(map[string]string)
 	}
 
@@ -162,7 +116,7 @@ func (vc statusControl) UpdateLastRequestTimestmap(new time.Time) error {
 
 	annotation[annLastRequestTime] = string(t)
 	deploy.SetAnnotations(annotation)
-	_, err = vc.register.client.UpdateResource("", "Deployment", deploy.GetNamespace(), deploy, false)
+	_, err = vc.deployClient.Update(context.TODO(), deploy, metav1.UpdateOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "failed to update annotation %s for deployment %s in namespace %s", annLastRequestTime, deploy.GetName(), deploy.GetNamespace())
 	}

--- a/pkg/webhooks/checker.go
+++ b/pkg/webhooks/checker.go
@@ -5,8 +5,8 @@ import (
 )
 
 func (ws *WebhookServer) verifyHandler(request *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse {
-	logger := ws.log.WithValues("action", "verify", "uid", request.UID, "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation, "gvk", request.Kind.String())
-	logger.V(4).Info("incoming request")
+	logger := ws.log.WithValues("action", "verify", "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation, "gvk", request.Kind.String())
+	logger.V(3).Info("incoming request")
 	return &v1beta1.AdmissionResponse{
 		Allowed: true,
 	}

--- a/pkg/webhooks/checker.go
+++ b/pkg/webhooks/checker.go
@@ -5,8 +5,9 @@ import (
 )
 
 func (ws *WebhookServer) verifyHandler(request *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse {
-	logger := ws.log.WithValues("action", "verify", "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation, "gvk", request.Kind.String())
-	logger.V(3).Info("incoming request")
+	logger := ws.log.WithName("verifyHandler").WithValues("action", "verify", "kind", request.Kind, "namespace", request.Namespace, "name", request.Name, "operation", request.Operation, "gvk", request.Kind.String())
+	logger.V(3).Info("incoming request", "last admission request timestamp", ws.webhookMonitor.Time())
+
 	return &v1beta1.AdmissionResponse{
 		Allowed: true,
 	}

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -264,8 +264,6 @@ func (ws *WebhookServer) handlerFunc(handler func(request *v1beta1.AdmissionRequ
 		admissionReview.Response = handler(request)
 		writeResponse(rw, admissionReview)
 		logger.V(4).Info("admission review request processed", "time", time.Since(startTime).String())
-
-		return
 	}
 }
 


### PR DESCRIPTION
## Related issue

Closes https://github.com/kyverno/kyverno/issues/3265.
Closes https://github.com/kyverno/kyverno/issues/3286.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.6.2
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
This PR fixes webhook re-creation issue when the Kyverno is installed with multiple replicas and no policies. 

When we support `namespaceSelector` configuration of the webhook, it added a blocking call which blocks the webhook monitor from updating the `kyverno.io/last-request-time` annotation. Due to outdated request timestamp, Kyverno treats it as a webhook failure thus keeps re-creating webhook configurations.

In addition to the bug fix, this PR also switched to use the typed client to update/get Kyverno deployment, this avoids failures when using dynamic client, i.e., 
```
the object has been modified; please apply your changes to the latest version and try again
``` 

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
The test image is available via `ghcr.io/realshuting/kyverno:fix-webhook`.
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
