### PR TITLE
feat: Add container registry setting on Helm Chart

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -42,3 +42,5 @@ annotations:
       description: Extra args support for init container.
     - kind: added
       description: Allow overriding of test security context and resource block.
+    - kind: added
+      description: Added possibility to define custom image registries

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -107,15 +107,18 @@ The command removes all the Kubernetes components associated with the chart and 
 | rbac.serviceAccount.create | bool | `true` | Create a ServiceAccount |
 | rbac.serviceAccount.name | string | `nil` | The ServiceAccount name |
 | rbac.serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
+| image.registry | string | `nil` | Image registry |
 | image.repository | string | `"ghcr.io/kyverno/kyverno"` | Image repository |
 | image.tag | string | `nil` | Image tag Defaults to appVersion in Chart.yaml if omitted |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |
+| initImage.registry | string | `nil` | Image registry |
 | initImage.repository | string | `"ghcr.io/kyverno/kyvernopre"` | Image repository |
 | initImage.tag | string | `nil` | Image tag If initImage.tag is missing, defaults to image.tag |
 | initImage.pullPolicy | string | `nil` | Image pull policy If initImage.pullPolicy is missing, defaults to image.pullPolicy |
 | initContainer.extraArgs | list | `["--loggingFormat=text"]` | Extra arguments to give to the kyvernopre binary. |
-| testImage.repository | string | `nil` | Image repository Defaults to `busybox` if omitted |
+| testImage.registry | string | `nil` | Image registry |
+| testImage.repository | string | `"busybox"` | Image repository |
 | testImage.tag | string | `nil` | Image tag Defaults to `latest` if omitted |
 | testImage.pullPolicy | string | `nil` | Image pull policy Defaults to image.pullPolicy if omitted |
 | replicaCount | int | `nil` | Desired number of pods |

--- a/charts/kyverno/ci/imageRegistry-values.yaml
+++ b/charts/kyverno/ci/imageRegistry-values.yaml
@@ -1,0 +1,9 @@
+testImage:
+  registry: docker.io
+  repository: busybox
+image:
+  registry: ko.local
+  repository: github.com/kyverno/kyverno/cmd/kyverno
+initImage:
+  registry: ko.local
+  repository: github.com/kyverno/kyverno/cmd/initcontainer

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -125,6 +125,13 @@ maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
 {{- printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" .registry (printf "%s:%s" .username .password | b64enc) | b64enc }}
 {{- end }}
 
+{{- define "kyverno.image" -}}
+  {{- if .image.registry -}}
+{{ .image.registry }}/{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+  {{- else -}}
+{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+  {{- end -}}
+{{- end }}
 
 {{- define "kyverno.resourceFilters" -}}
 {{- $resourceFilters := .Values.config.resourceFilters }}

--- a/charts/kyverno/templates/deployment.yaml
+++ b/charts/kyverno/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         {{- toYaml .Values.extraInitContainers | nindent 8 }}
       {{- end }}
         - name: kyverno-pre
-          image: {{ .Values.initImage.repository }}:{{ default .Chart.AppVersion (default .Values.image.tag .Values.initImage.tag) }}
+          image: {{ include "kyverno.image" (dict "image" .Values.initImage "defaultTag" (default .Chart.AppVersion .Values.image.tag)) | quote }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.initImage.pullPolicy }}
           {{- if .Values.initContainer.extraArgs }}
           args:
@@ -102,7 +102,7 @@ spec:
         {{- toYaml .Values.extraContainers | nindent 8 }}
       {{- end }}
         - name: kyverno
-          image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
+          image: {{ include "kyverno.image" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if or .Values.extraArgs .Values.imagePullSecrets }}
           args:

--- a/charts/kyverno/templates/tests/test.yaml
+++ b/charts/kyverno/templates/tests/test.yaml
@@ -10,7 +10,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: wget
-      image: {{ .Values.testImage.repository | default "busybox" }}{{- if .Values.testImage.tag }}:{{ .Values.testImage.tag }}{{- end }}
+      image: {{ include "kyverno.image" (dict "image" .Values.testImage "defaultTag" "latest") | quote }}
       imagePullPolicy: {{ default .Values.image.pullPolicy .Values.testImage.pullPolicy }}
       {{- with .Values.testResources }}
       resources: {{ tpl (toYaml .) $ | nindent 8 }}
@@ -24,7 +24,7 @@ spec:
         - |
           sleep 20 ; wget -O- -S --no-check-certificate https://{{ template "kyverno.serviceName" . }}:{{ .Values.service.port }}/health/liveness
     - name: wget-metrics
-      image: {{ .Values.testImage.repository | default "busybox" }}{{- if .Values.testImage.tag }}:{{ .Values.testImage.tag }}{{- end }}
+      image: {{ include "kyverno.image" (dict "image" .Values.testImage "defaultTag" "latest") | quote }}
       imagePullPolicy: {{ default .Values.image.pullPolicy .Values.testImage.pullPolicy }}
       {{- with .Values.testResources }}
       resources: {{ tpl (toYaml .) $ | nindent 8 }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -23,6 +23,11 @@ rbac:
       # example.com/annotation: value
 
 image:
+  # -- Image registry
+  registry:
+  # If you want to manage the registry you should remove it from the repository
+  # registry: ghcr.io
+  # repository: kyverno/kyverno
   # -- Image repository
   repository: ghcr.io/kyverno/kyverno  # kyverno: replaced in e2e tests
   # -- Image tag
@@ -35,6 +40,11 @@ image:
   # - secretName
 
 initImage:
+  # -- Image registry
+  registry:
+  # If you want to manage the registry you should remove it from the repository
+  # registry: ghcr.io
+  # repository: kyverno/kyvernopre
   # -- Image repository
   repository: ghcr.io/kyverno/kyvernopre  # init: replaced in e2e tests
   # -- Image tag
@@ -51,9 +61,10 @@ initContainer:
 
 
 testImage:
+  # -- Image registry
+  registry:
   # -- Image repository
-  # Defaults to `busybox` if omitted
-  repository:
+  repository: busybox
   # -- Image tag
   # Defaults to `latest` if omitted
   tag:


### PR DESCRIPTION
## Explanation

To make the customization of the container registries easier, eg. a custom private registry, this change adds a new property on the images configuration to allow setting a custom image registry without needing to mess around the name of the image.

This is specially need if you use some GitOps tool like Flux / ArgoCD an you want to use a private container registry where its URL its stored ConfigMap. This change would allow us to simply replace the registry without having to have a custom ConfigMap entry with the `private.container.registry/kyverno/kyvernopre` to be replaced when installing Kyverno.

## Related issue

https://github.com/kyverno/kyverno/issues/4280

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
-->

/kind feature

## Proposed Changes

Add a registry property on the image settings in the Helm chart to allow for customization of the registry separately.


### Proof Manifests

# Kubernetes resource

```bash
❯ helm template kyverno . --set image.registry="custom.registry" --set image.repository="kyverno" --set image.tag="1.7.3" | grep -C1  custom.registry
        - name: kyverno
          image: "custom.registry/kyverno:1.7.3"
          imagePullPolicy: IfNotPresent
```

```bash
❯ helm template kyverno . --set initImage.registry="custom.registry" --set image.repository="kyvernopre" --set image.tag="1.7.3" | grep -C1  custom.registry
        - name: kyverno-pre
          image: "custom.registry/ghcr.io/kyverno/kyvernopre:1.7.3"
          imagePullPolicy: IfNotPresent
```

```bash
❯ helm template kyverno . --set testImage.registry="custom.registry" --set testImage.tag="latest" | grep -C1  custom.registry
    - name: wget
      image: "custom.registry/busybox:latest"
      imagePullPolicy: IfNotPresent
--
    - name: wget-metrics
      image: "custom.registry/busybox:latest"
      imagePullPolicy: IfNotPresent
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
