### PR TITLE
Implementing flag to show all failing tests only through the test command

### DIFF
--- a/cmd/cli/kubectl-kyverno/apply/apply_command.go
+++ b/cmd/cli/kubectl-kyverno/apply/apply_command.go
@@ -138,7 +138,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVarP(&userInfoPath, "userinfo", "u", "", "Admission Info including Roles, Cluster Roles and Subjects")
 	cmd.Flags().StringVarP(&variablesString, "set", "s", "", "Variables that are required")
 	cmd.Flags().StringVarP(&valuesFile, "values-file", "f", "", "File containing values for policy variables")
-	cmd.Flags().BoolVarP(&policyReport, "policy-report", "", false, "Generates policy report when passed (default policyviolation r")
+	cmd.Flags().BoolVarP(&policyReport, "policy-report", "p", false, "Generates policy report when passed (default policyviolation)")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Optional Policy parameter passed with cluster flag")
 	cmd.Flags().BoolVarP(&stdin, "stdin", "i", false, "Optional mutate policy parameter to pipe directly through to kubectl")
 	cmd.Flags().BoolVarP(&registryAccess, "registry", "", false, "If set to true, access the image registry using local docker credentials to populate external data")

--- a/cmd/cli/kubectl-kyverno/test/test_command.go
+++ b/cmd/cli/kubectl-kyverno/test/test_command.go
@@ -157,7 +157,7 @@ func Command() *cobra.Command {
 	var testCase string
 	var testFile []byte
 	var fileName, gitBranch string
-	var registryAccess bool
+	var registryAccess, failonly bool
 	cmd = &cobra.Command{
 		Use: "test <path_to_folder_Containing_test.yamls> [flags]\n  kyverno test <path_to_gitRepository_with_dir> --git-branch <branchName>\n  kyverno test --manifest-mutate > kyverno-test.yaml\n  kyverno test --manifest-validate > kyverno-test.yaml",
 		// Args:    cobra.ExactArgs(1),
@@ -216,7 +216,7 @@ results:
 				return nil
 			}
 			store.SetRegistryAccess(registryAccess)
-			_, err = testCommandExecute(dirPath, fileName, gitBranch, testCase)
+			_, err = testCommandExecute(dirPath, fileName, gitBranch, testCase, failonly)
 			if err != nil {
 				log.Log.V(3).Info("a directory is required")
 				return err
@@ -231,6 +231,7 @@ results:
 	cmd.Flags().BoolP("manifest-mutate", "", false, "prints out a template test manifest for a mutate policy")
 	cmd.Flags().BoolP("manifest-validate", "", false, "prints out a template test manifest for a validate policy")
 	cmd.Flags().BoolVarP(&registryAccess, "registry", "", false, "If set to true, access the image registry using local docker credentials to populate external data")
+	cmd.Flags().BoolVarP(&failonly, "fail-only", "", false, "If set to true, display all the failing test only as output for the test command")
 	return cmd
 }
 
@@ -317,7 +318,7 @@ type testFilter struct {
 
 var ftable = []Table{}
 
-func testCommandExecute(dirPath []string, fileName string, gitBranch string, testCase string) (rc *resultCounts, err error) {
+func testCommandExecute(dirPath []string, fileName string, gitBranch string, testCase string, failonly bool) (rc *resultCounts, err error) {
 	var errors []error
 	fs := memfs.New()
 	rc = &resultCounts{}
@@ -437,7 +438,7 @@ func testCommandExecute(dirPath []string, fileName string, gitBranch string, tes
 					errors = append(errors, sanitizederror.NewWithError("failed to convert to JSON", err))
 					continue
 				}
-				if err := applyPoliciesFromPath(fs, policyBytes, true, policyresoucePath, rc, openAPIController, tf); err != nil {
+				if err := applyPoliciesFromPath(fs, policyBytes, true, policyresoucePath, rc, openAPIController, tf, failonly); err != nil {
 					return rc, sanitizederror.NewWithError("failed to apply test command", err)
 				}
 			}
@@ -449,7 +450,7 @@ func testCommandExecute(dirPath []string, fileName string, gitBranch string, tes
 	} else {
 		var testFiles int
 		path := filepath.Clean(dirPath[0])
-		errors = getLocalDirTestFiles(fs, path, fileName, rc, &testFiles, openAPIController, tf)
+		errors = getLocalDirTestFiles(fs, path, fileName, rc, &testFiles, openAPIController, tf, failonly)
 
 		if testFiles == 0 {
 			fmt.Printf("\n No test files found. Please provide test YAML files named kyverno-test.yaml \n")
@@ -463,10 +464,14 @@ func testCommandExecute(dirPath []string, fileName string, gitBranch string, tes
 		}
 	}
 
-	fmt.Printf("\nTest Summary: %d tests passed and %d tests failed\n", rc.Pass+rc.Skip, rc.Fail)
+	if !failonly {
+		fmt.Printf("\nTest Summary: %d tests passed and %d tests failed\n", rc.Pass+rc.Skip, rc.Fail)
+	} else {
+		fmt.Printf("\nTest Summary: %d tests failed\n", rc.Fail)
+	}
 	fmt.Printf("\n")
 
-	if rc.Fail > 0 {
+	if rc.Fail > 0 && !failonly {
 		printFailedTestResult()
 		os.Exit(1)
 	}
@@ -474,7 +479,7 @@ func testCommandExecute(dirPath []string, fileName string, gitBranch string, tes
 	return rc, nil
 }
 
-func getLocalDirTestFiles(fs billy.Filesystem, path, fileName string, rc *resultCounts, testFiles *int, openAPIController *openapi.Controller, tf *testFilter) []error {
+func getLocalDirTestFiles(fs billy.Filesystem, path, fileName string, rc *resultCounts, testFiles *int, openAPIController *openapi.Controller, tf *testFilter, failonly bool) []error {
 	var errors []error
 
 	files, err := ioutil.ReadDir(path)
@@ -483,7 +488,7 @@ func getLocalDirTestFiles(fs billy.Filesystem, path, fileName string, rc *result
 	}
 	for _, file := range files {
 		if file.IsDir() {
-			getLocalDirTestFiles(fs, filepath.Join(path, file.Name()), fileName, rc, testFiles, openAPIController, tf)
+			getLocalDirTestFiles(fs, filepath.Join(path, file.Name()), fileName, rc, testFiles, openAPIController, tf, failonly)
 			continue
 		}
 		if file.Name() == fileName {
@@ -499,7 +504,7 @@ func getLocalDirTestFiles(fs billy.Filesystem, path, fileName string, rc *result
 				errors = append(errors, sanitizederror.NewWithError("failed to convert json", err))
 				continue
 			}
-			if err := applyPoliciesFromPath(fs, valuesBytes, false, path, rc, openAPIController, tf); err != nil {
+			if err := applyPoliciesFromPath(fs, valuesBytes, false, path, rc, openAPIController, tf, failonly); err != nil {
 				errors = append(errors, sanitizederror.NewWithError(fmt.Sprintf("failed to apply test command from file %s", file.Name()), err))
 				continue
 			}
@@ -813,7 +818,7 @@ func getFullPath(paths []string, policyResourcePath string, isGit bool) []string
 	return paths
 }
 
-func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, isGit bool, policyResourcePath string, rc *resultCounts, openAPIController *openapi.Controller, tf *testFilter) (err error) {
+func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, isGit bool, policyResourcePath string, rc *resultCounts, openAPIController *openapi.Controller, tf *testFilter, failonly bool) (err error) {
 	engineResponses := make([]*response.EngineResponse, 0)
 	var dClient dclient.Interface
 	values := &Test{}
@@ -1014,7 +1019,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, isGit bool, 
 		}
 	}
 	resultsMap, testResults := buildPolicyResults(engineResponses, values.Results, pvInfos, policyResourcePath, fs, isGit)
-	resultErr := printTestResult(resultsMap, testResults, rc)
+	resultErr := printTestResult(resultsMap, testResults, rc, failonly)
 	if resultErr != nil {
 		return sanitizederror.NewWithError("failed to print test result:", resultErr)
 	}
@@ -1022,7 +1027,7 @@ func applyPoliciesFromPath(fs billy.Filesystem, policyBytes []byte, isGit bool, 
 	return
 }
 
-func printTestResult(resps map[string]policyreportv1alpha2.PolicyReportResult, testResults []TestResults, rc *resultCounts) error {
+func printTestResult(resps map[string]policyreportv1alpha2.PolicyReportResult, testResults []TestResults, rc *resultCounts, failonly bool) error {
 	printer := tableprinter.New(os.Stdout)
 	table := []Table{}
 	boldGreen := color.New(color.FgGreen).Add(color.Bold)
@@ -1094,7 +1099,13 @@ func printTestResult(resps map[string]policyreportv1alpha2.PolicyReportResult, t
 					ftable = append(ftable, *res)
 				}
 
-				table = append(table, *res)
+				if failonly {
+					if res.Result == boldRed.Sprintf("Fail") {
+						table = append(table, *res)
+					}
+				} else {
+					table = append(table, *res)
+				}
 			}
 		} else if v.Resource != "" {
 			countDeprecatedResource++
@@ -1153,7 +1164,13 @@ func printTestResult(resps map[string]policyreportv1alpha2.PolicyReportResult, t
 				ftable = append(ftable, *res)
 			}
 
-			table = append(table, *res)
+			if failonly {
+				if res.Result == boldRed.Sprintf("Fail") {
+					table = append(table, *res)
+				}
+			} else {
+				table = append(table, *res)
+			}
 		}
 	}
 

--- a/cmd/cli/kubectl-kyverno/test/test_command.go
+++ b/cmd/cli/kubectl-kyverno/test/test_command.go
@@ -467,7 +467,7 @@ func testCommandExecute(dirPath []string, fileName string, gitBranch string, tes
 	if !failonly {
 		fmt.Printf("\nTest Summary: %d tests passed and %d tests failed\n", rc.Pass+rc.Skip, rc.Fail)
 	} else {
-		fmt.Printf("\nTest Summary: %d tests failed\n", rc.Fail)
+		fmt.Printf("\nTest Summary: %d out of %d tests failed\n", rc.Fail, rc.Pass+rc.Skip+rc.Fail)
 	}
 	fmt.Printf("\n")
 


### PR DESCRIPTION
Signed-off-by: anutosh491 <andersonbhat491@gmail.com>

## Explanation
As the issue statement describes clearly , this PR intends to add a flag to show only the failing tests to make debugging easier for the user.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Fixes #4220 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
`/kind feature`
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Now lets say we want to test `policies/best-practices/disallow_latest_tag` from the policies repo ( All tests would pass here so If I randomly switch few tests from pass to fail in `kyverno-test.yaml` we would have ....)
```
anutosh491:~/go/src/github.com/kyverno$ kyverno test ../policies/best-practices/disallow_latest_tag

Executing disallow_latest_tag...
applying 1 policy to 8 resources... 

 Note : The resource field is being deprecated in 1.8.0 release. Please provide the resources under the resources parameter as an array in the results field 

│────│─────────────────────│────────────────────│─────────────────────────────────│────────│
│ #  │ POLICY              │ RULE               │ RESOURCE                        │ RESULT │
│────│─────────────────────│────────────────────│─────────────────────────────────│────────│
│  1 │ disallow-latest-tag │ require-image-tag  │ /Pod/myapp-pod                  │ Pass   │
│  2 │ disallow-latest-tag │ require-image-tag  │ /Pod/badpod01                   │ Pass   │
│  3 │ disallow-latest-tag │ require-image-tag  │ /Pod/badpod02                   │ Fail   │
│  4 │ disallow-latest-tag │ require-image-tag  │ /Deployment/gooddeployment01    │ Pass   │
│  5 │ disallow-latest-tag │ require-image-tag  │ /Deployment/baddeployment01     │ Fail   │
│  6 │ disallow-latest-tag │ validate-image-tag │ /Pod/myapp-pod                  │ Fail   │
│  7 │ disallow-latest-tag │ validate-image-tag │ /Pod/vit-badpod01               │ Pass   │
│  8 │ disallow-latest-tag │ validate-image-tag │ /Pod/vit-badpod02               │ Pass   │
│  9 │ disallow-latest-tag │ validate-image-tag │ /Deployment/gooddeployment01    │ Fail   │
│ 10 │ disallow-latest-tag │ validate-image-tag │ /Deployment/vit-baddeployment01 │ Fail   │
│────│─────────────────────│────────────────────│─────────────────────────────────│────────│

Test Summary: 5 tests passed and 5 tests failed

Aggregated Failed Test Cases : 
│────│─────────────────────│────────────────────│─────────────────────────────────│────────│
│ #  │ POLICY              │ RULE               │ RESOURCE                        │ RESULT │
│────│─────────────────────│────────────────────│─────────────────────────────────│────────│
│  3 │ disallow-latest-tag │ require-image-tag  │ /Pod/badpod02                   │ Fail   │
│  5 │ disallow-latest-tag │ require-image-tag  │ /Deployment/baddeployment01     │ Fail   │
│  6 │ disallow-latest-tag │ validate-image-tag │ /Pod/myapp-pod                  │ Fail   │
│  9 │ disallow-latest-tag │ validate-image-tag │ /Deployment/gooddeployment01    │ Fail   │
│ 10 │ disallow-latest-tag │ validate-image-tag │ /Deployment/vit-baddeployment01 │ Fail   │
│────│─────────────────────│────────────────────│─────────────────────────────────│────────│
exit status 1
```
And with the flag we would have
```
anutosh491:~/go/src/github.com/kyverno$ kyverno test ../policies/best-practices/disallow_latest_tag --fail-only true

Executing disallow_latest_tag...
applying 1 policy to 8 resources... 

 Note : The resource field is being deprecated in 1.8.0 release. Please provide the resources under the resources parameter as an array in the results field 

│────│─────────────────────│────────────────────│─────────────────────────────────│────────│
│ #  │ POLICY              │ RULE               │ RESOURCE                        │ RESULT │
│────│─────────────────────│────────────────────│─────────────────────────────────│────────│
│  3 │ disallow-latest-tag │ require-image-tag  │ /Pod/badpod02                   │ Fail   │
│  5 │ disallow-latest-tag │ require-image-tag  │ /Deployment/baddeployment01     │ Fail   │
│  6 │ disallow-latest-tag │ validate-image-tag │ /Pod/myapp-pod                  │ Fail   │
│  9 │ disallow-latest-tag │ validate-image-tag │ /Deployment/gooddeployment01    │ Fail   │
│ 10 │ disallow-latest-tag │ validate-image-tag │ /Deployment/vit-baddeployment01 │ Fail   │
│────│─────────────────────│────────────────────│─────────────────────────────────│────────│

Test Summary: 5 out of 10 tests failed
```
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
