### PR TITLE
refactor: reduce policy mutations

### DIFF
--- a/pkg/policymutation/policymutation.go
+++ b/pkg/policymutation/policymutation.go
@@ -21,22 +21,22 @@ func GenerateJSONPatchesForDefaults(policy kyverno.PolicyInterface, log logr.Log
 	var patches [][]byte
 	var updateMsgs []string
 	spec := policy.GetSpec()
-	// default 'ValidationFailureAction'
-	if patch, updateMsg := defaultvalidationFailureAction(spec, log); patch != nil {
-		patches = append(patches, patch)
-		updateMsgs = append(updateMsgs, updateMsg)
-	}
-	// default 'Background'
-	if patch, updateMsg := defaultBackgroundFlag(spec, log); patch != nil {
-		patches = append(patches, patch)
-		updateMsgs = append(updateMsgs, updateMsg)
-	}
-	if patch, updateMsg := defaultFailurePolicy(spec, log); patch != nil {
-		patches = append(patches, patch)
-		updateMsgs = append(updateMsgs, updateMsg)
-	}
-	// if autogenInternals is enabled, we don't mutate rules in the webhook
+	// if autogenInternals is enabled, we don't mutate most of the policy fields
 	if !toggle.AutogenInternals() {
+		// default 'ValidationFailureAction'
+		if patch, updateMsg := defaultvalidationFailureAction(spec, log); patch != nil {
+			patches = append(patches, patch)
+			updateMsgs = append(updateMsgs, updateMsg)
+		}
+		// default 'Background'
+		if patch, updateMsg := defaultBackgroundFlag(spec, log); patch != nil {
+			patches = append(patches, patch)
+			updateMsgs = append(updateMsgs, updateMsg)
+		}
+		if patch, updateMsg := defaultFailurePolicy(spec, log); patch != nil {
+			patches = append(patches, patch)
+			updateMsgs = append(updateMsgs, updateMsg)
+		}
 		patch, errs := GeneratePodControllerRule(policy, log)
 		if len(errs) > 0 {
 			var errMsgs []string


### PR DESCRIPTION
This PR reduces policy mutations.
`background`, `validationFailureAction` and `failurePolicy` are now defaulted at runtime and can be removed from the mutation webhook.

Only when autogen internals feature flag is on for now.