### PR TITLE
Add validation check to ensure the annotations quoted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -195,6 +195,7 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jedisct1/go-minisign v0.0.0-20210703085342-c1f07ee84431 // indirect
 	github.com/jhump/protoreflect v1.9.0 // indirect
+	github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1310,6 +1310,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548 h1:dYTbLf4m0a5u0KLmPfB6mgxbcV7588bOCx79hxa5Sr4=
 github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548/go.mod h1:hGT6jSUVzF6no3QaDSMLGLEHtHSBSefs+MgcDWnmhmo=
+github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e h1:ZZCvgaRDZg1gC9/1xrsgaJzQUCQgniKtw0xjWywWAOE=
+github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e/go.mod h1:+rHyWac2R9oAZwFe1wGY2HBzFJJy++RHBg1cU23NkD8=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jmoiron/sqlx v1.3.4/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -605,7 +605,6 @@ func isLabelAndAnnotationsString(rule kyvernov1.Rule) bool {
 				metadata, _ := jsonq.NewQuery(patternMap).Object("spec", "template", "metadata")
 				fmt.Println("metadata", metadata)
 				return checkLableAnnotation(metadata)
-
 			}
 		}
 		return true

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -618,6 +618,11 @@ func isLabelAndAnnotationsString(rule kyvernov1.Rule) bool {
 			}
 		}
 	}
+
+	strategicMergeMap, ok := rule.Mutation.GetPatchStrategicMerge().(map[string]interface{})
+	if ok {
+		return checkMetadata(strategicMergeMap)
+	}
 	return true
 }
 

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -564,7 +564,7 @@ func validateMatchKindHelper(rule kyvernov1.Rule) error {
 // isLabelAndAnnotationsString :- Validate if labels and annotations contains only string values
 func isLabelAndAnnotationsString(rule kyvernov1.Rule) bool {
 
-	checkLableAnnotation := func(metaKey map[string]interface{}) bool {
+	checkLabelAnnotation := func(metaKey map[string]interface{}) bool {
 		for mk := range metaKey {
 			if mk == "labels" {
 				labelKey, ok := metaKey[mk].(map[string]interface{})
@@ -598,13 +598,12 @@ func isLabelAndAnnotationsString(rule kyvernov1.Rule) bool {
 				metaKey, ok := patternMap[k].(map[string]interface{})
 				if ok {
 					// range over metadata
-					return checkLableAnnotation(metaKey)
+					return checkLabelAnnotation(metaKey)
 				}
 			}
 			if k == "spec" {
 				metadata, _ := jsonq.NewQuery(patternMap).Object("spec", "template", "metadata")
-				fmt.Println("metadata", metadata)
-				return checkLableAnnotation(metadata)
+				return checkLabelAnnotation(metadata)
 			}
 		}
 		return true


### PR DESCRIPTION
## Related issue
Closes #3922 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
1.7.0

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
validation check to ensure the annotations/labels are  quoted
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Policy.yaml
```yaml
# inject-annotations.yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: inject-s3-logging-annotations-to-lb
  annotations:
    policies.kyverno.io/title: Inject S3 Logging Annotations to LB
    policies.kyverno.io/category: Logging
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Service
    policies.kyverno.io/description: >-
      Any new service of LoadBalancer type will be injected with the annotations for AWS S3 bucket access logging
spec:
  validationFailureAction: enforce
  rules:
  - name: inject-nlb-s3-annotations
    match:
      resources:
        kinds:
        - Service
    preconditions:
      all:
      - key: "{{request.object.spec.type}}"
        operator: Equals
        value: "LoadBalancer"
    mutate:
      patchStrategicMerge:
        metadata:
          annotations:
            +(service.beta.kubernetes.io/aws-load-balancer-access-log-enabled): "true"
            +(service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval): false
            +(service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name): "s3-poc"
            +(service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix): "default/test-loadbalancer"
```

```yaml
# inject-annotations.yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: inject-s3-logging-annotations-to-lb
  annotations:
    policies.kyverno.io/title: Inject S3 Logging Annotations to LB
    policies.kyverno.io/category: Logging
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Service
    policies.kyverno.io/description: >-
      Any new service of LoadBalancer type will be injected with the annotations for AWS S3 bucket access logging
spec:
  validationFailureAction: enforce
  rules:
  - name: inject-nlb-s3-annotations
    match:
      resources:
        kinds:
        - Service
    preconditions:
      all:
      - key: "{{request.object.spec.type}}"
        operator: Equals
        value: "LoadBalancer"
    mutate:
      patchStrategicMerge:
        metadata:
          annotations:
            +(service.beta.kubernetes.io/aws-load-balancer-access-log-enabled): "true"
            +(service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval): 60
            +(service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name): "s3-poc"
            +(service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix): "default/test-loadbalancer"
```

```yaml
# inject-annotations.yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: inject-s3-logging-annotations
  annotations:
    policies.kyverno.io/title: Inject S3 Logging Annotations to LB
    policies.kyverno.io/category: Logging
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Service
    policies.kyverno.io/description: >-
      Any new service of LoadBalancer type will be injected with the annotations for AWS S3 bucket access logging
spec:
  validationFailureAction: enforce
  rules:
  - name: inject-nlb-s3-annotations
    match:
      resources:
        kinds:
        - Service
    preconditions:
      all:
      - key: "{{request.object.spec.type}}"
        operator: Equals
        value: "LoadBalancer"
    mutate:
      foreach:
      - list: "request.object.spec.containers"
        patchStrategicMerge:
          metadata:
            annotations:
              +(service.beta.kubernetes.io/aws-load-balancer-access-log-enabled): "true"
              +(service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval): 60
              +(service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name): "s3-poc"
              +(service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix): "default/test-loadbalancer"
```

```yaml
# inject-annotations.yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: inject-s3-logging-annotations-to
  annotations:
    policies.kyverno.io/title: Inject S3 Logging Annotations to LB
    policies.kyverno.io/category: Logging
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Service
    policies.kyverno.io/description: >-
      Any new service of LoadBalancer type will be injected with the annotations for AWS S3 bucket access logging
spec:
  validationFailureAction: enforce
  rules:
  - name: inject-nlb-s3-annotations
    match:
      resources:
        kinds:
        - Deployment
    preconditions:
      all:
      - key: "{{request.object.spec.type}}"
        operator: Equals
        value: "LoadBalancer"
    mutate:
      patchStrategicMerge:
        spec:
          template:
            metadata:
              annotations:
                +(service.beta.kubernetes.io/aws-load-balancer-access-log-enabled): "true"
                +(service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval): 60
                +(service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name): "s3-poc"
                +(service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix): "default/test-loadbalancer"
```
Result
Policy creation get block.
```
Error from server: error when creating "test/policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: labels and annotations supports only string values, "use double quotes around the non string values"
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is release1.7.0
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
