### PR TITLE
Fix regression in wildcard matches in In/AnyIn operators

### DIFF
--- a/pkg/engine/variables/operator/anyin.go
+++ b/pkg/engine/variables/operator/anyin.go
@@ -63,7 +63,7 @@ func anyKeyExistsInArray(key string, value interface{}, log logr.Logger) (invali
 
 	case []interface{}:
 		for _, val := range valuesAvailable {
-			if wildcard.Match(fmt.Sprint(val), key) {
+			if wildcard.Match(fmt.Sprint(val), key) || wildcard.Match(key, fmt.Sprint(val)) {
 				return false, true
 			}
 		}

--- a/pkg/engine/variables/operator/in.go
+++ b/pkg/engine/variables/operator/in.go
@@ -63,7 +63,7 @@ func keyExistsInArray(key string, value interface{}, log logr.Logger) (invalidTy
 
 	case []interface{}:
 		for _, val := range valuesAvailable {
-			if wildcard.Match(fmt.Sprint(val), key) {
+			if wildcard.Match(fmt.Sprint(val), key) || wildcard.Match(key, fmt.Sprint(val)) {
 				return false, true
 			}
 		}

--- a/test/cli/test/context-entries/kyverno-test.yaml
+++ b/test/cli/test/context-entries/kyverno-test.yaml
@@ -44,3 +44,8 @@ results:
     resource: example
     kind: Pod
     result: pass
+  - policy: example
+    rule:  wildcard-match
+    resource: example
+    kind: Pod
+    result: pass

--- a/test/cli/test/context-entries/policies.yaml
+++ b/test/cli/test/context-entries/policies.yaml
@@ -146,3 +146,20 @@ spec:
             - key: "{{ to_string(obj.notName) }}"
               operator: NotEquals
               value: 'null'
+  - name: wildcard-match
+    context:
+    - name: obj
+      variable:
+        value: 
+         - A=ATest
+         - B=BTest
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      deny:
+        conditions:
+          - key: "A=*"
+            operator: AnyNotIn
+            value: "{{ obj }}"


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>

Fixes #3685 

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

/milestone 1.7.0

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind bug
## Proposed Changes

Allows for both wildcard keys and values in `AnyIn` operator.

### Proof Manifests
Added as a CLI test