### PR TITLE
chore: enable goprintffuncname linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - errcheck
     - exportloopref
     - gochecknoinits
+    - goprintffuncname
     - gosec
     - gosimple
     - govet


### PR DESCRIPTION
This PR enables `goprintffuncname` linter.