### PR TITLE
failurePolicy support in helm charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## v1.7.2-rc2
+# v1.7.2-rc3
+
+### Note
+
+- added support for failurePolicy to kyverno-policy helm chart
+
+# v1.7.2-rc2
 
 ### Note
 
@@ -7,7 +13,7 @@
 
 ### Note
 
-- A new flag `maxReportChangeRequests` is added to the Kyverno main container, this flag sets the up-limit of reportchangerequests that a namespace can take, or clusterreportchangerequests if matching kinds are cluster-wide resources. The default limit is set to 1000, and it's recommended to configure it to a small threshold on large clusters. Here the large clusters are considered that a policy report has more than 1k results. 
+- A new flag `maxReportChangeRequests` is added to the Kyverno main container, this flag sets the up-limit of reportchangerequests that a namespace can take, or clusterreportchangerequests if matching kinds are cluster-wide resources. The default limit is set to 1000, and it's recommended to configure it to a small threshold on large clusters. Here the large clusters are considered that a policy report has more than 1k results.
 
 
 ## v1.7.0-rc1
@@ -106,7 +112,7 @@ Thanks to all our contributors! 😊
 
 ## v1.4.3-rc1
 
-### Enhancements 
+### Enhancements
 - CLI variables should be coming from the resources itself (#1996)
 - Adding `ownerRef` with namespace for Kyverno managed webhook configurations (#2263)
 - Support new policy report CRD #1753, (#2376)
@@ -154,7 +160,7 @@ Thanks to all our contributors! 😊
 
 ## v1.4.2
 
-### Enhancements 
+### Enhancements
 - Remove unused variable from Kyverno CLI (#2252)
 
 ## v1.4.2-rc4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,4 @@
-# v1.7.2-rc3
-
-### Note
-
-- added support for failurePolicy to kyverno-policy helm chart
-
-# v1.7.2-rc2
+## v1.7.2-rc2
 
 ### Note
 
@@ -13,7 +7,7 @@
 
 ### Note
 
-- A new flag `maxReportChangeRequests` is added to the Kyverno main container, this flag sets the up-limit of reportchangerequests that a namespace can take, or clusterreportchangerequests if matching kinds are cluster-wide resources. The default limit is set to 1000, and it's recommended to configure it to a small threshold on large clusters. Here the large clusters are considered that a policy report has more than 1k results.
+- A new flag `maxReportChangeRequests` is added to the Kyverno main container, this flag sets the up-limit of reportchangerequests that a namespace can take, or clusterreportchangerequests if matching kinds are cluster-wide resources. The default limit is set to 1000, and it's recommended to configure it to a small threshold on large clusters. Here the large clusters are considered that a policy report has more than 1k results. 
 
 
 ## v1.7.0-rc1
@@ -112,7 +106,7 @@ Thanks to all our contributors! 😊
 
 ## v1.4.3-rc1
 
-### Enhancements
+### Enhancements 
 - CLI variables should be coming from the resources itself (#1996)
 - Adding `ownerRef` with namespace for Kyverno managed webhook configurations (#2263)
 - Support new policy report CRD #1753, (#2376)
@@ -160,7 +154,7 @@ Thanks to all our contributors! 😊
 
 ## v1.4.2
 
-### Enhancements
+### Enhancements 
 - Remove unused variable from Kyverno CLI (#2252)
 
 ## v1.4.2-rc4

--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -29,3 +29,5 @@ annotations:
       description: Fix Kyverno version check when image tag contains registry port number
     - kind: fixed
       description: Ensure preconditions are present with default values
+    - kind: added
+      description: Support for failurePolicy setting in kyverno-policies helm chart

--- a/charts/kyverno-policies/README.md
+++ b/charts/kyverno-policies/README.md
@@ -69,7 +69,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | includeOtherPolicies | list | `[]` | Additional policies to include from `other`. |
 | validationFailureAction | string | `"audit"` | Validation failure action (`audit`, `enforce`). For more info https://kyverno.io/docs/writing-policies/validate. |
 | validationFailureActionOverrides | object | `{"all":[]}` | Define validationFailureActionOverrides for specific policies. The overrides for `all` will apply to all policies. |
-| failurePolicy | string | `"Fail"` | FailurePolicy defines how unrecognized errors from the admission endpoint are handled.|
+| failurePolicy | string | `"Fail"` | API server behavior if the webhook fails to respond ('Ignore', 'Fail') For more info: https://kyverno.io/docs/writing-policies/policy-settings/ |
 | policyExclude | object | `{}` | Exclude resources from individual policies. Policies with multiple rules can have individual rules excluded by using the name of the rule as the key in the `policyExclude` map. |
 | policyPreconditions | object | `{}` | Add preconditions to individual policies. Policies with multiple rules can have individual rules excluded by using the name of the rule as the key in the `policyPreconditions` map. |
 | nameOverride | string | `nil` | Name override. |

--- a/charts/kyverno-policies/README.md
+++ b/charts/kyverno-policies/README.md
@@ -69,6 +69,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | includeOtherPolicies | list | `[]` | Additional policies to include from `other`. |
 | validationFailureAction | string | `"audit"` | Validation failure action (`audit`, `enforce`). For more info https://kyverno.io/docs/writing-policies/validate. |
 | validationFailureActionOverrides | object | `{"all":[]}` | Define validationFailureActionOverrides for specific policies. The overrides for `all` will apply to all policies. |
+| failurePolicy | string | `"Fail"` | FailurePolicy defines how unrecognized errors from the admission endpoint are handled.|
 | policyExclude | object | `{}` | Exclude resources from individual policies. Policies with multiple rules can have individual rules excluded by using the name of the rule as the key in the `policyExclude` map. |
 | policyPreconditions | object | `{}` | Add preconditions to individual policies. Policies with multiple rules can have individual rules excluded by using the name of the rule as the key in the `policyPreconditions` map. |
 | nameOverride | string | `nil` | Name override. |

--- a/charts/kyverno-policies/templates/baseline/disallow-capabilities.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-capabilities.yaml
@@ -23,6 +23,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: adding-capabilities
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.yaml
@@ -24,6 +24,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: host-namespaces
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-host-path.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-path.yaml
@@ -23,6 +23,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: host-path
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-host-ports.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-ports.yaml
@@ -16,13 +16,14 @@ metadata:
     policies.kyverno.io/description: >-
       Access to host ports allows potential snooping of network traffic and should not be
       allowed, or at minimum restricted to a known list. This policy ensures the `hostPort`
-      field is unset or set to `0`. 
+      field is unset or set to `0`.
 spec:
   validationFailureAction: {{ .Values.validationFailureAction }}
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: host-ports-none
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-host-process.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-process.yaml
@@ -24,6 +24,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: host-process-containers
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.yaml
@@ -22,6 +22,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: privileged-containers
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-proc-mount.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-proc-mount.yaml
@@ -24,6 +24,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: check-proc-mount
       match:

--- a/charts/kyverno-policies/templates/baseline/disallow-selinux.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-selinux.yaml
@@ -22,6 +22,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: selinux-type
       match:

--- a/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
@@ -25,6 +25,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: app-armor
       match:

--- a/charts/kyverno-policies/templates/baseline/restrict-seccomp.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-seccomp.yaml
@@ -14,8 +14,8 @@ metadata:
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
     policies.kyverno.io/description: >-
-      The seccomp profile must not be explicitly set to Unconfined. This policy, 
-      requiring Kubernetes v1.19 or later, ensures that seccomp is unset or 
+      The seccomp profile must not be explicitly set to Unconfined. This policy,
+      requiring Kubernetes v1.19 or later, ensures that seccomp is unset or
       set to `RuntimeDefault` or `Localhost`.
 spec:
   background: {{ .Values.background }}
@@ -23,6 +23,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: check-seccomp
       match:
@@ -50,7 +51,7 @@ spec:
           spec:
             =(securityContext):
               =(seccompProfile):
-                =(type): "RuntimeDefault | Localhost"      
+                =(type): "RuntimeDefault | Localhost"
             =(ephemeralContainers):
             - =(securityContext):
                 =(seccompProfile):

--- a/charts/kyverno-policies/templates/baseline/restrict-sysctls.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-sysctls.yaml
@@ -26,6 +26,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: check-sysctls
       match:

--- a/charts/kyverno-policies/templates/other/require-non-root-groups.yaml
+++ b/charts/kyverno-policies/templates/other/require-non-root-groups.yaml
@@ -24,6 +24,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: check-runasgroup
       match:

--- a/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.yaml
@@ -24,6 +24,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: require-drop-all
       match:

--- a/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.yaml
@@ -22,6 +22,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: privilege-escalation
       match:

--- a/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
@@ -22,6 +22,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: run-as-non-root-user
       match:

--- a/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
@@ -23,6 +23,7 @@ spec:
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
   background: {{ .Values.background }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: run-as-non-root
       match:

--- a/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.yaml
@@ -15,8 +15,8 @@ metadata:
     kyverno.io/kubernetes-version: "1.22-1.23"
     policies.kyverno.io/description: >-
       The seccomp profile in the Restricted group must not be explicitly set to Unconfined
-      but additionally must also not allow an unset value. This policy, 
-      requiring Kubernetes v1.19 or later, ensures that seccomp is 
+      but additionally must also not allow an unset value. This policy,
+      requiring Kubernetes v1.19 or later, ensures that seccomp is
       set to `RuntimeDefault` or `Localhost`. A known issue prevents a policy such as this
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
 spec:
@@ -25,6 +25,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
+  failurePolicy: {{ .Values.failurePolicy }}
   rules:
     - name: check-seccomp-strict
       match:

--- a/charts/kyverno-policies/templates/restricted/restrict-volume-types.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-volume-types.yaml
@@ -24,6 +24,7 @@ spec:
   {{- with concat (index .Values "validationFailureActionOverrides" "all") (default list (index .Values "validationFailureActionOverrides" $name)) }}
   validationFailureActionOverrides: {{ toYaml . | nindent 4 }}
   {{- end }}
+  failurePolicy: {{ .Values.failurePolicy }}
   background: {{ .Values.background }}
   rules:
     - name: restricted-volumes

--- a/charts/kyverno-policies/values.yaml
+++ b/charts/kyverno-policies/values.yaml
@@ -29,6 +29,10 @@ validationFailureActionOverrides:
   #     namespaces:
   #       - fluent
 
+# -- API server behavior if the webhook fails to respond ('Ignore', 'Fail')
+# For more info: https://kyverno.io/docs/writing-policies/policy-settings/
+failurePolicy: Fail
+
 # -- Exclude resources from individual policies.
 # Policies with multiple rules can have individual rules excluded by using the name of the rule as the key in the `policyExclude` map.
 policyExclude: {}

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -12378,7 +12378,8 @@ metadata:
   name: kyverno:events
 rules:
 - apiGroups:
-  - '*'
+  - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/config/install_debug.yaml
+++ b/config/install_debug.yaml
@@ -12361,7 +12361,8 @@ metadata:
   name: kyverno:events
 rules:
 - apiGroups:
-  - '*'
+  - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/pkg/engine/jsonContext.go
+++ b/pkg/engine/jsonContext.go
@@ -20,7 +20,19 @@ func LoadContext(logger logr.Logger, contextEntries []kyvernov1.ContextEntry, ct
 
 	policyName := ctx.Policy.GetName()
 	if store.GetMock() {
+		rule := store.GetPolicyRuleFromContext(policyName, ruleName)
+		if rule != nil && len(rule.Values) > 0 {
+			variables := rule.Values
+			for key, value := range variables {
+				if err := ctx.JSONContext.AddVariable(key, value); err != nil {
+					return err
+				}
+			}
+		}
+
 		hasRegistryAccess := store.GetRegistryAccess()
+
+		// Context Variable should be loaded after the values loaded from values file
 		for _, entry := range contextEntries {
 			if entry.ImageRegistry != nil && hasRegistryAccess {
 				if err := loadImageData(logger, entry, ctx); err != nil {
@@ -28,15 +40,6 @@ func LoadContext(logger logr.Logger, contextEntries []kyvernov1.ContextEntry, ct
 				}
 			} else if entry.Variable != nil {
 				if err := loadVariable(logger, entry, ctx); err != nil {
-					return err
-				}
-			}
-		}
-		rule := store.GetPolicyRuleFromContext(policyName, ruleName)
-		if rule != nil && len(rule.Values) > 0 {
-			variables := rule.Values
-			for key, value := range variables {
-				if err := ctx.JSONContext.AddVariable(key, value); err != nil {
 					return err
 				}
 			}

--- a/test/cli/test/unordered-context-variables/kyverno-test.yaml
+++ b/test/cli/test/unordered-context-variables/kyverno-test.yaml
@@ -1,0 +1,12 @@
+name: chained-variables
+policies:
+  - policy.yaml
+resources:
+  - resource.yaml
+variables: variables.yaml
+results:
+- policy: deny-something
+  rule: deny-everything
+  resource: valid-pod
+  kind: Pod
+  result: pass

--- a/test/cli/test/unordered-context-variables/policy.yaml
+++ b/test/cli/test/unordered-context-variables/policy.yaml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-something
+spec:
+  validationFailureAction: enforce
+  rules:
+    - name: deny-everything
+      context:
+      - name: varA
+        configMap:
+          name: kyverno-context-vars
+          namespace: default
+      - name: varB
+        variable:
+          jmesPath: varA.data.ValueOfB
+      match:
+        resources:
+          kinds:
+            - Pod
+      validate:
+        message: >-
+          Sharing the host namespaces is not allowed. The fields spec.hostNetwork,
+          spec.hostIPC, and spec.hostPID must be unset or set to `false`.
+        pattern:
+          spec:
+            =(hostPID): false
+            =(hostIPC): false

--- a/test/cli/test/unordered-context-variables/resource.yaml
+++ b/test/cli/test/unordered-context-variables/resource.yaml
@@ -1,0 +1,11 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: valid-pod
+  namespace: test
+  labels:
+    app: whatever
+spec:
+  containers:
+    - name: app
+      image: 'myorg/whatever:1.0.0'

--- a/test/cli/test/unordered-context-variables/variables.yaml
+++ b/test/cli/test/unordered-context-variables/variables.yaml
@@ -1,0 +1,7 @@
+policies:
+  - name: deny-something
+    rules:
+      - name: deny-everything
+        values:
+          varA.data.ValueOfB: "something"
+          # request.namespace: kyverno


### PR DESCRIPTION
## Explanation

Add support for failurePolicy to helm charts and some whitespace cleanup

## Related issue

For Feature request [4319](https://github.com/kyverno/kyverno/issues/4319)
## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

/kind feature

## Proposed Changes

Grants more flexibility to consumers of the kyverno-policies helm chart by allowing them to set failurePolicy.

### Proof Manifests

Helm Linting test
```bash
┌──kyverno/charts/kyverno-policies ─🕙 2022.08.09 14:22:30 ─on 🌱 failure-policy-helm ->
└─>via ⎈ v3.8.1 👌>  helm lint                                                                  
==> Linting .

1 chart(s) linted, 0 chart(s) failed
```

Helm  chart installation test with changes
```bash
 ┌──kyverno/charts/kyverno-policies ─🕙 2022.08.09 14:21:08 ─on 🌱 failure-policy-helm ->
└─>via ⎈ v3.8.1 👌>  helm install kyverno-policies --set failurePolicy=Ignore .
NAME: kyverno-policies
LAST DEPLOYED: Tue Aug  9 14:21:15 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thank you for installing kyverno-policies v2.5.2 😀

We have installed the "baseline" profile of Pod Security Standards and set them in audit mode.
```

Verifying change is live in cluster
```
┌──kyverno/charts/kyverno-policies ─🕙 2022.08.09 14:25:42 ─on 🌱 failure-policy-helm ->
└─>via ⎈ v3.8.1 👌>  k get ClusterPolicy disallow-capabilities -o json | grep failurePolicy
        "failurePolicy": "Ignore",

```

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [X] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

None
