### PR TITLE
Support `@` for mutate targets

### DIFF
--- a/pkg/engine/context/context.go
+++ b/pkg/engine/context/context.go
@@ -49,6 +49,9 @@ type Interface interface {
 	// AddOldResource merges resource json under request.oldObject
 	AddOldResource(data map[string]interface{}) error
 
+	// AddTargetResource merges resource json under target
+	AddTargetResource(data map[string]interface{}) error
+
 	// AddUserInfo merges userInfo json under kyverno.userInfo
 	AddUserInfo(userInfo kyvernov1beta1.RequestInfo) error
 
@@ -163,6 +166,11 @@ func (ctx *context) AddResource(data map[string]interface{}) error {
 // AddOldResource data at path: request.oldObject
 func (ctx *context) AddOldResource(data map[string]interface{}) error {
 	return addToContext(ctx, data, "request", "oldObject")
+}
+
+// AddTargetResource adds data at path: target
+func (ctx *context) AddTargetResource(data map[string]interface{}) error {
+	return addToContext(ctx, data, "target")
 }
 
 // AddUserInfo adds userInfo at path request.userInfo

--- a/pkg/engine/jsonContext.go
+++ b/pkg/engine/jsonContext.go
@@ -390,3 +390,8 @@ func fetchConfigMap(logger logr.Logger, entry kyvernov1.ContextEntry, ctx *Polic
 
 	return data, nil
 }
+
+func addTargetToContext(ctx *PolicyContext, target interface{}) error {
+	return nil
+
+}

--- a/pkg/engine/jsonContext.go
+++ b/pkg/engine/jsonContext.go
@@ -390,8 +390,3 @@ func fetchConfigMap(logger logr.Logger, entry kyvernov1.ContextEntry, ctx *Polic
 
 	return data, nil
 }
-
-func addTargetToContext(ctx *PolicyContext, target interface{}) error {
-	return nil
-
-}

--- a/pkg/engine/mutation.go
+++ b/pkg/engine/mutation.go
@@ -97,7 +97,6 @@ func Mutate(policyContext *PolicyContext) (resp *response.EngineResponse) {
 				continue
 			}
 
-			policyContext.JSONContext.Reset()
 			policyContext := policyContext.Copy()
 			if err := policyContext.JSONContext.AddTargetResource(patchedResource.Object); err != nil {
 				log.Log.Error(err, "failed to add target resource to the context")
@@ -122,6 +121,8 @@ func Mutate(policyContext *PolicyContext) (resp *response.EngineResponse) {
 					incrementAppliedCount(resp)
 				}
 			}
+
+			policyContext.JSONContext.Reset()
 		}
 	}
 

--- a/pkg/engine/mutation.go
+++ b/pkg/engine/mutation.go
@@ -97,10 +97,12 @@ func Mutate(policyContext *PolicyContext) (resp *response.EngineResponse) {
 				continue
 			}
 
-			policyContext := policyContext.Copy()
-			if err := policyContext.JSONContext.AddTargetResource(patchedResource.Object); err != nil {
-				log.Log.Error(err, "failed to add target resource to the context")
-				continue
+			if !policyContext.AdmissionOperation && rule.IsMutateExisting() {
+				policyContext := policyContext.Copy()
+				if err := policyContext.JSONContext.AddTargetResource(patchedResource.Object); err != nil {
+					log.Log.Error(err, "failed to add target resource to the context")
+					continue
+				}
 			}
 
 			logger.V(4).Info("apply rule to resource", "rule", rule.Name, "resource namespace", patchedResource.GetNamespace(), "resource name", patchedResource.GetName())
@@ -121,8 +123,6 @@ func Mutate(policyContext *PolicyContext) (resp *response.EngineResponse) {
 					incrementAppliedCount(resp)
 				}
 			}
-
-			policyContext.JSONContext.Reset()
 		}
 	}
 

--- a/pkg/engine/mutation.go
+++ b/pkg/engine/mutation.go
@@ -97,6 +97,13 @@ func Mutate(policyContext *PolicyContext) (resp *response.EngineResponse) {
 				continue
 			}
 
+			policyContext.JSONContext.Reset()
+			policyContext := policyContext.Copy()
+			if err := policyContext.JSONContext.AddTargetResource(patchedResource.Object); err != nil {
+				log.Log.Error(err, "failed to add target resource to the context")
+				continue
+			}
+
 			logger.V(4).Info("apply rule to resource", "rule", rule.Name, "resource namespace", patchedResource.GetNamespace(), "resource name", patchedResource.GetName())
 			var ruleResp *response.RuleResponse
 			if rule.Mutation.ForEachMutation != nil {

--- a/pkg/engine/mutation_test.go
+++ b/pkg/engine/mutation_test.go
@@ -1035,134 +1035,220 @@ func Test_mutate_existing_resources(t *testing.T) {
 		name       string
 		policy     []byte
 		trigger    []byte
-		target     []byte
+		targets    [][]byte
 		targetList string
 		patches    []string
 	}{
 		{
 			name: "test-different-trigger-target",
 			policy: []byte(`{
-        "apiVersion": "kyverno.io/v1",
-        "kind": "ClusterPolicy",
-        "metadata": {
-            "name": "test-post-mutation"
-        },
-        "spec": {
-            "rules": [
-                {
-                    "name": "mutate-deploy-on-configmap-update",
-                    "match": {
-                        "any": [
-                            {
-                                "resources": {
-                                    "kinds": [
-                                        "ConfigMap"
-                                    ],
-                                    "names": [
-                                        "dictionary"
-                                    ],
-                                    "namespaces": [
-                                        "staging"
-                                    ]
-                                }
-                            }
-                        ]
-                    },
-                    "preconditions": {
-                        "any": [
-                            {
-                                "key": "{{ request.object.data.foo }}",
-                                "operator": "Equals",
-                                "value": "bar"
-                            }
-                        ]
-                    },
-                    "mutate": {
-                        "targets": [
-                            {
-                                "apiVersion": "v1",
-                                "kind": "Deployment",
-                                "name": "example-A",
-                                "namespace": "staging"
-                            }
-                        ],
-                        "patchStrategicMerge": {
-                            "metadata": {
-                                "labels": {
-                                    "foo": "bar"
-                                }
-                            }
-                        }
-                    }
-                }
-            ]
-        }
-    }`),
+		        "apiVersion": "kyverno.io/v1",
+		        "kind": "ClusterPolicy",
+		        "metadata": {
+		            "name": "test-post-mutation"
+		        },
+		        "spec": {
+		            "rules": [
+		                {
+		                    "name": "mutate-deploy-on-configmap-update",
+		                    "match": {
+		                        "any": [
+		                            {
+		                                "resources": {
+		                                    "kinds": [
+		                                        "ConfigMap"
+		                                    ],
+		                                    "names": [
+		                                        "dictionary"
+		                                    ],
+		                                    "namespaces": [
+		                                        "staging"
+		                                    ]
+		                                }
+		                            }
+		                        ]
+		                    },
+		                    "preconditions": {
+		                        "any": [
+		                            {
+		                                "key": "{{ request.object.data.foo }}",
+		                                "operator": "Equals",
+		                                "value": "bar"
+		                            }
+		                        ]
+		                    },
+		                    "mutate": {
+		                        "targets": [
+		                            {
+		                                "apiVersion": "v1",
+		                                "kind": "Deployment",
+		                                "name": "example-A",
+		                                "namespace": "staging"
+		                            }
+		                        ],
+		                        "patchStrategicMerge": {
+		                            "metadata": {
+		                                "labels": {
+		                                    "foo": "bar"
+		                                }
+		                            }
+		                        }
+		                    }
+		                }
+		            ]
+		        }
+		    }`),
 			trigger: []byte(`{
-    "apiVersion": "v1",
-    "data": {
-        "foo": "bar"
-    },
-    "kind": "ConfigMap",
-    "metadata": {
-        "name": "dictionary",
-        "namespace": "staging"
-    }
-}`),
-			target: []byte(`{
-    "apiVersion": "apps/v1",
-    "kind": "Deployment",
-    "metadata": {
-        "name": "example-A",
-        "namespace": "staging",
-        "labels": {
-            "app": "nginx"
-        }
-    },
-    "spec": {
-        "replicas": 1,
-        "selector": {
-            "matchLabels": {
-                "app": "nginx"
-            }
-        },
-        "template": {
-            "metadata": {
-                "labels": {
-                    "app": "nginx"
-                }
-            },
-            "spec": {
-                "containers": [
-                    {
-                        "name": "nginx",
-                        "image": "nginx:1.14.2",
-                        "ports": [
-                            {
-                                "containerPort": 80
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
-    }
-}`),
+		    "apiVersion": "v1",
+		    "data": {
+		        "foo": "bar"
+		    },
+		    "kind": "ConfigMap",
+		    "metadata": {
+		        "name": "dictionary",
+		        "namespace": "staging"
+		    }
+		}`),
+			targets: [][]byte{[]byte(`{
+		    "apiVersion": "apps/v1",
+		    "kind": "Deployment",
+		    "metadata": {
+		        "name": "example-A",
+		        "namespace": "staging",
+		        "labels": {
+		            "app": "nginx"
+		        }
+		    },
+		    "spec": {
+		        "replicas": 1,
+		        "selector": {
+		            "matchLabels": {
+		                "app": "nginx"
+		            }
+		        },
+		        "template": {
+		            "metadata": {
+		                "labels": {
+		                    "app": "nginx"
+		                }
+		            },
+		            "spec": {
+		                "containers": [
+		                    {
+		                        "name": "nginx",
+		                        "image": "nginx:1.14.2",
+		                        "ports": [
+		                            {
+		                                "containerPort": 80
+		                            }
+		                        ]
+		                    }
+		                ]
+		            }
+		        }
+		    }
+		}`)},
 			targetList: "DeploymentList",
 			patches:    []string{`{"op":"add","path":"/metadata/labels/foo","value":"bar"}`},
 		},
 		{
 			name: "test-same-trigger-target",
 			policy: []byte(`{
+		        "apiVersion": "kyverno.io/v1",
+		        "kind": "ClusterPolicy",
+		        "metadata": {
+		            "name": "test-post-mutation"
+		        },
+		        "spec": {
+		            "rules": [
+		                {
+		                    "name": "mutate-deploy-on-configmap-update",
+		                    "match": {
+		                        "any": [
+		                            {
+		                                "resources": {
+		                                    "kinds": [
+		                                        "ConfigMap"
+		                                    ],
+		                                    "names": [
+		                                        "dictionary"
+		                                    ],
+		                                    "namespaces": [
+		                                        "staging"
+		                                    ]
+		                                }
+		                            }
+		                        ]
+		                    },
+		                    "preconditions": {
+		                        "any": [
+		                            {
+		                                "key": "{{ request.object.data.foo }}",
+		                                "operator": "Equals",
+		                                "value": "bar"
+		                            }
+		                        ]
+		                    },
+		                    "mutate": {
+		                        "targets": [
+		                            {
+		                                "apiVersion": "v1",
+		                                "kind": "ConfigMap",
+		                                "name": "dictionary",
+		                                "namespace": "staging"
+		                            }
+		                        ],
+		                        "patchStrategicMerge": {
+		                            "metadata": {
+		                                "labels": {
+		                                    "foo": "bar"
+		                                }
+		                            }
+		                        }
+		                    }
+		                }
+		            ]
+		        }
+		    }`),
+			trigger: []byte(`{
+		    "apiVersion": "v1",
+		    "data": {
+		        "foo": "bar"
+		    },
+		    "kind": "ConfigMap",
+		    "metadata": {
+		        "name": "dictionary",
+		        "namespace": "staging"
+		    }
+		}`),
+			targets: [][]byte{[]byte(`{
+		    "apiVersion": "v1",
+		    "data": {
+		        "foo": "bar"
+		    },
+		    "kind": "ConfigMap",
+		    "metadata": {
+		        "name": "dictionary",
+		        "namespace": "staging"
+		    }
+		}`)},
+			targetList: "ComfigMapList",
+			patches:    []string{`{"op":"add","path":"/metadata/labels","value":{"foo":"bar"}}`},
+		},
+		{
+			name: "test-in-place-variable",
+			policy: []byte(`
+      {
         "apiVersion": "kyverno.io/v1",
         "kind": "ClusterPolicy",
         "metadata": {
-            "name": "test-post-mutation"
+            "name": "sync-cms"
         },
         "spec": {
+            "mutateExistingOnPolicyUpdate": false,
             "rules": [
                 {
-                    "name": "mutate-deploy-on-configmap-update",
+                    "name": "concat-cm",
                     "match": {
                         "any": [
                             {
@@ -1171,21 +1257,12 @@ func Test_mutate_existing_resources(t *testing.T) {
                                         "ConfigMap"
                                     ],
                                     "names": [
-                                        "dictionary"
+                                        "cmone"
                                     ],
                                     "namespaces": [
-                                        "staging"
+                                        "foo"
                                     ]
                                 }
-                            }
-                        ]
-                    },
-                    "preconditions": {
-                        "any": [
-                            {
-                                "key": "{{ request.object.data.foo }}",
-                                "operator": "Equals",
-                                "value": "bar"
                             }
                         ]
                     },
@@ -1194,49 +1271,154 @@ func Test_mutate_existing_resources(t *testing.T) {
                             {
                                 "apiVersion": "v1",
                                 "kind": "ConfigMap",
-                                "name": "dictionary",
-                                "namespace": "staging"
+                                "name": "cmtwo",
+                                "namespace": "bar"
                             }
                         ],
                         "patchStrategicMerge": {
-                            "metadata": {
-                                "labels": {
-                                    "foo": "bar"
-                                }
+                            "data": {
+                                "keytwo": "{{@}}-{{request.object.data.keyone}}"
                             }
                         }
                     }
                 }
             ]
         }
-    }`),
-			trigger: []byte(`{
-    "apiVersion": "v1",
-    "data": {
-        "foo": "bar"
-    },
-    "kind": "ConfigMap",
-    "metadata": {
-        "name": "dictionary",
-        "namespace": "staging"
     }
-}`),
-			target: []byte(`{
-    "apiVersion": "v1",
-    "data": {
-        "foo": "bar"
-    },
-    "kind": "ConfigMap",
-    "metadata": {
-        "name": "dictionary",
-        "namespace": "staging"
+`),
+			trigger: []byte(`
+      {
+        "apiVersion": "v1",
+        "data": {
+            "keyone": "valueone"
+        },
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": "cmone",
+            "namespace": "foo"
+        }
     }
-}`),
+`),
+			targets: [][]byte{[]byte(`
+      {
+        "apiVersion": "v1",
+        "data": {
+            "keytwo": "valuetwo"
+        },
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": "cmtwo",
+            "namespace": "bar"
+        }
+    }
+`)},
 			targetList: "ComfigMapList",
-			patches:    []string{`{"op":"add","path":"/metadata/labels","value":{"foo":"bar"}}`},
+			patches:    []string{`{"op":"replace","path":"/data/keytwo","value":"valuetwo-valueone"}`},
+		},
+		{
+			name: "test-in-place-variable",
+			policy: []byte(`
+      {
+        "apiVersion": "kyverno.io/v1",
+        "kind": "ClusterPolicy",
+        "metadata": {
+            "name": "sync-cms"
+        },
+        "spec": {
+            "mutateExistingOnPolicyUpdate": false,
+            "rules": [
+                {
+                    "name": "concat-cm",
+                    "match": {
+                        "any": [
+                            {
+                                "resources": {
+                                    "kinds": [
+                                        "ConfigMap"
+                                    ],
+                                    "names": [
+                                        "cmone"
+                                    ],
+                                    "namespaces": [
+                                        "foo"
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "mutate": {
+                        "targets": [
+                            {
+                                "apiVersion": "v1",
+                                "kind": "ConfigMap",
+                                "name": "cmtwo",
+                                "namespace": "bar"
+                            },
+                            {
+                                "apiVersion": "v1",
+                                "kind": "ConfigMap",
+                                "name": "cmthree",
+                                "namespace": "bar"
+                            }
+                        ],
+                        "patchStrategicMerge": {
+                            "data": {
+                                "key": "{{@}}-{{request.object.data.keyone}}"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+`),
+			trigger: []byte(`
+      {
+        "apiVersion": "v1",
+        "data": {
+            "keyone": "valueone"
+        },
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": "cmone",
+            "namespace": "foo"
+        }
+    }
+`),
+			targets: [][]byte{
+				[]byte(`
+      {
+        "apiVersion": "v1",
+        "data": {
+            "key": "valuetwo"
+        },
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": "cmtwo",
+            "namespace": "bar"
+        }
+    }
+`),
+				[]byte(`
+				      {
+				        "apiVersion": "v1",
+				        "data": {
+				            "key": "valuethree"
+				        },
+				        "kind": "ConfigMap",
+				        "metadata": {
+				            "name": "cmthree",
+				            "namespace": "bar"
+				        }
+				    }
+				`),
+			},
+			targetList: "ComfigMapList",
+			patches:    []string{`{"op":"replace","path":"/data/key","value":"valuetwo-valueone"}`, `{"op":"replace","path":"/data/key","value":"valuethree-valueone"}`},
 		},
 	}
 
+	var policyContext *PolicyContext
 	for _, test := range tests {
 		var policy kyverno.ClusterPolicy
 		err := json.Unmarshal(test.policy, &policy)
@@ -1245,38 +1427,41 @@ func Test_mutate_existing_resources(t *testing.T) {
 		trigger, err := utils.ConvertToUnstructured(test.trigger)
 		assert.NilError(t, err)
 
-		target, err := utils.ConvertToUnstructured(test.target)
-		assert.NilError(t, err)
+		for _, target := range test.targets {
+			target, err := utils.ConvertToUnstructured(target)
+			assert.NilError(t, err)
 
-		ctx := context.NewContext()
-		err = ctx.AddResource(trigger.Object)
-		assert.NilError(t, err)
+			ctx := context.NewContext()
+			err = ctx.AddResource(trigger.Object)
+			assert.NilError(t, err)
 
-		gvrToListKind := map[schema.GroupVersionResource]string{
-			{Group: target.GroupVersionKind().Group, Version: target.GroupVersionKind().Version, Resource: target.GroupVersionKind().Kind}: test.targetList,
+			gvrToListKind := map[schema.GroupVersionResource]string{
+				{Group: target.GroupVersionKind().Group, Version: target.GroupVersionKind().Version, Resource: target.GroupVersionKind().Kind}: test.targetList,
+			}
+
+			objects := []runtime.Object{target}
+			scheme := runtime.NewScheme()
+			dclient, err := client.NewMockClient(scheme, gvrToListKind, objects...)
+			assert.NilError(t, err)
+			dclient.SetDiscovery(client.NewFakeDiscoveryClient(nil))
+
+			_, err = dclient.GetResource(target.GetAPIVersion(), target.GetKind(), target.GetNamespace(), target.GetName())
+			assert.NilError(t, err)
+
+			policyContext = &PolicyContext{
+				Client:      dclient,
+				Policy:      &policy,
+				JSONContext: ctx,
+				NewResource: *trigger,
+			}
 		}
-
-		objects := []runtime.Object{target}
-		scheme := runtime.NewScheme()
-		dclient, err := client.NewMockClient(scheme, gvrToListKind, objects...)
-		assert.NilError(t, err)
-		dclient.SetDiscovery(client.NewFakeDiscoveryClient(nil))
-
-		_, err = dclient.GetResource(target.GetAPIVersion(), target.GetKind(), target.GetNamespace(), target.GetName())
-		assert.NilError(t, err)
-
-		policyContext := &PolicyContext{
-			Client:      dclient,
-			Policy:      &policy,
-			JSONContext: ctx,
-			NewResource: *trigger,
-		}
-
 		er := Mutate(policyContext)
 
 		for _, rr := range er.PolicyResponse.Rules {
-			assert.Equal(t, test.patches[0], string(rr.Patches[0]))
-			assert.Equal(t, rr.Status, response.RuleStatusPass, rr.Status)
+			for i, p := range rr.Patches {
+				assert.Equal(t, test.patches[i], string(p), "test %s failed:\nGot %s\nExpected: %s", test.name, rr.Patches[i], test.patches[i])
+				assert.Equal(t, rr.Status, response.RuleStatusPass, rr.Status)
+			}
 		}
 	}
 }

--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -348,12 +348,16 @@ func substituteVariablesIfAny(log logr.Logger, ctx context.EvalInterface, vr Var
 				variable := replaceBracesAndTrimSpaces(v)
 
 				if variable == "@" {
+					pathPrefix := "target."
+					if _, err := ctx.Query("target"); err != nil {
+						pathPrefix = "request.object."
+					}
 					path := getJMESPath(data.Path)
 					var val string
 					if strings.HasPrefix(path, "[") {
-						val = fmt.Sprintf("target.%s", path)
+						val = fmt.Sprintf("%s%s", pathPrefix, path)
 					} else {
-						val = fmt.Sprintf("target.%s", path)
+						val = fmt.Sprintf("%s%s", pathPrefix, path)
 					}
 
 					variable = strings.Replace(variable, "@", val, -1)

--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -348,16 +348,16 @@ func substituteVariablesIfAny(log logr.Logger, ctx context.EvalInterface, vr Var
 				variable := replaceBracesAndTrimSpaces(v)
 
 				if variable == "@" {
-					pathPrefix := "target."
+					pathPrefix := "target"
 					if _, err := ctx.Query("target"); err != nil {
-						pathPrefix = "request.object."
+						pathPrefix = "request.object"
 					}
 					path := getJMESPath(data.Path)
 					var val string
 					if strings.HasPrefix(path, "[") {
 						val = fmt.Sprintf("%s%s", pathPrefix, path)
 					} else {
-						val = fmt.Sprintf("%s%s", pathPrefix, path)
+						val = fmt.Sprintf("%s.%s", pathPrefix, path)
 					}
 
 					variable = strings.Replace(variable, "@", val, -1)

--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -285,7 +285,7 @@ func substituteReferencesIfAny(log logr.Logger) jsonUtils.Action {
 			}
 
 			if resolvedReference == nil {
-				return data.Element, fmt.Errorf("failed to resolve %v at path %s: %v", v, data.Path, err)
+				return data.Element, fmt.Errorf("got nil resolved variable %v at path %s: %v", v, data.Path, err)
 			}
 
 			log.V(3).Info("reference resolved", "reference", v, "value", resolvedReference, "path", data.Path)

--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -351,9 +351,9 @@ func substituteVariablesIfAny(log logr.Logger, ctx context.EvalInterface, vr Var
 					path := getJMESPath(data.Path)
 					var val string
 					if strings.HasPrefix(path, "[") {
-						val = fmt.Sprintf("request.object%s", path)
+						val = fmt.Sprintf("target.%s", path)
 					} else {
-						val = fmt.Sprintf("request.object.%s", path)
+						val = fmt.Sprintf("target.%s", path)
 					}
 
 					variable = strings.Replace(variable, "@", val, -1)

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -31,9 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var allowedVariables = regexp.MustCompile(`request\.|serviceAccountName|serviceAccountNamespace|element|elementIndex|@|images\.|([a-z_0-9]+\()[^{}]`)
+var allowedVariables = regexp.MustCompile(`request\.|serviceAccountName|serviceAccountNamespace|element|elementIndex|@|images\.|target\.|([a-z_0-9]+\()[^{}]`)
 
-var allowedVariablesBackground = regexp.MustCompile(`request\.|element|elementIndex|@|images\.|([a-z_0-9]+\()[^{}]`)
+var allowedVariablesBackground = regexp.MustCompile(`request\.|element|elementIndex|@|images\.|target\.|([a-z_0-9]+\()[^{}]`)
 
 // wildCardAllowedVariables represents regex for the allowed fields in wildcards
 var wildCardAllowedVariables = regexp.MustCompile(`\{\{\s*(request\.|serviceAccountName|serviceAccountNamespace)[^{}]*\}\}`)
@@ -405,7 +405,7 @@ func ValidateOnPolicyUpdate(p kyvernov1.PolicyInterface, onPolicyUpdate bool) er
 	}
 
 	if err := hasInvalidVariables(p, onPolicyUpdate); err != nil {
-		return fmt.Errorf("policy contains invalid variables: %s", err.Error())
+		return fmt.Errorf("update event, policy contains invalid variables: %s", err.Error())
 	}
 
 	if err := containsUserVariables(p, vars); err != nil {


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Related issue
This PR
- supports `@` for mutate targets
- enable variables for target resources, i.e., `{{target.}}`
- closes https://github.com/kyverno/kyverno/issues/3997

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.7.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/enhancement
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: sync-cms
spec:
  mutateExistingOnPolicyUpdate: false
  rules:
  - name: concat-cm
    match:
      any:
      - resources:
          kinds:
          - ConfigMap
          names:
          - cmone
          namespaces:
          - foo
    mutate:
      targets:
        - apiVersion: v1
          kind: ConfigMap
          name: cmtwo
          namespace: bar
        - apiVersion: v1
          kind: ConfigMap
          name: cmthree
          namespace: bar
      patchStrategicMerge:
        data:
          key: "{{@}}-{{request.object.data.keyone}}"
```

Results:
```
✗ k -n bar get cm cmtwo -o yaml
apiVersion: v1
data:
  key: valuetwo-valueone
kind: ConfigMap
metadata:
  annotations:
    policies.kyverno.io/last-applied-patches: |
      concat-cm.sync-cms.kyverno.io: replaced /data/key
  creationTimestamp: "2022-05-23T15:28:22Z"
  name: cmtwo
  namespace: bar
  resourceVersion: "947367"
  uid: e396a68f-c243-442f-b130-65acf0dc4dbb

➜  kyverno git:(support_inplace_var) ✗ k -n bar get cm cmthree -o yaml
apiVersion: v1
data:
  key: valuethree-valueone
kind: ConfigMap
metadata:
  annotations:
    policies.kyverno.io/last-applied-patches: |
      concat-cm.sync-cms.kyverno.io: replaced /data/key
  creationTimestamp: "2022-05-23T17:15:59Z"
  name: cmthree
  namespace: bar
  resourceVersion: "947368"
  uid: bbfc10c1-248f-4b9d-be4b-e3b306ab6856
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added unit tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
