### PR TITLE
chore: enable nolintlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - makezero
     - misspell
     - noctx
+    - nolintlint
     - staticcheck
     - structcheck
     - tenv


### PR DESCRIPTION
This PR enables `nolintlint` linter.