### PR TITLE
feature: added new type of event, PolicySkipped

### DIFF
--- a/docs/crd/v1/index.html
+++ b/docs/crd/v1/index.html
@@ -1830,7 +1830,7 @@ Note - this field MUST be unique.</p>
 </table>
 <hr />
 <h3 id="kyverno.io/v1.ImageExtractorConfigs">ImageExtractorConfigs
-(<code>map[string][]github.com/kyverno/kyverno/api/kyverno/v1.ImageExtractorConfig</code> alias)</p></h3>
+(<code>map[string][]./api/kyverno/v1.ImageExtractorConfig</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
 <a href="#kyverno.io/v1.Rule">Rule</a>)
@@ -2612,7 +2612,7 @@ ResourceDescription
 </table>
 <hr />
 <h3 id="kyverno.io/v1.ResourceFilters">ResourceFilters
-(<code>[]github.com/kyverno/kyverno/api/kyverno/v1.ResourceFilter</code> alias)</p></h3>
+(<code>[]./api/kyverno/v1.ResourceFilter</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
 <a href="#kyverno.io/v1.MatchResources">MatchResources</a>)

--- a/docs/crd/v1/index.html
+++ b/docs/crd/v1/index.html
@@ -1830,7 +1830,7 @@ Note - this field MUST be unique.</p>
 </table>
 <hr />
 <h3 id="kyverno.io/v1.ImageExtractorConfigs">ImageExtractorConfigs
-(<code>map[string][]./api/kyverno/v1.ImageExtractorConfig</code> alias)</p></h3>
+(<code>map[string][]github.com/kyverno/kyverno/api/kyverno/v1.ImageExtractorConfig</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
 <a href="#kyverno.io/v1.Rule">Rule</a>)
@@ -2612,7 +2612,7 @@ ResourceDescription
 </table>
 <hr />
 <h3 id="kyverno.io/v1.ResourceFilters">ResourceFilters
-(<code>[]./api/kyverno/v1.ResourceFilter</code> alias)</p></h3>
+(<code>[]github.com/kyverno/kyverno/api/kyverno/v1.ResourceFilter</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
 <a href="#kyverno.io/v1.MatchResources">MatchResources</a>)

--- a/pkg/engine/response/response.go
+++ b/pkg/engine/response/response.go
@@ -139,6 +139,16 @@ func (er EngineResponse) IsSuccessful() bool {
 	return true
 }
 
+// IsSkipped checks if any rule has skipped resource or not.
+func (er EngineResponse) IsSkipped() bool {
+	for _, r := range er.PolicyResponse.Rules {
+		if r.Status == RuleStatusSkip {
+			return true
+		}
+	}
+	return false
+}
+
 // IsFailed checks if any rule has succeeded or not
 func (er EngineResponse) IsFailed() bool {
 	for _, r := range er.PolicyResponse.Rules {

--- a/pkg/event/controller.go
+++ b/pkg/event/controller.go
@@ -203,8 +203,10 @@ func (gen *Generator) syncHandler(key Info) error {
 	}
 
 	// set the event type based on reason
+	// if skip/pass, reason will be: NORMAL
+	// else reason will be: WARNING
 	eventType := corev1.EventTypeWarning
-	if key.Reason == PolicyApplied.String() {
+	if key.Reason == PolicyApplied.String() || key.Reason == PolicySkipped.String() {
 		eventType = corev1.EventTypeNormal
 	}
 

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -89,6 +89,26 @@ func NewResourceViolationEvent(source Source, reason Reason, engineResponse *res
 	}
 }
 
+func NewPolicySkippedEvent(source Source, reason Reason, engineResponse *response.EngineResponse, ruleResp *response.RuleResponse) Info {
+	var bldr strings.Builder
+	defer bldr.Reset()
+	resource := engineResponse.GetResourceSpec()
+
+	if resource.Namespace != "" {
+		fmt.Fprintf(&bldr, "%s %s/%s: %s", resource.Kind, resource.Namespace, resource.Name, ruleResp.Status.String())
+	} else {
+		fmt.Fprintf(&bldr, "%s %s: %s", resource.Kind, resource.Name, ruleResp.Status.String())
+	}
+	return Info{
+		Kind:      getPolicyKind(engineResponse.Policy),
+		Name:      engineResponse.PolicyResponse.Policy.Name,
+		Namespace: engineResponse.PolicyResponse.Policy.Namespace,
+		Reason:    PolicySkipped.String(),
+		Source:    source,
+		Message:   bldr.String(),
+	}
+}
+
 func NewBackgroundFailedEvent(err error, policy, rule string, source Source, r *unstructured.Unstructured) []Info {
 	if r == nil {
 		return nil

--- a/pkg/event/reason.go
+++ b/pkg/event/reason.go
@@ -7,6 +7,7 @@ const (
 	PolicyViolation Reason = iota
 	PolicyApplied
 	PolicyError
+	PolicySkipped
 )
 
 func (r Reason) String() string {
@@ -14,5 +15,6 @@ func (r Reason) String() string {
 		"PolicyViolation",
 		"PolicyApplied",
 		"PolicyError",
+		"PolicySkipped",
 	}[r]
 }

--- a/pkg/policy/report.go
+++ b/pkg/policy/report.go
@@ -308,13 +308,16 @@ func generateFailEventsPerEr(log logr.Logger, er *response.EngineResponse) []eve
 	for i, rule := range er.PolicyResponse.Rules {
 		if rule.Status == response.RuleStatusPass {
 			continue
+		} else if rule.Status == response.RuleStatusSkip {
+			eventResource := event.NewPolicySkippedEvent(event.PolicyController, event.PolicySkipped, er, &er.PolicyResponse.Rules[i])
+			eventInfos = append(eventInfos, eventResource)
+		} else {
+			eventResource := event.NewResourceViolationEvent(event.PolicyController, event.PolicyViolation, er, &er.PolicyResponse.Rules[i])
+			eventInfos = append(eventInfos, eventResource)
+
+			eventPolicy := event.NewPolicyFailEvent(event.PolicyController, event.PolicyViolation, er, &er.PolicyResponse.Rules[i], false)
+			eventInfos = append(eventInfos, eventPolicy)
 		}
-
-		eventResource := event.NewResourceViolationEvent(event.PolicyController, event.PolicyViolation, er, &er.PolicyResponse.Rules[i])
-		eventInfos = append(eventInfos, eventResource)
-
-		eventPolicy := event.NewPolicyFailEvent(event.PolicyController, event.PolicyViolation, er, &er.PolicyResponse.Rules[i], false)
-		eventInfos = append(eventInfos, eventPolicy)
 	}
 
 	if len(eventInfos) > 0 {


### PR DESCRIPTION
Signed-off-by: viveksahu26 <vivekkumarsahu650@gmail.com>

## Explanation
2 possible changes are implemented through this PR:-
For https://github.com/kyverno/kyverno/issues/4093

Added NORMAL event on background scans for skipped policies. Earlier it was WARNING event type.
For https://github.com/kyverno/kyverno/issues/4044

Added new REASON: PolicySkipped for skip policies on resources. Earlier it shows REASON: PolicyApplied for admission controller, whereas for Policy Controller, it shows REASON: PolicyViolation for skipped resources.
For more, refer to this [doc](https://docs.google.com/document/d/1czDT-DF5FP2LM8Lli0MrBD5OejrCAm4jGxWHxb574B0/edit#)
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
closes https://github.com/kyverno/kyverno/issues/4093 https://github.com/kyverno/kyverno/issues/4044
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
none
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/kind bug
/kind enhacement
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
On background scans if a policy skip resources, NORMAL info-type will be shown instead of WARNING info-type.
And second thing, a new type of event will be generated if a policy is skipped at the admission controller or by policy controller. In admission controller, policy is applied first and then resource in the cluster. If resource skip the policy then new event: PolicySkipped will be generated. Earlier PolicyApplied event use to generated. Whereas in policy Controller, resource is already present in the cluster and policy is applied later. As policy scans resource, and resource skip the policy then new event: PolicySkipped will be generated. Earlier PolicyViolation event use to generated.

Doc: [refer](https://docs.google.com/document/d/1czDT-DF5FP2LM8Lli0MrBD5OejrCAm4jGxWHxb574B0/edit#heading=h.yvtp2bjtmfvj)
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
For  Issue 4093
```
linuzz@hp:~/go/src/kyverno/kyverno$ date && kubectl get events
Monday 11 July 2022 10:39:05 AM IST
LAST SEEN   TYPE     REASON          OBJECT                               MESSAGE
14s         Normal   PolicySkipped   clusterpolicy/no-localhost-service   Service default/kubernetes: skip
14s         Normal   PolicySkipped   clusterpolicy/no-localhost-service   Service default/my-service: skip
```

For issue 4044
When Policy scans in background( resource applied first and later policy to the cluster): PolicyController
Note: background must be equals to true
```
linuzz@hp:~/go/src/kyverno/kyverno$ date && kubectl get events
Monday 11 July 2022 10:45:27 AM IST
LAST SEEN   TYPE     REASON          OBJECT                              MESSAGE
59s         Normal   PolicySkipped   clusterpolicy/disallow-naked-pods   Pod default/blank: skip
```
admission Controller : When policy applied first and resource later
```
linuzz@hp:~/go/src/kyverno/kyverno$ date && kubectl get events
Monday 11 July 2022 10:48:18 AM IST
LAST SEEN   TYPE     REASON          OBJECT                              MESSAGE
3s          Normal   PolicySkipped   clusterpolicy/disallow-naked-pods   Pod default/blank: skip
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
