### PR TITLE
Treat normal and precondition variable equally

### DIFF
--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -318,8 +318,16 @@ func (v *validator) validateElements(foreach kyvernov1.ForEachValidation, elemen
 			v.log.Info("skip rule", "reason", r.Message)
 			continue
 		} else if r.Status != response.RuleStatusPass {
+			if r.Status == response.RuleStatusError {
+				if i < len(elements)-1 {
+					continue
+				}
+				msg := fmt.Sprintf("validation failure: %v", r.Message)
+				return ruleResponse(*v.rule, response.Validation, msg, r.Status, nil), applyCount
+			}
 			msg := fmt.Sprintf("validation failure: %v", r.Message)
 			return ruleResponse(*v.rule, response.Validation, msg, r.Status, nil), applyCount
+
 		}
 
 		applyCount++

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -327,7 +327,6 @@ func (v *validator) validateElements(foreach kyvernov1.ForEachValidation, elemen
 			}
 			msg := fmt.Sprintf("validation failure: %v", r.Message)
 			return ruleResponse(*v.rule, response.Validation, msg, r.Status, nil), applyCount
-
 		}
 
 		applyCount++

--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -67,8 +67,8 @@ func newPreconditionsVariableResolver(log logr.Logger) VariableResolver {
 	return func(ctx context.EvalInterface, variable string) (interface{}, error) {
 		value, err := DefaultVariableResolver(ctx, variable)
 		if err != nil {
-			log.V(4).Info(fmt.Sprintf("using empty string for unresolved variable \"%s\" in preconditions", variable))
-			return "", nil
+			log.V(4).Info(fmt.Sprintf("Variable substitution failed in preconditions, therefore nil value assigned to variable,  \"%s\" ", variable))
+			return value, err
 		}
 
 		return value, nil

--- a/test/cli/test/nil-values-in-variables/exclude_namespaces_dynamically/exclude_namespaces_dynamically.yaml
+++ b/test/cli/test/nil-values-in-variables/exclude_namespaces_dynamically/exclude_namespaces_dynamically.yaml
@@ -1,0 +1,45 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: exclude-namespaces-example
+  annotations:
+    policies.kyverno.io/title: Exclude Namespaces Dynamically
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Namespace, Pod
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/description: >-
+      It's common where policy lookups need to consider a mapping to many possible values rather than a
+      static mapping. This is a sample which demonstrates how to dynamically look up an allow list of Namespaces from a ConfigMap
+      where the ConfigMap stores an array of strings. This policy validates that any Pods created
+      outside of the list of Namespaces have the label `foo` applied.
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+  - name: exclude-namespaces-dynamically
+    context:
+      - name: namespacefilters
+        configMap:
+          name: namespace-filters
+          namespace: default
+    match:
+      resources:
+        kinds:
+        - Pod
+    preconditions:
+      all:
+      - key: "{{request.object.metadata.namespace}}"
+        operator: AnyNotIn
+        value: "{{namespacefilters.data.exclude}}"
+    validate:
+      message: >
+        Creating Pods in the  namespace,
+        which is not in the excluded list of namespaces {{ namespacefilters.data.exclude }},
+        is forbidden unless it carries the label `foo`.
+      pattern:
+        metadata:
+          labels:
+            foo: "*"

--- a/test/cli/test/nil-values-in-variables/exclude_namespaces_dynamically/kyverno-test.yaml
+++ b/test/cli/test/nil-values-in-variables/exclude_namespaces_dynamically/kyverno-test.yaml
@@ -1,0 +1,17 @@
+name: exclude-namespaces-example
+policies:
+  - exclude_namespaces_dynamically.yaml
+resources:
+  - resource.yaml
+variables: values.yaml
+results:
+  - policy: exclude-namespaces-example
+    rule: exclude-namespaces-dynamically
+    resource: bad-pod01
+    kind: Pod
+    result: pass
+  - policy: exclude-namespaces-example
+    rule: exclude-namespaces-dynamically
+    resource: bad-pod02
+    kind: Pod
+    result: error

--- a/test/cli/test/nil-values-in-variables/exclude_namespaces_dynamically/resource.yaml
+++ b/test/cli/test/nil-values-in-variables/exclude_namespaces_dynamically/resource.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-pod01
+  namespace: vivek
+  labels:
+    foo: bar
+spec:
+  containers:
+  - name: nginx
+    image: nginx:alpine 
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-pod02
+  labels:
+    foo: bar
+spec:
+  containers:
+  - name: nginx
+    image: nginx:alpine 

--- a/test/cli/test/nil-values-in-variables/exclude_namespaces_dynamically/values.yaml
+++ b/test/cli/test/nil-values-in-variables/exclude_namespaces_dynamically/values.yaml
@@ -1,0 +1,10 @@
+policies:
+  - name: exclude-namespaces-example
+    rules:
+      - name: exclude-namespaces-dynamically
+    resources:
+    - name: bad-pod01
+      values:
+        namespacefilters.data.exclude: "[\"default\", \"test\"]"
+        request.namespace: default
+    - name: bad-pod02

--- a/test/cli/test/nil-values-in-variables/limit-duration/kyverno-test.yaml
+++ b/test/cli/test/nil-values-in-variables/limit-duration/kyverno-test.yaml
@@ -1,0 +1,16 @@
+name: limit-duration
+policies:
+  -  limit-duration.yaml
+resources:
+  -  resource.yaml
+results:
+  - policy: cert-manager-limit-duration
+    rule: certificate-duration-max-100days 
+    resource: letsencrypt-crt
+    kind: Certificate
+    result: error
+  - policy: cert-manager-limit-duration
+    rule: certificate-duration-max-100days 
+    resource: acme-crt
+    kind: Certificate
+    result: error

--- a/test/cli/test/nil-values-in-variables/limit-duration/limit-duration.yaml
+++ b/test/cli/test/nil-values-in-variables/limit-duration/limit-duration.yaml
@@ -1,0 +1,36 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cert-manager-limit-duration
+  annotations:
+    policies.kyverno.io/title: Certificate max duration 100 days
+    policies.kyverno.io/category: Cert-Manager
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.3.6
+    policies.kyverno.io/subject: Certificate
+    policies.kyverno.io/description: >-
+      Kubernetes managed non-letsencrypt certificates have to be renewed in every 100 days.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+  - name: certificate-duration-max-100days 
+    match:
+      resources:
+        kinds:
+        - Certificate
+    preconditions:
+      all:
+      - key: "{{ contains(request.object.spec.issuerRef.name, 'letsencrypt') }}"
+        operator: Equals
+        value: False
+      - key: "{{ request.object.spec.duration }}"
+        operator: NotEquals
+        value: ""
+    validate:
+      message: "certificate duration must be < than 2400h (100 days)"
+      deny:
+        conditions:
+        - key: "{{ max( [ to_number(regex_replace_all('h.*',request.object.spec.duration,'')), to_number('2400') ] ) }}"
+          operator: NotEquals
+          value: 2400

--- a/test/cli/test/nil-values-in-variables/limit-duration/resource.yaml
+++ b/test/cli/test/nil-values-in-variables/limit-duration/resource.yaml
@@ -1,0 +1,28 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: letsencrypt-crt
+spec:
+  secretName: letsencrypt-crt-secret
+  dnsNames:
+  - example.com
+  - foo.example.com
+  issuerRef:
+    name: letsencrypt-prod
+    kind: Issuer
+    group: cert-manager.io
+  # duration  field is not present, therefore nil be assigned.
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: acme-crt
+spec:
+  secretName: acme-crt-secret
+  dnsNames:
+  - example.com
+  issuerRef:
+    name: acme-prod
+    kind: Issuer
+    group: cert-manager.io
+  # duration  field is not present, therefore nil be assigned.


### PR DESCRIPTION
## Explanation
Currently, the value for any variable present in the precondition block is assigned as empty string(" ") when  value for the corresponding variable is not present, whereas value for variables present outside of precondition block or normal variables  is assigned as nil. Due to this partiality, normal variables throws an error when it's value is not found.  To deal with need to remove partiality and treat normal as well as precondition variables equally. Therefore proposed changes is to assigned nil value when  value for the corresponding variable is not present  for both normal as well as precondition variable.
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
closes https://github.com/kyverno/kyverno/issues/3982
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/kind bug 
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
The proposed changes is to assigned nil value when value for the corresponding variable is not present for both normal as well as precondition variable. Due to which, error will occurs in the rule of the policy because the value of the variable is nil. As a result, status of the result will be `error`.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [X] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
