### PR TITLE
Reset policy status on termination

### DIFF
--- a/pkg/webhookconfig/configmanager.go
+++ b/pkg/webhookconfig/configmanager.go
@@ -345,6 +345,7 @@ func (m *webhookConfigManager) reconcileWebhook(namespace, name string) error {
 	}
 
 	ready := true
+	var updateErr error
 	// build webhook only if auto-update is enabled, otherwise directly update status to ready
 	if m.autoUpdateWebhooks {
 		webhooks, err := m.buildWebhooks(namespace)
@@ -354,7 +355,7 @@ func (m *webhookConfigManager) reconcileWebhook(namespace, name string) error {
 
 		if err := m.updateWebhookConfig(webhooks); err != nil {
 			ready = false
-			logger.Error(err, "failed to update webhook configurations for policy")
+			updateErr = errors.Wrapf(err, "failed to update webhook configurations for policy")
 		}
 
 		// DELETION of the policy
@@ -370,7 +371,7 @@ func (m *webhookConfigManager) reconcileWebhook(namespace, name string) error {
 	if ready {
 		logger.Info("policy is ready to serve admission requests")
 	}
-	return nil
+	return updateErr
 }
 
 func (m *webhookConfigManager) getPolicy(namespace, name string) (kyvernov1.PolicyInterface, error) {

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -40,8 +40,9 @@ const (
 // 5. Webhook Status Mutation
 type Register struct {
 	// clients
-	kubeClient   kubernetes.Interface
-	clientConfig *rest.Config
+	kubeClient    kubernetes.Interface
+	kyvernoClient kyvernoclient.Interface
+	clientConfig  *rest.Config
 
 	// listers
 	mwcLister   admissionregistrationv1listers.MutatingWebhookConfigurationLister
@@ -84,6 +85,7 @@ func NewRegister(
 	register := &Register{
 		clientConfig:         clientConfig,
 		kubeClient:           kubeClient,
+		kyvernoClient:        kyvernoClient,
 		mwcLister:            mwcInformer.Lister(),
 		vwcLister:            vwcInformer.Lister(),
 		kDeplLister:          kDeplInformer.Lister(),
@@ -161,14 +163,49 @@ func (wrc *Register) Check() error {
 }
 
 // Remove removes all webhook configurations
-func (wrc *Register) Remove(cleanUp chan<- struct{}) {
-	defer close(cleanUp)
+func (wrc *Register) Remove(cleanupKyvernoResource bool, wg *sync.WaitGroup) {
+	defer wg.Done()
 	// delete Lease object to let init container do the cleanup
 	if err := wrc.kubeClient.CoordinationV1().Leases(config.KyvernoNamespace()).Delete(context.TODO(), "kyvernopre-lock", metav1.DeleteOptions{}); err != nil && errorsapi.IsNotFound(err) {
 		wrc.log.WithName("cleanup").Error(err, "failed to clean up Lease lock")
 	}
-	if wrc.shouldCleanupKyvernoResource() {
+	if cleanupKyvernoResource {
 		wrc.removeWebhookConfigurations()
+	}
+}
+
+func (wrc *Register) ResetPolicyStatus(kyvernoInTermination bool, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	if !kyvernoInTermination {
+		return
+	}
+
+	logger := wrc.log.WithName("ResetPolicyStatus")
+	cpols, err := wrc.kyvernoClient.KyvernoV1().ClusterPolicies().List(context.TODO(), metav1.ListOptions{})
+	if err == nil {
+		for _, cpol := range cpols.Items {
+			cpol.Status.SetReady(false)
+			_, err := wrc.kyvernoClient.KyvernoV1().ClusterPolicies().UpdateStatus(context.TODO(), &cpol, metav1.UpdateOptions{})
+			if err != nil {
+				logger.Error(err, "failed to set ClusterPolicy status READY=false", "name", cpol.GetName())
+			}
+		}
+	} else {
+		logger.Error(err, "failed to list clusterpolicies")
+	}
+
+	pols, err := wrc.kyvernoClient.KyvernoV1().Policies(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	if err == nil {
+		for _, pol := range pols.Items {
+			pol.Status.SetReady(false)
+			_, err := wrc.kyvernoClient.KyvernoV1().Policies(pol.GetNamespace()).UpdateStatus(context.TODO(), &pol, metav1.UpdateOptions{})
+			if err != nil {
+				logger.Error(err, "failed to set Policy status READY=false", "namespace", pol.GetNamespace(), "name", pol.GetName())
+			}
+		}
+	} else {
+		logger.Error(err, "failed to list namespaced policies")
 	}
 }
 
@@ -520,7 +557,7 @@ func (wrc *Register) updateValidatingWebhookConfiguration(targetConfig *admissio
 	return nil
 }
 
-func (wrc *Register) shouldCleanupKyvernoResource() bool {
+func (wrc *Register) ShouldCleanupKyvernoResource() bool {
 	logger := wrc.log.WithName("cleanupKyvernoResource")
 	deploy, err := wrc.kubeClient.AppsV1().Deployments(config.KyvernoNamespace()).Get(context.TODO(), config.KyvernoDeploymentName(), metav1.GetOptions{})
 	if err != nil {

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -186,8 +186,7 @@ func (wrc *Register) ResetPolicyStatus(kyvernoInTermination bool, wg *sync.WaitG
 	if err == nil {
 		for _, cpol := range cpols.Items {
 			cpol.Status.SetReady(false)
-			_, err := wrc.kyvernoClient.KyvernoV1().ClusterPolicies().UpdateStatus(context.TODO(), &cpol, metav1.UpdateOptions{})
-			if err != nil {
+			if _, err := wrc.kyvernoClient.KyvernoV1().ClusterPolicies().UpdateStatus(context.TODO(), &cpol, metav1.UpdateOptions{}); err != nil {
 				logger.Error(err, "failed to set ClusterPolicy status READY=false", "name", cpol.GetName())
 			}
 		}
@@ -199,8 +198,7 @@ func (wrc *Register) ResetPolicyStatus(kyvernoInTermination bool, wg *sync.WaitG
 	if err == nil {
 		for _, pol := range pols.Items {
 			pol.Status.SetReady(false)
-			_, err := wrc.kyvernoClient.KyvernoV1().Policies(pol.GetNamespace()).UpdateStatus(context.TODO(), &pol, metav1.UpdateOptions{})
-			if err != nil {
+			if _, err := wrc.kyvernoClient.KyvernoV1().Policies(pol.GetNamespace()).UpdateStatus(context.TODO(), &pol, metav1.UpdateOptions{}); err != nil {
 				logger.Error(err, "failed to set Policy status READY=false", "namespace", pol.GetNamespace(), "name", pol.GetName())
 			}
 		}


### PR DESCRIPTION
## Explanation
When no Kyverno pod is running, all policies show READY=true which does not reflect their true status. This PR resets the policy `.status.ready` to false on termination.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes https://github.com/kyverno/kyverno/issues/4190.
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.8.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

This PR:
- resets policies `.status.ready` to false on termination
- retreis reconciling failed policies when there's an error updating webhook configs

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Policies are set to `READY=false` when scaling down Kyverno
```
✗ k scale -n kyverno deploy/kyverno --replicas=0
```

```
✗ k get cpol
NAME                                    BACKGROUND   ACTION    READY
require-drop-all-capabilities           false        audit     false
disallow-istio-injection-bypass         true         audit     false
restrict-capabilities                   true         audit     false
restrict-proc-mount                     true         enforce   false
disallow-privilege-escalation           true         enforce   false
restrict-image-registries               true         enforce   false
disallow-privileged-containers          true         enforce   false
disallow-host-namespaces                true         enforce   false
disallow-shared-subpath-volume-writes   true         enforce   false
restrict-host-path-write                true         enforce   false
require-istio-on-namespaces             true         audit     false
require-non-root-user                   true         audit     false
restrict-external-ips                   true         enforce   false
restrict-host-ports                     true         enforce   false
restrict-seccomp                        true         enforce   false
restrict-sysctls                        true         enforce   false
restrict-external-names                 true         enforce   false
require-non-root-group                  true         audit     false
restrict-selinux-type                   true         enforce   false
restrict-volume-types                   false        enforce   false
disallow-selinux-options                true         enforce   false
restrict-apparmor                       true         enforce   false
restrict-host-path-mount                true         enforce   false
```

2. Retry reconciling failed policies on when there's an error updating webhook configs
```
✗ k logs -n kyverno -f deploy/kyverno | grep "restrict-host-path-mount"
I0727 07:44:22.042064       1 controller.go:85] policycache-controller "msg"="reconciling ..."  "key"="restrict-host-path-mount" "name"="restrict-host-path-mount" "namespace"=""
I0727 07:44:22.180839       1 controller.go:231] PolicyController "msg"="policy created"  "kind"="ClusterPolicy" "name"="restrict-host-path-mount" "uid"="8bfad5f7-86d8-48d4-a005-e09b08d6bb4c"
E0727 07:44:33.040480       1 configmanager.go:319] WebhookConfigManager "msg"="failed to sync policy" "error"="failed to update webhook configurations for policy: unable to update: kyverno-resource-mutating-webhook-cfg: Operation cannot be fulfilled on mutatingwebhookconfigurations.admissionregistration.k8s.io \"kyverno-resource-mutating-webhook-cfg\": the object has been modified; please apply your changes to the latest version and try again"  "key"="restrict-host-path-mount"
I0727 07:44:40.421444       1 configmanager.go:335] WebhookConfigManager/reconcileWebhook "msg"="policy is ready to serve admission requests" "namespace"="" "policy"="restrict-host-path-mount"
I0727 07:44:40.423194       1 controller.go:85] policycache-controller "msg"="reconciling ..."  "key"="restrict-host-path-mount" "name"="restrict-host-path-mount" "namespace"=""
I0727 07:44:41.227087       1 controller.go:85] policycache-controller "msg"="reconciling ..."  "key"="restrict-host-path-mount" "name"="restrict-host-path-mount" "namespace"=""
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
