### PR TITLE
Remove myself as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,12 +8,8 @@
 /pkg/policy/validate @vyankyGH
 /test @vyankyGH @chipzoller @eddycharly
 /docs @chipzoller
-/pkg/cosign @samj1912
-/pkg/engine @samj1912
-/pkg/kyverno @samj1912
-/pkg/policy @samj1912
-/pkg/registryclient @samj1912
-/api/kyverno/v1 @samj1912 @eddycharly
+/pkg/registryclient
+/api/kyverno/v1 @eddycharly
 /pkg/webhooks @prateekpandey14
 /pkg/engine @prateekpandey14
 /pkg/generate @prateekpandey14


### PR DESCRIPTION
I get a lot of noise on github notifications as I am a code-owner on quite a few of these files which distracts me from kyverno PR/issues where I am actually mentioned and a review is needed. Removing myself from code-owners for now.

Signed-off-by: Sambhav Kothari <sambhavs.email@gmail.com>
