### PR TITLE
feat: add observed policy generation in ur status

### DIFF
--- a/api/kyverno/v1beta1/updaterequest_types.go
+++ b/api/kyverno/v1beta1/updaterequest_types.go
@@ -38,6 +38,9 @@ type UpdateRequestStatus struct {
 	// This will track the resources that are updated by the generate Policy.
 	// Will be used during clean up resources.
 	GeneratedResources []kyvernov1.ResourceSpec `json:"generatedResources,omitempty" yaml:"generatedResources,omitempty"`
+
+	// The policy generation observed by the update request controller.
+	ObservedPolicyGeneration int64 `json:"observedPolicyGeneration,omitempty"`
 }
 
 // +genclient

--- a/charts/kyverno/templates/crds.yaml
+++ b/charts/kyverno/templates/crds.yaml
@@ -4679,6 +4679,10 @@ spec:
               message:
                 description: Specifies request status message.
                 type: string
+              observedPolicyGeneration:
+                description: The policy generation observed by the update request controller.
+                format: int64
+                type: integer
               state:
                 description: State represents state of the update request.
                 type: string

--- a/config/crds/kyverno.io_updaterequests.yaml
+++ b/config/crds/kyverno.io_updaterequests.yaml
@@ -182,6 +182,11 @@ spec:
               message:
                 description: Specifies request status message.
                 type: string
+              observedPolicyGeneration:
+                description: The policy generation observed by the update request
+                  controller.
+                format: int64
+                type: integer
               state:
                 description: State represents state of the update request.
                 type: string

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -7018,6 +7018,11 @@ spec:
               message:
                 description: Specifies request status message.
                 type: string
+              observedPolicyGeneration:
+                description: The policy generation observed by the update request
+                  controller.
+                format: int64
+                type: integer
               state:
                 description: State represents state of the update request.
                 type: string

--- a/config/install_debug.yaml
+++ b/config/install_debug.yaml
@@ -7009,6 +7009,11 @@ spec:
               message:
                 description: Specifies request status message.
                 type: string
+              observedPolicyGeneration:
+                description: The policy generation observed by the update request
+                  controller.
+                format: int64
+                type: integer
               state:
                 description: State represents state of the update request.
                 type: string

--- a/docs/crd/v1beta1/index.html
+++ b/docs/crd/v1beta1/index.html
@@ -455,6 +455,17 @@ string
 Will be used during clean up resources.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>observedPolicyGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>The policy generation observed by the update request controller.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr />


### PR DESCRIPTION
This PR adds observed policy generation in ur status.
This is needed to avoid mutating the ur in the event handler.