### PR TITLE
chore: use new distroless base image provided by distroless org

### DIFF
--- a/cmd/cli/kubectl-kyverno/Dockerfile
+++ b/cmd/cli/kubectl-kyverno/Dockerfile
@@ -25,13 +25,12 @@ RUN --mount=type=bind,target=. \
     CGO_ENABLED=0 xx-go build -o /output/kyverno -ldflags="${LD_FLAGS}" -v ./cmd/cli/kubectl-kyverno/
 
 # Packaging stage
-FROM scratch
+FROM ghcr.io/distroless/static:latest
 
 LABEL maintainer="Kyverno"
 
 COPY --from=builder /output/kyverno /
-COPY --from=builder /etc/passwd /etc/passwd
 
-USER 10001
+USER 65532
 
 ENTRYPOINT ["./kyverno"]

--- a/cmd/cli/kubectl-kyverno/Dockerfile
+++ b/cmd/cli/kubectl-kyverno/Dockerfile
@@ -31,6 +31,4 @@ LABEL maintainer="Kyverno"
 
 COPY --from=builder /output/kyverno /
 
-USER 65532
-
 ENTRYPOINT ["./kyverno"]

--- a/cmd/initContainer/Dockerfile
+++ b/cmd/initContainer/Dockerfile
@@ -25,13 +25,12 @@ RUN --mount=type=bind,target=. \
     CGO_ENABLED=0 xx-go build -o /output/kyvernopre -ldflags="${LD_FLAGS}" -v ./cmd/initContainer/
 
 # Packaging stage
-FROM scratch
+FROM ghcr.io/distroless/static:latest
 
 LABEL maintainer="Kyverno"
 
 COPY --from=builder /output/kyvernopre /
-COPY --from=builder /etc/passwd /etc/passwd
 
-USER 10001
+USER 65532
 
 ENTRYPOINT ["./kyvernopre"]

--- a/cmd/initContainer/Dockerfile
+++ b/cmd/initContainer/Dockerfile
@@ -31,6 +31,5 @@ LABEL maintainer="Kyverno"
 
 COPY --from=builder /output/kyvernopre /
 
-USER 65532
 
 ENTRYPOINT ["./kyvernopre"]

--- a/cmd/kyverno/Dockerfile
+++ b/cmd/kyverno/Dockerfile
@@ -34,6 +34,4 @@ FROM ghcr.io/distroless/static:latest
 LABEL maintainer="Kyverno"
 COPY --from=builder /output/kyverno /
 
-USER 65532
-
 ENTRYPOINT ["./kyverno"]

--- a/cmd/kyverno/Dockerfile
+++ b/cmd/kyverno/Dockerfile
@@ -29,13 +29,11 @@ RUN --mount=type=bind,target=. \
     CGO_ENABLED=0 xx-go build -o /output/kyverno -ldflags="${LD_FLAGS}" -v ./cmd/kyverno/
 
 # Packaging stage
-FROM scratch
+FROM ghcr.io/distroless/static:latest
 
 LABEL maintainer="Kyverno"
 COPY --from=builder /output/kyverno /
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-USER 10001
+USER 65532
 
 ENTRYPOINT ["./kyverno"]


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

There has been a new distroless base image concept around for a while, thanks to [apko](https://github.com/chainguard-dev/apko) + [melange](https://github.com/chainguard-dev/melange) technology stack from Chainguard, which made it possible. In kyverno, we use scratch as a base image, and copy /etc/passsword and necessary CA certs from the above stages, which we don't need to do when we use ghcr.io/distroless/static.

```sh
$ crane export ghcr.io/distroless/static:latest - | tar -Oxf - ./etc/passwd
root:x:0:0:root:/root:/bin/ash
bin:x:1:1:bin:/bin:/sbin/nologin
daemon:x:2:2:daemon:/sbin:/sbin/nologin
adm:x:3:4:adm:/var/adm:/sbin/nologin
lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
sync:x:5:0:sync:/sbin:/bin/sync
shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
halt:x:7:0:halt:/sbin:/sbin/halt
mail:x:8:12:mail:/var/mail:/sbin/nologin
news:x:9:13:news:/usr/lib/news:/sbin/nologin
uucp:x:10:14:uucp:/var/spool/uucppublic:/sbin/nologin
operator:x:11:0:operator:/root:/sbin/nologin
man:x:13:15:man:/usr/man:/sbin/nologin
postmaster:x:14:12:postmaster:/var/mail:/sbin/nologin
cron:x:16:16:cron:/var/spool/cron:/sbin/nologin
ftp:x:21:21::/var/lib/ftp:/sbin/nologin
sshd:x:22:22:sshd:/dev/null:/sbin/nologin
at:x:25:25:at:/var/spool/cron/atjobs:/sbin/nologin
squid:x:31:31:Squid:/var/cache/squid:/sbin/nologin
xfs:x:33:33:X Font Server:/etc/X11/fs:/sbin/nologin
games:x:35:35:games:/usr/games:/sbin/nologin
cyrus:x:85:12::/usr/cyrus:/sbin/nologin
vpopmail:x:89:89::/var/vpopmail:/sbin/nologin
ntp:x:123:123:NTP:/var/empty:/sbin/nologin
smmsp:x:209:209:smmsp:/var/spool/mqueue:/sbin/nologin
guest:x:405:100:guest:/dev/null:/sbin/nologin
nobody:x:65534:65534:nobody:/:/sbin/nologin
nonroot:x:65532:65532:Account created by apko:/home/nonroot:/bin/sh <-- non-root
```

and CA certs info:

```sh
$ crane export ghcr.io/distroless/static:latest - | tar -tvf - | grep -v zoneinfo
drwx------  0 bin    bin         0 Jul 14 05:23 bin
drwxr-xr-x  0 root   root        0 Jul 14 05:23 dev
crw-------  0 root   root      5,1 Jul 14 05:23 dev/console
crw-rw-rw-  0 root   root      1,3 Jul 14 05:23 dev/null
crw-rw-rw-  0 root   root      1,8 Jul 14 05:23 dev/random
crw-rw-rw-  0 root   root      1,9 Jul 14 05:23 dev/urandom
crw-rw-rw-  0 root   root      1,5 Jul 14 05:23 dev/zero
drwxr-xr-x  0 root   root        0 Jul 14 05:23 etc
drwxr-xr-x  0 root   root        0 Jul 14 05:23 etc/X11
drwx------  0 xfs    xfs         0 Jul 14 05:23 etc/X11/fs
-rw-r--r--  0 root   root        5 Jul 14 05:23 etc/alpine-release
drwxr-xr-x  0 root   root        0 Jul 14 05:23 etc/apk
-rw-r--r--  0 root   root        7 Jul 14 05:23 etc/apk/arch
drwxr-xr-x  0 root   root        0 Jul 14 05:23 etc/apk/keys
-rw-r--r--  0 root   root      451 Jul 14 05:23 etc/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
-rw-r--r--  0 root   root      451 Jul 14 05:23 etc/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub
-rw-r--r--  0 root   root      800 Jul 14 05:23 etc/apk/keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub
-rw-r--r--  0 root   root       47 Jul 14 05:23 etc/apk/repositories
-rw-r--r--  0 root   root       53 Jul 14 05:23 etc/apk/world
-rw-r--r--  0 root   root       89 Jul 14 05:23 etc/fstab
-rw-r--r--  0 root   root      714 Jul 14 05:23 etc/group
-rw-r--r--  0 root   root       10 Jul 14 05:23 etc/hostname
-rw-r--r--  0 root   root       79 Jul 14 05:23 etc/hosts
-rw-r--r--  0 root   root      570 Jul 14 05:23 etc/inittab
-rw-r--r--  0 root   root       15 Jul 14 05:23 etc/modules
lrwxrwxrwx  0 root   root        0 Jul 14 05:23 etc/mtab -> /proc/mounts
-rw-r--r--  0 root   root      139 Jul 14 05:23 etc/os-release
-rw-r--r--  0 root   root     1240 Jul 14 05:23 etc/passwd
-rw-r--r--  0 root   root      857 Jul 14 05:23 etc/profile
-rw-r--r--  0 root   root     2932 Jul 14 05:23 etc/protocols
-rw-r--r--  0 root   root    12966 Jul 14 05:23 etc/services
-rw-r-----  0 root   148       421 Jul 14 05:23 etc/shadow
-rw-r--r--  0 root   root       38 Jul 14 05:23 etc/shells
drwxr-xr-x  0 root   root        0 Jul 14 05:23 etc/ssl
lrwxrwxrwx  0 root   root        0 Jul 14 05:23 etc/ssl/cert.pem -> certs/ca-certificates.crt
drwxr-xr-x  0 root   root        0 Jul 14 05:23 etc/ssl/certs
-rw-r--r--  0 root   root   203223 Jul 14 05:23 etc/ssl/certs/ca-certificates.crt
-rw-r--r--  0 root   root       53 Jul 14 05:23 etc/sysctl.conf
drwxr-xr-x  0 root   root        0 Jul 14 05:23 home
drwx------  0 65532  65532       0 Jul 14 05:23 home/nonroot
drwxr-xr-x  0 root   root        0 Jul 14 05:23 lib
drwxr-xr-x  0 root   root        0 Jul 14 05:23 lib/apk
drwxr-xr-x  0 root   root        0 Jul 14 05:23 lib/apk/db
-rw-r--r--  0 root   root    55016 Jul 14 05:23 lib/apk/db/installed
-rw-------  0 root   root        0 Jul 14 05:23 lib/apk/db/lock
-rw-------  0 root   root     1024 Jul 14 05:23 lib/apk/db/scripts.tar
-rw-r--r--  0 root   root        0 Jul 14 05:23 lib/apk/db/triggers
dr-xr-xr-x  0 root   root        0 Jul 14 05:23 proc
drwx------  0 root   root        0 Jul 14 05:23 root
drwx------  0 daemon daemon      0 Jul 14 05:23 sbin
drwxrwxrwt  0 root   root        0 Jul 14 05:23 tmp
drwxr-xr-x  0 root   root        0 Jul 14 05:23 usr
drwx------  0 cyrus  mail        0 Jul 14 05:23 usr/cyrus
drwx------  0 games  games       0 Jul 14 05:23 usr/games
drwxr-xr-x  0 root   root        0 Jul 14 05:23 usr/lib
drwx------  0 news   news        0 Jul 14 05:23 usr/lib/news
drwx------  0 man    man         0 Jul 14 05:23 usr/man
drwxr-xr-x  0 root   root        0 Jul 14 05:23 usr/share
drwxr-xr-x  0 root   root        0 Jul 14 05:23 var
drwx------  0 adm    adm         0 Jul 14 05:23 var/adm
drwxr-xr-x  0 root   root        0 Jul 14 05:23 var/cache
drwxr-xr-x  0 root   root        0 Jul 14 05:23 var/cache/apk
drwxr-xr-x  0 root   root        0 Jul 14 05:23 var/cache/misc
drwx------  0 squid  squid       0 Jul 14 05:23 var/cache/squid
drwx------  0 ntp    ntp         0 Jul 14 05:23 var/empty
drwxr-xr-x  0 root   root        0 Jul 14 05:23 var/lib
drwx------  0 ftp    ftp         0 Jul 14 05:23 var/lib/ftp
drwx------  0 mail   mail        0 Jul 14 05:23 var/mail
drwxr-xr-x  0 root   root        0 Jul 14 05:23 var/spool
drwx------  0 cron   cron        0 Jul 14 05:23 var/spool/cron
drwx------  0 at     at          0 Jul 14 05:23 var/spool/cron/atjobs
drwx------  0 lp     lp          0 Jul 14 05:23 var/spool/lpd
drwx------  0 smmsp  smmsp       0 Jul 14 05:23 var/spool/mqueue
drwx------  0 uucp   uucp        0 Jul 14 05:23 var/spool/uucppublic
drwx------  0 vpopmail vpopmail    0 Jul 14 05:23 var/vpopmail
```

We also switched the user to non-root, which is id 65532.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind feature

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
