### PR TITLE
fix: do not remove webhooks during initialization

### DIFF
--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -896,7 +896,7 @@ func (wrc *Register) updateResourceMutatingWebhookConfiguration(webhookCfg confi
 // the targetConfig. If the targetConfig doesn't provide any rules, the existing rules will be preserved.
 func (wrc *Register) updateMutatingWebhookConfiguration(targetConfig *admregapi.MutatingWebhookConfiguration) error {
 	// Fetch the existing webhook.
-	obj, err := wrc.client.GetResource("", kindMutating, "", targetConfig.Name)
+	currentConfiguration, err := wrc.mwcLister.Get(targetConfig.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get %s %s: %v", kindMutating, targetConfig.Name, err)
 	}
@@ -905,14 +905,8 @@ func (wrc *Register) updateMutatingWebhookConfiguration(targetConfig *admregapi.
 	for _, w := range targetConfig.Webhooks {
 		targetWebhooksMap[w.Name] = w
 	}
-	// Convert the existing webhook.
-	newWebhooks := make([]admregapi.MutatingWebhook, 0)
-	var currentConfiguration *admregapi.MutatingWebhookConfiguration
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &currentConfiguration)
-	if err != nil {
-		return fmt.Errorf("failed to convert %s %s from unstructured: %v", kindMutating, targetConfig.Name, err)
-	}
 	// Update the webhooks.
+	newWebhooks := make([]admregapi.MutatingWebhook, 0)
 	for _, w := range currentConfiguration.Webhooks {
 		target, exist := targetWebhooksMap[w.Name]
 		if !exist {
@@ -947,7 +941,7 @@ func (wrc *Register) updateMutatingWebhookConfiguration(targetConfig *admregapi.
 // the targetConfig. If the targetConfig doesn't provide any rules, the existing rules will be preserved.
 func (wrc *Register) updateValidatingWebhookConfiguration(targetConfig *admregapi.ValidatingWebhookConfiguration) error {
 	// Fetch the existing webhook.
-	obj, err := wrc.client.GetResource("", kindValidating, "", targetConfig.Name)
+	currentConfiguration, err := wrc.vwcLister.Get(targetConfig.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get %s %s: %v", kindValidating, targetConfig.Name, err)
 	}
@@ -956,14 +950,8 @@ func (wrc *Register) updateValidatingWebhookConfiguration(targetConfig *admregap
 	for _, w := range targetConfig.Webhooks {
 		targetWebhooksMap[w.Name] = w
 	}
-	// Convert the existing webhook.
-	newWebhooks := make([]admregapi.ValidatingWebhook, 0)
-	var currentConfiguration *admregapi.ValidatingWebhookConfiguration
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &currentConfiguration)
-	if err != nil {
-		return fmt.Errorf("failed to convert %s %s from unstructured: %v", kindValidating, targetConfig.Name, err)
-	}
 	// Update the webhooks.
+	newWebhooks := make([]admregapi.ValidatingWebhook, 0)
 	for _, w := range currentConfiguration.Webhooks {
 		target, exist := targetWebhooksMap[w.Name]
 		if !exist {

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -901,7 +901,7 @@ func (wrc *Register) updateMutatingWebhookConfiguration(targetConfig *admregapi.
 		return fmt.Errorf("failed to get %s %s: %v", kindMutating, targetConfig.Name, err)
 	}
 	// Create a map of the target webhooks.
-	targetWebhooksMap := make(map[string]admregapi.MutatingWebhook, 0)
+	targetWebhooksMap := make(map[string]admregapi.MutatingWebhook)
 	for _, w := range targetConfig.Webhooks {
 		targetWebhooksMap[w.Name] = w
 	}
@@ -952,7 +952,7 @@ func (wrc *Register) updateValidatingWebhookConfiguration(targetConfig *admregap
 		return fmt.Errorf("failed to get %s %s: %v", kindValidating, targetConfig.Name, err)
 	}
 	// Create a map of the target webhooks.
-	targetWebhooksMap := make(map[string]admregapi.ValidatingWebhook, 0)
+	targetWebhooksMap := make(map[string]admregapi.ValidatingWebhook)
 	for _, w := range targetConfig.Webhooks {
 		targetWebhooksMap[w.Name] = w
 	}


### PR DESCRIPTION
## Related issue

Closes #3625

@realshuting 

## Milestone of this PR

/milestone 1.7.0

## What type of PR is this

/kind bug

## Proposed Changes

Currently during the webhook registration leader initialization all webhook configs are deleted and recreated. This creates a small time window that the cluster doesn't have any webhook configuration and as a result the resources are not validated.

This PR changes the registration logic to not remove the webhook configurations on the leader initialization. Instead it updates the existing webhook configuration to the current desired values. 

### Proof Manifests

To test this PR:
1. Create a Policy with `validationFailureAction: enforce` :

   ```yaml
   apiVersion: kyverno.io/v1
   kind: Policy
   metadata:
     name: disallow-host-namespaces
   spec:
     validationFailureAction: enforce
     background: true
     rules:
       - name: host-namespaces
         match:
           any:
           - resources:
               kinds:
                 - Pod
         validate:
           message: >-
             Sharing the host namespaces is disallowed. The fields spec.hostNetwork,
             spec.hostIPC, and spec.hostPID must be unset or set to `false`.          
           pattern:
             spec:
               =(hostPID): "false"
               =(hostIPC): "false"
               =(hostNetwork): "false"
   ```

2. Create an invalid resource based on the previous Policy, e.g. create a `pod.yaml`: 

   ```yaml
   apiVersion: v1
   kind: Pod
   metadata:
     name: privilegedr
   spec:
     hostPID: true
     hostNetwork: true
     containers:
     - name: alpine
       image: alpine:3.7
       command:
       - nsenter
       - "--mount=/proc/1/ns/mnt"
       - "--"
       - sh
       - "-"
       stdin: true
       tty: true
       resources:
         requests:
           cpu: 10m
       securityContext:
         privileged: true
   ```

3. Start applying the in a loop: 
   ```sh
   until kubectl apply -f pod.yaml; do echo "trying again"; done
   Error from server: error when creating "pod.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 
   
   resource Pod/kubeflow-user/privileged was blocked due to the following policies
   
   disallow-host-namespaces: 
 	  host-namespaces: 'validation error: Sharing the host namespaces is disallowed. The
   fields spec.hostNetwork, spec.hostIPC, and spec.hostPID must be unset or set to
   `false`.          . Rule host-namespaces failed at path /spec/hostNetwork/'
   trying again
   ```

4. In a new terminal delete the Kyverno pod: 
     ```bash
   kubectl delete pods -n kyverno --all
   ```

5. Wait until the new Kyverno pod initializes. When it does that, the command in step 3 will succeed and create the resource. 

This PR should fix this behavior and the command in step 3 will not succeed.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

The solution is not as simple as just removing the `wrc.removeWebhookConfigurations()` from the `Register` method. The reson for this is mainly the `autoUpdateWebhooks` flag.

More specifically if on the first run Kyverno has the flag `autoUpdateWebhooks: false` it will create a "catch all" `ValidatingWebhookConfiguration` for the resources with one webhook defined. 

If we later change the `autoUpdateWebhooks: true`, the webhooks are not reinitialized, thus the `ValidatingWebhookConfiguration` becomes out of sync with only the `validate.kyverno.svc-ignore` webhook defined. When the Config Manager is trying to update the webhook configuration, it will not find `validate.kyverno.svc-fail` and not apply the correct rules.

This PR solves it by implementing 2 methods in `registration`: 
1. `updateValidatingWebhookConfiguration`
1. `updateMutatingWebhookConfiguration`

These methods are updating the existing webhook configurations during initialization.  If the `autoUpdateWebhooks: true`, the existing rules will not be ovewritten and  the `validate.kyverno.svc-fail` resources will fail until the Kyverno Pod is up.
Also we need to syncrhonize the `caBundle` value to the existing webhook configuration, in case it changed.


An extra note is that there was a minor issue in the `webhookRulesEqual` function, that when the API had 1 value but the internal representation was empty it returned `true`. The reason for that is that the `len` of the 2 arrays was 1, but the internal representation had one empty object.

 
