### PR TITLE
fix: webhooks are not configured correctly

### DIFF
--- a/pkg/webhookconfig/configmanager.go
+++ b/pkg/webhookconfig/configmanager.go
@@ -550,6 +550,14 @@ func webhookRulesEqual(apiRules []interface{}, internalRules []interface{}) (boo
 		}
 	}
 
+	// Handle edge case when internal is empty but API has one rule.
+	// internal representation is one rule but with no selectors.
+	if len(apiRules) == 1 && len(internalRules) == 1 {
+		if len(internalRules[0].(map[string]interface{})) == 0 {
+			return false, nil
+		}
+	}
+
 	// Both *should* be length 1, but as long
 	// as they are equal the next loop works.
 	if len(apiRules) != len(internalRules) {

--- a/pkg/webhookconfig/configmanager_test.go
+++ b/pkg/webhookconfig/configmanager_test.go
@@ -117,6 +117,9 @@ func TestRulesEqual(t *testing.T) {
 		// Both rules select secrets and configmaps (reversed compared to previous). Should be equal.
 		{"secrets-cm-equal", secretsConfigmapsInternalRules, secretsConfigmapsAPIRules, true, false},
 
+		// Internal empty, API has one rule. Not equal.
+		{"internal-empty-api-single", emptyInternalRules, configmapsSecretsAPIRules, false, false},
+
 		// Internal is updated from nothing to configmaps. Not equal.
 		{"add-configmaps", configmapsInternalRules, emptyAPIRules, false, false},
 

--- a/test/e2e/common/common.go
+++ b/test/e2e/common/common.go
@@ -95,6 +95,8 @@ func checkPolicyCreated(policyName string) func() error {
 			return fmt.Errorf("policy not created: %v", err)
 		}
 
+		// Wait to make sure that the Policy is ready.
+		time.Sleep(2 * time.Second)
 		return nil
 	}
 }


### PR DESCRIPTION
## Related issue

Closes #3653
@realshuting 

## Milestone of this PR

/milestone 1.7.0

## What type of PR is this

 /kind bug

## Proposed Changes

There is an issue in the `webhookRulesEqual` function, that when the API had 1 value but the internal representation was empty it returned `true`. The reason for that is that the `len` of the 2 arrays was 1, but the internal representation had one empty object.

When you apply a Policy with `autoUpdateWebhooks: true` (default) Kyverno is updating the webhook rules dynamically to include the resources declared in your Policy and when you delete the Policy these rules should be removed. 
This bug affects the removal of the rules when the webhook has 1 rule and the target desired rules list is empty. 
When this happens, the existing rule is not removed, which results in a wrong state of the webhook configuration.

This PR fixes this equality mismatch between the target and the current state.

### Proof Manifests

You can reproduce this issue by: 

1. Apply a mutating policy, for example : 
   ```yaml
   apiVersion: kyverno.io/v1
   kind: ClusterPolicy
   metadata:
     name: add-volume
     annotations:
       policies.kyverno.io/title: Add Volume to Deployment
       policies.kyverno.io/category: Sample
       policies.kyverno.io/subject: Deployment, Volume
       policies.kyverno.io/description: >-
         Some Kubernetes applications like HashiCorp Vault must perform some modifications
         to resources in order to invoke their specific functionality. Often times, that functionality
         is controlled by the presence of a label or specific annotation. This policy, based on HashiCorp
         Vault, adds a volume and volumeMount to a Deployment if there is an annotation called
         "vault.k8s.corp.net/inject=enabled" present.
   spec:
     rules:
     - name: add-volume
       match:
         resources:
           kinds:
           - Deployment
       preconditions:
         any:
         - key: "{{request.object.spec.template.metadata.annotations.\"vault.k8s.corp.net/inject\"}}"
           operator: Equals
           value: "enabled"
       mutate:
         patchesJson6902: |-
           - op: add
             path: /spec/template/spec/volumes
             value: [{"name": "vault-secret","emptyDir": {"medium": "Memory"}}]
   ```
2. Verify that the `kyverno-resource-mutating-webhook-cfg` configuration rules are updated:
   ```yaml
   ...
    rules:
    - apiGroups:
      - apps
      apiVersions:
      - v1
      operations:
      - CREATE
      - UPDATE
      - DELETE
      resources:
      - deployments
      scope: '*'
   ...
   ``` 
3. Delete the policy you created in step 1: 
   ```bash
   kubectl delete clusterpolicy add-volume
   ```
4. Verify that the `kyverno-resource-mutating-webhook-cfg` configuration rules are **not** updated:
   ```yaml
   ...
    rules:
    - apiGroups:
      - apps
      apiVersions:
      - v1
      operations:
      - CREATE
      - UPDATE
      - DELETE
      resources:
      - deployments
      scope: '*'
   ...
   ``` 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

This fix raises some unrelated errors in the E2E tests. I couldn't pinpoint exactly why this happens, but it looks like when the `PolicyCreated` returns and the Policy is labeled as `ready`, it's not always ready. I think that the webhook rules are not effective immediately when the Policy is `ready` and this results in some generate/mutate tests passing.
Previously the webhook rules were not updated and that's the reason that the tests passed and now are failing, but I think the current behavior is the correct one.
I added a small time delay in the `checkPolicyCreated` to ensure that the Policy is indeed ready and that fixed the error.
 
