### PR TITLE
fix: generated api reference docs

### DIFF
--- a/api/kyverno/v1/clusterpolicy_types.go
+++ b/api/kyverno/v1/clusterpolicy_types.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -19,6 +18,8 @@ import (
 // +kubebuilder:printcolumn:name="Action",type="string",JSONPath=".spec.validationFailureAction"
 // +kubebuilder:printcolumn:name="Failure Policy",type="string",JSONPath=".spec.failurePolicy",priority=1
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.ready`
+
+// ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.
 type ClusterPolicy struct {
 	metav1.TypeMeta   `json:",inline,omitempty" yaml:",inline,omitempty"`
 	metav1.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
@@ -109,8 +110,9 @@ func (p *ClusterPolicy) CreateDeepCopy() PolicyInterface {
 	return p.DeepCopy()
 }
 
-// ClusterPolicyList is a list of ClusterPolicy instances.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// ClusterPolicyList is a list of ClusterPolicy instances.
 type ClusterPolicyList struct {
 	metav1.TypeMeta `json:",inline" yaml:",inline"`
 	metav1.ListMeta `json:"metadata" yaml:"metadata"`

--- a/api/kyverno/v1/policy_types.go
+++ b/api/kyverno/v1/policy_types.go
@@ -8,8 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// Policy declares validation, mutation, and generation behaviors for matching resources.
-// See: https://kyverno.io/docs/writing-policies/ for more information.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
@@ -19,6 +17,9 @@ import (
 // +kubebuilder:printcolumn:name="Failure Policy",type="string",JSONPath=".spec.failurePolicy",priority=1
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.ready`
 // +kubebuilder:resource:shortName=pol
+
+// Policy declares validation, mutation, and generation behaviors for matching resources.
+// See: https://kyverno.io/docs/writing-policies/ for more information.
 type Policy struct {
 	metav1.TypeMeta   `json:",inline,omitempty" yaml:",inline,omitempty"`
 	metav1.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
@@ -110,8 +111,9 @@ func (p *Policy) CreateDeepCopy() PolicyInterface {
 	return p.DeepCopy()
 }
 
-// PolicyList is a list of Policy instances.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// PolicyList is a list of Policy instances.
 type PolicyList struct {
 	metav1.TypeMeta `json:",inline" yaml:",inline"`
 	metav1.ListMeta `json:"metadata" yaml:"metadata"`

--- a/api/kyverno/v1alpha2/clusterreportchangerequest_types.go
+++ b/api/kyverno/v1alpha2/clusterreportchangerequest_types.go
@@ -22,10 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
-// ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests API
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
@@ -40,6 +36,8 @@ import (
 // +kubebuilder:printcolumn:name="Error",type=integer,JSONPath=`.summary.error`
 // +kubebuilder:printcolumn:name="Skip",type=integer,JSONPath=`.summary.skip`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+
+// ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests API
 type ClusterReportChangeRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -62,9 +60,10 @@ type ClusterReportChangeRequest struct {
 	Results []report.PolicyReportResult `json:"results,omitempty"`
 }
 
-// ClusterReportChangeRequestList contains a list of ClusterReportChangeRequest
 // +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// ClusterReportChangeRequestList contains a list of ClusterReportChangeRequest
 type ClusterReportChangeRequestList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/kyverno/v1alpha2/reportchangerequest_types.go
+++ b/api/kyverno/v1alpha2/reportchangerequest_types.go
@@ -25,7 +25,6 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// ReportChangeRequest is the Schema for the ReportChangeRequests API
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
@@ -39,6 +38,8 @@ import (
 // +kubebuilder:printcolumn:name="Skip",type=integer,JSONPath=`.summary.skip`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:shortName=rcr
+
+// ReportChangeRequest is the Schema for the ReportChangeRequests API
 type ReportChangeRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -61,9 +62,10 @@ type ReportChangeRequest struct {
 	Results []report.PolicyReportResult `json:"results,omitempty"`
 }
 
-// ReportChangeRequestList contains a list of ReportChangeRequest
 // +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// ReportChangeRequestList contains a list of ReportChangeRequest
 type ReportChangeRequestList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/kyverno/v1beta1/updaterequest_types.go
+++ b/api/kyverno/v1beta1/updaterequest_types.go
@@ -23,9 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // UpdateRequestStatus defines the observed state of UpdateRequest
 type UpdateRequestStatus struct {
 
@@ -41,7 +38,6 @@ type UpdateRequestStatus struct {
 	GeneratedResources []v1.ResourceSpec `json:"generatedResources,omitempty" yaml:"generatedResources,omitempty"`
 }
 
-// UpdateRequestStatus is a request to process mutate and generate rules in background.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
@@ -53,6 +49,8 @@ type UpdateRequestStatus struct {
 // +kubebuilder:printcolumn:name="status",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:shortName=ur
+
+// UpdateRequestStatus is a request to process mutate and generate rules in background.
 type UpdateRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/docs/config.json
+++ b/docs/config.json
@@ -12,7 +12,7 @@
             "docsURLTemplate": "https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"
         },
         {
-            "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
+            "typeMatchPrefix": "^k8s\\.io/(api|apimachinery|apiextensions-apiserver/pkg/apis)/",
             "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
@@ -22,7 +22,8 @@
     ],
     "typeDisplayNamePrefixOverrides": {
         "k8s.io/api/": "Kubernetes ",
-        "k8s.io/apimachinery/pkg/apis/": "Kubernetes "
+        "k8s.io/apimachinery/pkg/apis/": "Kubernetes ",
+        "k8s.io/apiextensions-apiserver/pkg/apis/": "Kubernetes "
     },
     "markdownDisabled": false
 }

--- a/docs/crd/v1/index.html
+++ b/docs/crd/v1/index.html
@@ -24,7 +24,371 @@ background-color: #1589dd;
 </nav>
 <h2 id="kyverno.io/v1">kyverno.io/v1</h2>
 Resource Types:
-<ul></ul>
+<ul><li>
+<a href="#kyverno.io/v1.ClusterPolicy">ClusterPolicy</a>
+</li><li>
+<a href="#kyverno.io/v1.Policy">Policy</a>
+</li></ul>
+<hr />
+<h3 id="kyverno.io/v1.ClusterPolicy">ClusterPolicy
+</h3>
+<p>
+<p>ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.</p>
+</p>
+<table class="table table-striped">
+<thead class="thead-dark">
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+kyverno.io/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ClusterPolicy</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#kyverno.io/v1.Spec">
+Spec
+</a>
+</em>
+</td>
+<td>
+<p>Spec declares policy behaviors.</p>
+<br/>
+<br/>
+<table class="table table-striped">
+<tr>
+<td>
+<code>rules</code></br>
+<em>
+<a href="#kyverno.io/v1.Rule">
+[]Rule
+</a>
+</em>
+</td>
+<td>
+<p>Rules is a list of Rule instances. A Policy contains multiple rules and
+each rule can validate, mutate, or generate resources.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>failurePolicy</code></br>
+<em>
+<a href="#kyverno.io/v1.FailurePolicyType">
+FailurePolicyType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FailurePolicy defines how unrecognized errors from the admission endpoint are handled.
+Rules within the same policy share the same failure behavior.
+Allowed values are Ignore or Fail. Defaults to Fail.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>validationFailureAction</code></br>
+<em>
+<a href="#kyverno.io/v1.ValidationFailureAction">
+ValidationFailureAction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ValidationFailureAction controls if a validation policy rule failure should disallow
+the admission review request (enforce), or allow (audit) the admission review request
+and report an error in a policy report. Optional. The default value is &ldquo;audit&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>validationFailureActionOverrides</code></br>
+<em>
+<a href="#kyverno.io/v1.ValidationFailureActionOverride">
+[]ValidationFailureActionOverride
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ValidationFailureActionOverrides is a Cluster Policy attribute that specifies ValidationFailureAction
+namespace-wise. It overrides ValidationFailureAction for the specified namespaces.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>background</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Background controls if rules are applied to existing resources during a background scan.
+Optional. Default value is &ldquo;true&rdquo;. The value must be set to &ldquo;false&rdquo; if the policy rule
+uses variables that are only available in the admission review request (e.g. user name).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schemaValidation</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SchemaValidation skips policy validation checks.
+Optional. The default value is set to &ldquo;true&rdquo;, it must be set to &ldquo;false&rdquo; to disable the validation checks.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>webhookTimeoutSeconds</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>WebhookTimeoutSeconds specifies the maximum time in seconds allowed to apply this policy.
+After the configured time expires, the admission request may fail, or may simply ignore the policy results,
+based on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#kyverno.io/v1.PolicyStatus">
+PolicyStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status contains policy runtime data.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h3 id="kyverno.io/v1.Policy">Policy
+</h3>
+<p>
+<p>Policy declares validation, mutation, and generation behaviors for matching resources.
+See: <a href="https://kyverno.io/docs/writing-policies/">https://kyverno.io/docs/writing-policies/</a> for more information.</p>
+</p>
+<table class="table table-striped">
+<thead class="thead-dark">
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+kyverno.io/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Policy</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#kyverno.io/v1.Spec">
+Spec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines policy behaviors and contains one or more rules.</p>
+<br/>
+<br/>
+<table class="table table-striped">
+<tr>
+<td>
+<code>rules</code></br>
+<em>
+<a href="#kyverno.io/v1.Rule">
+[]Rule
+</a>
+</em>
+</td>
+<td>
+<p>Rules is a list of Rule instances. A Policy contains multiple rules and
+each rule can validate, mutate, or generate resources.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>failurePolicy</code></br>
+<em>
+<a href="#kyverno.io/v1.FailurePolicyType">
+FailurePolicyType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FailurePolicy defines how unrecognized errors from the admission endpoint are handled.
+Rules within the same policy share the same failure behavior.
+Allowed values are Ignore or Fail. Defaults to Fail.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>validationFailureAction</code></br>
+<em>
+<a href="#kyverno.io/v1.ValidationFailureAction">
+ValidationFailureAction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ValidationFailureAction controls if a validation policy rule failure should disallow
+the admission review request (enforce), or allow (audit) the admission review request
+and report an error in a policy report. Optional. The default value is &ldquo;audit&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>validationFailureActionOverrides</code></br>
+<em>
+<a href="#kyverno.io/v1.ValidationFailureActionOverride">
+[]ValidationFailureActionOverride
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ValidationFailureActionOverrides is a Cluster Policy attribute that specifies ValidationFailureAction
+namespace-wise. It overrides ValidationFailureAction for the specified namespaces.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>background</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Background controls if rules are applied to existing resources during a background scan.
+Optional. Default value is &ldquo;true&rdquo;. The value must be set to &ldquo;false&rdquo; if the policy rule
+uses variables that are only available in the admission review request (e.g. user name).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schemaValidation</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SchemaValidation skips policy validation checks.
+Optional. The default value is set to &ldquo;true&rdquo;, it must be set to &ldquo;false&rdquo; to disable the validation checks.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>webhookTimeoutSeconds</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>WebhookTimeoutSeconds specifies the maximum time in seconds allowed to apply this policy.
+After the configured time expires, the admission request may fail, or may simply ignore the policy results,
+based on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#kyverno.io/v1.PolicyStatus">
+PolicyStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status contains policy runtime information.
+Deprecated. Policy metrics are available via the metrics endpoint</p>
+</td>
+</tr>
+</tbody>
+</table>
 <hr />
 <h3 id="kyverno.io/v1.APICall">APICall
 </h3>
@@ -266,7 +630,9 @@ See <a href="https://github.com/sigstore/cosign/blob/main/KEYLESS.md">https://gi
 <td>
 <code>attestor</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>
@@ -472,168 +838,6 @@ string
 </tbody>
 </table>
 <hr />
-<h3 id="kyverno.io/v1.ClusterPolicy">ClusterPolicy
-</h3>
-<p>
-<p>ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.</p>
-</p>
-<table class="table table-striped">
-<thead class="thead-dark">
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#kyverno.io/v1.Spec">
-Spec
-</a>
-</em>
-</td>
-<td>
-<p>Spec declares policy behaviors.</p>
-<br/>
-<br/>
-<table class="table table-striped">
-<tr>
-<td>
-<code>rules</code></br>
-<em>
-<a href="#kyverno.io/v1.Rule">
-[]Rule
-</a>
-</em>
-</td>
-<td>
-<p>Rules is a list of Rule instances. A Policy contains multiple rules and
-each rule can validate, mutate, or generate resources.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>failurePolicy</code></br>
-<em>
-<a href="#kyverno.io/v1.FailurePolicyType">
-FailurePolicyType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>FailurePolicy defines how unrecognized errors from the admission endpoint are handled.
-Rules within the same policy share the same failure behavior.
-Allowed values are Ignore or Fail. Defaults to Fail.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>validationFailureAction</code></br>
-<em>
-<a href="#kyverno.io/v1.ValidationFailureAction">
-ValidationFailureAction
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ValidationFailureAction controls if a validation policy rule failure should disallow
-the admission review request (enforce), or allow (audit) the admission review request
-and report an error in a policy report. Optional. The default value is &ldquo;audit&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>validationFailureActionOverrides</code></br>
-<em>
-<a href="#kyverno.io/v1.ValidationFailureActionOverride">
-[]ValidationFailureActionOverride
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ValidationFailureActionOverrides is a Cluster Policy attribute that specifies ValidationFailureAction
-namespace-wise. It overrides ValidationFailureAction for the specified namespaces.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>background</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Background controls if rules are applied to existing resources during a background scan.
-Optional. Default value is &ldquo;true&rdquo;. The value must be set to &ldquo;false&rdquo; if the policy rule
-uses variables that are only available in the admission review request (e.g. user name).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>schemaValidation</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SchemaValidation skips policy validation checks.
-Optional. The default value is set to &ldquo;true&rdquo;, it must be set to &ldquo;false&rdquo; to disable the validation checks.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>webhookTimeoutSeconds</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>WebhookTimeoutSeconds specifies the maximum time in seconds allowed to apply this policy.
-After the configured time expires, the admission request may fail, or may simply ignore the policy results,
-based on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#kyverno.io/v1.PolicyStatus">
-PolicyStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status contains policy runtime data.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr />
 <h3 id="kyverno.io/v1.Condition">Condition
 </h3>
 <p>
@@ -655,7 +859,9 @@ PolicyStatus
 <td>
 <code>key</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>
@@ -682,7 +888,9 @@ DurationLessThanOrEquals, DurationLessThan</p>
 <td>
 <code>value</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>
@@ -855,7 +1063,9 @@ Variable
 <td>
 <code>conditions</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>
@@ -940,7 +1150,9 @@ See: <a href="https://kyverno.io/docs/writing-policies/preconditions/">https://k
 <td>
 <code>patchStrategicMerge</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>
@@ -1043,7 +1255,9 @@ See: <a href="https://kyverno.io/docs/writing-policies/preconditions/">https://k
 <td>
 <code>pattern</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>
@@ -1055,7 +1269,9 @@ k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
 <td>
 <code>anyPattern</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>
@@ -1399,7 +1615,9 @@ Optional. Defaults to &ldquo;false&rdquo; if not specified.</p>
 <td>
 <code>data</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>
@@ -1893,7 +2111,9 @@ Optional. Defaults to &ldquo;false&rdquo; if not specified.</p>
 <td>
 <code>patchStrategicMerge</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>
@@ -1928,170 +2148,6 @@ See <a href="https://tools.ietf.org/html/rfc6902">https://tools.ietf.org/html/rf
 <td>
 <em>(Optional)</em>
 <p>ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr />
-<h3 id="kyverno.io/v1.Policy">Policy
-</h3>
-<p>
-<p>Policy declares validation, mutation, and generation behaviors for matching resources.
-See: <a href="https://kyverno.io/docs/writing-policies/">https://kyverno.io/docs/writing-policies/</a> for more information.</p>
-</p>
-<table class="table table-striped">
-<thead class="thead-dark">
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#kyverno.io/v1.Spec">
-Spec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines policy behaviors and contains one or more rules.</p>
-<br/>
-<br/>
-<table class="table table-striped">
-<tr>
-<td>
-<code>rules</code></br>
-<em>
-<a href="#kyverno.io/v1.Rule">
-[]Rule
-</a>
-</em>
-</td>
-<td>
-<p>Rules is a list of Rule instances. A Policy contains multiple rules and
-each rule can validate, mutate, or generate resources.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>failurePolicy</code></br>
-<em>
-<a href="#kyverno.io/v1.FailurePolicyType">
-FailurePolicyType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>FailurePolicy defines how unrecognized errors from the admission endpoint are handled.
-Rules within the same policy share the same failure behavior.
-Allowed values are Ignore or Fail. Defaults to Fail.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>validationFailureAction</code></br>
-<em>
-<a href="#kyverno.io/v1.ValidationFailureAction">
-ValidationFailureAction
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ValidationFailureAction controls if a validation policy rule failure should disallow
-the admission review request (enforce), or allow (audit) the admission review request
-and report an error in a policy report. Optional. The default value is &ldquo;audit&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>validationFailureActionOverrides</code></br>
-<em>
-<a href="#kyverno.io/v1.ValidationFailureActionOverride">
-[]ValidationFailureActionOverride
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ValidationFailureActionOverrides is a Cluster Policy attribute that specifies ValidationFailureAction
-namespace-wise. It overrides ValidationFailureAction for the specified namespaces.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>background</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Background controls if rules are applied to existing resources during a background scan.
-Optional. Default value is &ldquo;true&rdquo;. The value must be set to &ldquo;false&rdquo; if the policy rule
-uses variables that are only available in the admission review request (e.g. user name).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>schemaValidation</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SchemaValidation skips policy validation checks.
-Optional. The default value is set to &ldquo;true&rdquo;, it must be set to &ldquo;false&rdquo; to disable the validation checks.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>webhookTimeoutSeconds</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>WebhookTimeoutSeconds specifies the maximum time in seconds allowed to apply this policy.
-After the configured time expires, the admission request may fail, or may simply ignore the policy results,
-based on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#kyverno.io/v1.PolicyStatus">
-PolicyStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status contains policy runtime information.
-Deprecated. Policy metrics are available via the metrics endpoint</p>
 </td>
 </tr>
 </tbody>
@@ -2574,7 +2630,9 @@ This config is only valid for verifyImages rules.</p>
 <td>
 <code>preconditions</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>
@@ -2932,7 +2990,9 @@ string
 <td>
 <code>pattern</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>
@@ -2944,7 +3004,9 @@ k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
 <td>
 <code>anyPattern</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>
@@ -3042,7 +3104,9 @@ ValidationFailureAction
 <td>
 <code>value</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>
@@ -3067,7 +3131,9 @@ transform the variable.</p>
 <td>
 <code>default</code></br>
 <em>
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#json-v1-apiextensions">
+Kubernetes apiextensions/v1.JSON
+</a>
 </em>
 </td>
 <td>

--- a/docs/crd/v1alpha2/index.html
+++ b/docs/crd/v1alpha2/index.html
@@ -27,7 +27,11 @@ background-color: #1589dd;
 <p>Package v1alpha2 contains API Schema definitions for the policy v1alpha2 API group</p>
 </p>
 Resource Types:
-<ul></ul>
+<ul><li>
+<a href="#kyverno.io/v1alpha2.ClusterReportChangeRequest">ClusterReportChangeRequest</a>
+</li><li>
+<a href="#kyverno.io/v1alpha2.ReportChangeRequest">ReportChangeRequest</a>
+</li></ul>
 <hr />
 <h3 id="kyverno.io/v1alpha2.ClusterReportChangeRequest">ClusterReportChangeRequest
 </h3>
@@ -42,6 +46,23 @@ Resource Types:
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+kyverno.io/v1alpha2
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ClusterReportChangeRequest</code></td>
+</tr>
 <tr>
 <td>
 <code>metadata</code></br>
@@ -125,6 +146,23 @@ github.com/kyverno/kyverno/api/policyreport/v1alpha2.PolicyReportSummary
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+kyverno.io/v1alpha2
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ReportChangeRequest</code></td>
+</tr>
 <tr>
 <td>
 <code>metadata</code></br>

--- a/docs/crd/v1beta1/index.html
+++ b/docs/crd/v1beta1/index.html
@@ -27,7 +27,135 @@ background-color: #1589dd;
 <p>Package v1beta1 contains API Schema definitions for the policy v1alpha1 API group</p>
 </p>
 Resource Types:
-<ul></ul>
+<ul><li>
+<a href="#kyverno.io/v1beta1.UpdateRequest">UpdateRequest</a>
+</li></ul>
+<hr />
+<h3 id="kyverno.io/v1beta1.UpdateRequest">UpdateRequest
+</h3>
+<p>
+<p>UpdateRequestStatus is a request to process mutate and generate rules in background.</p>
+</p>
+<table class="table table-striped">
+<thead class="thead-dark">
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+kyverno.io/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>UpdateRequest</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#kyverno.io/v1beta1.UpdateRequestSpec">
+UpdateRequestSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec is the information to identify the update request.</p>
+<br/>
+<br/>
+<table class="table table-striped">
+<tr>
+<td>
+<code>requestType</code></br>
+<em>
+<a href="#kyverno.io/v1beta1.RequestType">
+RequestType
+</a>
+</em>
+</td>
+<td>
+<p>Type represents request type for background processing</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>policy</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Specifies the name of the policy.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resource</code></br>
+<em>
+github.com/kyverno/kyverno/api/kyverno/v1.ResourceSpec
+</em>
+</td>
+<td>
+<p>ResourceSpec is the information to identify the update request.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>context</code></br>
+<em>
+<a href="#kyverno.io/v1beta1.UpdateRequestSpecContext">
+UpdateRequestSpecContext
+</a>
+</em>
+</td>
+<td>
+<p>Context &hellip;</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#kyverno.io/v1beta1.UpdateRequestStatus">
+UpdateRequestStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status contains statistics related to update request.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <hr />
 <h3 id="kyverno.io/v1beta1.AdmissionRequestInfoObject">AdmissionRequestInfoObject
 </h3>
@@ -139,115 +267,6 @@ Kubernetes authentication/v1.UserInfo
 </p>
 <p>
 </p>
-<h3 id="kyverno.io/v1beta1.UpdateRequest">UpdateRequest
-</h3>
-<p>
-<p>UpdateRequestStatus is a request to process mutate and generate rules in background.</p>
-</p>
-<table class="table table-striped">
-<thead class="thead-dark">
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#kyverno.io/v1beta1.UpdateRequestSpec">
-UpdateRequestSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec is the information to identify the update request.</p>
-<br/>
-<br/>
-<table class="table table-striped">
-<tr>
-<td>
-<code>requestType</code></br>
-<em>
-<a href="#kyverno.io/v1beta1.RequestType">
-RequestType
-</a>
-</em>
-</td>
-<td>
-<p>Type represents request type for background processing</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>policy</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Specifies the name of the policy.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resource</code></br>
-<em>
-github.com/kyverno/kyverno/api/kyverno/v1.ResourceSpec
-</em>
-</td>
-<td>
-<p>ResourceSpec is the information to identify the update request.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>context</code></br>
-<em>
-<a href="#kyverno.io/v1beta1.UpdateRequestSpecContext">
-UpdateRequestSpecContext
-</a>
-</em>
-</td>
-<td>
-<p>Context &hellip;</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#kyverno.io/v1beta1.UpdateRequestStatus">
-UpdateRequestStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status contains statistics related to update request.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr />
 <h3 id="kyverno.io/v1beta1.UpdateRequestSpec">UpdateRequestSpec
 </h3>
 <p>


### PR DESCRIPTION
This PR fixes generated api reference docs:
- missing resource types list at the top
- missing k8s apiserver extensions in external packages

The tool we use is expecting comments in a specific format https://github.com/ahmetb/gen-crd-api-reference-docs/blob/af7c5e0048a3487c6164bcc6c3e43afe539d3131/main.go#L326