### PR TITLE
feat: split policy report per policy bases

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -395,6 +395,15 @@ func main() {
 		webhookCfg.UpdateWebhookChan <- true
 	}
 
+	if splitPolicyReport {
+		setupLog.Info("cleanup old policy reports", "splitPolicyReport", splitPolicyReport)
+		err = policyreport.CleanupPolicyReport(kyvernoClient)
+		if err != nil {
+			setupLog.Error(err, "failed to delete old reports")
+			os.Exit(1)
+		}
+	}
+
 	// leader election context
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -395,15 +395,6 @@ func main() {
 		webhookCfg.UpdateWebhookChan <- true
 	}
 
-	if splitPolicyReport {
-		setupLog.Info("cleanup old policy reports", "splitPolicyReport", splitPolicyReport)
-		err = policyreport.CleanupPolicyReport(kyvernoClient)
-		if err != nil {
-			setupLog.Error(err, "failed to delete old reports")
-			os.Exit(1)
-		}
-	}
-
 	// leader election context
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -70,6 +70,7 @@ var (
 	clientRateLimitQPS           float64
 	clientRateLimitBurst         int
 	changeRequestLimit           int
+	splitPolicyReport            bool
 	webhookRegistrationTimeout   time.Duration
 	setupLog                     = log.Log.WithName("setup")
 )
@@ -94,7 +95,7 @@ func main() {
 	flag.Func(toggle.AutogenInternalsFlagName, toggle.AutogenInternalsDescription, toggle.AutogenInternalsFlag)
 	flag.DurationVar(&webhookRegistrationTimeout, "webhookRegistrationTimeout", 120*time.Second, "Timeout for webhook registration, e.g., 30s, 1m, 5m.")
 	flag.IntVar(&changeRequestLimit, "maxReportChangeRequests", 1000, "maximum pending report change requests per namespace or for the cluster-wide policy report")
-
+	flag.BoolVar(&splitPolicyReport, "splitPolicyReport", false, "Set the flag to 'true', to enable the split-up PolicyReports per policy.")
 	if err := flag.Set("v", "2"); err != nil {
 		setupLog.Error(err, "failed to set log level")
 		os.Exit(1)
@@ -206,6 +207,7 @@ func main() {
 		kyvernoV1.ClusterPolicies(),
 		kyvernoV1.Policies(),
 		changeRequestLimit,
+		splitPolicyReport,
 		log.Log.WithName("ReportChangeRequestGenerator"),
 	)
 
@@ -218,6 +220,7 @@ func main() {
 		kyvernoV1alpha2.ClusterReportChangeRequests(),
 		kubeInformer.Core().V1().Namespaces(),
 		reportReqGen.CleanupChangeRequest,
+		splitPolicyReport,
 		log.Log.WithName("PolicyReportGenerator"),
 	)
 	if err != nil {

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -28,6 +28,7 @@ const (
 
 	// the following labels are used to list rcr / crcr
 	ResourceLabelNamespace string = "kyverno.io/resource.namespace"
+	policyLabel            string = "kyverno.io/policy-name"
 	deletedLabelPolicy     string = "kyverno.io/delete.policy"
 	deletedLabelRule       string = "kyverno.io/delete.rule"
 
@@ -209,6 +210,7 @@ func set(obj *unstructured.Unstructured, info Info) {
 
 	obj.SetLabels(map[string]string{
 		ResourceLabelNamespace: info.Namespace,
+		policyLabel:            info.PolicyName,
 		appVersion:             version.BuildVersion,
 	})
 }

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -57,6 +57,13 @@ func GeneratePolicyReportName(ns string) string {
 	return name
 }
 
+func TrimmedName(s string) string {
+	if len(s) > 63 {
+		return s[:63]
+	}
+	return s
+}
+
 // GeneratePRsFromEngineResponse generate Violations from engine responses
 func GeneratePRsFromEngineResponse(ers []*response.EngineResponse, log logr.Logger) (pvInfos []Info) {
 	for _, er := range ers {
@@ -210,7 +217,7 @@ func set(obj *unstructured.Unstructured, info Info) {
 
 	obj.SetLabels(map[string]string{
 		ResourceLabelNamespace: info.Namespace,
-		policyLabel:            info.PolicyName,
+		policyLabel:            TrimmedName(info.PolicyName),
 		appVersion:             version.BuildVersion,
 	})
 }

--- a/pkg/policyreport/changerequestcreator.go
+++ b/pkg/policyreport/changerequestcreator.go
@@ -153,7 +153,6 @@ func (c *changeRequestCreator) mergeRequests() (results []*unstructured.Unstruct
 	for _, uid := range c.queue {
 		if unstr, ok := c.CRCRCache.Get(uid); ok {
 			if crcr, ok := unstr.(*unstructured.Unstructured); ok {
-
 				policyName := crcr.GetLabels()[policyLabel]
 				mergedPolicyCRCR, ok := mergedCRCR[policyName]
 				if !ok {
@@ -168,7 +167,6 @@ func (c *changeRequestCreator) mergeRequests() (results []*unstructured.Unstruct
 
 					results = append(results, crcr)
 				} else {
-
 					if reflect.DeepEqual(mergedPolicyCRCR, &unstructured.Unstructured{}) {
 						mergedCRCR[policyName] = crcr
 						continue

--- a/pkg/policyreport/changerequestcreator.go
+++ b/pkg/policyreport/changerequestcreator.go
@@ -117,7 +117,6 @@ func (c *changeRequestCreator) run(stopChan <-chan struct{}) {
 	for {
 		select {
 		case <-ticker.C:
-
 			requests := []*unstructured.Unstructured{}
 			var size int
 			if c.splitPolicyReport {
@@ -188,7 +187,7 @@ func (c *changeRequestCreator) mergeRequests() (results []*unstructured.Unstruct
 
 		if unstr, ok := c.RCRCache.Get(uid); ok {
 			if rcr, ok := unstr.(*unstructured.Unstructured); ok {
-				resourceNS := rcr.GetLabels()[resourceLabelNamespace]
+				resourceNS := rcr.GetLabels()[ResourceLabelNamespace]
 				mergedNamespacedRCR, ok := mergedRCR[resourceNS]
 				if !ok {
 					mergedNamespacedRCR = &unstructured.Unstructured{}

--- a/pkg/policyreport/reportcontroller.go
+++ b/pkg/policyreport/reportcontroller.go
@@ -443,7 +443,6 @@ func (g *ReportGenerator) createReportIfNotPresent(namespace, policyName string,
 		}
 	} else {
 
-		log.V(2).Info("creating clusterpolicyReport>>>>>>>>>>>>>>>1", "splitPolicyReport", g.splitPolicyReport)
 		if g.splitPolicyReport {
 			report, err = g.clusterReportLister.Get(GeneratePolicyReportName(namespace) + "-" + policyName)
 		} else {
@@ -457,7 +456,6 @@ func (g *ReportGenerator) createReportIfNotPresent(namespace, policyName string,
 						return nil, fmt.Errorf("failed to convert to ClusterPolicyReport: %v", err)
 					}
 
-					log.V(2).Info("creating clusterpolicyReport>>>>>>2", "splitPolicyReport", g.splitPolicyReport)
 					if _, err := g.pclient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Create(context.TODO(), cpolr, metav1.CreateOptions{}); err != nil {
 						return nil, fmt.Errorf("failed to create ClusterPolicyReport: %v", err)
 					}
@@ -527,6 +525,7 @@ func (g *ReportGenerator) removeFromClusterPolicyReport(policyName, ruleName str
 }
 
 func (g *ReportGenerator) removeFromPolicyReport(policyName, ruleName string) error {
+
 	namespaces, err := g.client.ListResource("", "Namespace", "", nil)
 	if err != nil {
 		return fmt.Errorf("unable to list namespace %v", err)
@@ -562,6 +561,7 @@ func (g *ReportGenerator) removeFromPolicyReport(policyName, ruleName string) er
 		gv := policyreportv1alpha2.SchemeGroupVersion
 		gvk := schema.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: "PolicyReport"}
 		r.SetGroupVersionKind(gvk)
+
 		if _, err := g.pclient.Wgpolicyk8sV1alpha2().PolicyReports(r.GetNamespace()).Update(context.TODO(), r, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("failed to update PolicyReport %s %v", r.GetName(), err)
 		}

--- a/pkg/policyreport/reportrequest.go
+++ b/pkg/policyreport/reportrequest.go
@@ -70,6 +70,7 @@ func NewReportChangeRequestGenerator(client kyvernoclient.Interface,
 	cpolInformer kyvernov1informers.ClusterPolicyInformer,
 	polInformer kyvernov1informers.PolicyInformer,
 	changeRequestLimit int,
+	splitPolicyReport bool,
 	log logr.Logger,
 ) *Generator {
 	gen := Generator{
@@ -81,9 +82,9 @@ func NewReportChangeRequestGenerator(client kyvernoclient.Interface,
 		polLister:                        polInformer.Lister(),
 		queue:                            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), workQueueName),
 		dataStore:                        newDataStore(),
-		requestCreator:                   newChangeRequestCreator(client, 3*time.Second, log.WithName("requestCreator")),
 		changeRequestLimit:               changeRequestLimit,
 		CleanupChangeRequest:             make(chan ReconcileInfo, 10),
+		requestCreator:                   newChangeRequestCreator(client, 3*time.Second, splitPolicyReport, log.WithName("requestCreator")),
 		log:                              log,
 	}
 


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Explanation

The current PolicyReport  implementation works well for small scale environments but when the policy change report crosses the 2k+ entries hence the bigger size data resource in etcd. That may cause high CPU usage and `resourceExhausted` failures while adding/updating large reports and scan may not be completed in a given time frame.

This does not scale well for large clusters or the clusters have a relatively large number of policies configured. For example, one can hit this issue if the cluster has 20 policies (1 rule per policy) with 100 matching resources in a namespace (20 x 100 = 2k).

To overcome this problem we need to split  larger reports per namespace entries which have been explained in this [KDP PR](https://github.com/kyverno/KDP/pull/24).

### Note:
`splitPolicyReport` flag has been added in kyverno container args to enable/disable the split feature (disable by default).
Which can be enable by adding the args `--splitPolicyReport=true`  in kyverno container

## Related issue

Closes: #4125 


## Milestone of this PR

`/milestone 1.7.2`

## What type of PR is this

> /kind feature

## Proposed Changes
- Initial [design doc](https://docs.google.com/document/d/1msnOWk07nhnjJdvtU1RJzednle0aFlWjT8tZbZqVqBg/edit#heading=h.ny8a8qu59pb) for this enhancement. Will create an KDP with more details as reference here.
- KDP https://github.com/kyverno/KDP/pull/24
- `splitPolicyReport` flag has been added in kyverno container args to enable/disable the split feature (disable by default)

### Proof Manifests
- The key for namespaced polices is `namespace/policyname`, where namespace will be " " in case of clusterPolicy resource.

- With new changes namespace scope resource `PolicyReport` name will be updated to include the policy name as a suffix, for example
if we apply the below policy `disallow-privileged-containers` the generated `PolicyReport` name is `polr-ns-default-disallow-privileged-containers`

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-privileged-containers
  annotations:
    policies.kyverno.io/title: Disallow Privileged Containers
    policies.kyverno.io/category: Pod Security Standards (Baseline)
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod
    kyverno.io/kyverno-version: 1.6.0
    kyverno.io/kubernetes-version: "1.22-1.23"
    policies.kyverno.io/description: >-
      Privileged mode disables most security mechanisms and must not be allowed. This policy
      ensures Pods do not call for privileged mode.
spec:
  validationFailureAction: audit
  background: true
  rules:
    - name: privileged-containers
      match:
        any:
        - resources:
            kinds:
              - Pod
      validate:
        message: >-
          Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged
          and spec.initContainers[*].securityContext.privileged must be unset or set to `false`.
        pattern:
          spec:
            =(ephemeralContainers):
              - =(securityContext):
                  =(privileged): "false"
            =(initContainers):
              - =(securityContext):
                  =(privileged): "false"
            containers:
              - =(securityContext):
                  =(privileged): "false"
```

```sh
kubectl get polr -n default
NAMESPACE   NAME                                             PASS   FAIL   WARN   ERROR   SKIP   AGE
default     polr-ns-default-disallow-privileged-containers   18     15     0      0       0      114m
```

- With new changes cluster scope resource `ClusterPolicyReport` name will be updated to include the policy name as a suffix, for example
if we apply the below policy `require-ns-dev-labels` the generated `ClusterPolicyReport` name is `clusterpolicyreport-require-ns-dev-labels`.

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-ns-dev-labels
spec:
  validationFailureAction: audit
  background: true
  rules:
  - name: check-for-labels-on-namespace
    match:
      any:
      - resources:
          kinds:
          - Namespace
    validate:
      message: "The label `thisshouldnotexist` is required."
      pattern:
        metadata:
          labels:
            thisshouldnotexist: "?*"
```

```sh
kubectl get cpolr
NAME                                        PASS   FAIL   WARN   ERROR   SKIP   AGE
clusterpolicyreport-require-ns-dev-labels   0      2      0      0       0      18s  // generated for missing dev labels
clusterpolicyreport-require-ns-prod-labels  0      2      0      0       0      18s  // generated for missing prod labels
```

### Test various operation on resource to verify the policyreports updates
#### 1. Adding a missing label in resource

```sh

$ k get cpolr
NAME                                    PASS   FAIL   WARN   ERROR   SKIP   AGE
clusterpolicyreport-require-ns-labels   0      6      0      0       0      2m43s

$ k edit ns test5
namespace/test5 edited

$ k get cpolr
NAME                                    PASS   FAIL   WARN   ERROR   SKIP   AGE
clusterpolicyreport-require-ns-labels   1      5      0      0       0      2m54s

$ k delete ns test5
namespace "test5" deleted

 k get cpolr
NAME                                    PASS   FAIL   WARN   ERROR   SKIP   AGE
clusterpolicyreport-require-ns-labels   0      5      0      0       0      3m17s


```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
