### PR TITLE
chore: enable asciicheck and bidichk linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 linters:
   enable:
+    - asciicheck
+    - bidichk
     - bodyclose
     - deadcode
     - errcheck


### PR DESCRIPTION
This PR enables `asciicheck` and `bidichk` linters.