### PR TITLE
Fix cli apply command panic for --cluster flag

### DIFF
--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -735,33 +735,34 @@ func GetResourceAccordingToResourcePath(fs billy.Filesystem, resourcePaths []str
 					return nil, sanitizederror.NewWithError("failed to extract the resources", err)
 				}
 			}
-		} else if len(resourcePaths) > 0 {
-			fileDesc, err := os.Stat(resourcePaths[0])
-			if err != nil {
-				return nil, err
-			}
-			if fileDesc.IsDir() {
-
-				files, err := ioutil.ReadDir(resourcePaths[0])
+		} else {
+			if len(resourcePaths) > 0 {
+				fileDesc, err := os.Stat(resourcePaths[0])
 				if err != nil {
-					return nil, sanitizederror.NewWithError(fmt.Sprintf("failed to parse %v", resourcePaths[0]), err)
+					return nil, err
 				}
-				listOfFiles := make([]string, 0)
-				for _, file := range files {
-					ext := filepath.Ext(file.Name())
-					if ext == ".yaml" || ext == ".yml" {
-						listOfFiles = append(listOfFiles, filepath.Join(resourcePaths[0], file.Name()))
+				if fileDesc.IsDir() {
+
+					files, err := ioutil.ReadDir(resourcePaths[0])
+					if err != nil {
+						return nil, sanitizederror.NewWithError(fmt.Sprintf("failed to parse %v", resourcePaths[0]), err)
 					}
+					listOfFiles := make([]string, 0)
+					for _, file := range files {
+						ext := filepath.Ext(file.Name())
+						if ext == ".yaml" || ext == ".yml" {
+							listOfFiles = append(listOfFiles, filepath.Join(resourcePaths[0], file.Name()))
+						}
+					}
+					resourcePaths = listOfFiles
 				}
-				resourcePaths = listOfFiles
+			}
+
+			resources, err = GetResources(policies, resourcePaths, dClient, cluster, namespace, policyReport)
+			if err != nil {
+				return resources, err
 			}
 		}
-
-		resources, err = GetResources(policies, resourcePaths, dClient, cluster, namespace, policyReport)
-		if err != nil {
-			return resources, err
-		}
-
 	}
 	return resources, err
 }

--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -735,34 +735,31 @@ func GetResourceAccordingToResourcePath(fs billy.Filesystem, resourcePaths []str
 					return nil, sanitizederror.NewWithError("failed to extract the resources", err)
 				}
 			}
-		} else if (len(resourcePaths) > 0 && resourcePaths[0] != "-") || len(resourcePaths) < 0 || cluster {
-
-			if len(resourcePaths) > 0 {
-				fileDesc, err := os.Stat(resourcePaths[0])
-				if err != nil {
-					return nil, err
-				}
-				if fileDesc.IsDir() {
-
-					files, err := ioutil.ReadDir(resourcePaths[0])
-					if err != nil {
-						return nil, sanitizederror.NewWithError(fmt.Sprintf("failed to parse %v", resourcePaths[0]), err)
-					}
-					listOfFiles := make([]string, 0)
-					for _, file := range files {
-						ext := filepath.Ext(file.Name())
-						if ext == ".yaml" || ext == ".yml" {
-							listOfFiles = append(listOfFiles, filepath.Join(resourcePaths[0], file.Name()))
-						}
-					}
-					resourcePaths = listOfFiles
-				}
-			}
-
-			resources, err = GetResources(policies, resourcePaths, dClient, cluster, namespace, policyReport)
+		} else if len(resourcePaths) > 0 {
+			fileDesc, err := os.Stat(resourcePaths[0])
 			if err != nil {
-				return resources, err
+				return nil, err
 			}
+			if fileDesc.IsDir() {
+
+				files, err := ioutil.ReadDir(resourcePaths[0])
+				if err != nil {
+					return nil, sanitizederror.NewWithError(fmt.Sprintf("failed to parse %v", resourcePaths[0]), err)
+				}
+				listOfFiles := make([]string, 0)
+				for _, file := range files {
+					ext := filepath.Ext(file.Name())
+					if ext == ".yaml" || ext == ".yml" {
+						listOfFiles = append(listOfFiles, filepath.Join(resourcePaths[0], file.Name()))
+					}
+				}
+				resourcePaths = listOfFiles
+			}
+		}
+
+		resources, err = GetResources(policies, resourcePaths, dClient, cluster, namespace, policyReport)
+		if err != nil {
+			return resources, err
 		}
 
 	}

--- a/pkg/kyverno/common/common.go
+++ b/pkg/kyverno/common/common.go
@@ -737,25 +737,28 @@ func GetResourceAccordingToResourcePath(fs billy.Filesystem, resourcePaths []str
 			}
 		} else if (len(resourcePaths) > 0 && resourcePaths[0] != "-") || len(resourcePaths) < 0 || cluster {
 
-			fileDesc, err := os.Stat(resourcePaths[0])
-			if err != nil {
-				return nil, err
-			}
-			if fileDesc.IsDir() {
-
-				files, err := ioutil.ReadDir(resourcePaths[0])
+			if len(resourcePaths) > 0 {
+				fileDesc, err := os.Stat(resourcePaths[0])
 				if err != nil {
-					return nil, sanitizederror.NewWithError(fmt.Sprintf("failed to parse %v", resourcePaths[0]), err)
+					return nil, err
 				}
-				listOfFiles := make([]string, 0)
-				for _, file := range files {
-					ext := filepath.Ext(file.Name())
-					if ext == ".yaml" || ext == ".yml" {
-						listOfFiles = append(listOfFiles, filepath.Join(resourcePaths[0], file.Name()))
+				if fileDesc.IsDir() {
+
+					files, err := ioutil.ReadDir(resourcePaths[0])
+					if err != nil {
+						return nil, sanitizederror.NewWithError(fmt.Sprintf("failed to parse %v", resourcePaths[0]), err)
 					}
+					listOfFiles := make([]string, 0)
+					for _, file := range files {
+						ext := filepath.Ext(file.Name())
+						if ext == ".yaml" || ext == ".yml" {
+							listOfFiles = append(listOfFiles, filepath.Join(resourcePaths[0], file.Name()))
+						}
+					}
+					resourcePaths = listOfFiles
 				}
-				resourcePaths = listOfFiles
 			}
+
 			resources, err = GetResources(policies, resourcePaths, dClient, cluster, namespace, policyReport)
 			if err != nil {
 				return resources, err


### PR DESCRIPTION
Signed-off-by: Vyankatesh vyankateshkd@gmail.com
closes : https://github.com/kyverno/kyverno/issues/3435

## Milestone of this PR
/milestone 1.6.2

## What type of PR is this
 /kind bug

### Proof Manifests

Applied on local kind cluster

```
kubectl kyverno apply test/cli/policy.yaml --cluster                 

Applying 1 policy to 13 resources... 
(Total number of result count may vary as the policy is mutated by Kyverno. To check the mutated policy please try with log level 5)

pass: 13, fail: 0, warn: 0, error: 0, skip: 26 
```
with resource. yaml

```
 kubectl kyverno  apply test/cli/policy.yaml -r test/cli/resources.yaml

Applying 1 policy to 2 resources... 
(Total number of result count may vary as the policy is mutated by Kyverno. To check the mutated policy please try with log level 5)

policy disallow-latest-tag -> resource default/Pod/test-validate-image-tag-ignore failed: 
1. validate-image-tag: validation error: Using a mutable image tag e.g. 'latest' is not allowed. Rule validate-image-tag failed at path /spec/containers/0/image/ 

pass: 1, fail: 1, warn: 0, error: 0, skip: 4 
exit status 1
```



<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->



<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
