### PR TITLE
fix: undo policy length validation check for generate rule resource name

### DIFF
--- a/api/kyverno/v1/common_types.go
+++ b/api/kyverno/v1/common_types.go
@@ -468,7 +468,6 @@ type ResourceSpec struct {
 	// +optional
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	// Name specifies the resource name.
-	// +kubebuilder:validation:MaxLength=63
 	// +optional
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 }

--- a/charts/kyverno/templates/crds.yaml
+++ b/charts/kyverno/templates/crds.yaml
@@ -533,7 +533,6 @@ spec:
                           type: string
                         name:
                           description: Name specifies the resource name.
-                          maxLength: 63
                           type: string
                         namespace:
                           description: Namespace specifies resource namespace.
@@ -1106,7 +1105,6 @@ spec:
                                 type: string
                               name:
                                 description: Name specifies the resource name.
-                                maxLength: 63
                                 type: string
                               namespace:
                                 description: Namespace specifies resource namespace.
@@ -2291,7 +2289,6 @@ spec:
                     type: string
                   name:
                     description: Name specifies the resource name.
-                    maxLength: 63
                     type: string
                   namespace:
                     description: Namespace specifies resource namespace.
@@ -2317,7 +2314,6 @@ spec:
                       type: string
                     name:
                       description: Name specifies the resource name.
-                      maxLength: 63
                       type: string
                     namespace:
                       description: Namespace specifies resource namespace.
@@ -2881,7 +2877,6 @@ spec:
                           type: string
                         name:
                           description: Name specifies the resource name.
-                          maxLength: 63
                           type: string
                         namespace:
                           description: Namespace specifies resource namespace.
@@ -3454,7 +3449,6 @@ spec:
                                 type: string
                               name:
                                 description: Name specifies the resource name.
-                                maxLength: 63
                                 type: string
                               namespace:
                                 description: Namespace specifies resource namespace.
@@ -4648,7 +4642,6 @@ spec:
                     type: string
                   name:
                     description: Name specifies the resource name.
-                    maxLength: 63
                     type: string
                   namespace:
                     description: Namespace specifies resource namespace.
@@ -4674,7 +4667,6 @@ spec:
                       type: string
                     name:
                       description: Name specifies the resource name.
-                      maxLength: 63
                       type: string
                     namespace:
                       description: Namespace specifies resource namespace.

--- a/config/crds/kyverno.io_clusterpolicies.yaml
+++ b/config/crds/kyverno.io_clusterpolicies.yaml
@@ -832,7 +832,6 @@ spec:
                           type: string
                         name:
                           description: Name specifies the resource name.
-                          maxLength: 63
                           type: string
                         namespace:
                           description: Namespace specifies resource namespace.
@@ -1763,7 +1762,6 @@ spec:
                                 type: string
                               name:
                                 description: Name specifies the resource name.
-                                maxLength: 63
                                 type: string
                               namespace:
                                 description: Namespace specifies resource namespace.

--- a/config/crds/kyverno.io_generaterequests.yaml
+++ b/config/crds/kyverno.io_generaterequests.yaml
@@ -134,7 +134,6 @@ spec:
                     type: string
                   name:
                     description: Name specifies the resource name.
-                    maxLength: 63
                     type: string
                   namespace:
                     description: Namespace specifies resource namespace.
@@ -161,7 +160,6 @@ spec:
                       type: string
                     name:
                       description: Name specifies the resource name.
-                      maxLength: 63
                       type: string
                     namespace:
                       description: Namespace specifies resource namespace.

--- a/config/crds/kyverno.io_policies.yaml
+++ b/config/crds/kyverno.io_policies.yaml
@@ -833,7 +833,6 @@ spec:
                           type: string
                         name:
                           description: Name specifies the resource name.
-                          maxLength: 63
                           type: string
                         namespace:
                           description: Namespace specifies resource namespace.
@@ -1764,7 +1763,6 @@ spec:
                                 type: string
                               name:
                                 description: Name specifies the resource name.
-                                maxLength: 63
                                 type: string
                               namespace:
                                 description: Namespace specifies resource namespace.

--- a/config/crds/kyverno.io_updaterequests.yaml
+++ b/config/crds/kyverno.io_updaterequests.yaml
@@ -144,7 +144,6 @@ spec:
                     type: string
                   name:
                     description: Name specifies the resource name.
-                    maxLength: 63
                     type: string
                   namespace:
                     description: Namespace specifies resource namespace.
@@ -171,7 +170,6 @@ spec:
                       type: string
                     name:
                       description: Name specifies the resource name.
-                      maxLength: 63
                       type: string
                     namespace:
                       description: Namespace specifies resource namespace.

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -849,7 +849,6 @@ spec:
                           type: string
                         name:
                           description: Name specifies the resource name.
-                          maxLength: 63
                           type: string
                         namespace:
                           description: Namespace specifies resource namespace.
@@ -1780,7 +1779,6 @@ spec:
                                 type: string
                               name:
                                 description: Name specifies the resource name.
-                                maxLength: 63
                                 type: string
                               namespace:
                                 description: Namespace specifies resource namespace.
@@ -3464,7 +3462,6 @@ spec:
                     type: string
                   name:
                     description: Name specifies the resource name.
-                    maxLength: 63
                     type: string
                   namespace:
                     description: Namespace specifies resource namespace.
@@ -3491,7 +3488,6 @@ spec:
                       type: string
                     name:
                       description: Name specifies the resource name.
-                      maxLength: 63
                       type: string
                     namespace:
                       description: Namespace specifies resource namespace.
@@ -4361,7 +4357,6 @@ spec:
                           type: string
                         name:
                           description: Name specifies the resource name.
-                          maxLength: 63
                           type: string
                         namespace:
                           description: Namespace specifies resource namespace.
@@ -5292,7 +5287,6 @@ spec:
                                 type: string
                               name:
                                 description: Name specifies the resource name.
-                                maxLength: 63
                                 type: string
                               namespace:
                                 description: Namespace specifies resource namespace.
@@ -6986,7 +6980,6 @@ spec:
                     type: string
                   name:
                     description: Name specifies the resource name.
-                    maxLength: 63
                     type: string
                   namespace:
                     description: Namespace specifies resource namespace.
@@ -7013,7 +7006,6 @@ spec:
                       type: string
                     name:
                       description: Name specifies the resource name.
-                      maxLength: 63
                       type: string
                     namespace:
                       description: Namespace specifies resource namespace.

--- a/config/install_debug.yaml
+++ b/config/install_debug.yaml
@@ -847,7 +847,6 @@ spec:
                           type: string
                         name:
                           description: Name specifies the resource name.
-                          maxLength: 63
                           type: string
                         namespace:
                           description: Namespace specifies resource namespace.
@@ -1778,7 +1777,6 @@ spec:
                                 type: string
                               name:
                                 description: Name specifies the resource name.
-                                maxLength: 63
                                 type: string
                               namespace:
                                 description: Namespace specifies resource namespace.
@@ -3459,7 +3457,6 @@ spec:
                     type: string
                   name:
                     description: Name specifies the resource name.
-                    maxLength: 63
                     type: string
                   namespace:
                     description: Namespace specifies resource namespace.
@@ -3486,7 +3483,6 @@ spec:
                       type: string
                     name:
                       description: Name specifies the resource name.
-                      maxLength: 63
                       type: string
                     namespace:
                       description: Namespace specifies resource namespace.
@@ -4355,7 +4351,6 @@ spec:
                           type: string
                         name:
                           description: Name specifies the resource name.
-                          maxLength: 63
                           type: string
                         namespace:
                           description: Namespace specifies resource namespace.
@@ -5286,7 +5281,6 @@ spec:
                                 type: string
                               name:
                                 description: Name specifies the resource name.
-                                maxLength: 63
                                 type: string
                               namespace:
                                 description: Namespace specifies resource namespace.
@@ -6977,7 +6971,6 @@ spec:
                     type: string
                   name:
                     description: Name specifies the resource name.
-                    maxLength: 63
                     type: string
                   namespace:
                     description: Namespace specifies resource namespace.
@@ -7004,7 +6997,6 @@ spec:
                       type: string
                     name:
                       description: Name specifies the resource name.
-                      maxLength: 63
                       type: string
                     namespace:
                       description: Namespace specifies resource namespace.


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Related issue

Related: https://github.com/kyverno/kyverno/issues/3858


## What type of PR is this

/kind bug

## Proposed Changes

Undo the OpenAPIV3 Policy validation check for generate rule resource name if it exceeds the 63 char limit, has been done as part of #3640, since there are policy that can used with combination of variables to construct the name , for example:

```yaml
      kind: KubernetesRole
      name: k8s-{{request.object.metadata.namespace}}-{{request.object.metadata.name}}
      namespace: '{{request.object.metadata.namespace}}'

```

Also limits should adhere to k8s spec ([ resource names up to 253 chars )](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)