### PR TITLE
Update json annotations for ImageVerification

### DIFF
--- a/api/kyverno/v1/image_verification_types.go
+++ b/api/kyverno/v1/image_verification_types.go
@@ -69,17 +69,17 @@ type ImageVerification struct {
 	// Defaults to true.
 	// +kubebuilder:default=true
 	// +kubebuilder:validation:Optional
-	MutateDigest bool `json:"mutateDigest" yaml:"mutateDigest"`
+	MutateDigest bool `json:"mutateDigest,omitempty" yaml:"mutateDigest,omitempty"`
 
 	// VerifyDigest validates that images have a digest.
 	// +kubebuilder:default=true
 	// +kubebuilder:validation:Optional
-	VerifyDigest bool `json:"verifyDigest" yaml:"verifyDigest"`
+	VerifyDigest bool `json:"verifyDigest,omitempty" yaml:"verifyDigest,omitempty"`
 
 	// Required validates that images are verified i.e. have matched passed a signature or attestation check.
 	// +kubebuilder:default=true
 	// +kubebuilder:validation:Optional
-	Required bool `json:"required" yaml:"required"`
+	Required bool `json:"required,omitempty" yaml:"required,omitempty"`
 }
 
 type AttestorSet struct {


### PR DESCRIPTION
## Explanation

The json annotations for `MutateDigest`, `VerifyDigest` and `Required` in the `ImageVerification` struct currently do not allow them to be omitted from a JSON representation.

Importing the existing struct into CUE results in these fields being required for each `ImageVerification` instance.

Signed-off-by: Brad Beck <bradley.beck@gmail.com>


## What type of PR is this

/kind bug

## Proposed Changes

Update the json annotations for `MutateDigest`, `VerifyDigest` and `Required` in the `ImageVerification` struct to make them consistent with the other fields.

### Proof Manifests

If the current implementation of `ImageVerification` is imported via `cue get go ...` it results in the following definitions for the fields mentioned:

```cue
	// MutateDigest enables replacement of image tags with digests.
	// Defaults to true.
	// +kubebuilder:default=true
	// +kubebuilder:validation:Optional
	mutateDigest: bool @go(MutateDigest)

	// VerifyDigest validates that images have a digest.
	// +kubebuilder:default=true
	// +kubebuilder:validation:Optional
	verifyDigest: bool @go(VerifyDigest)

	// Required validates that images are verified i.e. have matched passed a signature or attestation check.
	// +kubebuilder:default=true
	// +kubebuilder:validation:Optional
	required: bool @go(Required)
```

The proposed changes will result in the following definitions for these same fields, effectively making them optional in CUE syntax.

```cue
	// MutateDigest enables replacement of image tags with digests.
	// Defaults to true.
	// +kubebuilder:default=true
	// +kubebuilder:validation:Optional
	mutateDigest?: bool @go(MutateDigest)

	// VerifyDigest validates that images have a digest.
	// +kubebuilder:default=true
	// +kubebuilder:validation:Optional
	verifyDigest?: bool @go(VerifyDigest)

	// Required validates that images are verified i.e. have matched passed a signature or attestation check.
	// +kubebuilder:default=true
	// +kubebuilder:validation:Optional
	required?: bool @go(Required)
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
