### PR TITLE
Tighten the scope on API group

### DIFF
--- a/charts/kyverno/templates/clusterrole.yaml
+++ b/charts/kyverno/templates/clusterrole.yaml
@@ -156,7 +156,7 @@ metadata:
     app: kyverno
 rules:
 - apiGroups:
-  - "*"
+  - ""
   resources:
   - events
   verbs:


### PR DESCRIPTION
The kyverno:events ClusterRole was tightened:

Previously the kyverno:events ClusterRole is currently configured like apiGroups: "*" , as a reason it was looking at all API groups. In this PR it is modified as:
apigroups: ""

`apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: {{ template "kyverno.fullname" . }}:events
  labels: {{ include "kyverno.labels" . | nindent 4 }}
    app: kyverno
rules:
- apiGroups:
  - ""
  resources:
  - events
  verbs:
  - create
  - update
  - patch
  - delete`

Signed-off-by: Nawaz Siddiqui <nawazsiddiqui27@gmail.com>
