### PR TITLE
Test Summary printing for failure test cases

### DIFF
--- a/cmd/cli/kubectl-kyverno/test/test_command.go
+++ b/cmd/cli/kubectl-kyverno/test/test_command.go
@@ -441,6 +441,7 @@ func testCommandExecute(dirPath []string, fileName string, gitBranch string, tes
 	}
 
 	if rc.Fail > 0 {
+		fmt.Printf("\nTest Summary: %d tests passed and %d tests failed\n", rc.Pass+rc.Skip, rc.Fail)
 		os.Exit(1)
 	}
 

--- a/cmd/cli/kubectl-kyverno/test/test_command.go
+++ b/cmd/cli/kubectl-kyverno/test/test_command.go
@@ -440,13 +440,11 @@ func testCommandExecute(dirPath []string, fileName string, gitBranch string, tes
 		}
 	}
 
-	if rc.Fail > 0 {
-		fmt.Printf("\nTest Summary: %d tests passed and %d tests failed\n", rc.Pass+rc.Skip, rc.Fail)
-		os.Exit(1)
-	}
-
 	fmt.Printf("\nTest Summary: %d tests passed and %d tests failed\n", rc.Pass+rc.Skip, rc.Fail)
 
+	if rc.Fail > 0 {
+		os.Exit(1)
+	}
 	os.Exit(0)
 	return rc, nil
 }


### PR DESCRIPTION
Signed-off-by: Prateeknandle <prateeknandle@gmail.com>

## Related issue
Closes #3747 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
`/kind bug`
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Due to [this](https://github.com/kyverno/kyverno/blob/main/cmd/cli/kubectl-kyverno/test/test_command.go#L444) printing was not happening after failure it's getting exit with error, due to `os.Exit(1)`, Now priniting statement is added before it get exit with error.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
```
$ go run ./cmd/cli/kubectl-kyverno/main.go test ./test/cli/test/simple

Executing test-simple...
applying 3 policies to 7 resources... 

│─────────│─────────────────────│────────────────────│────────────────────────────────────────────│────────│
│ # (15)  │ POLICY              │ RULE               │ RESOURCE                                   │ RESULT │
│─────────│─────────────────────│────────────────────│────────────────────────────────────────────│────────│
│       1 │ disallow-latest-tag │ require-image-tag  │ default/Pod/test-require-image-tag-pass    │ Pass   │
│       2 │ disallow-latest-tag │ require-image-tag  │ default/Pod/test-require-image-tag-fail    │ Fail   │
│       3 │ disallow-latest-tag │ validate-image-tag │ default/Pod/test-validate-image-tag-ignore │ Pass   │
│       4 │ disallow-latest-tag │ validate-image-tag │ default/Pod/test-validate-image-tag-fail   │ Pass   │
│       5 │ disallow-latest-tag │ validate-image-tag │ default/Pod/test-validate-image-tag-pass   │ Pass   │
│       6 │ duration-test       │ greater-than       │ default/Pod/test-lifetime-fail             │ Pass   │
│       7 │ duration-test       │ less-than          │ default/Pod/test-lifetime-fail             │ Pass   │
│       8 │ duration-test       │ greater-equal-than │ default/Pod/test-lifetime-fail             │ Pass   │
│       9 │ duration-test       │ less-equal-than    │ default/Pod/test-lifetime-fail             │ Pass   │
│      10 │ restrict-pod-counts │ restrict-pod-count │ default/Pod/myapp-pod                      │ Pass   │
│      11 │ restrict-pod-counts │ restrict-pod-count │ default/Pod/test-require-image-tag-pass    │ Pass   │
│      12 │ restrict-pod-counts │ restrict-pod-count │ default/Pod/test-require-image-tag-fail    │ Pass   │
│      13 │ restrict-pod-counts │ restrict-pod-count │ default/Pod/test-validate-image-tag-ignore │ Pass   │
│      14 │ restrict-pod-counts │ restrict-pod-count │ default/Pod/test-validate-image-tag-fail   │ Pass   │
│      15 │ restrict-pod-counts │ restrict-pod-count │ default/Pod/test-validate-image-tag-pass   │ Pass   │
│─────────│─────────────────────│────────────────────│────────────────────────────────────────────│────────│

Test Summary: 14 tests passed and 1 tests failed
exit status 1
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
