### PR TITLE
chore: remove broken .ca from helm chart

### DIFF
--- a/charts/kyverno/templates/secret.yaml
+++ b/charts/kyverno/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.createSelfSignedCert }}
-{{- $ca := .ca | default (genCA (printf "*.%s.svc" (include "kyverno.namespace" .)) 1024) -}}
+{{- $ca := genCA (printf "*.%s.svc" (include "kyverno.namespace" .)) 1024 -}}
 {{- $cert := genSignedCert (printf "%s.%s.svc" (include "kyverno.serviceName" .) (include "kyverno.namespace" .)) nil nil 1024 $ca -}}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
This PR removes broken `.ca` from helm chart.