### PR TITLE
fix: disallow all in autogen annotation

### DIFF
--- a/api/kyverno/v1/clusterpolicy_test.go
+++ b/api/kyverno/v1/clusterpolicy_test.go
@@ -38,3 +38,17 @@ func Test_ClusterPolicy_IsNamespaced(t *testing.T) {
 	assert.Equal(t, namespaced.IsNamespaced(), true)
 	assert.Equal(t, notNamespaced.IsNamespaced(), false)
 }
+
+func Test_ClusterPolicy_Autogen_All(t *testing.T) {
+	subject := ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "policy",
+			Annotations: map[string]string{
+				PodControllersAnnotation: "all",
+			},
+		},
+	}
+	errs := subject.Validate(nil)
+	assert.Equal(t, len(errs), 1)
+	assert.Equal(t, errs[0].Error(), "metadata.annotations: Forbidden: Autogen annotation does not support 'all' anymore, remove the annotation or set it to a valid value")
+}

--- a/api/kyverno/v1/clusterpolicy_types.go
+++ b/api/kyverno/v1/clusterpolicy_types.go
@@ -95,6 +95,7 @@ func (p *ClusterPolicy) IsReady() bool {
 // namespaced means that the policy is bound to a namespace and therefore
 // should not filter/generate cluster wide resources.
 func (p *ClusterPolicy) Validate(clusterResources sets.String) (errs field.ErrorList) {
+	errs = append(errs, ValidateAutogenAnnotation(field.NewPath("metadata").Child("annotations"), p.GetAnnotations())...)
 	errs = append(errs, ValidatePolicyName(field.NewPath("name"), p.Name)...)
 	errs = append(errs, p.Spec.Validate(field.NewPath("spec"), p.IsNamespaced(), clusterResources)...)
 	return errs

--- a/api/kyverno/v1/policy_test.go
+++ b/api/kyverno/v1/policy_test.go
@@ -37,3 +37,18 @@ func Test_Policy_IsNamespaced(t *testing.T) {
 	assert.Equal(t, namespaced.IsNamespaced(), false)
 	assert.Equal(t, notNamespaced.IsNamespaced(), false)
 }
+
+func Test_Policy_Autogen_All(t *testing.T) {
+	subject := Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "policy",
+			Namespace: "abcd",
+			Annotations: map[string]string{
+				PodControllersAnnotation: "all",
+			},
+		},
+	}
+	errs := subject.Validate(nil)
+	assert.Equal(t, len(errs), 1)
+	assert.Equal(t, errs[0].Error(), "metadata.annotations: Forbidden: Autogen annotation does not support 'all' anymore, remove the annotation or set it to a valid value")
+}

--- a/api/kyverno/v1/policy_types.go
+++ b/api/kyverno/v1/policy_types.go
@@ -96,6 +96,7 @@ func (p *Policy) IsReady() bool {
 // namespaced means that the policy is bound to a namespace and therefore
 // should not filter/generate cluster wide resources.
 func (p *Policy) Validate(clusterResources sets.String) (errs field.ErrorList) {
+	errs = append(errs, ValidateAutogenAnnotation(field.NewPath("metadata").Child("annotations"), p.GetAnnotations())...)
 	errs = append(errs, ValidatePolicyName(field.NewPath("name"), p.Name)...)
 	errs = append(errs, p.Spec.Validate(field.NewPath("spec"), p.IsNamespaced(), clusterResources)...)
 	return errs

--- a/api/kyverno/v1/utils.go
+++ b/api/kyverno/v1/utils.go
@@ -30,6 +30,17 @@ func ToJSON(in apiextensions.JSON) *apiextv1.JSON {
 }
 
 // ValidatePolicyName validates policy name
+func ValidateAutogenAnnotation(path *field.Path, annotations map[string]string) (errs field.ErrorList) {
+	value, ok := annotations[PodControllersAnnotation]
+	if ok {
+		if value == "all" {
+			errs = append(errs, field.Forbidden(path, "Autogen annotation does not support 'all' anymore, remove the annotation or set it to a valid value"))
+		}
+	}
+	return errs
+}
+
+// ValidatePolicyName validates policy name
 func ValidatePolicyName(path *field.Path, name string) (errs field.ErrorList) {
 	// policy name is stored in the label of the report change request
 	if len(name) > 63 {


### PR DESCRIPTION
This PR validates the autogen annotation and fails if it is set to `all`.