### PR TITLE
Fix PR update flow and allow updates from release branches

### DIFF
--- a/.github/workflows/pr-update.yaml
+++ b/.github/workflows/pr-update.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'release-*'
 jobs:
   autoupdate:
     permissions:
@@ -13,8 +14,8 @@ jobs:
       - name: Automatically update PR
         uses: adRise/update-pr-branch@437fab6e0ac7d2a668f2c479f64225edd7f303fd # v0.6.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          base: 'main'
+          token: ${{ secrets.PR_UPDATE_TOKEN }}
+          base: ${{ env.GITHUB_REF_NAME }}
           required_approval_count: 1
           require_passed_checks: true
           sort: 'updated'


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>

Fixes the PR update flow.

@realshuting - we will need to inject a token in the repo as a secret that can be accessed by this action. The token should have appropriate permissions to modify fork repos.

See https://github.com/adRise/update-pr-branch/#token

I also added the ability to update PRs that are targeted for release branches. 