### PR TITLE
refactor: webhooks server logger

### DIFF
--- a/pkg/webhooks/handlers/admission.go
+++ b/pkg/webhooks/handlers/admission.go
@@ -14,7 +14,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 )
 
-type AdmissionHandler func(*admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse
+type AdmissionHandler func(logr.Logger, *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse
 
 func Admission(logger logr.Logger, inner AdmissionHandler) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
@@ -43,7 +43,7 @@ func Admission(logger logr.Logger, inner AdmissionHandler) http.HandlerFunc {
 			http.Error(writer, "Can't decode body as AdmissionReview", http.StatusExpectationFailed)
 			return
 		}
-		logger = logger.WithValues(
+		logger := logger.WithValues(
 			"kind", admissionReview.Request.Kind,
 			"namespace", admissionReview.Request.Namespace,
 			"name", admissionReview.Request.Name,
@@ -54,7 +54,7 @@ func Admission(logger logr.Logger, inner AdmissionHandler) http.HandlerFunc {
 			Allowed: true,
 			UID:     admissionReview.Request.UID,
 		}
-		adminssionResponse := inner(admissionReview.Request)
+		adminssionResponse := inner(logger, admissionReview.Request)
 		if adminssionResponse != nil {
 			admissionReview.Response = adminssionResponse
 		}
@@ -67,7 +67,6 @@ func Admission(logger logr.Logger, inner AdmissionHandler) http.HandlerFunc {
 		if _, err := writer.Write(responseJSON); err != nil {
 			http.Error(writer, fmt.Sprintf("could not write response: %v", err), http.StatusInternalServerError)
 		}
-
 		if admissionReview.Request.Kind.Kind == "Lease" {
 			logger.V(6).Info("admission review request processed", "time", time.Since(startTime).String())
 		} else {
@@ -77,24 +76,16 @@ func Admission(logger logr.Logger, inner AdmissionHandler) http.HandlerFunc {
 }
 
 func Filter(c config.Configuration, inner AdmissionHandler) AdmissionHandler {
-	return func(request *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	return func(logger logr.Logger, request *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 		if c.ToFilter(request.Kind.Kind, request.Namespace, request.Name) {
 			return nil
 		}
-		return inner(request)
+		return inner(logger, request)
 	}
 }
 
 func Verify(m *webhookconfig.Monitor, logger logr.Logger) AdmissionHandler {
-	return func(request *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
-		logger = logger.WithValues(
-			"action", "verify",
-			"kind", request.Kind,
-			"namespace", request.Namespace,
-			"name", request.Name,
-			"operation", request.Operation,
-			"gvk", request.Kind.String(),
-		)
+	return func(logger logr.Logger, request *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 		logger.V(6).Info("incoming request", "last admission request timestamp", m.Time())
 		return admissionutils.Response(true)
 	}


### PR DESCRIPTION
This PR refactors webhooks server logger.
The logger is now passed through the handlers chain, each element in the chain can add values to the logger and pass it to the next one.
This eliminates the need for each logger to setup the logger sparately.