### PR TITLE
refactor: use pointers instead of empty structs

### DIFF
--- a/api/kyverno/v1/rule_types.go
+++ b/api/kyverno/v1/rule_types.go
@@ -28,13 +28,13 @@ type Rule struct {
 	// criteria can include resource information (e.g. kind, name, namespace, labels)
 	// and admission review request information like the user name or role.
 	// At least one kind is required.
-	MatchResources MatchResources `json:"match,omitempty" yaml:"match,omitempty"`
+	MatchResources *MatchResources `json:"match,omitempty" yaml:"match,omitempty"`
 
 	// ExcludeResources defines when this policy rule should not be applied. The exclude
 	// criteria can include resource information (e.g. kind, name, namespace, labels)
 	// and admission review request information like the name or role.
 	// +optional
-	ExcludeResources MatchResources `json:"exclude,omitempty" yaml:"exclude,omitempty"`
+	ExcludeResources *MatchResources `json:"exclude,omitempty" yaml:"exclude,omitempty"`
 
 	// Preconditions are used to determine if a policy rule should be applied by evaluating a
 	// set of conditions. The declaration can contain nested `any` or `all` statements. A direct list
@@ -148,7 +148,7 @@ func (r *Rule) ValidateMathExcludeConflict(path *field.Path) (errs field.ErrorLi
 		}
 		return errs
 	}
-	if reflect.DeepEqual(r.ExcludeResources, MatchResources{}) {
+	if r.ExcludeResources == nil {
 		return errs
 	}
 	excludeRoles := sets.NewString(r.ExcludeResources.Roles...)

--- a/api/kyverno/v1/spec_test.go
+++ b/api/kyverno/v1/spec_test.go
@@ -12,7 +12,7 @@ func Test_Validate_UniqueRuleName(t *testing.T) {
 	subject := Spec{
 		Rules: []Rule{{
 			Name: "deny-privileged-disallowpriviligedescalation",
-			MatchResources: MatchResources{
+			MatchResources: &MatchResources{
 				ResourceDescription: ResourceDescription{
 					Kinds: []string{
 						"Pod",
@@ -27,7 +27,7 @@ func Test_Validate_UniqueRuleName(t *testing.T) {
 			},
 		}, {
 			Name: "deny-privileged-disallowpriviligedescalation",
-			MatchResources: MatchResources{
+			MatchResources: &MatchResources{
 				ResourceDescription: ResourceDescription{
 					Kinds: []string{
 						"Pod",

--- a/api/kyverno/v1/zz_generated.deepcopy.go
+++ b/api/kyverno/v1/zz_generated.deepcopy.go
@@ -861,8 +861,16 @@ func (in *Rule) DeepCopyInto(out *Rule) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	in.MatchResources.DeepCopyInto(&out.MatchResources)
-	in.ExcludeResources.DeepCopyInto(&out.ExcludeResources)
+	if in.MatchResources != nil {
+		in, out := &in.MatchResources, &out.MatchResources
+		*out = new(MatchResources)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ExcludeResources != nil {
+		in, out := &in.ExcludeResources, &out.ExcludeResources
+		*out = new(MatchResources)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.RawAnyAllConditions != nil {
 		in, out := &in.RawAnyAllConditions, &out.RawAnyAllConditions
 		*out = new(apiextensionsv1.JSON)

--- a/pkg/autogen/autogen.go
+++ b/pkg/autogen/autogen.go
@@ -291,10 +291,10 @@ func convertRule(rule kyvernoRule, kind string) (*kyverno.Rule, error) {
 		VerifyImages: rule.VerifyImages,
 	}
 	if rule.MatchResources != nil {
-		out.MatchResources = *rule.MatchResources
+		out.MatchResources = rule.MatchResources
 	}
 	if rule.ExcludeResources != nil {
-		out.ExcludeResources = *rule.ExcludeResources
+		out.ExcludeResources = rule.ExcludeResources
 	}
 	if rule.Context != nil {
 		out.Context = *rule.Context

--- a/pkg/autogen/rule.go
+++ b/pkg/autogen/rule.go
@@ -40,11 +40,11 @@ func createRuleMap(rules []kyverno.Rule) map[string]kyvernoRule {
 
 		jsonFriendlyStruct.Name = rule.Name
 
-		if !reflect.DeepEqual(rule.MatchResources, kyverno.MatchResources{}) {
+		if rule.MatchResources != nil {
 			jsonFriendlyStruct.MatchResources = rule.MatchResources.DeepCopy()
 		}
 
-		if !reflect.DeepEqual(rule.ExcludeResources, kyverno.MatchResources{}) {
+		if rule.ExcludeResources != nil {
 			jsonFriendlyStruct.ExcludeResources = rule.ExcludeResources.DeepCopy()
 		}
 
@@ -133,7 +133,7 @@ func generateRuleForControllers(rule kyverno.Rule, controllers string, log logr.
 		}
 	}
 
-	if !reflect.DeepEqual(exclude, kyverno.MatchResources{}) {
+	if exclude != nil {
 		controllerRule.ExcludeResources = exclude.DeepCopy()
 	}
 

--- a/pkg/engine/utils_test.go
+++ b/pkg/engine/utils_test.go
@@ -965,7 +965,7 @@ func TestResourceDescriptionMatch_MultipleKind(t *testing.T) {
 			MatchExpressions: nil,
 		},
 	}
-	rule := v1.Rule{MatchResources: v1.MatchResources{ResourceDescription: resourceDescription}}
+	rule := v1.Rule{MatchResources: &v1.MatchResources{ResourceDescription: resourceDescription}}
 
 	if err := MatchesResourceDescription(*resource, rule, v1.RequestInfo{}, []string{}, nil, ""); err != nil {
 		t.Errorf("Testcase has failed due to the following:%v", err)
@@ -1026,7 +1026,7 @@ func TestResourceDescriptionMatch_Name(t *testing.T) {
 			MatchExpressions: nil,
 		},
 	}
-	rule := v1.Rule{MatchResources: v1.MatchResources{ResourceDescription: resourceDescription}}
+	rule := v1.Rule{MatchResources: &v1.MatchResources{ResourceDescription: resourceDescription}}
 
 	if err := MatchesResourceDescription(*resource, rule, v1.RequestInfo{}, []string{}, nil, ""); err != nil {
 		t.Errorf("Testcase has failed due to the following:%v", err)
@@ -1086,7 +1086,7 @@ func TestResourceDescriptionMatch_Name_Regex(t *testing.T) {
 			MatchExpressions: nil,
 		},
 	}
-	rule := v1.Rule{MatchResources: v1.MatchResources{ResourceDescription: resourceDescription}}
+	rule := v1.Rule{MatchResources: &v1.MatchResources{ResourceDescription: resourceDescription}}
 
 	if err := MatchesResourceDescription(*resource, rule, v1.RequestInfo{}, []string{}, nil, ""); err != nil {
 		t.Errorf("Testcase has failed due to the following:%v", err)
@@ -1154,7 +1154,7 @@ func TestResourceDescriptionMatch_Label_Expression_NotMatch(t *testing.T) {
 			},
 		},
 	}
-	rule := v1.Rule{MatchResources: v1.MatchResources{ResourceDescription: resourceDescription}}
+	rule := v1.Rule{MatchResources: &v1.MatchResources{ResourceDescription: resourceDescription}}
 
 	if err := MatchesResourceDescription(*resource, rule, v1.RequestInfo{}, []string{}, nil, ""); err != nil {
 		t.Errorf("Testcase has failed due to the following:%v", err)
@@ -1223,7 +1223,7 @@ func TestResourceDescriptionMatch_Label_Expression_Match(t *testing.T) {
 			},
 		},
 	}
-	rule := v1.Rule{MatchResources: v1.MatchResources{ResourceDescription: resourceDescription}}
+	rule := v1.Rule{MatchResources: &v1.MatchResources{ResourceDescription: resourceDescription}}
 
 	if err := MatchesResourceDescription(*resource, rule, v1.RequestInfo{}, []string{}, nil, ""); err != nil {
 		t.Errorf("Testcase has failed due to the following:%v", err)
@@ -1302,8 +1302,10 @@ func TestResourceDescriptionExclude_Label_Expression_Match(t *testing.T) {
 		},
 	}
 
-	rule := v1.Rule{MatchResources: v1.MatchResources{ResourceDescription: resourceDescription},
-		ExcludeResources: v1.MatchResources{ResourceDescription: resourceDescriptionExclude}}
+	rule := v1.Rule{
+		MatchResources:   &v1.MatchResources{ResourceDescription: resourceDescription},
+		ExcludeResources: &v1.MatchResources{ResourceDescription: resourceDescriptionExclude},
+	}
 
 	if err := MatchesResourceDescription(*resource, rule, v1.RequestInfo{}, []string{}, nil, ""); err == nil {
 		t.Errorf("Testcase has failed due to the following:\n Function has returned no error, even though it was supposed to fail")


### PR DESCRIPTION
This PR makes use of pointers instead of empty structs to reduce usage of `reflect.DeepEqual`.