### PR TITLE
CLI should respect scored annotation for warnings

### DIFF
--- a/cmd/cli/kubectl-kyverno/apply/apply_command_test.go
+++ b/cmd/cli/kubectl-kyverno/apply/apply_command_test.go
@@ -53,9 +53,9 @@ func Test_Apply(t *testing.T) {
 					Summary: preport.PolicyReportSummary{
 						Pass:  1,
 						Fail:  1,
-						Skip:  4,
+						Skip:  8,
 						Error: 0,
-						Warn:  0,
+						Warn:  2,
 					},
 				},
 			},

--- a/cmd/cli/kubectl-kyverno/utils/common/common.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common.go
@@ -703,8 +703,6 @@ func GetResourceAccordingToResourcePath(fs billy.Filesystem, resourcePaths []str
 	return resources, err
 }
 
-const scoredAnnotation = "policies.kyverno.io/scored"
-
 func ProcessValidateEngineResponse(policy v1.PolicyInterface, validateResponse *response.EngineResponse, resPath string, rc *ResultCounts, policyReport bool) policyreport.Info {
 	var violatedRules []v1.ViolatedRule
 
@@ -731,7 +729,7 @@ func ProcessValidateEngineResponse(policy v1.PolicyInterface, validateResponse *
 
 				case response.RuleStatusFail:
 					ann := policy.GetAnnotations()
-					if scored, ok := ann[scoredAnnotation]; ok && scored == "false" {
+					if scored, ok := ann[policyreport.ScoredLabel]; ok && scored == "false" {
 						rc.Warn++
 						vrule.Status = report.StatusWarn
 						break

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -313,7 +313,7 @@ func toPolicyResult(status response.RuleStatus) string {
 
 const categoryLabel string = "policies.kyverno.io/category"
 const severityLabel string = "policies.kyverno.io/severity"
-const scoredLabel string = "policies.kyverno.io/scored"
+const ScoredLabel string = "policies.kyverno.io/scored"
 
 type annotationValues struct {
 	category string
@@ -342,7 +342,7 @@ func (builder *requestBuilder) fetchAnnotationValues(policy, ns string) annotati
 	if severity, ok := ann[severityLabel]; ok {
 		av.setSeverityFromString(severity)
 	}
-	if scored, ok := ann[scoredLabel]; ok {
+	if scored, ok := ann[ScoredLabel]; ok {
 		if scored == "false" {
 			av.scored = false
 		} else {

--- a/test/cli/apply/policies/policy.yaml
+++ b/test/cli/apply/policies/policy.yaml
@@ -22,3 +22,35 @@ spec:
         spec:
           containers:
           - image: "!*:latest"
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: drop-all-capabilities
+  annotations:
+    policies.kyverno.io/scored: "false"
+spec:
+  validationFailureAction: audit
+  rules:
+    - name: require-drop-all
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      preconditions:
+        all:
+        - key: "{{ request.operation }}"
+          operator: NotEquals
+          value: DELETE
+      validate:
+        message: >-
+          Containers must drop `ALL` capabilities.
+        foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            deny:
+              conditions:
+                all:
+                - key: ALL
+                  operator: AnyNotIn
+                  value: "{{ element.securityContext.capabilities.drop || '' }}"

--- a/test/cli/test/depecated_apis/kyverno-test.yaml
+++ b/test/cli/test/depecated_apis/kyverno-test.yaml
@@ -13,4 +13,4 @@ results:
     rule: validate-v1-25-removal
     resource: hello-fail
     kind: CronJob
-    status: fail
+    status: warn

--- a/test/cli/test/depecated_apis/policy.yaml
+++ b/test/cli/test/depecated_apis/policy.yaml
@@ -3,6 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: check-deprecated-api
   annotations:
+    policies.kyverno.io/scored: "false"
     policies.kyverno.io/title: Check deprecated APIs
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/subject: Kubernetes APIs


### PR DESCRIPTION
## Related issue
Closes #3818

## Milestone of this PR

## What type of PR is this
/kind bug

## Proposed Changes

The `policies.kyverno.io/scored` annotation does not result in a `warn` when testing a resource through `kyverno apply`. This PR fixes that behaviour. I think this was intended in the first place.

### Proof Manifests

#### Kubernetes resource

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: add-capabilities-bad
spec:
  initContainers:
  - name: init
    image: gcr.io/google-samples/node-hello:1.0
  containers:
  - name: add-capabilities
    image: gcr.io/google-samples/node-hello:1.0
    securityContext:
      capabilities:
        add: ["SYS_TIME"]
        drop:
          - ALL
```

Kyverno Policy
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: drop-all-capabilities
  annotations:
    policies.kyverno.io/scored: "false"
spec:
  validationFailureAction: enforce
  background: true
  rules:
    - name: require-drop-all
      match:
        any:
        - resources:
            kinds:
              - Pod
      preconditions:
        all:
        - key: "{{ request.operation }}"
          operator: NotEquals
          value: DELETE
      validate:
        message: >-
          Containers must drop `ALL` capabilities.
        foreach:
          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
            deny:
              conditions:
                all:
                - key: ALL
                  operator: AnyNotIn
                  value: "{{ element.securityContext.capabilities.drop || '' }}"
```

Result before PR
```
$ kyverno apply ./drop-all.yaml --resource ./drop-all-res.yaml
Applying 1 policy to 1 resource... 
(Total number of result count may vary as the policy is mutated by Kyverno. To check the mutated policy please try with log level 5)

policy drop-all-capabilities -> resource default/Pod/add-capabilities-bad failed: 
1. require-drop-all: validation failure: Containers must drop `ALL` capabilities. 

pass: 0, fail: 1, warn: 0, error: 0, skip: 2 

EXIT CODE 1

```

Result with this PR
```
$ kyverno apply ./drop-all.yaml --resource ./drop-all-res.yaml
Applying 1 policy to 1 resource... 
(Total number of result count may vary as the policy is mutated by Kyverno. To check the mutated policy please try with log level 5)

pass: 0, fail: 0, warn: 1, error: 0, skip: 2 

EXIT CODE 0

```
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
