### PR TITLE
Change resource names to plurals

### DIFF
--- a/charts/kyverno/templates/aggregateroles.yaml
+++ b/charts/kyverno/templates/aggregateroles.yaml
@@ -32,8 +32,8 @@ rules:
   - apiGroups:
       - wgpolicyk8s.io
     resources:
-      - policyreport
-      - clusterpolicyreport
+      - policyreports
+      - clusterpolicyreports
     verbs:
       - create
       - delete


### PR DESCRIPTION
Signed-off-by: aofekiko <aofekiko@gmail.com>

## Explanation

ClusterRoles should have resource names as plurals

## Related issue
Closes https://github.com/kyverno/kyverno/issues/4311

## What type of PR is this

/kind bug


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
