### PR TITLE
delete policy reports on policy deletion

### DIFF
--- a/pkg/policyreport/reportcontroller.go
+++ b/pkg/policyreport/reportcontroller.go
@@ -514,7 +514,17 @@ func (g *ReportGenerator) removeFromClusterPolicyReport(policyName, ruleName str
 			if ruleName != "" && result.Rule == ruleName && result.Policy == policyName {
 				continue
 			} else if ruleName == "" && result.Policy == policyName {
-				continue
+				if g.splitPolicyReport {
+					if err := g.pclient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Delete(context.TODO(), cpolr.GetName(), metav1.DeleteOptions{}); err != nil {
+						if apierrors.IsNotFound(err) {
+							return nil
+						} else {
+							return fmt.Errorf("failed to delete clusterPolicyReport %s %v", policyName, err)
+						}
+					}
+				} else {
+					continue
+				}
 			}
 			newRes = append(newRes, result)
 		}
@@ -556,7 +566,17 @@ func (g *ReportGenerator) removeFromPolicyReport(policyName, ruleName string) er
 			if ruleName != "" && result.Rule == ruleName && result.Policy == policyName {
 				continue
 			} else if ruleName == "" && result.Policy == policyName {
-				continue
+				if g.splitPolicyReport {
+					if err := g.pclient.Wgpolicyk8sV1alpha2().PolicyReports(r.GetNamespace()).Delete(context.TODO(), r.GetName(), metav1.DeleteOptions{}); err != nil {
+						if apierrors.IsNotFound(err) {
+							return nil
+						} else {
+							return fmt.Errorf("failed to delete PolicyReport %s %v", r.GetName(), err)
+						}
+					}
+				} else {
+					continue
+				}
 			}
 			newRes = append(newRes, result)
 		}


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Explanation

Delete policy reports if the clusterpolicy/policy has been deleted from the cluster.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone-1.7.2

## What type of PR is this

> /kind feature

## Proposed Changes

Delete policy reports if the clusterpolicy/policy has been deleted from the cluster.

### Proof Manifests

```sh
$ k get cpolr
NAME                                    PASS   FAIL   WARN   ERROR   SKIP   AGE
clusterpolicyreport-require-ns-labels   0      2      0      0       0      5s

$ kubectl delete -f clusterpolicy.yaml 
clusterpolicy.kyverno.io "require-ns-labels" deleted

$ k get cpolr
No resources found

$ k get polr -A
NAMESPACE   NAME                                                PASS   FAIL   WARN   ERROR   SKIP   AGE
default     polr-ns-default-secrets-not-from-env-vars   1      0      0      0       0      14m
test5       polr-ns-test5-secrets-not-from-env-vars       1      0      0      0       0      14m

$ kubectl delete -f pod-clusterpolicy.yaml 
clusterpolicy.kyverno.io "secrets-not-from-env-vars" deleted

$ k get polr -A
No resources found
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
