### PR TITLE
Add tests for required checks for image verify

### DIFF
--- a/test/e2e/verifyimages/config.go
+++ b/test/e2e/verifyimages/config.go
@@ -69,4 +69,15 @@ var VerifyImagesTests = []struct {
 		ResourceRaw:       tektonTaskVerified,
 		MustSucceed:       true,
 	},
+	{
+		// Case for custom image extraction
+		TestName:          "checks that custom images are populated and verified for all images",
+		PolicyName:        "tasks-keyless-required",
+		PolicyRaw:         kyvernoTaskPolicyKeylessRequired,
+		ResourceName:      "example-task-name",
+		ResourceNamespace: "test-verify-images",
+		ResourceGVR:       taskGVR,
+		ResourceRaw:       tektonTaskVerified,
+		MustSucceed:       true,
+	},
 }

--- a/test/e2e/verifyimages/resources.go
+++ b/test/e2e/verifyimages/resources.go
@@ -150,6 +150,34 @@ spec:
       required: false
 `)
 
+var kyvernoTaskPolicyKeylessRequired = []byte(`
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: tasks-keyless-required
+spec:
+  validationFailureAction: enforce
+  webhookTimeoutSeconds: 30
+  rules:
+  - name: verify-images
+    match:
+      resources:
+        kinds:
+        - tekton.dev/v1beta1/Task
+    preconditions:
+    - key: '{{request.operation}}'
+      operator: NotEquals
+      value: DELETE
+    imageExtractors:
+      Task:
+        - path: /spec/steps/*/image
+    verifyImages:
+    - image: "ghcr.io/*"
+      subject: "https://github.com/*"
+      issuer: "https://token.actions.githubusercontent.com"
+      required: true
+`)
+
 var kyvernoTaskPolicyWithoutExtractor = []byte(`
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>

Adds a test case for e2e tests for `required:true` for image verify.