### PR TITLE
Remove helm mode setting

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -63,7 +63,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | nameOverride | string | `nil` | Override the name of the chart |
 | fullnameOverride | string | `nil` | Override the expanded name of the chart |
 | namespace | string | `nil` | Namespace the chart deploys to |
-| mode | string | `"standalone"` | Mode for Kyverno installation |
 | customLabels | object | `{}` | Additional labels |
 | rbac.create | bool | `true` | Create ClusterRoles, ClusterRoleBindings, and ServiceAccount |
 | rbac.serviceAccount.create | bool | `true` | Create a ServiceAccount |
@@ -79,7 +78,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | testImage.repository | string | `nil` | Image repository Defaults to `busybox` if omitted |
 | testImage.tag | string | `nil` | Image tag Defaults to `latest` if omitted |
 | testImage.pullPolicy | string | `nil` | Image pull policy Defaults to image.pullPolicy if omitted |
-| replicaCount | int | `0` | Desired number of pods |
+| replicaCount | int | `nil` | Desired number of pods |
 | podLabels | object | `{}` | Additional labels to add to each pod |
 | podAnnotations | object | `{}` | Additional annotations to add to each pod |
 | podSecurityContext | object | `{}` | Security context for the pod |
@@ -170,6 +169,13 @@ You can however override the default resource filters by setting the `config.res
 It contains an array of string templates that are passed through the `tpl` Helm function and joined together to produce the final `resourceFilters` written in the Kyverno config map.
 
 Please consult the [values.yaml](./values.yaml) file before overriding `config.resourceFilters` and use the apropriate templates to build your desired exclusions list.
+
+## High availability
+
+Running highly available Kyverno is crucial as the Kubernetes api server will invoke Kyverno webhook for almost all resource operations in the cluster.
+
+In order to run Kyverno in high availability mode, you should set `replicaCount` to `3` or more.
+You should also pay attention to anti affinity rules, spreading pods across nodes and availability zones.
 
 ## Source Code
 

--- a/charts/kyverno/README.md.gotmpl
+++ b/charts/kyverno/README.md.gotmpl
@@ -92,6 +92,13 @@ It contains an array of string templates that are passed through the `tpl` Helm 
 
 Please consult the [values.yaml](./values.yaml) file before overriding `config.resourceFilters` and use the apropriate templates to build your desired exclusions list.
 
+## High availability
+
+Running highly available Kyverno is crucial as the Kubernetes api server will invoke Kyverno webhook for almost all resource operations in the cluster.
+
+In order to run Kyverno in high availability mode, you should set `replicaCount` to `3` or more.
+You should also pay attention to anti affinity rules, spreading pods across nodes and availability zones.
+
 {{ template "chart.sourcesSection" . }}
 
 {{ template "chart.requirementsSection" . }}

--- a/charts/kyverno/templates/NOTES.txt
+++ b/charts/kyverno/templates/NOTES.txt
@@ -2,3 +2,12 @@ Thank you for installing {{ .Chart.Name }} {{ .Chart.Version }} 😀
 
 Your release is named {{ .Release.Name }}, app version {{ default .Chart.AppVersion (default .Values.image.tag .Values.initImage.tag) }}
 
+{{- if not .Values.replicaCount }}
+WARNING: Setting replicas count below 3 means Kyverno is not running in high availability mode.
+{{- else if lt .Values.replicaCount 3 }}
+WARNING: Setting replicas count below 3 means Kyverno is not running in high availability mode.
+{{- end }}
+
+{{- if empty .Values.config.webhooks }}
+WARNING: Kyverno has been installed with no Namespace exclusions which may prevent normal cluster operations in cluster or Node failure scenarios.
+{{- end }}

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -105,16 +105,6 @@ maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
 {{- end }}
 {{- end }}
 
-{{- define "kyverno.replicaCount" -}}
-{{- if not (empty .Values.replicaCount) -}}
-{{- .Values.replicaCount -}}
-{{- else if eq .Values.mode "standalone" -}}
-1
-{{- else if eq .Values.mode "ha" -}}
-3
-{{- end }}
-{{- end }}
-
 {{- define "kyverno.securityContext" -}}
 {{- if semverCompare "<1.19" .Capabilities.KubeVersion.Version }}
 {{ toYaml (omit .Values.securityContext "seccompProfile") }}

--- a/charts/kyverno/templates/deployment.yaml
+++ b/charts/kyverno/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: kyverno
   namespace: {{ template "kyverno.namespace" . }}
 spec:
-  replicas: {{ include "kyverno.replicaCount" . }}
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{ include "kyverno.matchLabels" . | nindent 6 }}
   {{- if .Values.updateStrategy }}

--- a/charts/kyverno/templates/poddisruptionbudget.yaml
+++ b/charts/kyverno/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if (gt (int (include "kyverno.replicaCount" .)) 1) }}
+{{- if (gt (int .Values.replicaCount) 1) }}
 {{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
 {{- else }}

--- a/charts/kyverno/templates/validate.yaml
+++ b/charts/kyverno/templates/validate.yaml
@@ -1,0 +1,3 @@
+{{- if hasKey .Values "mode" }}
+  {{ fail "mode is not supported anymore, please remove it from your release and use replicaCount instead." }}
+{{- end }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -7,9 +7,6 @@ fullnameOverride:
 # -- Namespace the chart deploys to
 namespace:
 
-# -- Mode for Kyverno installation
-mode: standalone
-
 # -- Additional labels
 customLabels: {}
 
@@ -58,8 +55,8 @@ testImage:
   # Defaults to image.pullPolicy if omitted
   pullPolicy:
 
-# -- Desired number of pods
-replicaCount: 0
+# -- (int) Desired number of pods
+replicaCount: ~
 
 # -- Additional labels to add to each pod
 podLabels: {}

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -11468,7 +11468,7 @@ spec:
         - name: TUF_ROOT
           value: /.sigstore
         image: ghcr.io/kyverno/kyverno:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 2
           httpGet:
@@ -11523,7 +11523,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: ghcr.io/kyverno/kyvernopre:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: kyverno-pre
         resources:
           limits:


### PR DESCRIPTION
This PR removes helm mode setting.
The `ha` vs `standalone` mode can be replaced with a simpler replicas count (the `ha` mode only influenced replicas count, making it hard to understand).
It also adds a couple of warnings in `NOTES.TXT` when deployed in non-ha and/or without namespace exclusions.