### PR TITLE
Add e2e tests for mutate existing policies

### DIFF
--- a/config/github/rbac.yaml
+++ b/config/github/rbac.yaml
@@ -11,6 +11,9 @@ rules:
       - clusterroles
       - rolebindings
       - clusterrolebindings
+      - secrets
+      - configmaps
+      - deployments
     verbs:
       - create
       - delete

--- a/test/e2e/mutate/config.go
+++ b/test/e2e/mutate/config.go
@@ -171,3 +171,104 @@ var ingressTests = struct {
 		},
 	},
 }
+
+type mutateExistingOperation string
+
+const (
+	createTrigger mutateExistingOperation = "createTrigger"
+	deleteTrigger mutateExistingOperation = "deleteTrigger"
+	createPolicy  mutateExistingOperation = "createPolicy"
+)
+
+// Note: sometimes deleting namespaces takes time.
+// Using different names for namespaces prevents collisions.
+var mutateExistingTests = []struct {
+	// TestDescription - Description of the Test
+	TestDescription string
+	// Operation describes how to trigger the policy
+	Operation mutateExistingOperation
+	// PolicyName - Name of the Policy
+	PolicyName string
+	// PolicyRaw - The Yaml file of the ClusterPolicy
+	PolicyRaw []byte
+	// TriggerName - Name of the Trigger Resource
+	TriggerName string
+	// TriggerNamespace - Namespace of the Trigger Resource
+	TriggerNamespace string
+	// TriggerGVR - GVR of the Trigger Resource
+	TriggerGVR schema.GroupVersionResource
+	// TriggerRaw - The Yaml file of the Trigger Resource
+	TriggerRaw []byte
+	// TargetName - Name of the Target Resource
+	TargetName string
+	// TargetNamespace - Namespace of the Target Resource
+	TargetNamespace string
+	// TargetGVR - GVR of the Target Resource
+	TargetGVR schema.GroupVersionResource
+	// TargetRaw - The Yaml file of the Target ClusterPolicy
+	TargetRaw []byte
+	// ExpectedTargetRaw - The Yaml file that contains validate pattern for the expected result
+	// This is not the final result. It is just used to validate the result from the engine.
+	ExpectedTargetRaw []byte
+}{
+	{
+		TestDescription:   "mutate existing on resource creation",
+		Operation:         createTrigger,
+		PolicyName:        "test-post-mutation-create-trigger",
+		PolicyRaw:         policyCreateTrigger,
+		TriggerName:       "dictionary-1",
+		TriggerNamespace:  "staging-1",
+		TriggerGVR:        configmGVR,
+		TriggerRaw:        triggerCreateTrigger,
+		TargetName:        "test-secret-1",
+		TargetNamespace:   "staging-1",
+		TargetGVR:         secretGVR,
+		TargetRaw:         targetCreateTrigger,
+		ExpectedTargetRaw: expectedTargetCreateTrigger,
+	},
+	{
+		TestDescription:   "mutate existing on resource deletion",
+		Operation:         deleteTrigger,
+		PolicyName:        "test-post-mutation-delete-trigger",
+		PolicyRaw:         policyDeleteTrigger,
+		TriggerName:       "dictionary-2",
+		TriggerNamespace:  "staging-2",
+		TriggerGVR:        configmGVR,
+		TriggerRaw:        triggerDeleteTrigger,
+		TargetName:        "test-secret-2",
+		TargetNamespace:   "staging-2",
+		TargetGVR:         secretGVR,
+		TargetRaw:         targetDeleteTrigger,
+		ExpectedTargetRaw: expectedTargetDeleteTrigger,
+	},
+	{
+		TestDescription:   "mutate existing on policy creation",
+		Operation:         createPolicy,
+		PolicyName:        "test-post-mutation-create-policy",
+		PolicyRaw:         policyCreatePolicy,
+		TriggerName:       "dictionary-3",
+		TriggerNamespace:  "staging-3",
+		TriggerGVR:        configmGVR,
+		TriggerRaw:        triggerCreatePolicy,
+		TargetName:        "test-secret-3",
+		TargetNamespace:   "staging-3",
+		TargetGVR:         secretGVR,
+		TargetRaw:         targetCreatePolicy,
+		ExpectedTargetRaw: expectedTargetCreatePolicy,
+	},
+	{
+		TestDescription:   "mutate existing (patchesJson6902) on resource creation",
+		Operation:         createTrigger,
+		PolicyName:        "test-post-mutation-json-patch-create-trigger",
+		PolicyRaw:         policyCreateTriggerJsonPatch,
+		TriggerName:       "dictionary-4",
+		TriggerNamespace:  "staging-4",
+		TriggerGVR:        configmGVR,
+		TriggerRaw:        triggerCreateTriggerJsonPatch,
+		TargetName:        "test-secret-4",
+		TargetNamespace:   "staging-4",
+		TargetGVR:         secretGVR,
+		TargetRaw:         targetCreateTriggerJsonPatch,
+		ExpectedTargetRaw: expectedCreateTriggerJsonPatch,
+	},
+}


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

This PR adds the following e2e tests for mutate existing policies:

- mutate the existing secret on configmap creation
- mutate the existing secret on configmap deletion
- mutate the existing secret on policy creation
- mutate the existing secret (Json Patch) on configmap creation