### PR TITLE
Wait for informer caches to be synced before starting controllers

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -44,6 +44,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -365,7 +366,11 @@ func main() {
 			setupLog.Error(err, "tls initialization error")
 			os.Exit(1)
 		}
-		waitForCacheSync(stopCh, kyvernoInformer, kubeInformer, kubeKyvernoInformer)
+		// wait for cache to be synced before use it
+		cache.WaitForCacheSync(stopCh,
+			kubeInformer.Admissionregistration().V1().MutatingWebhookConfigurations().Informer().HasSynced,
+			kubeInformer.Admissionregistration().V1().ValidatingWebhookConfigurations().Informer().HasSynced,
+		)
 
 		// validate the ConfigMap format
 		if err := webhookCfg.ValidateWebhookConfigurations(config.KyvernoNamespace(), config.KyvernoConfigMapName()); err != nil {

--- a/pkg/background/update_request_controller.go
+++ b/pkg/background/update_request_controller.go
@@ -53,6 +53,17 @@ type controller struct {
 	nsLister   corev1listers.NamespaceLister
 	podLister  corev1listers.PodLister
 
+	// cpolSynced returns true if the cluster policy shared informer has synced at least once
+	cpolSynced cache.InformerSynced
+	// polSynced returns true if the policy shared informer has synced at least once
+	polSynced cache.InformerSynced
+	// urSynced returns true if the update request shared informer has synced at least once
+	urSynced cache.InformerSynced
+	// nsSynced returns true if the namespace shared informer has synced at least once
+	nsSynced cache.InformerSynced
+	// podSynced returns true if the pod shared informer has synced at least once
+	podSynced cache.InformerSynced
+
 	// queue
 	queue workqueue.RateLimitingInterface
 
@@ -82,7 +93,7 @@ func NewController(
 		urLister:      urLister,
 		nsLister:      namespaceInformer.Lister(),
 		podLister:     podInformer.Lister(),
-		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "generate-request"),
+		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "update-request"),
 		eventGen:      eventGen,
 		configuration: dynamicConfig,
 	}
@@ -99,6 +110,13 @@ func NewController(
 		UpdateFunc: c.updatePolicy,
 		DeleteFunc: c.deletePolicy,
 	})
+
+	c.cpolSynced = cpolInformer.Informer().HasSynced
+	c.polSynced = polInformer.Informer().HasSynced
+	c.urSynced = urInformer.Informer().HasSynced
+	c.nsSynced = namespaceInformer.Informer().HasSynced
+	c.podSynced = podInformer.Informer().HasSynced
+
 	return &c
 }
 
@@ -108,6 +126,10 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 
 	logger.Info("starting")
 	defer logger.Info("shutting down")
+
+	if !cache.WaitForNamedCacheSync("background", stopCh, c.cpolSynced, c.polSynced, c.urSynced, c.nsSynced, c.podSynced) {
+		return
+	}
 
 	for i := 0; i < workers; i++ {
 		go wait.Until(c.worker, time.Second, stopCh)

--- a/pkg/controllers/certmanager/controller.go
+++ b/pkg/controllers/certmanager/controller.go
@@ -23,8 +23,10 @@ type Controller interface {
 }
 
 type controller struct {
-	renewer         *tls.CertRenewer
-	secretLister    corev1listers.SecretLister
+	renewer      *tls.CertRenewer
+	secretLister corev1listers.SecretLister
+	// secretSynced returns true if the secret shared informer has synced at least once
+	secretSynced    cache.InformerSynced
 	secretQueue     chan bool
 	onSecretChanged func() error
 }
@@ -33,6 +35,7 @@ func NewController(secretInformer corev1informers.SecretInformer, certRenewer *t
 	manager := &controller{
 		renewer:         certRenewer,
 		secretLister:    secretInformer.Lister(),
+		secretSynced:    secretInformer.Informer().HasSynced,
 		secretQueue:     make(chan bool, 1),
 		onSecretChanged: onSecretChanged,
 	}

--- a/pkg/controllers/config/controller.go
+++ b/pkg/controllers/config/controller.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -20,6 +21,9 @@ type controller struct {
 	// listers
 	configmapLister corev1listers.ConfigMapLister
 
+	// configmapSynced returns true if the configmap shared informer has synced at least once
+	configmapSynced cache.InformerSynced
+
 	// queue
 	queue workqueue.RateLimitingInterface
 }
@@ -30,12 +34,14 @@ func NewController(configuration config.Configuration, configmapInformer corev1i
 		configmapLister: configmapInformer.Lister(),
 		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "config-controller"),
 	}
+
+	c.configmapSynced = configmapInformer.Informer().HasSynced
 	controllerutils.AddDefaultEventHandlers(logger, configmapInformer.Informer(), c.queue)
 	return &c
 }
 
 func (c *controller) Run(stopCh <-chan struct{}) {
-	controllerutils.Run(logger, c.queue, workers, maxRetries, c.reconcile, stopCh)
+	controllerutils.Run(controllerName, logger, c.queue, workers, maxRetries, c.reconcile, stopCh, c.configmapSynced)
 }
 
 func (c *controller) reconcile(key, namespace, name string) error {

--- a/pkg/controllers/config/log.go
+++ b/pkg/controllers/config/log.go
@@ -2,4 +2,5 @@ package config
 
 import "sigs.k8s.io/controller-runtime/pkg/log"
 
-var logger = log.Log.WithName("config-controller")
+var controllerName = "config-controller"
+var logger = log.Log.WithName(controllerName)


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Explanation
With one of the refactoring changes in 1.7.0, Kyverno does not consistently wait for its informer caches to sync before processing events . Doing this is a best practice in Kubernetes controller development and can help avoid issues related to those caches not being fully populated (e.g. items missing from the listers).

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Fixes https://github.com/kyverno/kyverno/issues/4086.

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
1.7.2
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/bug

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

Wait for informers' caches to be synced before starting controllers.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Before this change Kyverno cannot get webhookconfigurations due to `NotFound` error, thus blocking its pod from running.
```
E0615 10:16:02.211594       1 asm_amd64.s:1581] Register/UpdateWebhookConfigurations "msg"="unable to update mutatingWebhookConfigurations" "error"="unable to get mutatingWebhookConfigurations: mutatingwebhookconfiguration.admissionregistration.k8s.io \"kyverno-resource-mutating-webhook-cfg\" not found"  "name"="kyverno-resource-mutating-webhook-cfg"
```

With this change, Kyverno can start successfully.

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
