### PR TITLE
refactor: use pointer for old resource in engine policy context

### DIFF
--- a/pkg/engine/generation.go
+++ b/pkg/engine/generation.go
@@ -127,20 +127,20 @@ func filterRule(rule kyverno.Rule, policyContext *PolicyContext) *response.RuleR
 		"kind", newResource.GetKind(), "namespace", newResource.GetNamespace(), "name", newResource.GetName())
 
 	if err = MatchesResourceDescription(newResource, rule, admissionInfo, excludeGroupRole, namespaceLabels, ""); err != nil {
-
-		// if the oldResource matched, return "false" to delete GR for it
-		if err = MatchesResourceDescription(oldResource, rule, admissionInfo, excludeGroupRole, namespaceLabels, ""); err == nil {
-			return &response.RuleResponse{
-				Name:   rule.Name,
-				Type:   "Generation",
-				Status: response.RuleStatusFail,
-				RuleStats: response.RuleStats{
-					ProcessingTime:         time.Since(startTime),
-					RuleExecutionTimestamp: startTime.Unix(),
-				},
+		if oldResource != nil {
+			// if the oldResource matched, return "false" to delete GR for it
+			if err = MatchesResourceDescription(*oldResource, rule, admissionInfo, excludeGroupRole, namespaceLabels, ""); err == nil {
+				return &response.RuleResponse{
+					Name:   rule.Name,
+					Type:   "Generation",
+					Status: response.RuleStatusFail,
+					RuleStats: response.RuleStats{
+						ProcessingTime:         time.Since(startTime),
+						RuleExecutionTimestamp: startTime.Unix(),
+					},
+				}
 			}
 		}
-
 		return nil
 	}
 

--- a/pkg/engine/policyContext.go
+++ b/pkg/engine/policyContext.go
@@ -16,7 +16,7 @@ type PolicyContext struct {
 	NewResource unstructured.Unstructured
 
 	// OldResource is the prior resource for an update, or nil
-	OldResource unstructured.Unstructured
+	OldResource *unstructured.Unstructured
 
 	// Element is set when the context is used for processing a foreach loop
 	Element unstructured.Unstructured

--- a/pkg/engine/validation_test.go
+++ b/pkg/engine/validation_test.go
@@ -2140,7 +2140,7 @@ func executeTest(t *testing.T, err error, test testCase) {
 	pc := &PolicyContext{
 		Policy:        &policy,
 		NewResource:   newR,
-		OldResource:   oldR,
+		OldResource:   &oldR,
 		AdmissionInfo: userInfo,
 		JSONContext:   ctx,
 	}
@@ -3080,7 +3080,8 @@ func Test_delete_ignore_pattern(t *testing.T) {
 	policyContextDelete := &PolicyContext{
 		Policy:      &policy,
 		JSONContext: ctx,
-		OldResource: *resourceUnstructured}
+		OldResource: resourceUnstructured,
+	}
 	engineResponseDelete := Validate(policyContextDelete)
 	assert.Equal(t, len(engineResponseDelete.PolicyResponse.Rules), 0)
 }

--- a/pkg/webhooks/generation.go
+++ b/pkg/webhooks/generation.go
@@ -70,7 +70,7 @@ func (ws *WebhookServer) handleGenerate(
 
 		policyContext := &engine.PolicyContext{
 			NewResource:         new,
-			OldResource:         old,
+			OldResource:         &old,
 			AdmissionInfo:       userRequestInfo,
 			ExcludeGroupRole:    dynamicConfig.GetExcludeGroupRole(),
 			ExcludeResourceFunc: ws.configHandler.ToFilter,

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -392,7 +392,7 @@ func (ws *WebhookServer) buildPolicyContext(request *v1beta1.AdmissionRequest, a
 	}
 
 	if request.Operation == v1beta1.Update {
-		policyContext.OldResource = resource
+		policyContext.OldResource = &resource
 	}
 
 	return policyContext, nil
@@ -548,7 +548,7 @@ func (ws *WebhookServer) resourceValidation(request *v1beta1.AdmissionRequest) *
 
 	policyContext := &engine.PolicyContext{
 		NewResource:         newResource,
-		OldResource:         oldResource,
+		OldResource:         &oldResource,
 		AdmissionInfo:       userRequestInfo,
 		ExcludeGroupRole:    ws.configHandler.GetExcludeGroupRole(),
 		ExcludeResourceFunc: ws.configHandler.ToFilter,

--- a/pkg/webhooks/validate_audit.go
+++ b/pkg/webhooks/validate_audit.go
@@ -187,7 +187,7 @@ func (h *auditHandler) process(request *v1beta1.AdmissionRequest) error {
 
 	policyContext := &engine.PolicyContext{
 		NewResource:         newResource,
-		OldResource:         oldResource,
+		OldResource:         &oldResource,
 		AdmissionInfo:       userRequestInfo,
 		ExcludeGroupRole:    h.configHandler.GetExcludeGroupRole(),
 		ExcludeResourceFunc: h.configHandler.ToFilter,

--- a/pkg/webhooks/validation.go
+++ b/pkg/webhooks/validation.go
@@ -123,7 +123,9 @@ func (v *validationHandler) handleValidation(
 		}
 
 		if !managed {
-			v.prGenerator.Add(buildDeletionPrInfo(policyContext.OldResource))
+			if policyContext.OldResource != nil {
+				v.prGenerator.Add(buildDeletionPrInfo(*policyContext.OldResource))
+			}
 		}
 
 		return true, ""


### PR DESCRIPTION
This PR makes use of a pointer for old resource in engine policy context.
This allows simply setting it to `nil` when it doesn't exist, we don't need to check if it's empty or not.