### PR TITLE
Allow kyverno jp to take yaml files as inputs

### DIFF
--- a/cmd/cli/kubectl-kyverno/jp/jp_command.go
+++ b/cmd/cli/kubectl-kyverno/jp/jp_command.go
@@ -12,6 +12,7 @@ import (
 	gojmespath "github.com/jmespath/go-jmespath"
 	jmespath "github.com/kyverno/kyverno/pkg/engine/jmespath"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 )
 
 // Command returns jp command
@@ -57,18 +58,20 @@ func Command() *cobra.Command {
 				return nil
 			}
 			var input interface{}
-			var jsonParser *json.Decoder
 			if filename != "" {
 				f, err := ioutil.ReadFile(filename)
 				if err != nil {
 					return fmt.Errorf("error opening input file: %w", err)
 				}
-				if err := json.Unmarshal(f, &input); err != nil {
+				if err := yaml.Unmarshal(f, &input); err != nil {
 					return fmt.Errorf("error parsing input json: %w", err)
 				}
 			} else {
-				jsonParser = json.NewDecoder(os.Stdin)
-				if err := jsonParser.Decode(&input); err != nil {
+				f, err := ioutil.ReadAll(os.Stdin)
+				if err != nil {
+					return fmt.Errorf("error opening input file: %w", err)
+				}
+				if err := yaml.Unmarshal(f, &input); err != nil {
 					return fmt.Errorf("error parsing input json: %w", err)
 				}
 			}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/go-logr/logr v1.2.2
 	github.com/google/go-containerregistry v0.8.1-0.20220209165246-a44adc326839
 	github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20220301182634-bfe2ffc6b6bd
-	github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible
 	github.com/googleapis/gnostic v0.5.5
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/in-toto/in-toto-golang v0.3.4-0.20211211042327-af1f9fb822bf


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>


Fixes #3767 

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

/milestone 1.7.0

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind feature

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

```yaml
apiVersion: tekton.dev/v1beta1
kind: Task
metadata:
  name: example-task-name
spec:
  steps:
    - name: cosign
      image: ghcr.io/sigstore/cosign/cosign
```

```json
{
  "apiVersion": "tekton.dev/v1beta1",
  "kind": "Task",
  "metadata": {
    "name": "example-task-name"
  },
  "spec": {
    "steps": [
      {
        "image": "ghcr.io/sigstore/cosign/cosign",
        "name": "cosign"
      }
    ]
  }
}
```
### With YAML input

```bash
$ cat task.yml | ./cmd/cli/kubectl-kyverno/kyverno jp '@'
{
  "apiVersion": "tekton.dev/v1beta1",
  "kind": "Task",
  "metadata": {
    "name": "example-task-name"
  },
  "spec": {
    "steps": [
      {
        "image": "ghcr.io/sigstore/cosign/cosign",
        "name": "cosign"
      }
    ]
  }
}
```

```bash
$ ./cmd/cli/kubectl-kyverno/kyverno jp '@' -f task.yml
{
  "apiVersion": "tekton.dev/v1beta1",
  "kind": "Task",
  "metadata": {
    "name": "example-task-name"
  },
  "spec": {
    "steps": [
      {
        "image": "ghcr.io/sigstore/cosign/cosign",
        "name": "cosign"
      }
    ]
  }
}
```

### With JSON input

```bash
$ cat task.json | ./cmd/cli/kubectl-kyverno/kyverno jp '@'
{
  "apiVersion": "tekton.dev/v1beta1",
  "kind": "Task",
  "metadata": {
    "name": "example-task-name"
  },
  "spec": {
    "steps": [
      {
        "image": "ghcr.io/sigstore/cosign/cosign",
        "name": "cosign"
      }
    ]
  }
}
```

```bash
$ ./cmd/cli/kubectl-kyverno/kyverno jp '@' -f task.json
{
  "apiVersion": "tekton.dev/v1beta1",
  "kind": "Task",
  "metadata": {
    "name": "example-task-name"
  },
  "spec": {
    "steps": [
      {
        "image": "ghcr.io/sigstore/cosign/cosign",
        "name": "cosign"
      }
    ]
  }
}
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
