### PR TITLE
Fix webhook configuration issue when auto update is disabled

### DIFF
--- a/pkg/webhookconfig/resource.go
+++ b/pkg/webhookconfig/resource.go
@@ -26,7 +26,7 @@ func (wrc *Register) constructDefaultDebugMutatingWebhookConfig(caData []byte) *
 	logger := wrc.log
 	url := fmt.Sprintf("https://%s%s", wrc.serverIP, config.MutatingWebhookServicePath)
 	logger.V(4).Info("Debug MutatingWebhookConfig registered", "url", url)
-	return &admregapi.MutatingWebhookConfiguration{
+	webhook := &admregapi.MutatingWebhookConfiguration{
 		ObjectMeta: v1.ObjectMeta{
 			Name: config.MutatingWebhookConfigurationDebugName,
 		},
@@ -41,22 +41,26 @@ func (wrc *Register) constructDefaultDebugMutatingWebhookConfig(caData []byte) *
 				[]admregapi.OperationType{admregapi.Create, admregapi.Update},
 				admregapi.Ignore,
 			),
-			generateDebugMutatingWebhook(
-				config.MutatingWebhookName+"-fail",
-				url,
-				caData,
-				true,
-				wrc.timeoutSeconds,
-				wrc.defaultResourceWebhookRule(),
-				[]admregapi.OperationType{admregapi.Create, admregapi.Update},
-				admregapi.Fail,
-			),
 		},
 	}
+
+	if wrc.autoUpdateWebhooks {
+		webhook.Webhooks = append(webhook.Webhooks, generateDebugMutatingWebhook(
+			config.MutatingWebhookName+"-fail",
+			url,
+			caData,
+			true,
+			wrc.timeoutSeconds,
+			wrc.defaultResourceWebhookRule(),
+			[]admregapi.OperationType{admregapi.Create, admregapi.Update},
+			admregapi.Fail,
+		))
+	}
+	return webhook
 }
 
 func (wrc *Register) constructDefaultMutatingWebhookConfig(caData []byte) *admregapi.MutatingWebhookConfiguration {
-	return &admregapi.MutatingWebhookConfiguration{
+	webhook := &admregapi.MutatingWebhookConfiguration{
 		ObjectMeta: v1.ObjectMeta{
 			Name: config.MutatingWebhookConfigurationName,
 			OwnerReferences: []v1.OwnerReference{
@@ -74,18 +78,22 @@ func (wrc *Register) constructDefaultMutatingWebhookConfig(caData []byte) *admre
 				[]admregapi.OperationType{admregapi.Create, admregapi.Update},
 				admregapi.Ignore,
 			),
-			generateMutatingWebhook(
-				config.MutatingWebhookName+"-fail",
-				config.MutatingWebhookServicePath,
-				caData,
-				false,
-				wrc.timeoutSeconds,
-				wrc.defaultResourceWebhookRule(),
-				[]admregapi.OperationType{admregapi.Create, admregapi.Update},
-				admregapi.Fail,
-			),
 		},
 	}
+
+	if wrc.autoUpdateWebhooks {
+		webhook.Webhooks = append(webhook.Webhooks, generateMutatingWebhook(
+			config.MutatingWebhookName+"-fail",
+			config.MutatingWebhookServicePath,
+			caData,
+			false,
+			wrc.timeoutSeconds,
+			wrc.defaultResourceWebhookRule(),
+			[]admregapi.OperationType{admregapi.Create, admregapi.Update},
+			admregapi.Fail,
+		))
+	}
+	return webhook
 }
 
 //getResourceMutatingWebhookConfigName returns the webhook configuration name
@@ -125,7 +133,7 @@ func (wrc *Register) removeResourceMutatingWebhookConfiguration(wg *sync.WaitGro
 func (wrc *Register) constructDefaultDebugValidatingWebhookConfig(caData []byte) *admregapi.ValidatingWebhookConfiguration {
 	url := fmt.Sprintf("https://%s%s", wrc.serverIP, config.ValidatingWebhookServicePath)
 
-	return &admregapi.ValidatingWebhookConfiguration{
+	webhook := &admregapi.ValidatingWebhookConfiguration{
 		ObjectMeta: v1.ObjectMeta{
 			Name: config.ValidatingWebhookConfigurationDebugName,
 		},
@@ -140,22 +148,26 @@ func (wrc *Register) constructDefaultDebugValidatingWebhookConfig(caData []byte)
 				[]admregapi.OperationType{admregapi.Create, admregapi.Update, admregapi.Delete, admregapi.Connect},
 				admregapi.Ignore,
 			),
-			generateDebugValidatingWebhook(
-				config.ValidatingWebhookName+"-fail",
-				url,
-				caData,
-				true,
-				wrc.timeoutSeconds,
-				wrc.defaultResourceWebhookRule(),
-				[]admregapi.OperationType{admregapi.Create, admregapi.Update, admregapi.Delete, admregapi.Connect},
-				admregapi.Fail,
-			),
 		},
 	}
+
+	if wrc.autoUpdateWebhooks {
+		webhook.Webhooks = append(webhook.Webhooks, generateDebugValidatingWebhook(
+			config.ValidatingWebhookName+"-fail",
+			url,
+			caData,
+			true,
+			wrc.timeoutSeconds,
+			wrc.defaultResourceWebhookRule(),
+			[]admregapi.OperationType{admregapi.Create, admregapi.Update, admregapi.Delete, admregapi.Connect},
+			admregapi.Fail,
+		))
+	}
+	return webhook
 }
 
 func (wrc *Register) constructDefaultValidatingWebhookConfig(caData []byte) *admregapi.ValidatingWebhookConfiguration {
-	return &admregapi.ValidatingWebhookConfiguration{
+	webhook := &admregapi.ValidatingWebhookConfiguration{
 		ObjectMeta: v1.ObjectMeta{
 			Name: config.ValidatingWebhookConfigurationName,
 			OwnerReferences: []v1.OwnerReference{
@@ -173,18 +185,22 @@ func (wrc *Register) constructDefaultValidatingWebhookConfig(caData []byte) *adm
 				[]admregapi.OperationType{admregapi.Create, admregapi.Update, admregapi.Delete, admregapi.Connect},
 				admregapi.Ignore,
 			),
-			generateValidatingWebhook(
-				config.ValidatingWebhookName+"-fail",
-				config.ValidatingWebhookServicePath,
-				caData,
-				false,
-				wrc.timeoutSeconds,
-				wrc.defaultResourceWebhookRule(),
-				[]admregapi.OperationType{admregapi.Create, admregapi.Update, admregapi.Delete, admregapi.Connect},
-				admregapi.Fail,
-			),
 		},
 	}
+
+	if wrc.autoUpdateWebhooks {
+		webhook.Webhooks = append(webhook.Webhooks, generateValidatingWebhook(
+			config.ValidatingWebhookName+"-fail",
+			config.ValidatingWebhookServicePath,
+			caData,
+			false,
+			wrc.timeoutSeconds,
+			wrc.defaultResourceWebhookRule(),
+			[]admregapi.OperationType{admregapi.Create, admregapi.Update, admregapi.Delete, admregapi.Connect},
+			admregapi.Fail,
+		))
+	}
+	return webhook
 }
 
 // getResourceValidatingWebhookConfigName returns the webhook configuration name


### PR DESCRIPTION
## Related issue

Closes https://github.com/kyverno/kyverno/issues/3360.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).

-->

## Milestone of this PR
/1.6.2
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
When `autoUpdateWebhooks` is set to false, Kyverno registers both mutating and validating webhooks with a single rule that matches "*", and the failure policy is set to `Ignore`.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
With this change, the pod creation passed through when Kyverno pod was not running.

```
✗ k get -n kyverno pod                                  
NAME                       READY   STATUS             RESTARTS   AGE
kyverno-5b4cf6dd5b-rpxsr   0/1     ImagePullBackOff   0          2m54s
```

Pod was created successfully.
```
✗ k run nginx --image=nginx:latest                                 
pod/nginx created
```

mutatingwebhookconfiguration is registered with a single rule and `failurePolicy=Ignore`:
```
✗ k get mutatingwebhookconfigurations kyverno-resource-mutating-webhook-cfg -o yaml 
apiVersion: admissionregistration.k8s.io/v1
kind: MutatingWebhookConfiguration
metadata:
  creationTimestamp: "2022-03-18T08:45:56Z"
  generation: 1
  name: kyverno-resource-mutating-webhook-cfg
  ownerReferences:
  - apiVersion: rbac.authorization.k8s.io/v1
    kind: ClusterRole
    name: kyverno:webhook
    uid: bd51c597-e7d7-48c4-aed4-d5e2f9f49f90
  resourceVersion: "87403"
  uid: 10aeda54-456c-4313-943c-3a66b96592f7
webhooks:
- admissionReviewVersions:
...
    service:
      name: kyverno-svc
      namespace: kyverno
      path: /mutate
      port: 443
  failurePolicy: Ignore
  matchPolicy: Equivalent
  name: mutate.kyverno.svc-ignore
  namespaceSelector: {}
  objectSelector: {}
  reinvocationPolicy: IfNeeded
  rules:
  - apiGroups:
    - '*'
    apiVersions:
    - '*'
    operations:
    - CREATE
    - UPDATE
    resources:
    - '*/*'
    scope: '*'
  sideEffects: NoneOnDryRun
  timeoutSeconds: 15
```
validatingwebhookconfiguration is registered with a single rule and `failurePolicy=Ignore`:
```
✗ k get validatingwebhookconfigurations kyverno-resource-validating-webhook-cfg -o yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  creationTimestamp: "2022-03-18T08:45:56Z"
  generation: 1
  name: kyverno-resource-validating-webhook-cfg
  ownerReferences:
  - apiVersion: rbac.authorization.k8s.io/v1
    kind: ClusterRole
    name: kyverno:webhook
    uid: bd51c597-e7d7-48c4-aed4-d5e2f9f49f90
  resourceVersion: "87402"
  uid: a15dd6fc-20ff-4c92-bdc9-aaa8b32afc7a
webhooks:
- admissionReviewVersions:
  - v1beta1
...
    service:
      name: kyverno-svc
      namespace: kyverno
      path: /validate
      port: 443
  failurePolicy: Ignore
  matchPolicy: Equivalent
  name: validate.kyverno.svc-ignore
  namespaceSelector: {}
  objectSelector: {}
  rules:
  - apiGroups:
    - '*'
    apiVersions:
    - '*'
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - '*/*'
    scope: '*'
  sideEffects: NoneOnDryRun
  timeoutSeconds: 15
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```

-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
