### PR TITLE
chore: add previous pod logs in case of job failure

### DIFF
--- a/.github/workflows/e2e-autogen-internals.yaml
+++ b/.github/workflows/e2e-autogen-internals.yaml
@@ -86,4 +86,5 @@ jobs:
           kubectl get mutatingwebhookconfigurations,validatingwebhookconfigurations
           kubectl -n kyverno get pod
           kubectl -n kyverno describe pod | grep -i events -A10
+          kubectl -n kyverno logs deploy/kyverno -p || true
           kubectl -n kyverno logs deploy/kyverno

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -97,4 +97,5 @@ jobs:
           kubectl get mutatingwebhookconfigurations,validatingwebhookconfigurations
           kubectl -n kyverno get pod
           kubectl -n kyverno describe pod | grep -i events -A10
+          kubectl -n kyverno logs deploy/kyverno -p || true
           kubectl -n kyverno logs deploy/kyverno


### PR DESCRIPTION
This PR adds previous pod logs in case of job failure.
This is useful when the failure comes from a pod restart to understand why the container crashed.