### PR TITLE
feature: added new type of event, PolicySkipped

### DIFF
--- a/charts/kyverno/templates/crds.yaml
+++ b/charts/kyverno/templates/crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
     config.kubernetes.io/index: '1'
     internal.config.kubernetes.io/index: '1'
   creationTimestamp: null
@@ -198,6 +198,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
@@ -233,6 +234,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role names for the user.
@@ -260,6 +262,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -324,6 +327,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
@@ -359,6 +363,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role names for the user.
@@ -386,6 +391,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -445,6 +451,7 @@ spec:
                                   description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                               items:
@@ -480,6 +487,7 @@ spec:
                                   description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names for the user.
@@ -507,6 +515,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     generate:
@@ -627,6 +636,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
@@ -662,6 +672,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role names for the user.
@@ -689,6 +700,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -753,6 +765,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
@@ -788,6 +801,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role names for the user.
@@ -815,6 +829,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -874,6 +889,7 @@ spec:
                                   description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                               items:
@@ -909,6 +925,7 @@ spec:
                                   description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names for the user.
@@ -936,6 +953,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     mutate:
@@ -1616,7 +1634,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
     config.kubernetes.io/index: '2'
     internal.config.kubernetes.io/index: '2'
   creationTimestamp: null
@@ -1727,6 +1745,7 @@ spec:
                       description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource checked by the policy and rule
                   items:
@@ -1754,6 +1773,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -1824,6 +1844,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
             properties:
@@ -1854,6 +1875,7 @@ spec:
                 description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
@@ -1882,7 +1904,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
     config.kubernetes.io/index: '3'
     internal.config.kubernetes.io/index: '3'
   creationTimestamp: null
@@ -1993,6 +2015,7 @@ spec:
                       description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource checked by the policy and rule
                   items:
@@ -2020,6 +2043,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -2090,6 +2114,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
             properties:
@@ -2120,6 +2145,7 @@ spec:
                 description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
@@ -2148,7 +2174,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
     config.kubernetes.io/index: '4'
     internal.config.kubernetes.io/index: '4'
   creationTimestamp: null
@@ -2323,7 +2349,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
     config.kubernetes.io/index: '5'
     internal.config.kubernetes.io/index: '5'
   creationTimestamp: null
@@ -2518,6 +2544,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
@@ -2553,6 +2580,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role names for the user.
@@ -2580,6 +2608,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -2644,6 +2673,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
@@ -2679,6 +2709,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role names for the user.
@@ -2706,6 +2737,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -2765,6 +2797,7 @@ spec:
                                   description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                               items:
@@ -2800,6 +2833,7 @@ spec:
                                   description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names for the user.
@@ -2827,6 +2861,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     generate:
@@ -2947,6 +2982,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
@@ -2982,6 +3018,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role names for the user.
@@ -3009,6 +3046,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -3073,6 +3111,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                                     items:
@@ -3108,6 +3147,7 @@ spec:
                                         description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role names for the user.
@@ -3135,6 +3175,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -3194,6 +3235,7 @@ spec:
                                   description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names. Each name supports wildcard characters "*" (matches zero or many characters) and "?" (at least one character).
                               items:
@@ -3229,6 +3271,7 @@ spec:
                                   description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names for the user.
@@ -3256,6 +3299,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     mutate:
@@ -3936,7 +3980,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
     config.kubernetes.io/index: '6'
     internal.config.kubernetes.io/index: '6'
   creationTimestamp: null
@@ -4047,6 +4091,7 @@ spec:
                       description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource checked by the policy and rule
                   items:
@@ -4074,6 +4119,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -4144,6 +4190,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
             properties:
@@ -4174,6 +4221,7 @@ spec:
                 description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
@@ -4202,7 +4250,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
     config.kubernetes.io/index: '7'
     internal.config.kubernetes.io/index: '7'
   creationTimestamp: null
@@ -4313,6 +4361,7 @@ spec:
                       description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource checked by the policy and rule
                   items:
@@ -4340,6 +4389,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -4410,6 +4460,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector should be specified.
             properties:
@@ -4440,6 +4491,7 @@ spec:
                 description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
@@ -4468,7 +4520,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
     config.kubernetes.io/index: '8'
     internal.config.kubernetes.io/index: '8'
   creationTimestamp: null

--- a/config/crds/kyverno.io_clusterpolicies.yaml
+++ b/config/crds/kyverno.io_clusterpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   name: clusterpolicies.kyverno.io
 spec:
@@ -280,6 +280,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -345,6 +346,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -388,6 +390,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -495,6 +498,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -560,6 +564,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -603,6 +608,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -699,6 +705,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names.
                                 Each name supports wildcard characters "*" (matches
@@ -758,6 +765,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names
@@ -800,6 +808,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     generate:
@@ -990,6 +999,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -1055,6 +1065,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -1098,6 +1109,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -1205,6 +1217,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -1270,6 +1283,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -1313,6 +1327,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -1409,6 +1424,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names.
                                 Each name supports wildcard characters "*" (matches
@@ -1468,6 +1484,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names
@@ -1510,6 +1527,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     mutate:

--- a/config/crds/kyverno.io_clusterreportchangerequests.yaml
+++ b/config/crds/kyverno.io_clusterreportchangerequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   name: clusterreportchangerequests.kyverno.io
 spec:
@@ -132,6 +132,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource
                     checked by the policy and rule
@@ -195,6 +196,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -283,6 +285,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes
               (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
@@ -326,6 +329,7 @@ spec:
                   contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:

--- a/config/crds/kyverno.io_generaterequests.yaml
+++ b/config/crds/kyverno.io_generaterequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   name: generaterequests.kyverno.io
 spec:

--- a/config/crds/kyverno.io_policies.yaml
+++ b/config/crds/kyverno.io_policies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   name: policies.kyverno.io
 spec:
@@ -281,6 +281,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -346,6 +347,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -389,6 +391,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -496,6 +499,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -561,6 +565,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -604,6 +609,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -700,6 +706,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names.
                                 Each name supports wildcard characters "*" (matches
@@ -759,6 +766,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names
@@ -801,6 +809,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     generate:
@@ -991,6 +1000,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -1056,6 +1066,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -1099,6 +1110,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -1206,6 +1218,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -1271,6 +1284,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -1314,6 +1328,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -1410,6 +1425,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names.
                                 Each name supports wildcard characters "*" (matches
@@ -1469,6 +1485,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names
@@ -1511,6 +1528,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     mutate:

--- a/config/crds/kyverno.io_reportchangerequests.yaml
+++ b/config/crds/kyverno.io_reportchangerequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   name: reportchangerequests.kyverno.io
 spec:
@@ -132,6 +132,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource
                     checked by the policy and rule
@@ -195,6 +196,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -283,6 +285,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes
               (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
@@ -326,6 +329,7 @@ spec:
                   contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:

--- a/config/crds/kyverno.io_updaterequests.yaml
+++ b/config/crds/kyverno.io_updaterequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   name: updaterequests.kyverno.io
 spec:

--- a/config/crds/wgpolicyk8s.io_clusterpolicyreports.yaml
+++ b/config/crds/wgpolicyk8s.io_clusterpolicyreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   name: clusterpolicyreports.wgpolicyk8s.io
 spec:
@@ -132,6 +132,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource
                     checked by the policy and rule
@@ -195,6 +196,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -283,6 +285,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes
               (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
@@ -326,6 +329,7 @@ spec:
                   contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:

--- a/config/crds/wgpolicyk8s.io_policyreports.yaml
+++ b/config/crds/wgpolicyk8s.io_policyreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   name: policyreports.wgpolicyk8s.io
 spec:
@@ -131,6 +131,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource
                     checked by the policy and rule
@@ -194,6 +195,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -282,6 +284,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes
               (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
@@ -325,6 +328,7 @@ spec:
                   contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -14,7 +14,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -297,6 +297,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -362,6 +363,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -405,6 +407,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -512,6 +515,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -577,6 +581,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -620,6 +625,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -716,6 +722,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names.
                                 Each name supports wildcard characters "*" (matches
@@ -775,6 +782,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names
@@ -817,6 +825,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     generate:
@@ -1007,6 +1016,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -1072,6 +1082,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -1115,6 +1126,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -1222,6 +1234,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -1287,6 +1300,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -1330,6 +1344,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -1426,6 +1441,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names.
                                 Each name supports wildcard characters "*" (matches
@@ -1485,6 +1501,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names
@@ -1527,6 +1544,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     mutate:
@@ -2583,7 +2601,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -2718,6 +2736,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource
                     checked by the policy and rule
@@ -2781,6 +2800,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -2869,6 +2889,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes
               (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
@@ -2912,6 +2933,7 @@ spec:
                   contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
@@ -2945,7 +2967,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -3080,6 +3102,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource
                     checked by the policy and rule
@@ -3143,6 +3166,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -3231,6 +3255,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes
               (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
@@ -3274,6 +3299,7 @@ spec:
                   contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
@@ -3307,7 +3333,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -3497,7 +3523,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -3781,6 +3807,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -3846,6 +3873,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -3889,6 +3917,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -3996,6 +4025,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -4061,6 +4091,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -4104,6 +4135,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -4200,6 +4232,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names.
                                 Each name supports wildcard characters "*" (matches
@@ -4259,6 +4292,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names
@@ -4301,6 +4335,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     generate:
@@ -4491,6 +4526,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -4556,6 +4592,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -4599,6 +4636,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -4706,6 +4744,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -4771,6 +4810,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -4814,6 +4854,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -4910,6 +4951,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names.
                                 Each name supports wildcard characters "*" (matches
@@ -4969,6 +5011,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names
@@ -5011,6 +5054,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     mutate:
@@ -6068,7 +6112,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -6202,6 +6246,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource
                     checked by the policy and rule
@@ -6265,6 +6310,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -6353,6 +6399,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes
               (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
@@ -6396,6 +6443,7 @@ spec:
                   contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
@@ -6429,7 +6477,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -6564,6 +6612,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource
                     checked by the policy and rule
@@ -6627,6 +6676,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -6715,6 +6765,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes
               (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
@@ -6758,6 +6809,7 @@ spec:
                   contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
@@ -6791,7 +6843,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno

--- a/config/install_debug.yaml
+++ b/config/install_debug.yaml
@@ -13,7 +13,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -295,6 +295,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -360,6 +361,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -403,6 +405,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -510,6 +513,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -575,6 +579,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -618,6 +623,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -714,6 +720,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names.
                                 Each name supports wildcard characters "*" (matches
@@ -773,6 +780,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names
@@ -815,6 +823,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     generate:
@@ -1005,6 +1014,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -1070,6 +1080,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -1113,6 +1124,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -1220,6 +1232,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -1285,6 +1298,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -1328,6 +1342,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -1424,6 +1439,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names.
                                 Each name supports wildcard characters "*" (matches
@@ -1483,6 +1499,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names
@@ -1525,6 +1542,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     mutate:
@@ -2581,7 +2599,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -2715,6 +2733,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource
                     checked by the policy and rule
@@ -2778,6 +2797,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -2866,6 +2886,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes
               (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
@@ -2909,6 +2930,7 @@ spec:
                   contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
@@ -2942,7 +2964,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -3076,6 +3098,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource
                     checked by the policy and rule
@@ -3139,6 +3162,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -3227,6 +3251,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes
               (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
@@ -3270,6 +3295,7 @@ spec:
                   contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
@@ -3303,7 +3329,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -3492,7 +3518,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -3775,6 +3801,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -3840,6 +3867,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -3883,6 +3911,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -3990,6 +4019,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -4055,6 +4085,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -4098,6 +4129,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -4194,6 +4226,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names.
                                 Each name supports wildcard characters "*" (matches
@@ -4253,6 +4286,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names
@@ -4295,6 +4329,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     generate:
@@ -4485,6 +4520,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -4550,6 +4586,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -4593,6 +4630,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -4700,6 +4738,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: Namespaces is a list of namespaces
                                       names. Each name supports wildcard characters
@@ -4765,6 +4804,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               roles:
                                 description: Roles is the list of namespaced role
@@ -4808,6 +4848,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             type: object
                           type: array
@@ -4904,6 +4945,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: Namespaces is a list of namespaces names.
                                 Each name supports wildcard characters "*" (matches
@@ -4963,6 +5005,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         roles:
                           description: Roles is the list of namespaced role names
@@ -5005,6 +5048,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                       type: object
                     mutate:
@@ -6062,7 +6106,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -6195,6 +6239,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource
                     checked by the policy and rule
@@ -6258,6 +6303,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -6346,6 +6392,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes
               (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
@@ -6389,6 +6436,7 @@ spec:
                   contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
@@ -6422,7 +6470,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno
@@ -6556,6 +6604,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 resources:
                   description: Resources is an optional reference to the resource
                     checked by the policy and rule
@@ -6619,6 +6668,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 result:
                   description: Result indicates the outcome of the policy rule execution
@@ -6707,6 +6757,7 @@ spec:
                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           scopeSelector:
             description: ScopeSelector is an optional selector for multiple scopes
               (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
@@ -6750,6 +6801,7 @@ spec:
                   contains only "value". The requirements are ANDed.
                 type: object
             type: object
+            x-kubernetes-map-type: atomic
           summary:
             description: PolicyReportSummary provides a summary of results
             properties:
@@ -6783,7 +6835,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.1-0.20220629131006-1878064c4cdf
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kyverno

--- a/docs/crd/v1/index.html
+++ b/docs/crd/v1/index.html
@@ -1837,7 +1837,7 @@ Note - this field MUST be unique.</p>
 </table>
 <hr />
 <h3 id="kyverno.io/v1.ImageExtractorConfigs">ImageExtractorConfigs
-(<code>map[string][]./api/kyverno/v1.ImageExtractorConfig</code> alias)</p></h3>
+(<code>map[string][]kyverno/kyverno/api/kyverno/v1.ImageExtractorConfig</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
 <a href="#kyverno.io/v1.Rule">Rule</a>)
@@ -2605,7 +2605,7 @@ ResourceDescription
 </table>
 <hr />
 <h3 id="kyverno.io/v1.ResourceFilters">ResourceFilters
-(<code>[]./api/kyverno/v1.ResourceFilter</code> alias)</p></h3>
+(<code>[]kyverno/kyverno/api/kyverno/v1.ResourceFilter</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
 <a href="#kyverno.io/v1.MatchResources">MatchResources</a>)

--- a/pkg/engine/response/response.go
+++ b/pkg/engine/response/response.go
@@ -139,6 +139,16 @@ func (er EngineResponse) IsSuccessful() bool {
 	return true
 }
 
+// IsSkipped checks if any rule has skipped resource or not.
+func (er EngineResponse) IsSkipped() bool {
+	for _, r := range er.PolicyResponse.Rules {
+		if r.Status == RuleStatusSkip {
+			return true
+		}
+	}
+	return false
+}
+
 // IsFailed checks if any rule has succeeded or not
 func (er EngineResponse) IsFailed() bool {
 	for _, r := range er.PolicyResponse.Rules {

--- a/pkg/event/controller.go
+++ b/pkg/event/controller.go
@@ -197,8 +197,10 @@ func (gen *Generator) syncHandler(key Info) error {
 	}
 
 	// set the event type based on reason
+	// if skip/pass, reason will be: NORMAL
+	// else reason will be: WARNING
 	eventType := corev1.EventTypeWarning
-	if key.Reason == PolicyApplied.String() {
+	if key.Reason == PolicyApplied.String() || key.Reason == PolicySkipped.String() {
 		eventType = corev1.EventTypeNormal
 	}
 

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -89,6 +89,26 @@ func NewResourceViolationEvent(source Source, reason Reason, engineResponse *res
 	}
 }
 
+func NewPolicySkippedEvent(source Source, reason Reason, engineResponse *response.EngineResponse, ruleResp *response.RuleResponse) Info {
+	var bldr strings.Builder
+	defer bldr.Reset()
+	resource := engineResponse.GetResourceSpec()
+
+	if resource.Namespace != "" {
+		fmt.Fprintf(&bldr, "%s %s/%s: %s", resource.Kind, resource.Namespace, resource.Name, ruleResp.Status.String())
+	} else {
+		fmt.Fprintf(&bldr, "%s %s: %s", resource.Kind, resource.Name, ruleResp.Status.String())
+	}
+	return Info{
+		Kind:      getPolicyKind(engineResponse.Policy),
+		Name:      engineResponse.PolicyResponse.Policy.Name,
+		Namespace: engineResponse.PolicyResponse.Policy.Namespace,
+		Reason:    PolicySkipped.String(),
+		Source:    source,
+		Message:   bldr.String(),
+	}
+}
+
 func NewBackgroundFailedEvent(err error, policy, rule string, source Source, r *unstructured.Unstructured) []Info {
 	if r == nil {
 		return nil

--- a/pkg/event/reason.go
+++ b/pkg/event/reason.go
@@ -7,6 +7,7 @@ const (
 	PolicyViolation Reason = iota
 	PolicyApplied
 	PolicyError
+	PolicySkipped
 )
 
 func (r Reason) String() string {
@@ -14,5 +15,6 @@ func (r Reason) String() string {
 		"PolicyViolation",
 		"PolicyApplied",
 		"PolicyError",
+		"PolicySkipped",
 	}[r]
 }

--- a/pkg/policy/report.go
+++ b/pkg/policy/report.go
@@ -193,13 +193,16 @@ func generateFailEventsPerEr(log logr.Logger, er *response.EngineResponse) []eve
 	for i, rule := range er.PolicyResponse.Rules {
 		if rule.Status == response.RuleStatusPass {
 			continue
+		} else if rule.Status == response.RuleStatusSkip {
+			eventResource := event.NewPolicySkippedEvent(event.PolicyController, event.PolicySkipped, er, &er.PolicyResponse.Rules[i])
+			eventInfos = append(eventInfos, eventResource)
+		} else {
+			eventResource := event.NewResourceViolationEvent(event.PolicyController, event.PolicyViolation, er, &er.PolicyResponse.Rules[i])
+			eventInfos = append(eventInfos, eventResource)
+
+			eventPolicy := event.NewPolicyFailEvent(event.PolicyController, event.PolicyViolation, er, &er.PolicyResponse.Rules[i], false)
+			eventInfos = append(eventInfos, eventPolicy)
 		}
-
-		eventResource := event.NewResourceViolationEvent(event.PolicyController, event.PolicyViolation, er, &er.PolicyResponse.Rules[i])
-		eventInfos = append(eventInfos, eventResource)
-
-		eventPolicy := event.NewPolicyFailEvent(event.PolicyController, event.PolicyViolation, er, &er.PolicyResponse.Rules[i], false)
-		eventInfos = append(eventInfos, eventPolicy)
 	}
 
 	if len(eventInfos) > 0 {

--- a/pkg/webhooks/resource/report.go
+++ b/pkg/webhooks/resource/report.go
@@ -15,6 +15,8 @@ func generateEvents(engineResponses []*response.EngineResponse, blocked bool, lo
 	//     - report failure events on resource
 	//   - Some/All policies succeeded
 	//     - report success event on resource
+	//   - Some/All policies skipped
+	//     - report skipped event on resource
 
 	for _, er := range engineResponses {
 		if !er.IsSuccessful() {
@@ -30,8 +32,15 @@ func generateEvents(engineResponses []*response.EngineResponse, blocked bool, lo
 				}
 			}
 		} else {
-			e := event.NewPolicyAppliedEvent(event.AdmissionController, er)
-			events = append(events, e)
+			if er.IsSkipped() {
+				for i, _ := range er.PolicyResponse.Rules {
+					e := event.NewPolicySkippedEvent(event.AdmissionController, event.PolicySkipped, er, &er.PolicyResponse.Rules[i])
+					events = append(events, e)
+				}
+			} else {
+				e := event.NewPolicyAppliedEvent(event.AdmissionController, er)
+				events = append(events, e)
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: viveksahu26 <vivekkumarsahu650@gmail.com>

## Explanation
2 possible changes are implemented through this PR:-
For  https://github.com/kyverno/kyverno/issues/4093
1) Added `NORMAL`  event on background scans for skipped policies.  Earlier it was `WARNING` event type.

For  https://github.com/kyverno/kyverno/issues/4044

2) Added new REASON: `PolicySkipped` for skip policies on resources. Earlier it shows REASON: `PolicyApplied`  for admission controller, whereas for Policy Controller, it shows REASON: `PolicyViolation` for skipped resources.

For more, refer to this [doc](https://docs.google.com/document/d/1czDT-DF5FP2LM8Lli0MrBD5OejrCAm4jGxWHxb574B0/edit#)

## Related issue
closes https://github.com/kyverno/kyverno/issues/4093  https://github.com/kyverno/kyverno/issues/4044

## Milestone of this PR
none

## What type of PR is this
/kind bug 
/kind enhacement

## Proposed Changes
On background scans if a policy skip resources, NORMAL info-type will be shown instead of WARNING info-type. 
And second thing, a new type of event will be generated if a policy is skipped at the admission controller or by policy controller. In admission controller, policy is applied first and then resource in the cluster.  If resource  skip the policy then new event: `PolicySkipped` will be generated. Earlier `PolicyApplied` event use to generated. Whereas in policy Controller, resource is already present in the cluster and policy is applied later. As policy scans resource,  and resource skip the policy then new event: `PolicySkipped` will be generated. Earlier `PolicyViolation` event use to generated.

Doc: [refer](https://docs.google.com/document/d/1czDT-DF5FP2LM8Lli0MrBD5OejrCAm4jGxWHxb574B0/edit#heading=h.yvtp2bjtmfvj)

### Proof Manifests
For Issue  4093
```
linuzz@hp:~/go/src/kyverno/kyverno$ date && kubectl get events
Monday 11 July 2022 10:39:05 AM IST
LAST SEEN   TYPE     REASON          OBJECT                               MESSAGE
14s         Normal   PolicySkipped   clusterpolicy/no-localhost-service   Service default/kubernetes: skip
14s         Normal   PolicySkipped   clusterpolicy/no-localhost-service   Service default/my-service: skip
```


For issue 4044
When Policy scans in background( resource applied first and later policy to the cluster): PolicyController
Note: `background` must be equals to `true`
```
linuzz@hp:~/go/src/kyverno/kyverno$ date && kubectl get events
Monday 11 July 2022 10:45:27 AM IST
LAST SEEN   TYPE     REASON          OBJECT                              MESSAGE
59s         Normal   PolicySkipped   clusterpolicy/disallow-naked-pods   Pod default/blank: skip

```

admission Controller : When policy applied first and resource later
```
linuzz@hp:~/go/src/kyverno/kyverno$ date && kubectl get events
Monday 11 July 2022 10:48:18 AM IST
LAST SEEN   TYPE     REASON          OBJECT                              MESSAGE
3s          Normal   PolicySkipped   clusterpolicy/disallow-naked-pods   Pod default/blank: skip
```


## Checklist


- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments
