### PR TITLE
fix: use policyName key to get the policy name

### DIFF
--- a/pkg/webhooks/updaterequest/generator.go
+++ b/pkg/webhooks/updaterequest/generator.go
@@ -71,10 +71,11 @@ func (g *generator) applyResource(policyName string, urSpec kyvernov1beta1.Updat
 func (g *generator) tryApplyResource(policyName string, urSpec kyvernov1beta1.UpdateRequestSpec) error {
 	l := logger.WithValues("ruleType", urSpec.Type, "kind", urSpec.Resource.Kind, "name", urSpec.Resource.Name, "namespace", urSpec.Resource.Namespace)
 	var queryLabels labels.Set
+
 	if urSpec.Type == kyvernov1beta1.Mutate {
-		queryLabels = common.MutateLabelsSet(urSpec.Policy, urSpec.Resource)
+		queryLabels = common.MutateLabelsSet(policyName, urSpec.Resource)
 	} else if urSpec.Type == kyvernov1beta1.Generate {
-		queryLabels = common.GenerateLabelsSet(urSpec.Policy, urSpec.Resource)
+		queryLabels = common.GenerateLabelsSet(policyName, urSpec.Resource)
 	}
 	urList, err := g.urLister.List(labels.SelectorFromSet(queryLabels))
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Related issue

Closes #4140
Cherry-pick: #4114 


## Milestone of this PR

`/milestone 1.7.1`

## What type of PR is this

> /kind bug

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

In case of namespace policy `ur.spec.policy` contains namespace/policy-name combinations, hence can't be used to set the policy name label.


### Proof Manifests


# Kubernetes resource

```yaml
apiVersion: kyverno.io/v1
kind: Policy
metadata:
  name: scale-deployment-zero
  namespace: test
spec:
  rules:
  - name: annotate-deployment-rule
    match:
      any:
      - resources:
          kinds:
          - v1/Pod.status
    preconditions:
      all:
      - key: "{{request.operation}}"
        operator: Equals
        value: UPDATE
      - key: "{{request.object.status.containerStatuses[0].restartCount}}"
        operator: GreaterThan
        value: 2 # Pods like minio often restarts few times before going healthy.
    context:
    - name: rsname
      variable:
        jmesPath: "request.object.metadata.ownerReferences[0].name"
        default: ''
    - name: deploymentname
      apiCall:
        urlPath: "/apis/apps/v1/namespaces/{{request.namespace}}/replicasets"
        jmesPath: "items[?metadata.name=='{{rsname}}'].metadata.ownerReferences[0].name | [0]"
    mutate:
      targets:
        - apiVersion: apps/v1
          kind: Deployment
          name: "{{deploymentname}}"
          namespace: "{{request.namespace}}"
      patchStrategicMerge:
        metadata:
          annotations:
            sre.corp.org/troubleshooting-needed: "true"
        spec:
          replicas: 0
```
### Verify the fix for generate Namespace policy
```sh
 k get ur
NAME       POLICY                    RULETYPE   RESOURCEKIND   RESOURCENAME            RESOURCENAMESPACE   STATUS      AGE
ur-bbgwv   test/create-default-pdb   generate   Deployment     nginx-deployment        test                Completed   25m
ur-dpzqr   test/create-default-pdb   generate   Deployment     scale-down-if-failing   test                Completed      19m

```

### Verify the fix using generate clusterPolicy 
```sh
k get ur
NAME       POLICY               RULETYPE   RESOURCEKIND   RESOURCENAME            RESOURCENAMESPACE   STATUS      AGE
ur-cz5qf   create-default-pdb   generate   Deployment     nginx-deployment-new    test                Completed   94s
ur-mqrbl   create-default-pdb   generate   Deployment     scale-down-if-failing   test                Completed   66s
ur-rmrbt   create-default-pdb   generate   Deployment     nginx-deployment        test                Completed   86s

```

### Verify the fix for namespace mutate scale-down policy

```sh
k get deploy -n test
NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
scale-down-if-failing   0/1     1            0           29s

$ k get deploy -n test
NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
scale-down-if-failing   0/1     1            0           57s
$ k get deploy -n test
NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
scale-down-if-failing   0/0     0            0           66s

```
### ### Verify the fix for mutate scale-down ClusterPolicy

```sh
kubectl get pods -n test
NAME                                     READY   STATUS             RESTARTS      AGE
scale-down-if-failing-686b7878ff-72f5h   0/1     CrashLoopBackOff   2 (28s ago)   58s

k get deploy -n test
NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
scale-down-if-failing   0/1     1            0           68s

$ k get deploy -n test
NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
scale-down-if-failing   0/1     1            0           68s

$ k get deploy -n test
NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
scale-down-if-failing   0/1     1            0           69s

$ k get deploy -n test
NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
scale-down-if-failing   0/0     0            0           70s


```


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
