### PR TITLE
Fix check for generated webhook rules being equal to what the API server has

### DIFF
--- a/pkg/webhookconfig/configmanager_test.go
+++ b/pkg/webhookconfig/configmanager_test.go
@@ -1,0 +1,140 @@
+package webhookconfig
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+var (
+	emptyInternalRules []interface{}
+	emptyAPIRules      []interface{}
+
+	configmapsInternalRules []interface{}
+	configmapsAPIRules      []interface{}
+
+	configmapsSecretsInternalRules []interface{}
+	configmapsSecretsAPIRules      []interface{}
+
+	secretsConfigmapsInternalRules []interface{}
+	secretsConfigmapsAPIRules      []interface{}
+
+	badAPIRules []interface{}
+)
+
+func init() {
+	// No rules.
+	// Internal representation is a rule with no selectors.
+	// API server representation is no rule (nil).
+	emptyInternalRules = []interface{}{map[string]interface{}{}}
+	emptyAPIRules = nil
+
+	// Rule selecting configmaps.
+	// API server representation matches the internal
+	// representation but has extra fields "operations" and "scope",
+	// and is of interface types instead of strings.
+	configmapsInternalRules = []interface{}{
+		map[string]interface{}{
+			"apiGroups":   []string{""},
+			"apiVersions": []string{"v1"},
+			"resources":   []string{"configmaps"},
+		},
+	}
+	configmapsAPIRules = []interface{}{
+		map[string]interface{}{
+			"apiGroups":   []interface{}{""},
+			"apiVersions": []interface{}{"v1"},
+			"resources":   []interface{}{"configmaps"},
+			"operations":  []interface{}{"CREATE", "UPDATE", "DELETE", "CONNECT"},
+			"scope":       "*",
+		},
+	}
+
+	// Rule selecting configmaps and secrets.
+	// API server representation matches the internal
+	// representation but has extra fields "operations" and "scope",
+	// and is of interface types instead of strings.
+	configmapsSecretsInternalRules = []interface{}{
+		map[string]interface{}{
+			"apiGroups":   []string{""},
+			"apiVersions": []string{"v1"},
+			"resources":   []string{"configmaps", "secrets"},
+		},
+	}
+	configmapsSecretsAPIRules = []interface{}{
+		map[string]interface{}{
+			"apiGroups":   []interface{}{""},
+			"apiVersions": []interface{}{"v1"},
+			"resources":   []interface{}{"configmaps", "secrets"},
+			"operations":  []interface{}{"CREATE", "UPDATE", "DELETE", "CONNECT"},
+			"scope":       "*",
+		},
+	}
+
+	// Same as previous but reversing the order of configmaps and secrets.
+	secretsConfigmapsInternalRules = []interface{}{
+		map[string]interface{}{
+			"apiGroups":   []string{""},
+			"apiVersions": []string{"v1"},
+			"resources":   []string{"secrets", "configmaps"},
+		},
+	}
+	secretsConfigmapsAPIRules = []interface{}{
+		map[string]interface{}{
+			"apiGroups":   []interface{}{""},
+			"apiVersions": []interface{}{"v1"},
+			"resources":   []interface{}{"secrets", "configmaps"},
+			"operations":  []interface{}{"CREATE", "UPDATE", "DELETE", "CONNECT"},
+			"scope":       "*",
+		},
+	}
+
+	// API rules with missing fields.
+	badAPIRules = []interface{}{
+		map[string]interface{}{
+			"apiGroups": []interface{}{""},
+		},
+	}
+}
+
+func TestRulesEqual(t *testing.T) {
+	tests := []struct {
+		name      string
+		internal  []interface{}
+		apiserver []interface{}
+		equal     bool
+		shouldErr bool
+	}{
+		// Both empty. Should be equal.
+		{"empty-equal", emptyInternalRules, emptyAPIRules, true, false},
+
+		// Both rules select configmaps. Should be equal.
+		{"configmaps-equal", configmapsInternalRules, configmapsAPIRules, true, false},
+
+		// Both rules select configmaps and secrets. Should be equal.
+		{"cm-secrets-equal", configmapsSecretsInternalRules, configmapsSecretsAPIRules, true, false},
+
+		// Both rules select secrets and configmaps (reversed compared to previous). Should be equal.
+		{"secrets-cm-equal", secretsConfigmapsInternalRules, secretsConfigmapsAPIRules, true, false},
+
+		// Internal is updated from nothing to configmaps. Not equal.
+		{"add-configmaps", configmapsInternalRules, emptyAPIRules, false, false},
+
+		// Internal is updated from configmaps to configmaps and secrets. Not equal.
+		{"add-secrets", configmapsSecretsInternalRules, configmapsAPIRules, false, false},
+
+		// Order of configmaps and secrets is switched. Not equal.
+		{"order-switched", configmapsSecretsInternalRules, secretsConfigmapsAPIRules, false, false},
+
+		// Malformed API rules, if modified by user or something like that. Not equal.
+		{"bad-api-rules", configmapsInternalRules, badAPIRules, false, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			equal, err := webhookRulesEqual(test.apiserver, test.internal)
+			assert.Equal(t, err != nil, test.shouldErr)
+			assert.Equal(t, equal, test.equal)
+		})
+	}
+}


### PR DESCRIPTION
## Related issue
#3380

## Milestone of this PR


## What type of PR is this

/kind bug

## Proposed Changes

Add a function webhookRulesEqual to handle edge cases in comparing the internal representation of webhook rules with what is currently on the API server's webhook object.
At the moment the equals comparison always returns false, so the webhook is always updated.

The first commit moves the current method of comparison (reflect.DeepEqual) into the function, and adds a test that shows the issue. Any test cases that should be returning equal are failing.
```
--- FAIL: TestRulesEqual (0.00s)
    --- FAIL: TestRulesEqual/empty-equal (0.00s)
    --- FAIL: TestRulesEqual/configmaps-equal (0.00s)
    --- FAIL: TestRulesEqual/cm-secrets-equal (0.00s)
    --- PASS: TestRulesEqual/add-configmaps (0.00s)
    --- PASS: TestRulesEqual/add-secrets (0.00s)
```

The second commit expands the function to account for the differences I described in #3380.
With those changes applied, the function can now return equal for those cases and the tests pass.
```
--- PASS: TestRulesEqual (0.00s)
    --- PASS: TestRulesEqual/empty-equal (0.00s)
    --- PASS: TestRulesEqual/configmaps-equal (0.00s)
    --- PASS: TestRulesEqual/cm-secrets-equal (0.00s)
    --- PASS: TestRulesEqual/add-configmaps (0.00s)
    --- PASS: TestRulesEqual/add-secrets (0.00s)
```

### Proof Manifests


- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
