### PR TITLE
Fix handling of kyverno-policies version check when port in image tag

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -25,3 +25,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Support for artifacthub.io/changes annotation
+    - kind: fixed
+      description: Fix Kyverno version check when image tag  contains registry port number

--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -26,4 +26,4 @@ annotations:
     - kind: added
       description: Support for artifacthub.io/changes annotation
     - kind: fixed
-      description: Fix Kyverno version check when image tag  contains registry port number
+      description: Fix Kyverno version check when image tag contains registry port number

--- a/charts/kyverno-policies/templates/_helpers.tpl
+++ b/charts/kyverno-policies/templates/_helpers.tpl
@@ -59,7 +59,7 @@ helm.sh/chart: {{ template "kyverno-policies.chart" . }}
 {{- $version := "" -}}
 {{- with (lookup "apps/v1" "Deployment" .Release.Namespace "kyverno") -}}
   {{- with (first .spec.template.spec.containers) -}}
-    {{- $imageTag := (last (split ":" .image)) -}}
+    {{- $imageTag := (last (splitList ":" .image)) -}}
     {{- $version = trimPrefix "v" $imageTag -}}
   {{- end -}}
 {{- end -}}

--- a/charts/kyverno-policies/templates/_helpers.tpl
+++ b/charts/kyverno-policies/templates/_helpers.tpl
@@ -59,7 +59,7 @@ helm.sh/chart: {{ template "kyverno-policies.chart" . }}
 {{- $version := "" -}}
 {{- with (lookup "apps/v1" "Deployment" .Release.Namespace "kyverno") -}}
   {{- with (first .spec.template.spec.containers) -}}
-    {{- $imageTag := (split ":" .image)._1 -}}
+    {{- $imageTag := (last (split ":" .image)) -}}
     {{- $version = trimPrefix "v" $imageTag -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->
Fixes #4031

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
> /kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

Get the last element of image to ensure only getting tag version and not breaking when image has registry port number.
