### PR TITLE
chore: enable exportloopref linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
     - bodyclose
     - deadcode
     - errcheck
+    - exportloopref
     - gosec
     - gosimple
     - govet


### PR DESCRIPTION
This PR enables `exportloopref` linter.