### PR TITLE
chore: enable goimports linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - gochecknoinits
     - gofmt
     - gofumpt
+    - goimports
     - goprintffuncname
     - gosec
     - gosimple


### PR DESCRIPTION
This PR enables `goimports` linter.