### PR TITLE
chore: increase golangci-lint timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - structcheck
 
 run:
+  timeout: 5m
   skip-files:
     - ".+_test.go"
     - ".+_test_.+.go"


### PR DESCRIPTION
This PR increases `golangci-lint` timeout.