### PR TITLE
Remove permissions in helm-release workflow

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -5,11 +5,6 @@ on:
       - 'kyverno-chart-v*'
       - 'kyverno-policies-chart-v*'
 
-permissions: 
-  contents: read
-  packages: write
-  id-token: write 
-
 jobs:
   helm-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

This PR removes permissions settings in helm-release workflow due to https://github.com/kyverno/kyverno/runs/6401161466?check_suite_focus=true:

```
remote: Permission to kyverno/kyverno.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/kyverno/kyverno/': The requested URL returned error: 403
```