### PR TITLE
fix missing `policy.kyverno.io/policy-name` label

### DIFF
--- a/pkg/background/generate/generate.go
+++ b/pkg/background/generate/generate.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
@@ -74,6 +75,7 @@ func NewGenerateController(
 	npolicyLister kyvernolister.PolicyLister,
 	grLister kyvernolister.GenerateRequestNamespaceLister,
 	eventGen event.Interface,
+	dynamicInformer dynamicinformer.DynamicSharedInformerFactory,
 	log logr.Logger,
 	dynamicConfig config.Interface,
 ) (*GenerateController, error) {
@@ -90,6 +92,13 @@ func NewGenerateController(
 	}
 
 	c.statusControl = common.StatusControl{Client: kyvernoClient}
+
+	gvr, err := client.DiscoveryClient.GetGVRFromKind("Namespace")
+	if err != nil {
+		return nil, err
+	}
+
+	c.nsInformer = dynamicInformer.ForResource(gvr)
 
 	return &c, nil
 }
@@ -185,7 +194,7 @@ func (c *GenerateController) applyGenerate(resource unstructured.Unstructured, g
 
 	logger.V(3).Info("applying generate policy rule")
 
-	policySpec, err := c.getPolicySpec(gr)
+	policy, err := c.getPolicySpec(gr)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			for _, e := range gr.Status.GeneratedResources {
@@ -246,9 +255,6 @@ func (c *GenerateController) applyGenerate(resource unstructured.Unstructured, g
 		logger.Error(err, "unable to add image info to variables context")
 	}
 
-	policy := kyverno.ClusterPolicy{
-		Spec: policySpec,
-	}
 	policyContext := &engine.PolicyContext{
 		NewResource:         resource,
 		Policy:              &policy,
@@ -300,26 +306,31 @@ func (c *GenerateController) applyGenerate(resource unstructured.Unstructured, g
 }
 
 // getPolicySpec gets the policy spec from the ClusterPolicy/Policy
-func (c *GenerateController) getPolicySpec(gr kyverno.GenerateRequest) (kyverno.Spec, error) {
-	var policySpec kyverno.Spec
+func (c *GenerateController) getPolicySpec(gr kyverno.GenerateRequest) (kyverno.ClusterPolicy, error) {
+	var policy kyverno.ClusterPolicy
 
 	pNamespace, pName, err := cache.SplitMetaNamespaceKey(gr.Spec.Policy)
 	if err != nil {
-		return policySpec, err
+		return policy, err
 	}
 
 	if pNamespace == "" {
 		policyObj, err := c.policyLister.Get(pName)
 		if err != nil {
-			return policySpec, err
+			return policy, err
 		}
-		return policyObj.Spec, err
+		return *policyObj, err
 	} else {
 		npolicyObj, err := c.npolicyLister.Policies(pNamespace).Get(pName)
 		if err != nil {
-			return policySpec, err
+			return policy, err
 		}
-		return npolicyObj.Spec, nil
+		return kyverno.ClusterPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pName,
+			},
+			Spec: npolicyObj.Spec,
+		}, nil
 	}
 }
 

--- a/pkg/background/request_process.go
+++ b/pkg/background/request_process.go
@@ -7,7 +7,7 @@ import (
 
 func (c *Controller) ProcessGR(gr *kyverno.GenerateRequest) error {
 	ctrl, _ := generate.NewGenerateController(c.kyvernoClient, c.client,
-		c.policyLister, c.npolicyLister, c.grLister, c.eventGen, c.log, c.Config,
+		c.policyLister, c.npolicyLister, c.grLister, c.eventGen, c.dynamicInformer, c.log, c.Config,
 	)
 	return ctrl.ProcessGR(gr)
 }


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
 `/milestone 1.7.0`.


## What type of PR is this

fix the missing `policy.kyverno.io/policy-name` label in target resources
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
