### PR TITLE
refact: run last four supported k8s version in e2e github CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.16.15, v1.17.17, v1.18.19, v1.19.11, v1.20.7, v1.21.2, v1.22.5, v1.23.3]
+        k8s-version: [v1.20.7, v1.21.2, v1.22.5, v1.23.3]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.20.7, v1.21.2, v1.22.5, v1.23.3]
+        k8s-version: [v1.20.15, v1.21.11, v1.22.8, v1.23.5]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Related issue

## Milestone of this PR

`/milestone 1.7.0`.

## What type of PR is this
run last four supported k8s version in e2e github CI
