### PR TITLE
Fix UpdateRequest labeling

### DIFF
--- a/pkg/background/common/labels.go
+++ b/pkg/background/common/labels.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	pkglabels "k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"k8s.io/client-go/tools/cache"
 )
 
 type Object interface {
@@ -35,8 +36,10 @@ func ManageLabels(unstr *unstructured.Unstructured, triggerResource unstructured
 }
 
 func MutateLabelsSet(policyKey string, trigger Object) pkglabels.Set {
+	_, policyName, _ := cache.SplitMetaNamespaceKey(policyKey)
+
 	set := pkglabels.Set{
-		kyvernov1beta1.URMutatePolicyLabel: policyKey,
+		kyvernov1beta1.URMutatePolicyLabel: policyName,
 	}
 	isNil := trigger == nil || (reflect.ValueOf(trigger).Kind() == reflect.Ptr && reflect.ValueOf(trigger).IsNil())
 	if !isNil {
@@ -51,8 +54,10 @@ func MutateLabelsSet(policyKey string, trigger Object) pkglabels.Set {
 }
 
 func GenerateLabelsSet(policyKey string, trigger Object) pkglabels.Set {
+	_, policyName, _ := cache.SplitMetaNamespaceKey(policyKey)
+
 	set := pkglabels.Set{
-		kyvernov1beta1.URGeneratePolicyLabel: policyKey,
+		kyvernov1beta1.URGeneratePolicyLabel: policyName,
 	}
 	isNil := trigger == nil || (reflect.ValueOf(trigger).Kind() == reflect.Ptr && reflect.ValueOf(trigger).IsNil())
 	if !isNil {

--- a/pkg/background/common/labels.go
+++ b/pkg/background/common/labels.go
@@ -8,8 +8,8 @@ import (
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	pkglabels "k8s.io/apimachinery/pkg/labels"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type Object interface {

--- a/pkg/background/update_request_controller.go
+++ b/pkg/background/update_request_controller.go
@@ -201,7 +201,7 @@ func (c *controller) syncUpdateRequest(key string) error {
 	}
 	// try to get the linked policy
 	if _, err := c.getPolicy(ur.Spec.Policy); err != nil {
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) && ur.Spec.Type == kyvernov1beta1.Mutate {
 			// here only takes care of mutateExisting policies
 			// generate cleanup controller handles policy deletion
 			selector := &metav1.LabelSelector{
@@ -384,5 +384,5 @@ func (c *controller) getPolicy(key string) (kyvernov1.PolicyInterface, error) {
 	if namespace == "" {
 		return c.cpolLister.Get(name)
 	}
-	return c.polLister.Policies(namespace).Get(key)
+	return c.polLister.Policies(namespace).Get(name)
 }


### PR DESCRIPTION
Signed-off-by: Byron Ibarra V <bibarrav@falabella.cl>

## Explanation

This PR is to FIX Update Request (UR) labeling for creation and query usage, this was patched but the problem still exist (#4104), and to FIX kyverno keeps processing completed update requests (#4152)

In Kyverno v1.7.0 and v1.71, namespaced Policy has a create error when generateExistingOnPolicyUpdate: true is used, because label error, the UR resource can't be created.  And with ClusterPolicy,  when generateExistingOnPolicyUpdate: true is used, kyverno keeps processing completed update requests.

And I cleanup some unused parameters.


## Related issue

Closes #4152 

Closes #4104 (Still appears in v1.7.1) 
@realshuting 
@prateekpandey14 


## Milestone of this PR

/milestone 1.7.2


## What type of PR is this


/kind bug


## Proposed Changes

Modify UR labeling functions (Generate and Mutate) to continue receive namespace/policy-name value, but always asign only policy-name to generate.kyverno.io/policy-name and mutate.kyverno.io/policy-name labels to UR resource.

This is required because namespace/policy-name format can't be applied, because the used char "/" isn't valid there.


### Proof Manifests

# Kyverno ClusterPolicy

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: sync-spot-controller-data
  annotations:
    policies.kyverno.io/title: Sync Spot Controller Data
    policies.kyverno.io/category: RightSizing
    policies.kyverno.io/subject: Spot.io
    policies.kyverno.io/minversion: 1.7.0
    policies.kyverno.io/description: >-
      Sync Secret and Configmap from kube-system namespace to cloud-services-system.
      Those objects are required to run spot-io-right-size-cm-update, to get spot
      recommendations and create/update configmaps with name <Deployment-Name>-rightsize.
spec:
  failurePolicy: Ignore
  generateExistingOnPolicyUpdate: true
  rules:
    - name: sync-spot-controller-secret
      match:
        all:
          - resources:
              kinds:
                - CronJob
              names:
                - spot-io-right-size-cm-update
              namespaces:
                - cloud-services-system
      generate:
        apiVersion: v1
        kind: Secret
        name: spotinst-kubernetes-cluster-controller
        namespace: cloud-services-system
        synchronize: true
        clone:
          namespace: kube-system
          name: spotinst-kubernetes-cluster-controller
    - name: sync-spot-controller-configmap
      match:
        all:
          - resources:
              kinds:
                - CronJob
              names:
                - spot-io-right-size-cm-update
              namespaces:
                - cloud-services-system
      generate:
        apiVersion: v1
        kind: ConfigMap
        name: spotinst-kubernetes-cluster-controller-config
        namespace: cloud-services-system
        synchronize: true
        clone:
          namespace: kube-system
          name: spotinst-kubernetes-cluster-controller-config
```

# Kyverno Policy

```yaml
apiVersion: kyverno.io/v1
kind: Policy
metadata:
  name: sync-spot-controller-data
  annotations:
    policies.kyverno.io/title: Sync Spot Controller Data
    policies.kyverno.io/category: RightSizing
    policies.kyverno.io/subject: Spot.io
    policies.kyverno.io/minversion: 1.7.0
    policies.kyverno.io/description: >-
      Sync Secret and Configmap from kube-system namespace to cloud-services-system.
      Those objects are required to run spot-io-right-size-cm-update, to get spot
      recommendations and create/update configmaps with name <Deployment-Name>-rightsize.
spec:
  failurePolicy: Ignore
  generateExistingOnPolicyUpdate: true
  rules:
    - name: sync-spot-controller-secret
      match:
        all:
          - resources:
              kinds:
                - CronJob
              names:
                - spot-io-right-size-cm-update
      generate:
        apiVersion: v1
        kind: Secret
        name: spotinst-kubernetes-cluster-controller
        namespace: cloud-services-system
        synchronize: true
        clone:
          namespace: kube-system
          name: spotinst-kubernetes-cluster-controller
    - name: sync-spot-controller-configmap
      match:
        all:
          - resources:
              kinds:
                - CronJob
              names:
                - spot-io-right-size-cm-update
      generate:
        apiVersion: v1
        kind: ConfigMap
        name: spotinst-kubernetes-cluster-controller-config
        namespace: cloud-services-system
        synchronize: true
        clone:
          namespace: kube-system
          name: spotinst-kubernetes-cluster-controller-config
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
