### PR TITLE
fix: use patch to update handler status in UR

### DIFF
--- a/pkg/background/common/util.go
+++ b/pkg/background/common/util.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"time"
 
 	urkyverno "github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	kyvernoclient "github.com/kyverno/kyverno/pkg/client/clientset/versioned"
@@ -9,7 +10,15 @@ import (
 	jsonutils "github.com/kyverno/kyverno/pkg/utils/json"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
+
+var DefaultRetry = wait.Backoff{
+	Steps:    5,
+	Duration: 30 * time.Millisecond,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
 
 // PatchUpdateRequest patches a update request object
 func PatchUpdateRequest(ur *urkyverno.UpdateRequest, patch jsonutils.Patch, client kyvernoclient.Interface, subresources ...string) (*urkyverno.UpdateRequest, error) {

--- a/pkg/background/request_process.go
+++ b/pkg/background/request_process.go
@@ -4,10 +4,15 @@ import (
 	"context"
 
 	urkyverno "github.com/kyverno/kyverno/api/kyverno/v1beta1"
+	"github.com/kyverno/kyverno/pkg/background/common"
 	"github.com/kyverno/kyverno/pkg/background/generate"
 	"github.com/kyverno/kyverno/pkg/background/mutate"
 	"github.com/kyverno/kyverno/pkg/config"
+	jsonutils "github.com/kyverno/kyverno/pkg/utils/json"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 func (c *Controller) ProcessUR(ur *urkyverno.UpdateRequest) error {
@@ -34,15 +39,20 @@ func (c *Controller) MarkUR(ur *urkyverno.UpdateRequest) (*urkyverno.UpdateReque
 		}
 		return ur, true, nil
 	}
-
 	handler = config.KyvernoPodName
 	ur.Status.Handler = handler
-	new, err := c.kyvernoClient.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace).UpdateStatus(context.TODO(), ur, metav1.UpdateOptions{})
-	return new, true, err
+	var updateRequest *urkyverno.UpdateRequest
+
+	err := retry.RetryOnConflict(common.DefaultRetry, func() error {
+		var retryError error
+		updateRequest, retryError = c.kyvernoClient.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace).UpdateStatus(context.TODO(), ur, metav1.UpdateOptions{})
+		return retryError
+	})
+	return updateRequest, true, err
 }
 
 func (c *Controller) UnmarkUR(ur *urkyverno.UpdateRequest) error {
-	newUR, err := c.urLister.Get(ur.Name)
+	_, err := c.PatchHandler(ur, "")
 	if err != nil {
 		return err
 	}
@@ -50,8 +60,23 @@ func (c *Controller) UnmarkUR(ur *urkyverno.UpdateRequest) error {
 	if ur.Spec.Type == urkyverno.Mutate && ur.Status.State == urkyverno.Completed {
 		return c.kyvernoClient.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace).Delete(context.TODO(), ur.GetName(), metav1.DeleteOptions{})
 	}
+	return nil
+}
 
-	newUR.Status.Handler = ""
-	_, err = c.kyvernoClient.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace).UpdateStatus(context.TODO(), newUR, metav1.UpdateOptions{})
-	return err
+func (c *Controller) PatchHandler(ur *urkyverno.UpdateRequest, val string) (*urkyverno.UpdateRequest, error) {
+	patch := jsonutils.NewPatch(
+		"/status/handler",
+		"replace",
+		val,
+	)
+
+	updateUR, err := common.PatchUpdateRequest(ur, patch, c.kyvernoClient, "status")
+	if err != nil && !apierrors.IsNotFound(err) {
+		c.log.Error(err, "failed to patch UpdateRequest: %v", patch)
+		if val == "" {
+			return nil, errors.Wrapf(err, "failed to patch UpdateRequest to clear /status/handler")
+		}
+		return nil, errors.Wrapf(err, "failed to patch UpdateRequest to update /status/handler to %s", val)
+	}
+	return updateUR, nil
 }

--- a/pkg/policy/updaterequest.go
+++ b/pkg/policy/updaterequest.go
@@ -75,7 +75,6 @@ func (pc *PolicyController) updateUR(policyKey string, policy kyverno.PolicyInte
 					continue
 				}
 
-				logger.Info("creating new UR for generate")
 				ur := newUR(policy, trigger, ruleType)
 				skip, err := pc.handleUpdateRequest(ur, trigger, rule, policy)
 				if err != nil {
@@ -116,6 +115,7 @@ func (pc *PolicyController) handleUpdateRequest(ur *urkyverno.UpdateRequest, tri
 			continue
 		}
 
+		pc.log.Info("creating new UR for generate")
 		new, err := pc.kyvernoClient.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace).Create(context.TODO(), ur, metav1.CreateOptions{})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Related issue
`/milestone 1.7.0`
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this


/kind bug

## Proposed Changes

use patch to update handler status in UR to resolve the resource version error

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
