### PR TITLE
fix: use an absolute path in docker entrypoint

### DIFF
--- a/cmd/cli/kubectl-kyverno/Dockerfile
+++ b/cmd/cli/kubectl-kyverno/Dockerfile
@@ -31,4 +31,4 @@ LABEL maintainer="Kyverno"
 
 COPY --from=builder /output/kyverno /
 
-ENTRYPOINT ["./kyverno"]
+ENTRYPOINT ["/kyverno"]

--- a/cmd/initContainer/Dockerfile
+++ b/cmd/initContainer/Dockerfile
@@ -32,4 +32,4 @@ LABEL maintainer="Kyverno"
 COPY --from=builder /output/kyvernopre /
 
 
-ENTRYPOINT ["./kyvernopre"]
+ENTRYPOINT ["/kyvernopre"]

--- a/cmd/kyverno/Dockerfile
+++ b/cmd/kyverno/Dockerfile
@@ -34,4 +34,4 @@ FROM ghcr.io/distroless/static:latest
 LABEL maintainer="Kyverno"
 COPY --from=builder /output/kyverno /
 
-ENTRYPOINT ["./kyverno"]
+ENTRYPOINT ["/kyverno"]


### PR DESCRIPTION
With a relative path, containers started with a different working directory will fail to find the entrypoint

Fixes: #4252
Signed-off-by: James Callahan <jamescallahan@bitgo.com>