### PR TITLE
Relax JMESPath variable validation

### DIFF
--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -868,18 +868,6 @@ func validateRuleContext(rule kyverno.Rule) error {
 			return err
 		}
 	}
-
-	ruleBytes, _ := json.Marshal(rule)
-	for _, contextName := range contextNames {
-		contextRegex, err := regexp.Compile(fmt.Sprintf(`{{.*\b%s\b.*}}`, contextName))
-		if err != nil {
-			return fmt.Errorf("unable to validate context variable `%s`, %w", contextName, err)
-		}
-		if !contextRegex.Match(ruleBytes) {
-			return fmt.Errorf("context variable `%s` is not used in the policy", contextName)
-		}
-	}
-
 	return nil
 }
 

--- a/test/cli/test/context-entries/kyverno-test.yaml
+++ b/test/cli/test/context-entries/kyverno-test.yaml
@@ -54,3 +54,8 @@ results:
     resource: example
     kind: Pod
     result: pass
+  - policy: example
+    rule:  unused-var
+    resource: example
+    kind: Pod
+    result: pass

--- a/test/cli/test/context-entries/policies.yaml
+++ b/test/cli/test/context-entries/policies.yaml
@@ -188,3 +188,30 @@ spec:
           - key: "{{ obj }}"
             operator: NotEqual
             value: "{{ expected }}"
+  - name: unused-var
+    context:
+    - name: obj
+      variable:
+        value:
+          a: 1
+          b: 2
+    - name: modifiedObj
+      variable:
+        jmesPath: items(obj, 'key', 'value')
+    - name: expected
+      variable:
+        value:
+          - key: a
+            value: 1
+          - key: b
+            value: 2
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      deny:
+        conditions:
+          - key: "{{ modifiedObj }}"
+            operator: NotEqual
+            value: "{{ expected }}"


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>
Relaxes the policy validation that does a regex check on the rule body to see if a context variable is being used. 

This specific commit was introduced in https://github.com/kyverno/kyverno/pull/2336 and the original issue it was meant to fix https://github.com/kyverno/kyverno/issues/2289 was actually still unfixed as the main cause was dereferencing a nil pointer at [NoSkillGirl/kyverno@ad0cb6e/pkg/engine/jsonContext.go#L30](https://github.com/NoSkillGirl/kyverno/blob/ad0cb6e1ee49338831bf816688650a47463bcc84/pkg/engine/jsonContext.go#L30) - given that jmespath vars might include expressions like above - it seems invalid to introduce additional constraints that don’t fully conform to the jmespath grammar. We should relax the constraint.


With the new inline context vars, users can easily use the variable in inline jmespath expression with actually substituting it using kyverno `{{ var }}` expressions and our unnecessarily strict validation disallows such use cases.

The PR finally removes this validation and is a continuation of https://github.com/kyverno/kyverno/pull/3129