### PR TITLE
fix external.metrics.k8s.io/v1beta1 issue

### DIFF
--- a/pkg/dclient/discovery.go
+++ b/pkg/dclient/discovery.go
@@ -117,12 +117,12 @@ func (c serverPreferredResources) findResource(apiVersion string, kind string) (
 	var serverResources []*metav1.APIResourceList
 	var err error
 	if apiVersion == "" {
-		serverResources, err = c.cachedClient.ServerPreferredResources()
+		serverResources, err = discovery.ServerPreferredResources(c.DiscoveryInterface())
 	} else {
-		_, serverResources, err = c.cachedClient.ServerGroupsAndResources()
+		_, serverResources, err = discovery.ServerGroupsAndResources(c.DiscoveryInterface())
 	}
 
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "Got empty response for") {
 		if discovery.IsGroupDiscoveryFailedError(err) {
 			logDiscoveryErrors(err, c)
 		} else if isMetricsServerUnavailable(kind, err) {

--- a/pkg/dclient/discovery.go
+++ b/pkg/dclient/discovery.go
@@ -21,6 +21,7 @@ type IDiscovery interface {
 	GetServerVersion() (*version.Info, error)
 	OpenAPISchema() (*openapiv2.Document, error)
 	DiscoveryCache() discovery.CachedDiscoveryInterface
+	DiscoveryInterface() discovery.DiscoveryInterface
 }
 
 // serverPreferredResources stores the cachedClient instance for discovery client
@@ -30,6 +31,10 @@ type serverPreferredResources struct {
 
 // DiscoveryCache gets the discovery client cache
 func (c serverPreferredResources) DiscoveryCache() discovery.CachedDiscoveryInterface {
+	return c.cachedClient
+}
+
+func (c serverPreferredResources) DiscoveryInterface() discovery.DiscoveryInterface {
 	return c.cachedClient
 }
 
@@ -56,6 +61,7 @@ func (c serverPreferredResources) Poll(resync time.Duration, stopCh <-chan struc
 // OpenAPISchema returns the API server OpenAPI schema document
 func (c serverPreferredResources) OpenAPISchema() (*openapiv2.Document, error) {
 	return c.cachedClient.OpenAPISchema()
+
 }
 
 // GetGVRFromKind get the Group Version Resource from kind

--- a/pkg/dclient/discovery.go
+++ b/pkg/dclient/discovery.go
@@ -34,6 +34,7 @@ func (c serverPreferredResources) DiscoveryCache() discovery.CachedDiscoveryInte
 	return c.cachedClient
 }
 
+// DiscoveryInterface gets the discovery client
 func (c serverPreferredResources) DiscoveryInterface() discovery.DiscoveryInterface {
 	return c.cachedClient
 }

--- a/pkg/dclient/fake.go
+++ b/pkg/dclient/fake.go
@@ -67,3 +67,6 @@ func (c *fakeDiscoveryClient) OpenAPISchema() (*openapiv2.Document, error) {
 func (c *fakeDiscoveryClient) DiscoveryCache() discovery.CachedDiscoveryInterface {
 	return nil
 }
+func (c *fakeDiscoveryClient) DiscoveryInterface() discovery.DiscoveryInterface {
+	return nil
+}

--- a/pkg/openapi/crdSync.go
+++ b/pkg/openapi/crdSync.go
@@ -10,6 +10,7 @@ import (
 	"github.com/googleapis/gnostic/compiler"
 	openapiv2 "github.com/googleapis/gnostic/openapiv2"
 	"github.com/kyverno/kyverno/pkg/dclient"
+	util "github.com/kyverno/kyverno/pkg/utils"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -124,7 +125,9 @@ func (c *crdSync) sync() {
 }
 
 func (c *crdSync) updateInClusterKindToAPIVersions() error {
+	util.OverrideRuntimeErrorHandler()
 	_, apiResourceLists, err := discovery.ServerGroupsAndResources(c.client.Discovery().DiscoveryInterface())
+
 	if err != nil && !strings.Contains(err.Error(), skipErrorMsg) {
 		return errors.Wrapf(err, "fetching API server groups and resources")
 	}

--- a/pkg/openapi/crdSync.go
+++ b/pkg/openapi/crdSync.go
@@ -112,7 +112,7 @@ func (c *crdSync) sync() {
 		log.Log.Error(err, "sync failed, unable to update in-cluster api versions")
 	}
 
-	newDoc, err := c.client.Discovery().DiscoveryCache().OpenAPISchema()
+	newDoc, err := c.client.Discovery().OpenAPISchema()
 	if err != nil {
 		log.Log.Error(err, "cannot get OpenAPI schema")
 	}

--- a/pkg/openapi/crdSync.go
+++ b/pkg/openapi/crdSync.go
@@ -91,7 +91,7 @@ func (c *crdSync) Run(workers int, stopCh <-chan struct{}) {
 }
 
 func (c *crdSync) sync() {
-	//c.client.Discovery().DiscoveryCache().Invalidate()
+	c.client.Discovery().DiscoveryCache().Invalidate()
 	crds, err := c.client.GetDynamicInterface().Resource(runtimeSchema.GroupVersionResource{
 		Group:    "apiextensions.k8s.io",
 		Version:  "v1",
@@ -112,7 +112,7 @@ func (c *crdSync) sync() {
 		log.Log.Error(err, "sync failed, unable to update in-cluster api versions")
 	}
 
-	newDoc, err := c.client.Discovery().OpenAPISchema()
+	newDoc, err := c.client.Discovery().DiscoveryCache().OpenAPISchema()
 	if err != nil {
 		log.Log.Error(err, "cannot get OpenAPI schema")
 	}

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -104,7 +103,7 @@ func Validate(policy kyvernov1.PolicyInterface, client dclient.Interface, mock b
 	clusterResources := sets.NewString()
 	if !mock && namespaced {
 		// Get all the cluster type kind supported by cluster
-		res, err := discovery.ServerPreferredResources(client.Discovery().DiscoveryInterface())
+		res, err := client.Discovery().DiscoveryCache().ServerPreferredResources()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -103,7 +104,7 @@ func Validate(policy kyvernov1.PolicyInterface, client dclient.Interface, mock b
 	clusterResources := sets.NewString()
 	if !mock && namespaced {
 		// Get all the cluster type kind supported by cluster
-		res, err := client.Discovery().DiscoveryCache().ServerPreferredResources()
+		res, err := discovery.ServerPreferredResources(client.Discovery().DiscoveryInterface())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -337,4 +338,14 @@ func ApiextensionsJsonToKyvernoConditions(original apiextensions.JSON) (interfac
 		return kyvernoAnyAllConditions, nil
 	}
 	return nil, fmt.Errorf("error occurred while parsing %s: %+v", path, err)
+}
+
+func OverrideRuntimeErrorHandler() {
+	if len(runtime.ErrorHandlers) > 0 {
+		runtime.ErrorHandlers[0] = func(err error) {}
+	} else {
+		runtime.ErrorHandlers = []func(err error){
+			func(err error) {},
+		}
+	}
 }

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -341,11 +341,17 @@ func ApiextensionsJsonToKyvernoConditions(original apiextensions.JSON) (interfac
 }
 
 func OverrideRuntimeErrorHandler() {
+	logger := log.Log.WithName("RuntimeErrorHandler")
 	if len(runtime.ErrorHandlers) > 0 {
-		runtime.ErrorHandlers[0] = func(err error) {}
+		runtime.ErrorHandlers[0] = func(err error) {
+			logger.V(6).Info("Runtime error occurred", err)
+		}
+
 	} else {
 		runtime.ErrorHandlers = []func(err error){
-			func(err error) {},
+			func(err error) {
+				logger.V(6).Info("Runtime error occurred", err)
+			},
 		}
 	}
 }

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -344,13 +344,13 @@ func OverrideRuntimeErrorHandler() {
 	logger := log.Log.WithName("RuntimeErrorHandler")
 	if len(runtime.ErrorHandlers) > 0 {
 		runtime.ErrorHandlers[0] = func(err error) {
-			logger.V(6).Info("Runtime error occurred", err)
+			logger.V(6).Info("runtime error: %s", err)
 		}
 
 	} else {
 		runtime.ErrorHandlers = []func(err error){
 			func(err error) {
-				logger.V(6).Info("Runtime error occurred", err)
+				logger.V(6).Info("runtime error: %s", err)
 			},
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Vyankatesh vyankateshkd@gmail.com

## Related issue
Closes #3244 , https://github.com/kyverno/kyverno/issues/2267
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->
## Explanation
This PR is fix the issue of getting  sync error continuously when we have external metrics install in cluster with kyverno.
this happen because of external.metrics API returns an empty array. 
Previously we are using DiscoveryCache ServerGroupsAndResource method which fails when the first error occurs.
discovery.ServerGroupsAndResources runs queries in parallel and collects all errors, and return errors back in a more graceful manner. 
Also customize the error handlers as we do not want the default logging behaviors.

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
1.7.2

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

### Proof Manifests

1. Install KEDA or DataDog Cluster Agent as External Metrics Provider
2. Install Kyverno
3. Install psp policies https://kyverno.io/policies/pod-security/ or mutate policies working as expected.
4. No error's in the logs

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is release1.7
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
