### PR TITLE
feat: use disk cache for discovery

### DIFF
--- a/charts/kyverno/templates/deployment.yaml
+++ b/charts/kyverno/templates/deployment.yaml
@@ -97,6 +97,9 @@ spec:
           {{- with .Values.envVarsInit }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
       containers:
       {{- if .Values.extraContainers }}
         {{- toYaml .Values.extraContainers | nindent 8 }}
@@ -159,6 +162,10 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.tufRootMountPath }}
               name: sigstore
+            - mountPath: /tmp
+              name: tmp
       volumes:
       - name: sigstore
+        emptyDir: {}
+      - name: tmp
         emptyDir: {}

--- a/config/manifest/deployment.yaml
+++ b/config/manifest/deployment.yaml
@@ -24,6 +24,8 @@ spec:
       volumes:
         - name: sigstore
           emptyDir: {}
+        - name: tmp
+          emptyDir: {}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -71,6 +73,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          volumeMounts:
+          - mountPath: /tmp
+            name: tmp
       containers:
         - name: kyverno
           image: ghcr.io/kyverno/kyverno:latest
@@ -148,6 +153,8 @@ spec:
           volumeMounts:
           - mountPath: /.sigstore
             name: sigstore
+          - mountPath: /tmp
+            name: tmp
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
## Explanation

Current dynamic client use a memory-based cache.
This cache doesn't have any TTL and must be entirely cleared every 15 min.
With big clusters and many replicas, it pushes a lot of pressure on API and take a lot of memory.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

/kind bug

## Proposed Changes

Use disk-based cache.
This cache is in `/tmp` to be push in an `emptydir` (for performance reasons) if needed.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

- `/tmp` must be writable by kyverno in the image

- we may update current manifest to use emptydir for `/tmp` and a safe to evict.