### PR TITLE
Removed confusing output message in CLI apply command and refactored it

### DIFF
--- a/cmd/cli/kubectl-kyverno/apply/apply_command.go
+++ b/cmd/cli/kubectl-kyverno/apply/apply_command.go
@@ -260,9 +260,22 @@ func applyCommandHelper(resourcePaths []string, userInfoPath string, cluster boo
 		variables = common.SetInStoreContext(mutatedPolicies, variables)
 	}
 
-	msgPolicies := "1 policy"
-	if len(mutatedPolicies) > 1 {
-		msgPolicies = fmt.Sprintf("%d policies", len(policies))
+	var policyRulesCount, mutatedPolicyRulesCount int
+	for _, policy := range policies {
+		policyRulesCount += len(policy.GetSpec().Rules)
+	}
+
+	for _, policy := range mutatedPolicies {
+		mutatedPolicyRulesCount += len(policy.GetSpec().Rules)
+	}
+
+	msgPolicyRules := "1 policy rule"
+	if policyRulesCount > 1 {
+		msgPolicyRules = fmt.Sprintf("%d policy rules", policyRulesCount)
+	}
+
+	if mutatedPolicyRulesCount > policyRulesCount {
+		msgPolicyRules = fmt.Sprintf("%d policy rules", mutatedPolicyRulesCount)
 	}
 
 	msgResources := "1 resource"
@@ -272,7 +285,11 @@ func applyCommandHelper(resourcePaths []string, userInfoPath string, cluster boo
 
 	if len(mutatedPolicies) > 0 && len(resources) > 0 {
 		if !stdin {
-			fmt.Printf("\nApplying %s to %s... \n(Total number of result count may vary as the policy is mutated by Kyverno. To check the mutated policy please try with log level 5)\n", msgPolicies, msgResources)
+			if mutatedPolicyRulesCount > policyRulesCount {
+				fmt.Printf("\nauto-generated pod policies\nApplying %s to %s...\n", msgPolicyRules, msgResources)
+			} else {
+				fmt.Printf("\nApplying %s to %s...\n", msgPolicyRules, msgResources)
+			}
 		}
 	}
 


### PR DESCRIPTION


## Explanation
As the issue statement describes , the output messages returned while using the apply command were odd and unclear to the user . As @JimBugwadia has pointed out in the issue statement
> Its a bit odd to ask users to check debug logs to understand the output:
(Total number of result count may vary as the policy is mutated by Kyverno. To check the mutated policy please try with log level 5)
And, in cases where the policies are not for a pod, this message is meaningless and confusing.

Also as pointed out in [this comment](https://github.com/kyverno/kyverno/issues/3414#issuecomment-1086718950) , it makes sense to switch from policy counts to policy rule counts . Hence we should be returning back correct rule counts and resource counts in our output messages. Also we could let the user know if pod policies are being autogenerated whenever they are . 
Snippets of what changes have been introduced are shown in the **Proposed Changes** section below
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Fixes #3414
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
`/kind feature`
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
The changes proposed are as follows . Let's say we take the policy and resource from the source code itself (`test/cli/apply/policies/policy.yaml` and `test/cli/apply/resource/resources.yaml` attached below in the manifests section)

Now onto the output 
```
// 1st output 
anutosh491@spbhat68:~/go/src/github.com/kyverno$ kyverno apply test/cli/apply/policies/policy.yaml -r test/cli/apply/resource/resources.yaml

auto-generated pod policies
Applying 6 policy rules to 2 resources...

policy disallow-latest-tag -> resource default/Pod/test-validate-image-tag-ignore failed: 
1. validate-image-tag: validation error: Using a mutable image tag e.g. 'latest' is not allowed. rule validate-image-tag failed at path /spec/containers/0/image/ 

pass: 1, fail: 1, warn: 2, error: 0, skip: 8 
exit status 1

// Let's say we get rid of 1 of the policies out of the 2
anutosh491@spbhat68:~/go/src/github.com/kyverno$ kyverno apply test/cli/apply/policies/policy.yaml -r test/cli/apply/resource/resources.yaml

auto-generated pod policies
Applying 3 policy rules to 2 resources...

policy disallow-latest-tag -> resource default/Pod/test-validate-image-tag-ignore failed: 
1. validate-image-tag: validation error: Using a mutable image tag e.g. 'latest' is not allowed. rule validate-image-tag failed at path /spec/containers/0/image/ 

pass: 1, fail: 1, warn: 0, error: 0, skip: 4 
exit status 1

// If we take up a policy where we don't expect auto generation of pod policies
anutosh491@spbhat68:~/go/src/github.com/kyverno$ kyverno apply ../policies/other/add_node_affinity/add_node_affinity.yaml -r test/cli/apply/resource/resources.yaml

Applying 1 policy rule to 2 resources...

pass: 0, fail: 0, warn: 0, error: 0, skip: 2 
```
Hence I see that we would be getting the expected outputs from the commands pass 

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-latest-tag
  annotations:
    policies.kyverno.io/category: Best Practices
    policies.kyverno.io/description: >-
      The ':latest' tag is mutable and can lead to unexpected errors if the
      image changes. A best practice is to use an immutable tag that maps to
      a specific version of an application pod.
spec:
  validationFailureAction: audit
  rules:
  - name: validate-image-tag
    match:
      resources:
        kinds:
        - Pod
    validate:
      message: "Using a mutable image tag e.g. 'latest' is not allowed."
      pattern:
        spec:
          containers:
          - image: "!*:latest"
---
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: drop-all-capabilities
  annotations:
    policies.kyverno.io/scored: "false"
spec:
  validationFailureAction: audit
  rules:
    - name: require-drop-all
      match:
        any:
        - resources:
            kinds:
              - Pod
      preconditions:
        all:
        - key: "{{ request.operation }}"
          operator: NotEquals
          value: DELETE
      validate:
        message: >-
          Containers must drop `ALL` capabilities.
        foreach:
          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
            deny:
              conditions:
                all:
                - key: ALL
                  operator: AnyNotIn
                  value: "{{ element.securityContext.capabilities.drop || '' }}"
```
```
apiVersion: v1
kind: Pod
metadata:
  name: test-require-image-tag-fail
  labels:
    app: app
spec:
  containers:
  - name: nginx
    image: nginx
---
apiVersion: v1
kind: Pod
metadata:
  name: test-validate-image-tag-ignore
  labels:
    app: app
spec:
  containers:
  - name: nginx
    image: nginx:latest
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
