### PR TITLE
fix split policyreport name with background scan

### DIFF
--- a/cmd/initContainer/main.go
+++ b/cmd/initContainer/main.go
@@ -340,6 +340,8 @@ func removePolicyReport(client dclient.Interface, kind string) error {
 	return nil
 }
 
+// Deprecated: New ClusterPolicyReports already has required labels, will be removed in
+// 1.8.0 version
 func addClusterPolicyReportSelectorLabel(client dclient.Interface) {
 	logger := log.Log.WithName("addClusterPolicyReportSelectorLabel")
 
@@ -356,6 +358,8 @@ func addClusterPolicyReportSelectorLabel(client dclient.Interface) {
 	}
 }
 
+// Deprecated: New PolicyReports already has required labels, will be removed in
+// 1.8.0 version
 func addPolicyReportSelectorLabel(client dclient.Interface) {
 	logger := log.Log.WithName("addPolicyReportSelectorLabel")
 

--- a/cmd/initContainer/main.go
+++ b/cmd/initContainer/main.go
@@ -352,7 +352,7 @@ func addClusterPolicyReportSelectorLabel(client dclient.Interface) {
 	}
 
 	for _, cpolr := range cpolrs.Items {
-		if cpolr.GetName() == policyreport.GeneratePolicyReportName("", cpolr.GetName()) {
+		if cpolr.GetName() == policyreport.GeneratePolicyReportName("", "") {
 			addSelectorLabel(client, cpolr.GetAPIVersion(), cpolr.GetKind(), "", cpolr.GetName())
 		}
 	}
@@ -370,7 +370,7 @@ func addPolicyReportSelectorLabel(client dclient.Interface) {
 	}
 
 	for _, polr := range polrs.Items {
-		if polr.GetName() == policyreport.GeneratePolicyReportName(polr.GetNamespace(), polr.GetName()) {
+		if polr.GetName() == policyreport.GeneratePolicyReportName(polr.GetNamespace(), "") {
 			addSelectorLabel(client, polr.GetAPIVersion(), polr.GetKind(), polr.GetNamespace(), polr.GetName())
 		}
 	}

--- a/cmd/initContainer/main.go
+++ b/cmd/initContainer/main.go
@@ -352,7 +352,7 @@ func addClusterPolicyReportSelectorLabel(client dclient.Interface) {
 	}
 
 	for _, cpolr := range cpolrs.Items {
-		if cpolr.GetName() == policyreport.GeneratePolicyReportName("") {
+		if cpolr.GetName() == policyreport.GeneratePolicyReportName("", cpolr.GetName()) {
 			addSelectorLabel(client, cpolr.GetAPIVersion(), cpolr.GetKind(), "", cpolr.GetName())
 		}
 	}
@@ -370,7 +370,7 @@ func addPolicyReportSelectorLabel(client dclient.Interface) {
 	}
 
 	for _, polr := range polrs.Items {
-		if polr.GetName() == policyreport.GeneratePolicyReportName(polr.GetNamespace()) {
+		if polr.GetName() == policyreport.GeneratePolicyReportName(polr.GetNamespace(), polr.GetName()) {
 			addSelectorLabel(client, polr.GetAPIVersion(), polr.GetKind(), polr.GetNamespace(), polr.GetName())
 		}
 	}

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -75,7 +75,6 @@ var (
 	clientRateLimitQPS           float64
 	clientRateLimitBurst         int
 	changeRequestLimit           int
-	splitPolicyReport            bool
 	webhookRegistrationTimeout   time.Duration
 	setupLog                     = log.Log.WithName("setup")
 )
@@ -105,7 +104,7 @@ func main() {
 	flag.Func(toggle.AutogenInternalsFlagName, toggle.AutogenInternalsDescription, toggle.AutogenInternalsFlag)
 	flag.DurationVar(&webhookRegistrationTimeout, "webhookRegistrationTimeout", 120*time.Second, "Timeout for webhook registration, e.g., 30s, 1m, 5m.")
 	flag.IntVar(&changeRequestLimit, "maxReportChangeRequests", 1000, "Maximum pending report change requests per namespace or for the cluster-wide policy report.")
-	flag.BoolVar(&splitPolicyReport, "splitPolicyReport", false, "Set the flag to 'true', to enable the split-up PolicyReports per policy.")
+	flag.Func(toggle.SplitPolicyReportFlagName, "Set the flag to 'true', to enable the split-up PolicyReports per policy.", toggle.SplitPolicyReportFlag)
 	if err := flag.Set("v", "2"); err != nil {
 		setupLog.Error(err, "failed to set log level")
 		os.Exit(1)
@@ -216,7 +215,6 @@ func main() {
 		kyvernoV1.ClusterPolicies(),
 		kyvernoV1.Policies(),
 		changeRequestLimit,
-		splitPolicyReport,
 		log.Log.WithName("ReportChangeRequestGenerator"),
 	)
 
@@ -229,7 +227,6 @@ func main() {
 		kyvernoV1alpha2.ClusterReportChangeRequests(),
 		kubeInformer.Core().V1().Namespaces(),
 		reportReqGen.CleanupChangeRequest,
-		splitPolicyReport,
 		log.Log.WithName("PolicyReportGenerator"),
 	)
 	if err != nil {

--- a/pkg/policy/report.go
+++ b/pkg/policy/report.go
@@ -114,22 +114,19 @@ func (pc *PolicyController) forceReconciliation(reconcileCh <-chan bool, cleanup
 	}
 }
 
-func cleanupReportChangeRequests(pclient kyvernoclient.Interface, rcrLister kyvernov1alpha2listers.ReportChangeRequestLister, crcrLister kyvernov1alpha2listers.ClusterReportChangeRequestLister, labels map[string]string) error {
+func cleanupReportChangeRequests(pclient kyvernoclient.Interface, rcrLister kyvernov1alpha2listers.ReportChangeRequestLister, crcrLister kyvernov1alpha2listers.ClusterReportChangeRequestLister, nslabels map[string]string) error {
 	var errors []string
-
 	var gracePeriod int64 = 0
 	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
 
-	selector := &metav1.LabelSelector{
-		MatchLabels: labels,
-	}
+	selector := labels.SelectorFromSet(labels.Set(nslabels))
 
-	err := pclient.KyvernoV1alpha2().ClusterReportChangeRequests().DeleteCollection(context.TODO(), deleteOptions, metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(selector)})
+	err := pclient.KyvernoV1alpha2().ClusterReportChangeRequests().DeleteCollection(context.TODO(), deleteOptions, metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		errors = append(errors, err.Error())
 	}
 
-	err = pclient.KyvernoV1alpha2().ReportChangeRequests(config.KyvernoNamespace()).DeleteCollection(context.TODO(), deleteOptions, metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(selector)})
+	err = pclient.KyvernoV1alpha2().ReportChangeRequests(config.KyvernoNamespace()).DeleteCollection(context.TODO(), deleteOptions, metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		errors = append(errors, err.Error())
 	}

--- a/pkg/policy/report.go
+++ b/pkg/policy/report.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine/response"
 	"github.com/kyverno/kyverno/pkg/event"
 	"github.com/kyverno/kyverno/pkg/policyreport"
+	"github.com/kyverno/kyverno/pkg/toggle"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -147,32 +148,37 @@ func eraseResultEntries(pclient kyvernoclient.Interface, reportLister policyrepo
 	var polrName string
 
 	if ns != nil {
-		polrName = policyreport.GeneratePolicyReportName(*ns, polrName)
-		if polrName != "" {
-			polr, err := reportLister.PolicyReports(*ns).Get(polrName)
+		if toggle.SplitPolicyReport() {
+			err = eraseSplitResultEntries(pclient, ns, selector)
 			if err != nil {
-				return fmt.Errorf("failed to erase results entries for PolicyReport %s: %v", polrName, err)
-			}
-
-			polr.Results = []v1alpha2.PolicyReportResult{}
-			polr.Summary = v1alpha2.PolicyReportSummary{}
-			if _, err = pclient.Wgpolicyk8sV1alpha2().PolicyReports(polr.GetNamespace()).Update(context.TODO(), polr, metav1.UpdateOptions{}); err != nil {
-				errors = append(errors, fmt.Sprintf("%s/%s/%s: %v", polr.Kind, polr.Namespace, polr.Name, err))
+				errors = append(errors, fmt.Sprintf("%v", err))
 			}
 		} else {
-			cpolr, err := clusterReportLister.Get(policyreport.GeneratePolicyReportName(*ns, polrName))
+			polrName = policyreport.GeneratePolicyReportName(*ns, "")
+			if polrName != "" {
+				polr, err := reportLister.PolicyReports(*ns).Get(polrName)
+				if err != nil {
+					return fmt.Errorf("failed to erase results entries for PolicyReport %s: %v", polrName, err)
+				}
 
-			if err != nil {
-				errors = append(errors, err.Error())
-			}
+				polr.Results = []v1alpha2.PolicyReportResult{}
+				polr.Summary = v1alpha2.PolicyReportSummary{}
+				if _, err = pclient.Wgpolicyk8sV1alpha2().PolicyReports(polr.GetNamespace()).Update(context.TODO(), polr, metav1.UpdateOptions{}); err != nil {
+					errors = append(errors, fmt.Sprintf("%s/%s/%s: %v", polr.Kind, polr.Namespace, polr.Name, err))
+				}
+			} else {
+				cpolr, err := clusterReportLister.Get(policyreport.GeneratePolicyReportName(*ns, ""))
+				if err != nil {
+					errors = append(errors, err.Error())
+				}
 
-			cpolr.Results = []v1alpha2.PolicyReportResult{}
-			cpolr.Summary = v1alpha2.PolicyReportSummary{}
-			if _, err = pclient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Update(context.TODO(), cpolr, metav1.UpdateOptions{}); err != nil {
-				return fmt.Errorf("failed to erase results entries for ClusterPolicyReport %s: %v", polrName, err)
+				cpolr.Results = []v1alpha2.PolicyReportResult{}
+				cpolr.Summary = v1alpha2.PolicyReportSummary{}
+				if _, err = pclient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Update(context.TODO(), cpolr, metav1.UpdateOptions{}); err != nil {
+					return fmt.Errorf("failed to erase results entries for ClusterPolicyReport %s: %v", polrName, err)
+				}
 			}
 		}
-
 		if len(errors) == 0 {
 			return nil
 		}
@@ -209,6 +215,44 @@ func eraseResultEntries(pclient kyvernoclient.Interface, reportLister policyrepo
 	}
 
 	return fmt.Errorf("failed to erase results entries %v", strings.Join(errors, ";"))
+}
+
+func eraseSplitResultEntries(pclient kyvernoclient.Interface, ns *string, selector labels.Selector) error {
+	var errors []string
+
+	if ns != nil {
+		if *ns != "" {
+			polrs, err := pclient.Wgpolicyk8sV1alpha2().PolicyReports(*ns).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+			if err != nil {
+				return fmt.Errorf("failed to list PolicyReports for given namespace %s : %v", *ns, err)
+			}
+			for _, polr := range polrs.Items {
+				polr := polr
+				polr.Results = []v1alpha2.PolicyReportResult{}
+				polr.Summary = v1alpha2.PolicyReportSummary{}
+				if _, err := pclient.Wgpolicyk8sV1alpha2().PolicyReports(polr.GetNamespace()).Update(context.TODO(), &polr, metav1.UpdateOptions{}); err != nil {
+					errors = append(errors, fmt.Sprintf("%s/%s/%s: %v", polr.Kind, polr.Namespace, polr.Name, err))
+				}
+			}
+		} else {
+			cpolrs, err := pclient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+			if err != nil {
+				return fmt.Errorf("failed to list ClusterPolicyReports : %v", err)
+			}
+			for _, cpolr := range cpolrs.Items {
+				cpolr := cpolr
+				cpolr.Results = []v1alpha2.PolicyReportResult{}
+				cpolr.Summary = v1alpha2.PolicyReportSummary{}
+				if _, err := pclient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Update(context.TODO(), &cpolr, metav1.UpdateOptions{}); err != nil {
+					errors = append(errors, fmt.Sprintf("%s/%s/%s: %v", cpolr.Kind, cpolr.Namespace, cpolr.Name, err))
+				}
+			}
+		}
+		if len(errors) == 0 {
+			return nil
+		}
+	}
+	return fmt.Errorf("failed to erase results entries for split reports in namespace %s: %v", *ns, strings.Join(errors, ";"))
 }
 
 func (pc *PolicyController) requeuePolicies() {

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/engine"
 	"github.com/kyverno/kyverno/pkg/engine/response"
+	"github.com/kyverno/kyverno/pkg/toggle"
 	"github.com/kyverno/kyverno/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,12 +45,20 @@ const (
 	SourceValue = "Kyverno"
 )
 
-func GeneratePolicyReportName(ns string) string {
+func GeneratePolicyReportName(ns, policyName string) string {
 	if ns == "" {
-		return clusterpolicyreport
+		if toggle.SplitPolicyReport() {
+			return clusterpolicyreport + "-" + policyName
+		}
+		return TrimmedName(clusterpolicyreport)
 	}
 
-	name := fmt.Sprintf("polr-ns-%s", ns)
+	var name string
+	if toggle.SplitPolicyReport() {
+		name = fmt.Sprintf("polr-ns-%s-%s", ns, policyName)
+	} else {
+		name = fmt.Sprintf("polr-ns-%s", ns)
+	}
 	if len(name) > 63 {
 		return name[:63]
 	}

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -48,9 +48,9 @@ const (
 func GeneratePolicyReportName(ns, policyName string) string {
 	if ns == "" {
 		if toggle.SplitPolicyReport() {
-			return clusterpolicyreport + "-" + policyName
+			return TrimmedName(clusterpolicyreport + "-" + policyName)
 		}
-		return TrimmedName(clusterpolicyreport)
+		return clusterpolicyreport
 	}
 
 	var name string

--- a/pkg/policyreport/changerequestcreator.go
+++ b/pkg/policyreport/changerequestcreator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	kyvernoclient "github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	"github.com/kyverno/kyverno/pkg/config"
+	"github.com/kyverno/kyverno/pkg/toggle"
 	"github.com/patrickmn/go-cache"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -44,15 +45,14 @@ type changeRequestCreator struct {
 	log logr.Logger
 }
 
-func newChangeRequestCreator(client kyvernoclient.Interface, tickerInterval time.Duration, splitPolicyReport bool, log logr.Logger) creator {
+func newChangeRequestCreator(client kyvernoclient.Interface, tickerInterval time.Duration, log logr.Logger) creator {
 	return &changeRequestCreator{
-		client:            client,
-		RCRCache:          cache.New(0, 24*time.Hour),
-		CRCRCache:         cache.New(0, 24*time.Hour),
-		queue:             []string{},
-		tickerInterval:    tickerInterval,
-		splitPolicyReport: splitPolicyReport,
-		log:               log,
+		client:         client,
+		RCRCache:       cache.New(0, 24*time.Hour),
+		CRCRCache:      cache.New(0, 24*time.Hour),
+		queue:          []string{},
+		tickerInterval: tickerInterval,
+		log:            log,
 	}
 }
 
@@ -114,7 +114,7 @@ func (c *changeRequestCreator) run(stopChan <-chan struct{}) {
 	ticker := time.NewTicker(c.tickerInterval)
 	defer ticker.Stop()
 
-	if c.splitPolicyReport {
+	if toggle.SplitPolicyReport() {
 		err := CleanupPolicyReport(c.client)
 		if err != nil {
 			c.log.Error(err, "failed to delete old reports")

--- a/pkg/policyreport/reportcontroller.go
+++ b/pkg/policyreport/reportcontroller.go
@@ -364,11 +364,7 @@ func (g *ReportGenerator) syncHandler(key string) (aggregatedRequests interface{
 	}
 
 	var report *policyreportv1alpha2.PolicyReport
-	if toggle.SplitPolicyReport() {
-		report, err = g.reportLister.PolicyReports(namespace).Get(TrimmedName(GeneratePolicyReportName(namespace) + "-" + policyName))
-	} else {
-		report, err = g.reportLister.PolicyReports(namespace).Get(GeneratePolicyReportName(namespace))
-	}
+	report, err = g.reportLister.PolicyReports(namespace).Get(GeneratePolicyReportName(namespace, policyName))
 	if err == nil {
 		if val, ok := report.GetLabels()[inactiveLabelKey]; ok && val == inactiveLabelVal {
 			g.log.Info("got resourceExhausted error, please opt-in via \"splitPolicyReport\" to generate report per policy")
@@ -420,11 +416,7 @@ func (g *ReportGenerator) createReportIfNotPresent(namespace, policyName string,
 			return nil, nil
 		}
 
-		if toggle.SplitPolicyReport() {
-			report, err = g.reportLister.PolicyReports(namespace).Get(TrimmedName(GeneratePolicyReportName(namespace) + "-" + policyName))
-		} else {
-			report, err = g.reportLister.PolicyReports(namespace).Get(GeneratePolicyReportName(namespace))
-		}
+		report, err = g.reportLister.PolicyReports(namespace).Get(GeneratePolicyReportName(namespace, policyName))
 		if err != nil {
 			if apierrors.IsNotFound(err) && new != nil {
 				polr, err := convertToPolr(new)
@@ -444,12 +436,7 @@ func (g *ReportGenerator) createReportIfNotPresent(namespace, policyName string,
 			return nil, fmt.Errorf("unable to get policyReport: %v", err)
 		}
 	} else {
-
-		if toggle.SplitPolicyReport() {
-			report, err = g.clusterReportLister.Get(TrimmedName(GeneratePolicyReportName(namespace) + "-" + policyName))
-		} else {
-			report, err = g.clusterReportLister.Get(GeneratePolicyReportName(namespace))
-		}
+		report, err = g.clusterReportLister.Get(GeneratePolicyReportName(namespace, policyName))
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				if new != nil {
@@ -730,20 +717,12 @@ func (g *ReportGenerator) setReport(reportUnstructured *unstructured.Unstructure
 	}
 
 	if ns == nil {
-		if toggle.SplitPolicyReport() {
-			reportUnstructured.SetName(TrimmedName(GeneratePolicyReportName("") + "-" + policyname))
-		} else {
-			reportUnstructured.SetName(GeneratePolicyReportName(""))
-		}
+		reportUnstructured.SetName(GeneratePolicyReportName("", policyname))
 		reportUnstructured.SetKind("ClusterPolicyReport")
 		return
 	}
 
-	if toggle.SplitPolicyReport() {
-		reportUnstructured.SetName(TrimmedName(GeneratePolicyReportName(ns.GetName()) + "-" + policyname))
-	} else {
-		reportUnstructured.SetName(GeneratePolicyReportName(ns.GetName()))
-	}
+	reportUnstructured.SetName(GeneratePolicyReportName(ns.GetName(), policyname))
 	reportUnstructured.SetNamespace(ns.GetName())
 	reportUnstructured.SetKind("PolicyReport")
 }

--- a/pkg/policyreport/reportrequest.go
+++ b/pkg/policyreport/reportrequest.go
@@ -70,7 +70,6 @@ func NewReportChangeRequestGenerator(client kyvernoclient.Interface,
 	cpolInformer kyvernov1informers.ClusterPolicyInformer,
 	polInformer kyvernov1informers.PolicyInformer,
 	changeRequestLimit int,
-	splitPolicyReport bool,
 	log logr.Logger,
 ) *Generator {
 	gen := Generator{
@@ -84,7 +83,7 @@ func NewReportChangeRequestGenerator(client kyvernoclient.Interface,
 		dataStore:                        newDataStore(),
 		changeRequestLimit:               changeRequestLimit,
 		CleanupChangeRequest:             make(chan ReconcileInfo, 10),
-		requestCreator:                   newChangeRequestCreator(client, 3*time.Second, splitPolicyReport, log.WithName("requestCreator")),
+		requestCreator:                   newChangeRequestCreator(client, 3*time.Second, log.WithName("requestCreator")),
 		log:                              log,
 	}
 

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -10,9 +10,17 @@ const (
 	AutogenInternalsDescription = "Enables autogen internal policies. When this is 'true' policy rules should not be mutated."
 	AutogenInternalsEnvVar      = "FLAG_AUTOGEN_INTERNALS"
 	DefaultAutogenInternals     = false
+
+	// split policy report ...
+	SplitPolicyReportFlagName = "splitPolicyReport"
+	SplitPolicyReportEnvVar   = "FLAG_SPLIT_POLICY_REPORT"
+	DefaultSplitPolicyReport  = false
 )
 
-var autogenInternals *bool
+var (
+	autogenInternals  *bool
+	splitPolicyReport *bool
+)
 
 func getBool(in string) (*bool, error) {
 	if in == "" {
@@ -42,4 +50,23 @@ func AutogenInternals() bool {
 		return *value
 	}
 	return DefaultAutogenInternals
+}
+
+func SplitPolicyReportFlag(in string) error {
+	if value, err := getBool(in); err != nil {
+		return err
+	} else {
+		splitPolicyReport = value
+		return nil
+	}
+}
+
+func SplitPolicyReport() bool {
+	if splitPolicyReport != nil {
+		return *splitPolicyReport
+	}
+	if value, err := getBool(os.Getenv(SplitPolicyReportEnvVar)); err == nil && value != nil {
+		return *value
+	}
+	return DefaultSplitPolicyReport
 }


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Explanation

Refactor the code to handle the updated policyName in case of eraseResultsEntries in policy reports during background scan.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR

 `/milestone 1.7.2`.

## What type of PR is this

> /kind bug

## Proposed Changes

Refactor the code to handle the updated policyName in case of eraseResultsEntries in policy reports during background scan

### Proof Manifests

The test set up https://github.com/kyverno/kyverno/issues/4126#issuecomment-1187645542.

The memory stays around ~400 Mi in about an hour with --maxReportChangeRequests=100 and continuous load.

```
kubectl -n kyverno top pod
NAME                       CPU(cores)   MEMORY(bytes)   
kyverno-86f8dd44d9-9rzrc   516m         401Mi           

kubectl -n kyverno get pod
NAME                       READY   STATUS    RESTARTS   AGE
kyverno-86f8dd44d9-9rzrc   1/1     Running   0          95m



```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
