### PR TITLE
Fix labels with invalid chars

### DIFF
--- a/pkg/background/common/labels.go
+++ b/pkg/background/common/labels.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -43,7 +44,7 @@ func MutateLabelsSet(policyKey string, trigger Object) pkglabels.Set {
 		set[kyvernov1beta1.URMutateTriggerNSLabel] = trigger.GetNamespace()
 		set[kyvernov1beta1.URMutatetriggerKindLabel] = trigger.GetKind()
 		if trigger.GetAPIVersion() != "" {
-			set[kyvernov1beta1.URMutatetriggerAPIVersionLabel] = trigger.GetAPIVersion()
+			set[kyvernov1beta1.URMutatetriggerAPIVersionLabel] = strings.ReplaceAll(trigger.GetAPIVersion(), "/", "-")
 		}
 	}
 	return set


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

MutateExisting policies with target's `apiVersion` specified fail to apply prior to this change.

This PR replaces `/` in labels by `-` to fix it.

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: add-sec
  annotations:
    foo: bar
spec:
  mutateExistingOnPolicyUpdate: true
  rules:
  - name: add-sec-rule
    match:
      any:
      - resources:
          kinds:
          - Deployment
    mutate:
      targets:
        - apiVersion: apps/v1
          kind: Deployment
      patchStrategicMerge:
        spec:
          template:
            spec:
              containers:
                - (name): "nginx"
                  securityContext:
                    runAsNonRoot: true
                    allowPrivilegeEscalation: false
                    privileged: false
```

With the above policy installed, create a new deployment and the pod template gets mutated:
```
✗ k create deploy foobar --image=nginx

✗ k get pod -w
NAME                      READY   STATUS              RESTARTS   AGE
foobar-79b69c987c-ct7t2   1/1     Running             0          13s
foobar-7cbf8df4dd-msxd2   0/1     ContainerCreating   0          3s
```

Annotation:
```
✗ k get deploy -o yaml
apiVersion: v1
items:
- apiVersion: apps/v1
  kind: Deployment
  metadata:
    annotations:
      deployment.kubernetes.io/revision: "2"
      policies.kyverno.io/last-applied-patches: |
        add-sec-rule.add-sec.kyverno.io: added /spec/template/spec/containers/0/securityContext
```

Event:
```
5m27s       Normal    PolicyApplied             deployment/foobar              policy add-sec/add-sec-rule applied
```