### PR TITLE
Update GH workflow config

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.21.2, v1.22.5, v1.23.3]
+        k8s-version: [v1.20.7, v1.21.2, v1.22.5, v1.23.3]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.20.15, v1.21.11, v1.22.8, v1.23.5]
+        k8s-version: [v1.20.15, v1.21.10, v1.22.7, v1.23.5]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.20.7, v1.21.2, v1.22.5, v1.23.3]
+        k8s-version: [v1.20.15, v1.21.11, v1.22.8, v1.23.5]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.16.15, v1.17.17, v1.18.19, v1.19.11, v1.20.7, v1.21.2, v1.22.5, v1.23.3]
+        k8s-version: [v1.21.2, v1.22.5, v1.23.3]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Related issue
See Slack [discussion](https://kubernetes.slack.com/archives/C032MM2CH7X/p1649658307920869), this PR:
- run CodeCov on Ubuntu
- removes 1.16 - 1.19 e2e tests and keeps the last 4 K8s releases
