### PR TITLE
fix: prevent installing chart with 2 replicas

### DIFF
--- a/charts/kyverno/templates/validate.yaml
+++ b/charts/kyverno/templates/validate.yaml
@@ -1,3 +1,9 @@
 {{- if hasKey .Values "mode" }}
   {{ fail "mode is not supported anymore, please remove it from your release and use replicaCount instead." }}
 {{- end }}
+
+{{- if .Values.replicaCount }}
+  {{- if eq .Values.replicaCount 2 }}
+    {{ fail "Kyverno does not support running with 2 replicas. For a highly-available deployment, select 3 replicas or for standalone select 1 replica." }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
This PR prevents installing chart with 2 replicas.