### PR TITLE
fix: print helm install warnings

### DIFF
--- a/charts/kyverno/templates/NOTES.txt
+++ b/charts/kyverno/templates/NOTES.txt
@@ -9,5 +9,7 @@ WARNING: Setting replicas count below 3 means Kyverno is not running in high ava
 {{- end }}
 
 {{- if empty .Values.config.webhooks }}
-WARNING: Kyverno has been installed with no Namespace exclusions which may prevent normal cluster operations in cluster or Node failure scenarios.
+WARNING: Kyverno has been installed with no Namespace exclusions which may prevent normal cluster operations in cluster or Node failure scenarios. Please see the documentation at https://kyverno.io/foo to understand the risks.
+{{- else }}
+WARNING: Kyverno has been installed and some Namespaces and/or resources have been excluded from webhooks. Please see the documentation at https://kyverno.io/bar to understand the risks.
 {{- end }}


### PR DESCRIPTION
This PR print warnings when using helm install in non HA mode and/or depending on webhooks exclusions.

TODO: set correct links in NOTES.

Fixes: #3607 