### PR TITLE
chore: warn if kube version is too old in helm notes

### DIFF
--- a/charts/kyverno/templates/NOTES.txt
+++ b/charts/kyverno/templates/NOTES.txt
@@ -11,3 +11,7 @@ WARNING: Setting replicas count below 3 means Kyverno is not running in high ava
 {{- if empty .Values.config.webhooks }}
 WARNING: Kyverno has been installed with no Namespace exclusions which may prevent normal cluster operations in cluster or Node failure scenarios.
 {{- end }}
+
+{{- if semverCompare "<1.21.0" .Capabilities.KubeVersion.Version }}
+WARNING: The minimal Kubernetes version officially supported by Kyverno is 1.21. We don't run tests against previous versions and Kyverno is not guaranteed to work with Kubernetes {{ .Capabilities.KubeVersion.Version }}.
+{{- end }}


### PR DESCRIPTION
This PR warns if kube version is too old in helm notes.