### PR TITLE
Added appropriate logging levels to log.Info() calls wherever necessary

### DIFF
--- a/cmd/initContainer/main.go
+++ b/cmd/initContainer/main.go
@@ -139,7 +139,7 @@ func main() {
 		name := tls.GenerateRootCASecretName()
 		_, err = kubeClient.CoreV1().Secrets(config.KyvernoNamespace()).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			log.Log.V(3).Info("failed to fetch root CA secret", "name", name, "error", err.Error())
+			log.Log.V(2).Info("failed to fetch root CA secret", "name", name, "error", err.Error())
 			if !errors.IsNotFound(err) {
 				os.Exit(1)
 			}
@@ -148,14 +148,14 @@ func main() {
 		name = tls.GenerateTLSPairSecretName()
 		_, err = kubeClient.CoreV1().Secrets(config.KyvernoNamespace()).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			log.Log.V(3).Info("failed to fetch TLS Pair secret", "name", name, "error", err.Error())
+			log.Log.V(2).Info("failed to fetch TLS Pair secret", "name", name, "error", err.Error())
 			if !errors.IsNotFound(err) {
 				os.Exit(1)
 			}
 		}
 
 		if err = acquireLeader(ctx, kubeClient); err != nil {
-			log.Log.V(3).Info("Failed to create lease 'kyvernopre-lock'")
+			log.Log.V(2).Info("Failed to create lease 'kyvernopre-lock'")
 			os.Exit(1)
 		}
 
@@ -174,7 +174,7 @@ func main() {
 		}
 		// if there is any failure then we fail process
 		if failure {
-			log.Log.V(3).Info("failed to cleanup prior configurations")
+			log.Log.V(2).Info("failed to cleanup prior configurations")
 			os.Exit(1)
 		}
 
@@ -193,9 +193,9 @@ func main() {
 func acquireLeader(ctx context.Context, kubeClient kubernetes.Interface) error {
 	_, err := kubeClient.CoordinationV1().Leases(config.KyvernoNamespace()).Get(ctx, "kyvernopre-lock", metav1.GetOptions{})
 	if err != nil {
-		log.Log.V(4).Info("Lease 'kyvernopre-lock' not found. Starting clean-up...")
+		log.Log.V(2).Info("Lease 'kyvernopre-lock' not found. Starting clean-up...")
 	} else {
-		log.Log.V(4).Info("Leader was elected, quitting")
+		log.Log.V(2).Info("Leader was elected, quitting")
 		os.Exit(0)
 	}
 
@@ -417,7 +417,7 @@ func deleteResource(client dclient.Interface, apiversion, kind, ns, name string)
 		return
 	}
 
-	log.Log.V(4).Info("successfully cleaned up resource", "kind", kind, "name", name)
+	log.Log.V(2).Info("successfully cleaned up resource", "kind", kind, "name", name)
 }
 
 func addSelectorLabel(client dclient.Interface, apiversion, kind, ns, name string) {
@@ -441,7 +441,7 @@ func addSelectorLabel(client dclient.Interface, apiversion, kind, ns, name strin
 		return
 	}
 
-	log.Log.V(4).Info("successfully updated resource labels", "kind", kind, "name", name)
+	log.Log.V(2).Info("successfully updated resource labels", "kind", kind, "name", name)
 }
 
 func convertGR(pclient kyvernoclient.Interface) error {

--- a/cmd/initContainer/main.go
+++ b/cmd/initContainer/main.go
@@ -139,7 +139,7 @@ func main() {
 		name := tls.GenerateRootCASecretName()
 		_, err = kubeClient.CoreV1().Secrets(config.KyvernoNamespace()).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			log.Log.Info("failed to fetch root CA secret", "name", name, "error", err.Error())
+			log.Log.V(3).Info("failed to fetch root CA secret", "name", name, "error", err.Error())
 			if !errors.IsNotFound(err) {
 				os.Exit(1)
 			}
@@ -148,14 +148,14 @@ func main() {
 		name = tls.GenerateTLSPairSecretName()
 		_, err = kubeClient.CoreV1().Secrets(config.KyvernoNamespace()).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			log.Log.Info("failed to fetch TLS Pair secret", "name", name, "error", err.Error())
+			log.Log.V(3).Info("failed to fetch TLS Pair secret", "name", name, "error", err.Error())
 			if !errors.IsNotFound(err) {
 				os.Exit(1)
 			}
 		}
 
 		if err = acquireLeader(ctx, kubeClient); err != nil {
-			log.Log.Info("Failed to create lease 'kyvernopre-lock'")
+			log.Log.V(3).Info("Failed to create lease 'kyvernopre-lock'")
 			os.Exit(1)
 		}
 
@@ -174,7 +174,7 @@ func main() {
 		}
 		// if there is any failure then we fail process
 		if failure {
-			log.Log.Info("failed to cleanup prior configurations")
+			log.Log.V(3).Info("failed to cleanup prior configurations")
 			os.Exit(1)
 		}
 
@@ -193,9 +193,9 @@ func main() {
 func acquireLeader(ctx context.Context, kubeClient kubernetes.Interface) error {
 	_, err := kubeClient.CoordinationV1().Leases(config.KyvernoNamespace()).Get(ctx, "kyvernopre-lock", metav1.GetOptions{})
 	if err != nil {
-		log.Log.Info("Lease 'kyvernopre-lock' not found. Starting clean-up...")
+		log.Log.V(4).Info("Lease 'kyvernopre-lock' not found. Starting clean-up...")
 	} else {
-		log.Log.Info("Leader was elected, quitting")
+		log.Log.V(4).Info("Leader was elected, quitting")
 		os.Exit(0)
 	}
 
@@ -417,7 +417,7 @@ func deleteResource(client dclient.Interface, apiversion, kind, ns, name string)
 		return
 	}
 
-	log.Log.Info("successfully cleaned up resource", "kind", kind, "name", name)
+	log.Log.V(4).Info("successfully cleaned up resource", "kind", kind, "name", name)
 }
 
 func addSelectorLabel(client dclient.Interface, apiversion, kind, ns, name string) {
@@ -441,7 +441,7 @@ func addSelectorLabel(client dclient.Interface, apiversion, kind, ns, name strin
 		return
 	}
 
-	log.Log.Info("successfully updated resource labels", "kind", kind, "name", name)
+	log.Log.V(4).Info("successfully updated resource labels", "kind", kind, "name", name)
 }
 
 func convertGR(pclient kyvernoclient.Interface) error {

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -160,7 +160,7 @@ func main() {
 
 	if profile {
 		addr := ":" + profilePort
-		setupLog.V(4).Info("Enable profiling, see details at https://github.com/kyverno/kyverno/wiki/Profiling-Kyverno-on-Kubernetes", "port", profilePort)
+		setupLog.V(2).Info("Enable profiling, see details at https://github.com/kyverno/kyverno/wiki/Profiling-Kyverno-on-Kubernetes", "port", profilePort)
 		go func() {
 			if err := http.ListenAndServe(addr, nil); err != nil {
 				setupLog.Error(err, "Failed to enable profiling")
@@ -184,7 +184,7 @@ func main() {
 	// load image registry secrets
 	secrets := strings.Split(imagePullSecrets, ",")
 	if imagePullSecrets != "" && len(secrets) > 0 {
-		setupLog.Info("initializing registry credentials", "secrets", secrets)
+		setupLog.V(2).Info("initializing registry credentials", "secrets", secrets)
 		registryOptions = append(
 			registryOptions,
 			registryclient.WithKeychainPullSecrets(kubeClient, config.KyvernoNamespace(), "", secrets),
@@ -192,7 +192,7 @@ func main() {
 	}
 
 	if allowInsecureRegistry {
-		setupLog.Info("initializing registry with allowing insecure connections to registries")
+		setupLog.V(2).Info("initializing registry with allowing insecure connections to registries")
 		registryOptions = append(
 			registryOptions,
 			registryclient.WithAllowInsecureRegistry(),
@@ -303,7 +303,7 @@ func main() {
 
 	if otel == "prometheus" {
 		go func() {
-			setupLog.V(4).Info("Enabling Metrics for Kyverno", "address", metricsAddr)
+			setupLog.V(2).Info("Enabling Metrics for Kyverno", "address", metricsAddr)
 			if err := http.ListenAndServe(metricsAddr, metricsServerMux); err != nil {
 				setupLog.Error(err, "failed to enable metrics", "address", metricsAddr)
 			}
@@ -313,7 +313,7 @@ func main() {
 
 	// Tracing Configuration
 	if enableTracing {
-		setupLog.V(4).Info("Enabling tracing for Kyverno...")
+		setupLog.V(2).Info("Enabling tracing for Kyverno...")
 		tracerProvider, err := tracing.NewTraceConfig(otelCollector, transportCreds, kubeClient, log.Log.WithName("Tracing"))
 		if err != nil {
 			setupLog.Error(err, "Failed to enable tracing for Kyverno")
@@ -551,7 +551,7 @@ func main() {
 	// resource cleanup
 	// remove webhook configurations
 	<-cleanUp
-	setupLog.V(4).Info("Kyverno shutdown successful")
+	setupLog.V(2).Info("Kyverno shutdown successful")
 }
 
 func startOpenAPIController(client dclient.Interface, stopCh <-chan struct{}) *openapi.Controller {

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -160,7 +160,7 @@ func main() {
 
 	if profile {
 		addr := ":" + profilePort
-		setupLog.Info("Enable profiling, see details at https://github.com/kyverno/kyverno/wiki/Profiling-Kyverno-on-Kubernetes", "port", profilePort)
+		setupLog.V(4).Info("Enable profiling, see details at https://github.com/kyverno/kyverno/wiki/Profiling-Kyverno-on-Kubernetes", "port", profilePort)
 		go func() {
 			if err := http.ListenAndServe(addr, nil); err != nil {
 				setupLog.Error(err, "Failed to enable profiling")
@@ -303,7 +303,7 @@ func main() {
 
 	if otel == "prometheus" {
 		go func() {
-			setupLog.Info("Enabling Metrics for Kyverno", "address", metricsAddr)
+			setupLog.V(4).Info("Enabling Metrics for Kyverno", "address", metricsAddr)
 			if err := http.ListenAndServe(metricsAddr, metricsServerMux); err != nil {
 				setupLog.Error(err, "failed to enable metrics", "address", metricsAddr)
 			}
@@ -313,7 +313,7 @@ func main() {
 
 	// Tracing Configuration
 	if enableTracing {
-		setupLog.Info("Enabling tracing for Kyverno...")
+		setupLog.V(4).Info("Enabling tracing for Kyverno...")
 		tracerProvider, err := tracing.NewTraceConfig(otelCollector, transportCreds, kubeClient, log.Log.WithName("Tracing"))
 		if err != nil {
 			setupLog.Error(err, "Failed to enable tracing for Kyverno")
@@ -551,7 +551,7 @@ func main() {
 	// resource cleanup
 	// remove webhook configurations
 	<-cleanUp
-	setupLog.Info("Kyverno shutdown successful")
+	setupLog.V(4).Info("Kyverno shutdown successful")
 }
 
 func startOpenAPIController(client dclient.Interface, stopCh <-chan struct{}) *openapi.Controller {

--- a/pkg/background/common/labels.go
+++ b/pkg/background/common/labels.go
@@ -75,7 +75,7 @@ func managedBy(labels map[string]string) {
 	val, ok := labels[key]
 	if ok {
 		if val != value {
-			log.Log.V(4).Info(fmt.Sprintf("resource managed by %s, kyverno wont over-ride the label", val))
+			log.Log.V(2).Info(fmt.Sprintf("resource managed by %s, kyverno wont over-ride the label", val))
 			return
 		}
 	}
@@ -103,7 +103,7 @@ func checkGeneratedBy(labels map[string]string, key, value string) {
 	val, ok := labels[key]
 	if ok {
 		if val != value {
-			log.Log.V(4).Info(fmt.Sprintf("kyverno wont over-ride the label %s", key))
+			log.Log.V(2).Info(fmt.Sprintf("kyverno wont over-ride the label %s", key))
 			return
 		}
 	}

--- a/pkg/background/common/labels.go
+++ b/pkg/background/common/labels.go
@@ -75,7 +75,7 @@ func managedBy(labels map[string]string) {
 	val, ok := labels[key]
 	if ok {
 		if val != value {
-			log.Log.Info(fmt.Sprintf("resource managed by %s, kyverno wont over-ride the label", val))
+			log.Log.V(4).Info(fmt.Sprintf("resource managed by %s, kyverno wont over-ride the label", val))
 			return
 		}
 	}
@@ -103,7 +103,7 @@ func checkGeneratedBy(labels map[string]string, key, value string) {
 	val, ok := labels[key]
 	if ok {
 		if val != value {
-			log.Log.Info(fmt.Sprintf("kyverno wont over-ride the label %s", key))
+			log.Log.V(4).Info(fmt.Sprintf("kyverno wont over-ride the label %s", key))
 			return
 		}
 	}

--- a/pkg/background/common/resource.go
+++ b/pkg/background/common/resource.go
@@ -50,6 +50,6 @@ func GetResource(client dclient.Interface, urSpec kyvernov1beta1.UpdateRequestSp
 		return nil, err
 	}
 
-	log.V(4).Info("fetched trigger resource", "resourceSpec", resourceSpec)
+	log.V(2).Info("fetched trigger resource", "resourceSpec", resourceSpec)
 	return resource, err
 }

--- a/pkg/background/common/resource.go
+++ b/pkg/background/common/resource.go
@@ -50,6 +50,6 @@ func GetResource(client dclient.Interface, urSpec kyvernov1beta1.UpdateRequestSp
 		return nil, err
 	}
 
-	log.Info("fetched trigger resource", "resourceSpec", resourceSpec)
+	log.V(4).Info("fetched trigger resource", "resourceSpec", resourceSpec)
 	return resource, err
 }

--- a/pkg/engine/common/pattern.go
+++ b/pkg/engine/common/pattern.go
@@ -44,10 +44,10 @@ func ValidateValueWithPattern(log logr.Logger, value, pattern interface{}) bool 
 	case map[string]interface{}:
 		return validateValueWithMapPattern(log, value, typedPattern)
 	case []interface{}:
-		log.Info("arrays are not supported as patterns")
+		log.V(4).Info("arrays are not supported as patterns")
 		return false
 	default:
-		log.Info("Unknown type", "type", fmt.Sprintf("%T", typedPattern), "value", typedPattern)
+		log.V(4).Info("Unknown type", "type", fmt.Sprintf("%T", typedPattern), "value", typedPattern)
 		return false
 	}
 }
@@ -57,7 +57,7 @@ func validateValueWithMapPattern(log logr.Logger, value interface{}, typedPatter
 	// we only check for existence of object, not the equality of content and value
 	_, ok := value.(map[string]interface{})
 	if !ok {
-		log.Info("Expected type map[string]interface{}", "type", fmt.Sprintf("%T", value), "value", value)
+		log.V(4).Info("Expected type map[string]interface{}", "type", fmt.Sprintf("%T", value), "value", value)
 		return false
 	}
 	return true
@@ -76,7 +76,7 @@ func validateValueWithIntPattern(log logr.Logger, value interface{}, pattern int
 			return int64(typedValue) == pattern
 		}
 
-		log.Info("Expected type int", "type", fmt.Sprintf("%T", typedValue), "value", typedValue)
+		log.V(4).Info("Expected type int", "type", fmt.Sprintf("%T", typedValue), "value", typedValue)
 		return false
 	case string:
 		// extract int64 from string
@@ -87,7 +87,7 @@ func validateValueWithIntPattern(log logr.Logger, value interface{}, pattern int
 		}
 		return int64Num == pattern
 	default:
-		log.Info("Expected type int", "type", fmt.Sprintf("%T", value), "value", value)
+		log.V(4).Info("Expected type int", "type", fmt.Sprintf("%T", value), "value", value)
 		return false
 	}
 }
@@ -100,14 +100,14 @@ func validateValueWithFloatPattern(log logr.Logger, value interface{}, pattern f
 		if pattern == math.Trunc(pattern) {
 			return int(pattern) == value
 		}
-		log.Info("Expected type float", "type", fmt.Sprintf("%T", typedValue), "value", typedValue)
+		log.V(4).Info("Expected type float", "type", fmt.Sprintf("%T", typedValue), "value", typedValue)
 		return false
 	case int64:
 		// check that float has no fraction
 		if pattern == math.Trunc(pattern) {
 			return int64(pattern) == value
 		}
-		log.Info("Expected type float", "type", fmt.Sprintf("%T", typedValue), "value", typedValue)
+		log.V(4).Info("Expected type float", "type", fmt.Sprintf("%T", typedValue), "value", typedValue)
 		return false
 	case float64:
 		return typedValue == pattern
@@ -120,7 +120,7 @@ func validateValueWithFloatPattern(log logr.Logger, value interface{}, pattern f
 		}
 		return float64Num == pattern
 	default:
-		log.Info("Expected type float", "type", fmt.Sprintf("%T", value), "value", value)
+		log.V(4).Info("Expected type float", "type", fmt.Sprintf("%T", value), "value", value)
 		return false
 	}
 }
@@ -141,10 +141,10 @@ func validateValueWithNilPattern(log logr.Logger, value interface{}) bool {
 	case nil:
 		return true
 	case map[string]interface{}, []interface{}:
-		log.Info("Maps and arrays could not be checked with nil pattern")
+		log.V(4).Info("Maps and arrays could not be checked with nil pattern")
 		return false
 	default:
-		log.Info("Unknown type as value when checking for nil pattern", "type", fmt.Sprintf("%T", value), "value", value)
+		log.V(4).Info("Unknown type as value when checking for nil pattern", "type", fmt.Sprintf("%T", value), "value", value)
 		return false
 	}
 }
@@ -259,7 +259,7 @@ func validateString(log logr.Logger, value interface{}, pattern string, operator
 
 		return wildcardResult
 	}
-	log.Info("Operators >, >=, <, <= are not applicable to strings")
+	log.V(4).Info("Operators >, >=, <, <= are not applicable to strings")
 	return false
 }
 

--- a/pkg/engine/common/pattern.go
+++ b/pkg/engine/common/pattern.go
@@ -44,10 +44,10 @@ func ValidateValueWithPattern(log logr.Logger, value, pattern interface{}) bool 
 	case map[string]interface{}:
 		return validateValueWithMapPattern(log, value, typedPattern)
 	case []interface{}:
-		log.V(4).Info("arrays are not supported as patterns")
+		log.V(2).Info("arrays are not supported as patterns")
 		return false
 	default:
-		log.V(4).Info("Unknown type", "type", fmt.Sprintf("%T", typedPattern), "value", typedPattern)
+		log.V(2).Info("Unknown type", "type", fmt.Sprintf("%T", typedPattern), "value", typedPattern)
 		return false
 	}
 }
@@ -57,7 +57,7 @@ func validateValueWithMapPattern(log logr.Logger, value interface{}, typedPatter
 	// we only check for existence of object, not the equality of content and value
 	_, ok := value.(map[string]interface{})
 	if !ok {
-		log.V(4).Info("Expected type map[string]interface{}", "type", fmt.Sprintf("%T", value), "value", value)
+		log.V(2).Info("Expected type map[string]interface{}", "type", fmt.Sprintf("%T", value), "value", value)
 		return false
 	}
 	return true
@@ -76,7 +76,7 @@ func validateValueWithIntPattern(log logr.Logger, value interface{}, pattern int
 			return int64(typedValue) == pattern
 		}
 
-		log.V(4).Info("Expected type int", "type", fmt.Sprintf("%T", typedValue), "value", typedValue)
+		log.V(2).Info("Expected type int", "type", fmt.Sprintf("%T", typedValue), "value", typedValue)
 		return false
 	case string:
 		// extract int64 from string
@@ -87,7 +87,7 @@ func validateValueWithIntPattern(log logr.Logger, value interface{}, pattern int
 		}
 		return int64Num == pattern
 	default:
-		log.V(4).Info("Expected type int", "type", fmt.Sprintf("%T", value), "value", value)
+		log.V(2).Info("Expected type int", "type", fmt.Sprintf("%T", value), "value", value)
 		return false
 	}
 }
@@ -100,14 +100,14 @@ func validateValueWithFloatPattern(log logr.Logger, value interface{}, pattern f
 		if pattern == math.Trunc(pattern) {
 			return int(pattern) == value
 		}
-		log.V(4).Info("Expected type float", "type", fmt.Sprintf("%T", typedValue), "value", typedValue)
+		log.V(2).Info("Expected type float", "type", fmt.Sprintf("%T", typedValue), "value", typedValue)
 		return false
 	case int64:
 		// check that float has no fraction
 		if pattern == math.Trunc(pattern) {
 			return int64(pattern) == value
 		}
-		log.V(4).Info("Expected type float", "type", fmt.Sprintf("%T", typedValue), "value", typedValue)
+		log.V(2).Info("Expected type float", "type", fmt.Sprintf("%T", typedValue), "value", typedValue)
 		return false
 	case float64:
 		return typedValue == pattern
@@ -120,7 +120,7 @@ func validateValueWithFloatPattern(log logr.Logger, value interface{}, pattern f
 		}
 		return float64Num == pattern
 	default:
-		log.V(4).Info("Expected type float", "type", fmt.Sprintf("%T", value), "value", value)
+		log.V(2).Info("Expected type float", "type", fmt.Sprintf("%T", value), "value", value)
 		return false
 	}
 }
@@ -141,10 +141,10 @@ func validateValueWithNilPattern(log logr.Logger, value interface{}) bool {
 	case nil:
 		return true
 	case map[string]interface{}, []interface{}:
-		log.V(4).Info("Maps and arrays could not be checked with nil pattern")
+		log.V(2).Info("Maps and arrays could not be checked with nil pattern")
 		return false
 	default:
-		log.V(4).Info("Unknown type as value when checking for nil pattern", "type", fmt.Sprintf("%T", value), "value", value)
+		log.V(2).Info("Unknown type as value when checking for nil pattern", "type", fmt.Sprintf("%T", value), "value", value)
 		return false
 	}
 }
@@ -259,7 +259,7 @@ func validateString(log logr.Logger, value interface{}, pattern string, operator
 
 		return wildcardResult
 	}
-	log.V(4).Info("Operators >, >=, <, <= are not applicable to strings")
+	log.V(2).Info("Operators >, >=, <, <= are not applicable to strings")
 	return false
 }
 

--- a/pkg/engine/imageVerifyValidate.go
+++ b/pkg/engine/imageVerifyValidate.go
@@ -69,7 +69,7 @@ func processImageValidationRule(log logr.Logger, ctx *PolicyContext, rule *kyver
 func validateImage(ctx *PolicyContext, imageVerify *kyvernov1.ImageVerification, name string, imageInfo apiutils.ImageInfo, log logr.Logger) error {
 	image := imageInfo.String()
 	if imageVerify.VerifyDigest && imageInfo.Digest == "" {
-		log.V(4).Info("missing digest", "image", imageInfo.String())
+		log.V(2).Info("missing digest", "image", imageInfo.String())
 		return fmt.Errorf("missing digest for %s", image)
 	}
 

--- a/pkg/engine/imageVerifyValidate.go
+++ b/pkg/engine/imageVerifyValidate.go
@@ -69,7 +69,7 @@ func processImageValidationRule(log logr.Logger, ctx *PolicyContext, rule *kyver
 func validateImage(ctx *PolicyContext, imageVerify *kyvernov1.ImageVerification, name string, imageInfo apiutils.ImageInfo, log logr.Logger) error {
 	image := imageInfo.String()
 	if imageVerify.VerifyDigest && imageInfo.Digest == "" {
-		log.Info("missing digest", "image", imageInfo.String())
+		log.V(4).Info("missing digest", "image", imageInfo.String())
 		return fmt.Errorf("missing digest for %s", image)
 	}
 

--- a/pkg/engine/mutate/patch/strategicMergePatch.go
+++ b/pkg/engine/mutate/patch/strategicMergePatch.go
@@ -66,7 +66,7 @@ func ProcessStrategicMergePatch(ruleName string, overlay interface{}, resource u
 	if err != nil {
 		msg := fmt.Sprintf("failed to generated JSON patches from patched resource: %v", err.Error())
 		resp.Status = response.RuleStatusFail
-		log.V(4).Info(msg)
+		log.V(2).Info(msg)
 		resp.Message = msg
 		return resp, patchedResource
 	}

--- a/pkg/engine/mutate/patch/strategicMergePatch.go
+++ b/pkg/engine/mutate/patch/strategicMergePatch.go
@@ -66,7 +66,7 @@ func ProcessStrategicMergePatch(ruleName string, overlay interface{}, resource u
 	if err != nil {
 		msg := fmt.Sprintf("failed to generated JSON patches from patched resource: %v", err.Error())
 		resp.Status = response.RuleStatusFail
-		log.Info(msg)
+		log.V(4).Info(msg)
 		resp.Message = msg
 		return resp, patchedResource
 	}

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -250,7 +250,7 @@ func (v *validator) validate() *response.RuleResponse {
 		return ruleResponse
 	}
 
-	v.log.Info("invalid validation rule: either patterns or deny conditions are expected")
+	v.log.V(2).Info("invalid validation rule: either patterns or deny conditions are expected")
 	return nil
 }
 
@@ -275,7 +275,7 @@ func (v *validator) validateForEach() *response.RuleResponse {
 	for _, foreach := range foreachList {
 		elements, err := evaluateList(foreach.List, v.ctx.JSONContext)
 		if err != nil {
-			v.log.Info("failed to evaluate list", "list", foreach.List, "error", err.Error())
+			v.log.V(3).Info("failed to evaluate list", "list", foreach.List, "error", err.Error())
 			continue
 		}
 
@@ -312,10 +312,10 @@ func (v *validator) validateElements(foreach kyvernov1.ForEachValidation, elemen
 		foreachValidator := newForeachValidator(foreach, v.rule, ctx, v.log)
 		r := foreachValidator.validate()
 		if r == nil {
-			v.log.Info("skip rule due to empty result")
+			v.log.V(3).Info("skip rule due to empty result")
 			continue
 		} else if r.Status == response.RuleStatusSkip {
-			v.log.Info("skip rule", "reason", r.Message)
+			v.log.V(3).Info("skip rule", "reason", r.Message)
 			continue
 		} else if r.Status != response.RuleStatusPass {
 			msg := fmt.Sprintf("validation failure: %v", r.Message)
@@ -592,7 +592,7 @@ func (v *validator) buildErrorMessage(err error, path string) string {
 
 	msgRaw, sErr := variables.SubstituteAll(v.log, v.ctx.JSONContext, v.rule.Validation.Message)
 	if sErr != nil {
-		v.log.Info("failed to substitute variables in message: %v", sErr)
+		v.log.V(3).Info("failed to substitute variables in message: %v", sErr)
 	}
 
 	msg := msgRaw.(string)

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -275,7 +275,7 @@ func (v *validator) validateForEach() *response.RuleResponse {
 	for _, foreach := range foreachList {
 		elements, err := evaluateList(foreach.List, v.ctx.JSONContext)
 		if err != nil {
-			v.log.V(3).Info("failed to evaluate list", "list", foreach.List, "error", err.Error())
+			v.log.V(2).Info("failed to evaluate list", "list", foreach.List, "error", err.Error())
 			continue
 		}
 
@@ -312,10 +312,10 @@ func (v *validator) validateElements(foreach kyvernov1.ForEachValidation, elemen
 		foreachValidator := newForeachValidator(foreach, v.rule, ctx, v.log)
 		r := foreachValidator.validate()
 		if r == nil {
-			v.log.V(3).Info("skip rule due to empty result")
+			v.log.V(2).Info("skip rule due to empty result")
 			continue
 		} else if r.Status == response.RuleStatusSkip {
-			v.log.V(3).Info("skip rule", "reason", r.Message)
+			v.log.V(2).Info("skip rule", "reason", r.Message)
 			continue
 		} else if r.Status != response.RuleStatusPass {
 			msg := fmt.Sprintf("validation failure: %v", r.Message)
@@ -592,7 +592,7 @@ func (v *validator) buildErrorMessage(err error, path string) string {
 
 	msgRaw, sErr := variables.SubstituteAll(v.log, v.ctx.JSONContext, v.rule.Validation.Message)
 	if sErr != nil {
-		v.log.V(3).Info("failed to substitute variables in message: %v", sErr)
+		v.log.V(2).Info("failed to substitute variables in message: %v", sErr)
 	}
 
 	msg := msgRaw.(string)

--- a/pkg/engine/variables/operator/allin.go
+++ b/pkg/engine/variables/operator/allin.go
@@ -38,7 +38,7 @@ func (allin AllInHandler) Evaluate(key, value interface{}) bool {
 		}
 		return allin.validateValueWithStringSetPattern(stringSlice, value)
 	default:
-		allin.log.Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		allin.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -46,7 +46,7 @@ func (allin AllInHandler) Evaluate(key, value interface{}) bool {
 func (allin AllInHandler) validateValueWithStringPattern(key string, value interface{}) (keyExists bool) {
 	invalidType, keyExists := allKeyExistsInArray(key, value, allin.log)
 	if invalidType {
-		allin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		allin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
@@ -98,7 +98,7 @@ func allKeyExistsInArray(key string, value interface{}, log logr.Logger) (invali
 func (allin AllInHandler) validateValueWithStringSetPattern(key []string, value interface{}) (keyExists bool) {
 	invalidType, isAllIn := allSetExistsInArray(key, value, allin.log, false)
 	if invalidType {
-		allin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		allin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 

--- a/pkg/engine/variables/operator/allin.go
+++ b/pkg/engine/variables/operator/allin.go
@@ -38,7 +38,7 @@ func (allin AllInHandler) Evaluate(key, value interface{}) bool {
 		}
 		return allin.validateValueWithStringSetPattern(stringSlice, value)
 	default:
-		allin.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		allin.log.V(2).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -46,7 +46,7 @@ func (allin AllInHandler) Evaluate(key, value interface{}) bool {
 func (allin AllInHandler) validateValueWithStringPattern(key string, value interface{}) (keyExists bool) {
 	invalidType, keyExists := allKeyExistsInArray(key, value, allin.log)
 	if invalidType {
-		allin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		allin.log.V(2).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
@@ -98,7 +98,7 @@ func allKeyExistsInArray(key string, value interface{}, log logr.Logger) (invali
 func (allin AllInHandler) validateValueWithStringSetPattern(key []string, value interface{}) (keyExists bool) {
 	invalidType, isAllIn := allSetExistsInArray(key, value, allin.log, false)
 	if invalidType {
-		allin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		allin.log.V(2).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 

--- a/pkg/engine/variables/operator/allnotin.go
+++ b/pkg/engine/variables/operator/allnotin.go
@@ -35,7 +35,7 @@ func (allnin AllNotInHandler) Evaluate(key, value interface{}) bool {
 		}
 		return allnin.validateValueWithStringSetPattern(stringSlice, value)
 	default:
-		allnin.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		allnin.log.V(2).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -43,7 +43,7 @@ func (allnin AllNotInHandler) Evaluate(key, value interface{}) bool {
 func (allnin AllNotInHandler) validateValueWithStringPattern(key string, value interface{}) bool {
 	invalidType, keyExists := allKeyExistsInArray(key, value, allnin.log)
 	if invalidType {
-		allnin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		allnin.log.V(2).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
@@ -53,7 +53,7 @@ func (allnin AllNotInHandler) validateValueWithStringPattern(key string, value i
 func (allnin AllNotInHandler) validateValueWithStringSetPattern(key []string, value interface{}) bool {
 	invalidType, isNotIn := allSetExistsInArray(key, value, allnin.log, true)
 	if invalidType {
-		allnin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		allnin.log.V(2).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 

--- a/pkg/engine/variables/operator/allnotin.go
+++ b/pkg/engine/variables/operator/allnotin.go
@@ -35,7 +35,7 @@ func (allnin AllNotInHandler) Evaluate(key, value interface{}) bool {
 		}
 		return allnin.validateValueWithStringSetPattern(stringSlice, value)
 	default:
-		allnin.log.Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		allnin.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -43,7 +43,7 @@ func (allnin AllNotInHandler) Evaluate(key, value interface{}) bool {
 func (allnin AllNotInHandler) validateValueWithStringPattern(key string, value interface{}) bool {
 	invalidType, keyExists := allKeyExistsInArray(key, value, allnin.log)
 	if invalidType {
-		allnin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		allnin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
@@ -53,7 +53,7 @@ func (allnin AllNotInHandler) validateValueWithStringPattern(key string, value i
 func (allnin AllNotInHandler) validateValueWithStringSetPattern(key []string, value interface{}) bool {
 	invalidType, isNotIn := allSetExistsInArray(key, value, allnin.log, true)
 	if invalidType {
-		allnin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		allnin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 

--- a/pkg/engine/variables/operator/anyin.go
+++ b/pkg/engine/variables/operator/anyin.go
@@ -40,7 +40,7 @@ func (anyin AnyInHandler) Evaluate(key, value interface{}) bool {
 		}
 		return anyin.validateValueWithStringSetPattern(stringSlice, value)
 	default:
-		anyin.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		anyin.log.V(2).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -48,7 +48,7 @@ func (anyin AnyInHandler) Evaluate(key, value interface{}) bool {
 func (anyin AnyInHandler) validateValueWithStringPattern(key string, value interface{}) (keyExists bool) {
 	invalidType, keyExists := anyKeyExistsInArray(key, value, anyin.log)
 	if invalidType {
-		anyin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		anyin.log.V(2).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
@@ -111,7 +111,7 @@ func handleRange(key string, value interface{}, log logr.Logger) bool {
 func (anyin AnyInHandler) validateValueWithStringSetPattern(key []string, value interface{}) (keyExists bool) {
 	invalidType, isAnyIn := anySetExistsInArray(key, value, anyin.log, false)
 	if invalidType {
-		anyin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		anyin.log.V(2).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 

--- a/pkg/engine/variables/operator/anyin.go
+++ b/pkg/engine/variables/operator/anyin.go
@@ -40,7 +40,7 @@ func (anyin AnyInHandler) Evaluate(key, value interface{}) bool {
 		}
 		return anyin.validateValueWithStringSetPattern(stringSlice, value)
 	default:
-		anyin.log.Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		anyin.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -48,7 +48,7 @@ func (anyin AnyInHandler) Evaluate(key, value interface{}) bool {
 func (anyin AnyInHandler) validateValueWithStringPattern(key string, value interface{}) (keyExists bool) {
 	invalidType, keyExists := anyKeyExistsInArray(key, value, anyin.log)
 	if invalidType {
-		anyin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		anyin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
@@ -111,7 +111,7 @@ func handleRange(key string, value interface{}, log logr.Logger) bool {
 func (anyin AnyInHandler) validateValueWithStringSetPattern(key []string, value interface{}) (keyExists bool) {
 	invalidType, isAnyIn := anySetExistsInArray(key, value, anyin.log, false)
 	if invalidType {
-		anyin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		anyin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 

--- a/pkg/engine/variables/operator/anynotin.go
+++ b/pkg/engine/variables/operator/anynotin.go
@@ -35,7 +35,7 @@ func (anynin AnyNotInHandler) Evaluate(key, value interface{}) bool {
 		}
 		return anynin.validateValueWithStringSetPattern(stringSlice, value)
 	default:
-		anynin.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		anynin.log.V(2).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -43,7 +43,7 @@ func (anynin AnyNotInHandler) Evaluate(key, value interface{}) bool {
 func (anynin AnyNotInHandler) validateValueWithStringPattern(key string, value interface{}) bool {
 	invalidType, keyExists := anyKeyExistsInArray(key, value, anynin.log)
 	if invalidType {
-		anynin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		anynin.log.V(2).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
@@ -53,7 +53,7 @@ func (anynin AnyNotInHandler) validateValueWithStringPattern(key string, value i
 func (anynin AnyNotInHandler) validateValueWithStringSetPattern(key []string, value interface{}) bool {
 	invalidType, isAnyNotIn := anySetExistsInArray(key, value, anynin.log, true)
 	if invalidType {
-		anynin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		anynin.log.V(2).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 

--- a/pkg/engine/variables/operator/anynotin.go
+++ b/pkg/engine/variables/operator/anynotin.go
@@ -35,7 +35,7 @@ func (anynin AnyNotInHandler) Evaluate(key, value interface{}) bool {
 		}
 		return anynin.validateValueWithStringSetPattern(stringSlice, value)
 	default:
-		anynin.log.Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		anynin.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -43,7 +43,7 @@ func (anynin AnyNotInHandler) Evaluate(key, value interface{}) bool {
 func (anynin AnyNotInHandler) validateValueWithStringPattern(key string, value interface{}) bool {
 	invalidType, keyExists := anyKeyExistsInArray(key, value, anynin.log)
 	if invalidType {
-		anynin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		anynin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
@@ -53,7 +53,7 @@ func (anynin AnyNotInHandler) validateValueWithStringPattern(key string, value i
 func (anynin AnyNotInHandler) validateValueWithStringSetPattern(key []string, value interface{}) bool {
 	invalidType, isAnyNotIn := anySetExistsInArray(key, value, anynin.log, true)
 	if invalidType {
-		anynin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		anynin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 

--- a/pkg/engine/variables/operator/duration.go
+++ b/pkg/engine/variables/operator/duration.go
@@ -37,7 +37,7 @@ func durationCompareByCondition(key time.Duration, value time.Duration, op kyver
 	case kyvernov1.ConditionOperators["DurationLessThan"]:
 		return key < value
 	default:
-		log.V(4).Info(fmt.Sprintf("Expected operator, one of [DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan], found %s", op))
+		log.V(2).Info(fmt.Sprintf("Expected operator, one of [DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan], found %s", op))
 		return false
 	}
 }
@@ -53,7 +53,7 @@ func (doh DurationOperatorHandler) Evaluate(key, value interface{}) bool {
 	case string:
 		return doh.validateValueWithStringPattern(typedKey, value)
 	default:
-		doh.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		doh.log.V(2).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -74,7 +74,7 @@ func (doh DurationOperatorHandler) validateValueWithIntPattern(key int64, value 
 		doh.log.Error(fmt.Errorf("parse error: "), "Failed to parse time duration from the string value")
 		return false
 	default:
-		doh.log.V(4).Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
+		doh.log.V(2).Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }
@@ -95,7 +95,7 @@ func (doh DurationOperatorHandler) validateValueWithFloatPattern(key float64, va
 		doh.log.Error(fmt.Errorf("parse error: "), "Failed to parse time duration from the string value")
 		return false
 	default:
-		doh.log.V(4).Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
+		doh.log.V(2).Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }
@@ -121,7 +121,7 @@ func (doh DurationOperatorHandler) validateValueWithStringPattern(key string, va
 		doh.log.Error(fmt.Errorf("parse error: "), "Failed to parse time duration from the string value")
 		return false
 	default:
-		doh.log.V(4).Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
+		doh.log.V(2).Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }

--- a/pkg/engine/variables/operator/duration.go
+++ b/pkg/engine/variables/operator/duration.go
@@ -37,7 +37,7 @@ func durationCompareByCondition(key time.Duration, value time.Duration, op kyver
 	case kyvernov1.ConditionOperators["DurationLessThan"]:
 		return key < value
 	default:
-		log.Info(fmt.Sprintf("Expected operator, one of [DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan], found %s", op))
+		log.V(4).Info(fmt.Sprintf("Expected operator, one of [DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan], found %s", op))
 		return false
 	}
 }
@@ -53,7 +53,7 @@ func (doh DurationOperatorHandler) Evaluate(key, value interface{}) bool {
 	case string:
 		return doh.validateValueWithStringPattern(typedKey, value)
 	default:
-		doh.log.Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		doh.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -74,7 +74,7 @@ func (doh DurationOperatorHandler) validateValueWithIntPattern(key int64, value 
 		doh.log.Error(fmt.Errorf("parse error: "), "Failed to parse time duration from the string value")
 		return false
 	default:
-		doh.log.Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
+		doh.log.V(4).Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }
@@ -95,7 +95,7 @@ func (doh DurationOperatorHandler) validateValueWithFloatPattern(key float64, va
 		doh.log.Error(fmt.Errorf("parse error: "), "Failed to parse time duration from the string value")
 		return false
 	default:
-		doh.log.Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
+		doh.log.V(4).Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }
@@ -121,7 +121,7 @@ func (doh DurationOperatorHandler) validateValueWithStringPattern(key string, va
 		doh.log.Error(fmt.Errorf("parse error: "), "Failed to parse time duration from the string value")
 		return false
 	default:
-		doh.log.Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
+		doh.log.V(4).Info("Unexpected type", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }

--- a/pkg/engine/variables/operator/equal.go
+++ b/pkg/engine/variables/operator/equal.go
@@ -45,7 +45,7 @@ func (eh EqualHandler) Evaluate(key, value interface{}) bool {
 	case []interface{}:
 		return eh.validateValueWithSlicePattern(typedKey, value)
 	default:
-		eh.log.Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		eh.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -54,7 +54,7 @@ func (eh EqualHandler) validateValueWithSlicePattern(key []interface{}, value in
 	if val, ok := value.([]interface{}); ok {
 		return reflect.DeepEqual(key, val)
 	}
-	eh.log.Info("Expected type []interface{}", "value", value, "type", fmt.Sprintf("%T", value))
+	eh.log.V(4).Info("Expected type []interface{}", "value", value, "type", fmt.Sprintf("%T", value))
 	return false
 }
 
@@ -62,7 +62,7 @@ func (eh EqualHandler) validateValueWithMapPattern(key map[string]interface{}, v
 	if val, ok := value.(map[string]interface{}); ok {
 		return reflect.DeepEqual(key, val)
 	}
-	eh.log.Info("Expected type map[string]interface{}", "value", value, "type", fmt.Sprintf("%T", value))
+	eh.log.V(4).Info("Expected type map[string]interface{}", "value", value, "type", fmt.Sprintf("%T", value))
 	return false
 }
 
@@ -91,7 +91,7 @@ func (eh EqualHandler) validateValueWithStringPattern(key string, value interfac
 		return wildcard.Match(val, key)
 	}
 
-	eh.log.Info("Expected type string", "value", value, "type", fmt.Sprintf("%T", value))
+	eh.log.V(4).Info("Expected type string", "value", value, "type", fmt.Sprintf("%T", value))
 	return false
 }
 
@@ -102,13 +102,13 @@ func (eh EqualHandler) validateValueWithFloatPattern(key float64, value interfac
 		if key == math.Trunc(key) {
 			return int(key) == typedValue
 		}
-		eh.log.Info("Expected type float, found int", "typedValue", typedValue)
+		eh.log.V(4).Info("Expected type float, found int", "typedValue", typedValue)
 	case int64:
 		// check that float has not fraction
 		if key == math.Trunc(key) {
 			return int64(key) == typedValue
 		}
-		eh.log.Info("Expected type float, found int", "typedValue", typedValue)
+		eh.log.V(4).Info("Expected type float, found int", "typedValue", typedValue)
 	case float64:
 		return typedValue == key
 	case string:
@@ -120,7 +120,7 @@ func (eh EqualHandler) validateValueWithFloatPattern(key float64, value interfac
 		}
 		return float64Num == key
 	default:
-		eh.log.Info("Expected type float", "value", value, "type", fmt.Sprintf("%T", value))
+		eh.log.V(4).Info("Expected type float", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 	return false
@@ -129,7 +129,7 @@ func (eh EqualHandler) validateValueWithFloatPattern(key float64, value interfac
 func (eh EqualHandler) validateValueWithBoolPattern(key bool, value interface{}) bool {
 	typedValue, ok := value.(bool)
 	if !ok {
-		eh.log.Info("Expected type bool", "value", value, "type", fmt.Sprintf("%T", value))
+		eh.log.V(4).Info("Expected type bool", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 	return key == typedValue
@@ -146,7 +146,7 @@ func (eh EqualHandler) validateValueWithIntPattern(key int64, value interface{})
 		if typedValue == math.Trunc(typedValue) {
 			return int64(typedValue) == key
 		}
-		eh.log.Info("Expected type int, found float", "value", typedValue, "type", fmt.Sprintf("%T", typedValue))
+		eh.log.V(4).Info("Expected type int, found float", "value", typedValue, "type", fmt.Sprintf("%T", typedValue))
 		return false
 	case string:
 		// extract in64 from string
@@ -157,7 +157,7 @@ func (eh EqualHandler) validateValueWithIntPattern(key int64, value interface{})
 		}
 		return int64Num == key
 	default:
-		eh.log.Info("Expected type int", "value", value, "type", fmt.Sprintf("%T", value))
+		eh.log.V(4).Info("Expected type int", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }

--- a/pkg/engine/variables/operator/equal.go
+++ b/pkg/engine/variables/operator/equal.go
@@ -45,7 +45,7 @@ func (eh EqualHandler) Evaluate(key, value interface{}) bool {
 	case []interface{}:
 		return eh.validateValueWithSlicePattern(typedKey, value)
 	default:
-		eh.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		eh.log.V(2).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -54,7 +54,7 @@ func (eh EqualHandler) validateValueWithSlicePattern(key []interface{}, value in
 	if val, ok := value.([]interface{}); ok {
 		return reflect.DeepEqual(key, val)
 	}
-	eh.log.V(4).Info("Expected type []interface{}", "value", value, "type", fmt.Sprintf("%T", value))
+	eh.log.V(2).Info("Expected type []interface{}", "value", value, "type", fmt.Sprintf("%T", value))
 	return false
 }
 
@@ -62,7 +62,7 @@ func (eh EqualHandler) validateValueWithMapPattern(key map[string]interface{}, v
 	if val, ok := value.(map[string]interface{}); ok {
 		return reflect.DeepEqual(key, val)
 	}
-	eh.log.V(4).Info("Expected type map[string]interface{}", "value", value, "type", fmt.Sprintf("%T", value))
+	eh.log.V(2).Info("Expected type map[string]interface{}", "value", value, "type", fmt.Sprintf("%T", value))
 	return false
 }
 
@@ -91,7 +91,7 @@ func (eh EqualHandler) validateValueWithStringPattern(key string, value interfac
 		return wildcard.Match(val, key)
 	}
 
-	eh.log.V(4).Info("Expected type string", "value", value, "type", fmt.Sprintf("%T", value))
+	eh.log.V(2).Info("Expected type string", "value", value, "type", fmt.Sprintf("%T", value))
 	return false
 }
 
@@ -102,13 +102,13 @@ func (eh EqualHandler) validateValueWithFloatPattern(key float64, value interfac
 		if key == math.Trunc(key) {
 			return int(key) == typedValue
 		}
-		eh.log.V(4).Info("Expected type float, found int", "typedValue", typedValue)
+		eh.log.V(2).Info("Expected type float, found int", "typedValue", typedValue)
 	case int64:
 		// check that float has not fraction
 		if key == math.Trunc(key) {
 			return int64(key) == typedValue
 		}
-		eh.log.V(4).Info("Expected type float, found int", "typedValue", typedValue)
+		eh.log.V(2).Info("Expected type float, found int", "typedValue", typedValue)
 	case float64:
 		return typedValue == key
 	case string:
@@ -120,7 +120,7 @@ func (eh EqualHandler) validateValueWithFloatPattern(key float64, value interfac
 		}
 		return float64Num == key
 	default:
-		eh.log.V(4).Info("Expected type float", "value", value, "type", fmt.Sprintf("%T", value))
+		eh.log.V(2).Info("Expected type float", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 	return false
@@ -129,7 +129,7 @@ func (eh EqualHandler) validateValueWithFloatPattern(key float64, value interfac
 func (eh EqualHandler) validateValueWithBoolPattern(key bool, value interface{}) bool {
 	typedValue, ok := value.(bool)
 	if !ok {
-		eh.log.V(4).Info("Expected type bool", "value", value, "type", fmt.Sprintf("%T", value))
+		eh.log.V(2).Info("Expected type bool", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 	return key == typedValue
@@ -146,7 +146,7 @@ func (eh EqualHandler) validateValueWithIntPattern(key int64, value interface{})
 		if typedValue == math.Trunc(typedValue) {
 			return int64(typedValue) == key
 		}
-		eh.log.V(4).Info("Expected type int, found float", "value", typedValue, "type", fmt.Sprintf("%T", typedValue))
+		eh.log.V(2).Info("Expected type int, found float", "value", typedValue, "type", fmt.Sprintf("%T", typedValue))
 		return false
 	case string:
 		// extract in64 from string
@@ -157,7 +157,7 @@ func (eh EqualHandler) validateValueWithIntPattern(key int64, value interface{})
 		}
 		return int64Num == key
 	default:
-		eh.log.V(4).Info("Expected type int", "value", value, "type", fmt.Sprintf("%T", value))
+		eh.log.V(2).Info("Expected type int", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }

--- a/pkg/engine/variables/operator/in.go
+++ b/pkg/engine/variables/operator/in.go
@@ -39,7 +39,7 @@ func (in InHandler) Evaluate(key, value interface{}) bool {
 		}
 		return in.validateValueWithStringSetPattern(stringSlice, value)
 	default:
-		in.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		in.log.V(2).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -47,7 +47,7 @@ func (in InHandler) Evaluate(key, value interface{}) bool {
 func (in InHandler) validateValueWithStringPattern(key string, value interface{}) (keyExists bool) {
 	invalidType, keyExists := keyExistsInArray(key, value, in.log)
 	if invalidType {
-		in.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		in.log.V(2).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
@@ -94,7 +94,7 @@ func keyExistsInArray(key string, value interface{}, log logr.Logger) (invalidTy
 func (in InHandler) validateValueWithStringSetPattern(key []string, value interface{}) (keyExists bool) {
 	invalidType, isIn := setExistsInArray(key, value, in.log, false)
 	if invalidType {
-		in.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		in.log.V(2).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 

--- a/pkg/engine/variables/operator/in.go
+++ b/pkg/engine/variables/operator/in.go
@@ -39,7 +39,7 @@ func (in InHandler) Evaluate(key, value interface{}) bool {
 		}
 		return in.validateValueWithStringSetPattern(stringSlice, value)
 	default:
-		in.log.Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		in.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -47,7 +47,7 @@ func (in InHandler) Evaluate(key, value interface{}) bool {
 func (in InHandler) validateValueWithStringPattern(key string, value interface{}) (keyExists bool) {
 	invalidType, keyExists := keyExistsInArray(key, value, in.log)
 	if invalidType {
-		in.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		in.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
@@ -94,7 +94,7 @@ func keyExistsInArray(key string, value interface{}, log logr.Logger) (invalidTy
 func (in InHandler) validateValueWithStringSetPattern(key []string, value interface{}) (keyExists bool) {
 	invalidType, isIn := setExistsInArray(key, value, in.log, false)
 	if invalidType {
-		in.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		in.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 

--- a/pkg/engine/variables/operator/notequal.go
+++ b/pkg/engine/variables/operator/notequal.go
@@ -45,7 +45,7 @@ func (neh NotEqualHandler) Evaluate(key, value interface{}) bool {
 	case []interface{}:
 		return neh.validateValueWithSlicePattern(typedKey, value)
 	default:
-		neh.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		neh.log.V(2).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -54,7 +54,7 @@ func (neh NotEqualHandler) validateValueWithSlicePattern(key []interface{}, valu
 	if val, ok := value.([]interface{}); ok {
 		return !reflect.DeepEqual(key, val)
 	}
-	neh.log.V(4).Info("Expected type []interface{}", "value", value, "type", fmt.Sprintf("%T", value))
+	neh.log.V(2).Info("Expected type []interface{}", "value", value, "type", fmt.Sprintf("%T", value))
 	return true
 }
 
@@ -62,7 +62,7 @@ func (neh NotEqualHandler) validateValueWithMapPattern(key map[string]interface{
 	if val, ok := value.(map[string]interface{}); ok {
 		return !reflect.DeepEqual(key, val)
 	}
-	neh.log.V(4).Info("Expected type map[string]interface{}", "value", value, "type", fmt.Sprintf("%T", value))
+	neh.log.V(2).Info("Expected type map[string]interface{}", "value", value, "type", fmt.Sprintf("%T", value))
 	return true
 }
 
@@ -96,7 +96,7 @@ func (neh NotEqualHandler) validateValueWithStringPattern(key string, value inte
 		return !wildcard.Match(val, key)
 	}
 
-	neh.log.V(4).Info("Expected type string", "value", value, "type", fmt.Sprintf("%T", value))
+	neh.log.V(2).Info("Expected type string", "value", value, "type", fmt.Sprintf("%T", value))
 	return true
 }
 
@@ -107,13 +107,13 @@ func (neh NotEqualHandler) validateValueWithFloatPattern(key float64, value inte
 		if key == math.Trunc(key) {
 			return int(key) != typedValue
 		}
-		neh.log.V(4).Info("Expected type float, found int", "typedValue", typedValue)
+		neh.log.V(2).Info("Expected type float, found int", "typedValue", typedValue)
 	case int64:
 		// check that float has not fraction
 		if key == math.Trunc(key) {
 			return int64(key) != typedValue
 		}
-		neh.log.V(4).Info("Expected type float, found int", "typedValue", typedValue)
+		neh.log.V(2).Info("Expected type float, found int", "typedValue", typedValue)
 	case float64:
 		return typedValue != key
 	case string:
@@ -125,7 +125,7 @@ func (neh NotEqualHandler) validateValueWithFloatPattern(key float64, value inte
 		}
 		return float64Num != key
 	default:
-		neh.log.V(4).Info("Expected type float", "value", value, "type", fmt.Sprintf("%T", value))
+		neh.log.V(2).Info("Expected type float", "value", value, "type", fmt.Sprintf("%T", value))
 		return true
 	}
 	return true
@@ -134,7 +134,7 @@ func (neh NotEqualHandler) validateValueWithFloatPattern(key float64, value inte
 func (neh NotEqualHandler) validateValueWithBoolPattern(key bool, value interface{}) bool {
 	typedValue, ok := value.(bool)
 	if !ok {
-		neh.log.V(4).Info("Expected type bool", "value", value, "type", fmt.Sprintf("%T", value))
+		neh.log.V(2).Info("Expected type bool", "value", value, "type", fmt.Sprintf("%T", value))
 		return true
 	}
 	return key != typedValue
@@ -151,7 +151,7 @@ func (neh NotEqualHandler) validateValueWithIntPattern(key int64, value interfac
 		if typedValue == math.Trunc(typedValue) {
 			return int64(typedValue) != key
 		}
-		neh.log.V(4).Info("Expected type int, found float", "value", typedValue, "type", fmt.Sprintf("%T", typedValue))
+		neh.log.V(2).Info("Expected type int, found float", "value", typedValue, "type", fmt.Sprintf("%T", typedValue))
 		return false
 	case string:
 		// extract in64 from string
@@ -162,7 +162,7 @@ func (neh NotEqualHandler) validateValueWithIntPattern(key int64, value interfac
 		}
 		return int64Num != key
 	default:
-		neh.log.V(4).Info("Expected type int", "value", value, "type", fmt.Sprintf("%T", value))
+		neh.log.V(2).Info("Expected type int", "value", value, "type", fmt.Sprintf("%T", value))
 		return true
 	}
 }

--- a/pkg/engine/variables/operator/notequal.go
+++ b/pkg/engine/variables/operator/notequal.go
@@ -45,7 +45,7 @@ func (neh NotEqualHandler) Evaluate(key, value interface{}) bool {
 	case []interface{}:
 		return neh.validateValueWithSlicePattern(typedKey, value)
 	default:
-		neh.log.Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		neh.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -54,7 +54,7 @@ func (neh NotEqualHandler) validateValueWithSlicePattern(key []interface{}, valu
 	if val, ok := value.([]interface{}); ok {
 		return !reflect.DeepEqual(key, val)
 	}
-	neh.log.Info("Expected type []interface{}", "value", value, "type", fmt.Sprintf("%T", value))
+	neh.log.V(4).Info("Expected type []interface{}", "value", value, "type", fmt.Sprintf("%T", value))
 	return true
 }
 
@@ -62,7 +62,7 @@ func (neh NotEqualHandler) validateValueWithMapPattern(key map[string]interface{
 	if val, ok := value.(map[string]interface{}); ok {
 		return !reflect.DeepEqual(key, val)
 	}
-	neh.log.Info("Expected type map[string]interface{}", "value", value, "type", fmt.Sprintf("%T", value))
+	neh.log.V(4).Info("Expected type map[string]interface{}", "value", value, "type", fmt.Sprintf("%T", value))
 	return true
 }
 
@@ -96,7 +96,7 @@ func (neh NotEqualHandler) validateValueWithStringPattern(key string, value inte
 		return !wildcard.Match(val, key)
 	}
 
-	neh.log.Info("Expected type string", "value", value, "type", fmt.Sprintf("%T", value))
+	neh.log.V(4).Info("Expected type string", "value", value, "type", fmt.Sprintf("%T", value))
 	return true
 }
 
@@ -107,13 +107,13 @@ func (neh NotEqualHandler) validateValueWithFloatPattern(key float64, value inte
 		if key == math.Trunc(key) {
 			return int(key) != typedValue
 		}
-		neh.log.Info("Expected type float, found int", "typedValue", typedValue)
+		neh.log.V(4).Info("Expected type float, found int", "typedValue", typedValue)
 	case int64:
 		// check that float has not fraction
 		if key == math.Trunc(key) {
 			return int64(key) != typedValue
 		}
-		neh.log.Info("Expected type float, found int", "typedValue", typedValue)
+		neh.log.V(4).Info("Expected type float, found int", "typedValue", typedValue)
 	case float64:
 		return typedValue != key
 	case string:
@@ -125,7 +125,7 @@ func (neh NotEqualHandler) validateValueWithFloatPattern(key float64, value inte
 		}
 		return float64Num != key
 	default:
-		neh.log.Info("Expected type float", "value", value, "type", fmt.Sprintf("%T", value))
+		neh.log.V(4).Info("Expected type float", "value", value, "type", fmt.Sprintf("%T", value))
 		return true
 	}
 	return true
@@ -134,7 +134,7 @@ func (neh NotEqualHandler) validateValueWithFloatPattern(key float64, value inte
 func (neh NotEqualHandler) validateValueWithBoolPattern(key bool, value interface{}) bool {
 	typedValue, ok := value.(bool)
 	if !ok {
-		neh.log.Info("Expected type bool", "value", value, "type", fmt.Sprintf("%T", value))
+		neh.log.V(4).Info("Expected type bool", "value", value, "type", fmt.Sprintf("%T", value))
 		return true
 	}
 	return key != typedValue
@@ -151,7 +151,7 @@ func (neh NotEqualHandler) validateValueWithIntPattern(key int64, value interfac
 		if typedValue == math.Trunc(typedValue) {
 			return int64(typedValue) != key
 		}
-		neh.log.Info("Expected type int, found float", "value", typedValue, "type", fmt.Sprintf("%T", typedValue))
+		neh.log.V(4).Info("Expected type int, found float", "value", typedValue, "type", fmt.Sprintf("%T", typedValue))
 		return false
 	case string:
 		// extract in64 from string
@@ -162,7 +162,7 @@ func (neh NotEqualHandler) validateValueWithIntPattern(key int64, value interfac
 		}
 		return int64Num != key
 	default:
-		neh.log.Info("Expected type int", "value", value, "type", fmt.Sprintf("%T", value))
+		neh.log.V(4).Info("Expected type int", "value", value, "type", fmt.Sprintf("%T", value))
 		return true
 	}
 }

--- a/pkg/engine/variables/operator/notin.go
+++ b/pkg/engine/variables/operator/notin.go
@@ -37,7 +37,7 @@ func (nin NotInHandler) Evaluate(key, value interface{}) bool {
 		}
 		return nin.validateValueWithStringSetPattern(stringSlice, value)
 	default:
-		nin.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		nin.log.V(2).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -45,7 +45,7 @@ func (nin NotInHandler) Evaluate(key, value interface{}) bool {
 func (nin NotInHandler) validateValueWithStringPattern(key string, value interface{}) bool {
 	invalidType, keyExists := keyExistsInArray(key, value, nin.log)
 	if invalidType {
-		nin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		nin.log.V(2).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
@@ -55,7 +55,7 @@ func (nin NotInHandler) validateValueWithStringPattern(key string, value interfa
 func (nin NotInHandler) validateValueWithStringSetPattern(key []string, value interface{}) bool {
 	invalidType, isNotIn := setExistsInArray(key, value, nin.log, true)
 	if invalidType {
-		nin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		nin.log.V(2).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 

--- a/pkg/engine/variables/operator/notin.go
+++ b/pkg/engine/variables/operator/notin.go
@@ -37,7 +37,7 @@ func (nin NotInHandler) Evaluate(key, value interface{}) bool {
 		}
 		return nin.validateValueWithStringSetPattern(stringSlice, value)
 	default:
-		nin.log.Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		nin.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -45,7 +45,7 @@ func (nin NotInHandler) Evaluate(key, value interface{}) bool {
 func (nin NotInHandler) validateValueWithStringPattern(key string, value interface{}) bool {
 	invalidType, keyExists := keyExistsInArray(key, value, nin.log)
 	if invalidType {
-		nin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		nin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 
@@ -55,7 +55,7 @@ func (nin NotInHandler) validateValueWithStringPattern(key string, value interfa
 func (nin NotInHandler) validateValueWithStringSetPattern(key []string, value interface{}) bool {
 	invalidType, isNotIn := setExistsInArray(key, value, nin.log, true)
 	if invalidType {
-		nin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
+		nin.log.V(4).Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 

--- a/pkg/engine/variables/operator/numeric.go
+++ b/pkg/engine/variables/operator/numeric.go
@@ -39,7 +39,7 @@ func compareByCondition(key float64, value float64, op kyvernov1.ConditionOperat
 	case kyvernov1.ConditionOperators["LessThan"]:
 		return key < value
 	default:
-		log.Info(fmt.Sprintf("Expected operator, one of [GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, Equals, NotEquals], found %s", op))
+		log.V(4).Info(fmt.Sprintf("Expected operator, one of [GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, Equals, NotEquals], found %s", op))
 		return false
 	}
 }
@@ -55,7 +55,7 @@ func compareVersionByCondition(key semver.Version, value semver.Version, op kyve
 	case kyvernov1.ConditionOperators["LessThan"]:
 		return key.LT(value)
 	default:
-		log.Info(fmt.Sprintf("Expected operator, one of [GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, Equals, NotEquals], found %s", op))
+		log.V(4).Info(fmt.Sprintf("Expected operator, one of [GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, Equals, NotEquals], found %s", op))
 		return false
 	}
 }
@@ -71,7 +71,7 @@ func (noh NumericOperatorHandler) Evaluate(key, value interface{}) bool {
 	case string:
 		return noh.validateValueWithStringPattern(typedKey, value)
 	default:
-		noh.log.Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		noh.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -101,7 +101,7 @@ func (noh NumericOperatorHandler) validateValueWithIntPattern(key int64, value i
 		noh.log.Error(fmt.Errorf("parse error: "), "Failed to parse both float64 and int64 from the string value")
 		return false
 	default:
-		noh.log.Info("Expected type int", "value", value, "type", fmt.Sprintf("%T", value))
+		noh.log.V(4).Info("Expected type int", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }
@@ -130,7 +130,7 @@ func (noh NumericOperatorHandler) validateValueWithFloatPattern(key float64, val
 		noh.log.Error(fmt.Errorf("parse error: "), "Failed to parse both float64 and int64 from the string value")
 		return false
 	default:
-		noh.log.Info("Expected type float", "value", value, "type", fmt.Sprintf("%T", value))
+		noh.log.V(4).Info("Expected type float", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }
@@ -145,7 +145,7 @@ func (noh NumericOperatorHandler) validateValueWithVersionPattern(key semver.Ver
 		}
 		return compareVersionByCondition(key, versionValue, noh.condition, noh.log)
 	default:
-		noh.log.Info("Expected type string", "value", value, "type", fmt.Sprintf("%T", value))
+		noh.log.V(4).Info("Expected type string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }

--- a/pkg/engine/variables/operator/numeric.go
+++ b/pkg/engine/variables/operator/numeric.go
@@ -39,7 +39,7 @@ func compareByCondition(key float64, value float64, op kyvernov1.ConditionOperat
 	case kyvernov1.ConditionOperators["LessThan"]:
 		return key < value
 	default:
-		log.V(4).Info(fmt.Sprintf("Expected operator, one of [GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, Equals, NotEquals], found %s", op))
+		log.V(2).Info(fmt.Sprintf("Expected operator, one of [GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, Equals, NotEquals], found %s", op))
 		return false
 	}
 }
@@ -55,7 +55,7 @@ func compareVersionByCondition(key semver.Version, value semver.Version, op kyve
 	case kyvernov1.ConditionOperators["LessThan"]:
 		return key.LT(value)
 	default:
-		log.V(4).Info(fmt.Sprintf("Expected operator, one of [GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, Equals, NotEquals], found %s", op))
+		log.V(2).Info(fmt.Sprintf("Expected operator, one of [GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, Equals, NotEquals], found %s", op))
 		return false
 	}
 }
@@ -71,7 +71,7 @@ func (noh NumericOperatorHandler) Evaluate(key, value interface{}) bool {
 	case string:
 		return noh.validateValueWithStringPattern(typedKey, value)
 	default:
-		noh.log.V(4).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
+		noh.log.V(2).Info("Unsupported type", "value", typedKey, "type", fmt.Sprintf("%T", typedKey))
 		return false
 	}
 }
@@ -101,7 +101,7 @@ func (noh NumericOperatorHandler) validateValueWithIntPattern(key int64, value i
 		noh.log.Error(fmt.Errorf("parse error: "), "Failed to parse both float64 and int64 from the string value")
 		return false
 	default:
-		noh.log.V(4).Info("Expected type int", "value", value, "type", fmt.Sprintf("%T", value))
+		noh.log.V(2).Info("Expected type int", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }
@@ -130,7 +130,7 @@ func (noh NumericOperatorHandler) validateValueWithFloatPattern(key float64, val
 		noh.log.Error(fmt.Errorf("parse error: "), "Failed to parse both float64 and int64 from the string value")
 		return false
 	default:
-		noh.log.V(4).Info("Expected type float", "value", value, "type", fmt.Sprintf("%T", value))
+		noh.log.V(2).Info("Expected type float", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }
@@ -145,7 +145,7 @@ func (noh NumericOperatorHandler) validateValueWithVersionPattern(key semver.Ver
 		}
 		return compareVersionByCondition(key, versionValue, noh.condition, noh.log)
 	default:
-		noh.log.V(4).Info("Expected type string", "value", value, "type", fmt.Sprintf("%T", value))
+		noh.log.V(2).Info("Expected type string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false
 	}
 }

--- a/pkg/engine/variables/operator/operator.go
+++ b/pkg/engine/variables/operator/operator.go
@@ -66,11 +66,11 @@ func CreateOperatorHandler(log logr.Logger, ctx context.EvalInterface, op kyvern
 		strings.ToLower(string(kyvernov1.ConditionOperators["DurationGreaterThan"])),
 		strings.ToLower(string(kyvernov1.ConditionOperators["DurationLessThanOrEquals"])),
 		strings.ToLower(string(kyvernov1.ConditionOperators["DurationLessThan"])):
-		log.V(3).Info("DEPRECATED: The Duration* operators have been replaced with the other existing operators that now also support duration values", "operator", str)
+		log.V(2).Info("DEPRECATED: The Duration* operators have been replaced with the other existing operators that now also support duration values", "operator", str)
 		return NewDurationOperatorHandler(log, ctx, op)
 
 	default:
-		log.V(4).Info("operator not supported", "operator", str)
+		log.V(2).Info("operator not supported", "operator", str)
 	}
 
 	return nil

--- a/pkg/engine/variables/operator/operator.go
+++ b/pkg/engine/variables/operator/operator.go
@@ -66,11 +66,11 @@ func CreateOperatorHandler(log logr.Logger, ctx context.EvalInterface, op kyvern
 		strings.ToLower(string(kyvernov1.ConditionOperators["DurationGreaterThan"])),
 		strings.ToLower(string(kyvernov1.ConditionOperators["DurationLessThanOrEquals"])),
 		strings.ToLower(string(kyvernov1.ConditionOperators["DurationLessThan"])):
-		log.Info("DEPRECATED: The Duration* operators have been replaced with the other existing operators that now also support duration values", "operator", str)
+		log.V(3).Info("DEPRECATED: The Duration* operators have been replaced with the other existing operators that now also support duration values", "operator", str)
 		return NewDurationOperatorHandler(log, ctx, op)
 
 	default:
-		log.Info("operator not supported", "operator", str)
+		log.V(4).Info("operator not supported", "operator", str)
 	}
 
 	return nil

--- a/pkg/event/controller.go
+++ b/pkg/event/controller.go
@@ -165,7 +165,7 @@ func (gen *Generator) processNextWorkItem() bool {
 	var ok bool
 	if key, ok = obj.(Info); !ok {
 		gen.queue.Forget(obj)
-		gen.log.Info("Incorrect type; expected type 'info'", "obj", obj)
+		gen.log.V(4).Info("Incorrect type; expected type 'info'", "obj", obj)
 		return true
 	}
 	err := gen.syncHandler(key)

--- a/pkg/event/controller.go
+++ b/pkg/event/controller.go
@@ -165,7 +165,7 @@ func (gen *Generator) processNextWorkItem() bool {
 	var ok bool
 	if key, ok = obj.(Info); !ok {
 		gen.queue.Forget(obj)
-		gen.log.V(4).Info("Incorrect type; expected type 'info'", "obj", obj)
+		gen.log.V(2).Info("Incorrect type; expected type 'info'", "obj", obj)
 		return true
 	}
 	err := gen.syncHandler(key)

--- a/pkg/metrics/admissionrequests/admissionRequests.go
+++ b/pkg/metrics/admissionrequests/admissionRequests.go
@@ -15,11 +15,11 @@ func registerAdmissionRequestsMetric(
 ) error {
 	includeNamespaces, excludeNamespaces := m.Config.GetIncludeNamespaces(), m.Config.GetExcludeNamespaces()
 	if (resourceNamespace != "" && resourceNamespace != "-") && utils.ContainsString(excludeNamespaces, resourceNamespace) {
-		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_admission_requests_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
+		m.Log.V(2).Info(fmt.Sprintf("Skipping the registration of kyverno_admission_requests_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
 		return nil
 	}
 	if (resourceNamespace != "" && resourceNamespace != "-") && len(includeNamespaces) > 0 && !utils.ContainsString(includeNamespaces, resourceNamespace) {
-		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_admission_requests_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
+		m.Log.V(2).Info(fmt.Sprintf("Skipping the registration of kyverno_admission_requests_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
 		return nil
 	}
 

--- a/pkg/metrics/admissionrequests/admissionRequests.go
+++ b/pkg/metrics/admissionrequests/admissionRequests.go
@@ -15,11 +15,11 @@ func registerAdmissionRequestsMetric(
 ) error {
 	includeNamespaces, excludeNamespaces := m.Config.GetIncludeNamespaces(), m.Config.GetExcludeNamespaces()
 	if (resourceNamespace != "" && resourceNamespace != "-") && utils.ContainsString(excludeNamespaces, resourceNamespace) {
-		m.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_admission_requests_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
+		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_admission_requests_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
 		return nil
 	}
 	if (resourceNamespace != "" && resourceNamespace != "-") && len(includeNamespaces) > 0 && !utils.ContainsString(includeNamespaces, resourceNamespace) {
-		m.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_admission_requests_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
+		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_admission_requests_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
 		return nil
 	}
 

--- a/pkg/metrics/admissionreviewduration/admissionReviewDuration.go
+++ b/pkg/metrics/admissionreviewduration/admissionReviewDuration.go
@@ -16,11 +16,11 @@ func registerAdmissionReviewDurationMetric(
 ) error {
 	includeNamespaces, excludeNamespaces := m.Config.GetIncludeNamespaces(), m.Config.GetExcludeNamespaces()
 	if (resourceNamespace != "" && resourceNamespace != "-") && utils.ContainsString(excludeNamespaces, resourceNamespace) {
-		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_admission_review_duration_seconds metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
+		m.Log.V(2).Info(fmt.Sprintf("Skipping the registration of kyverno_admission_review_duration_seconds metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
 		return nil
 	}
 	if (resourceNamespace != "" && resourceNamespace != "-") && len(includeNamespaces) > 0 && !utils.ContainsString(includeNamespaces, resourceNamespace) {
-		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_admission_review_duration_seconds metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
+		m.Log.V(2).Info(fmt.Sprintf("Skipping the registration of kyverno_admission_review_duration_seconds metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
 		return nil
 	}
 

--- a/pkg/metrics/admissionreviewduration/admissionReviewDuration.go
+++ b/pkg/metrics/admissionreviewduration/admissionReviewDuration.go
@@ -16,11 +16,11 @@ func registerAdmissionReviewDurationMetric(
 ) error {
 	includeNamespaces, excludeNamespaces := m.Config.GetIncludeNamespaces(), m.Config.GetExcludeNamespaces()
 	if (resourceNamespace != "" && resourceNamespace != "-") && utils.ContainsString(excludeNamespaces, resourceNamespace) {
-		m.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_admission_review_duration_seconds metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
+		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_admission_review_duration_seconds metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
 		return nil
 	}
 	if (resourceNamespace != "" && resourceNamespace != "-") && len(includeNamespaces) > 0 && !utils.ContainsString(includeNamespaces, resourceNamespace) {
-		m.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_admission_review_duration_seconds metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
+		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_admission_review_duration_seconds metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
 		return nil
 	}
 

--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -26,7 +26,7 @@ func InitMetrics(
 	if !disableMetricsExport {
 		if otel == "grpc" {
 			// Otlpgrpc metrics will be served on port 4317: default port for otlpgrpcmetrics
-			log.V(4).Info("Enabling Metrics for Kyverno", "address", metricsAddr)
+			log.V(2).Info("Enabling Metrics for Kyverno", "address", metricsAddr)
 
 			endpoint := otelCollector + metricsAddr
 			metricsConfig, pusher, err = NewOTLPGRPCConfig(

--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -26,7 +26,7 @@ func InitMetrics(
 	if !disableMetricsExport {
 		if otel == "grpc" {
 			// Otlpgrpc metrics will be served on port 4317: default port for otlpgrpcmetrics
-			log.Info("Enabling Metrics for Kyverno", "address", metricsAddr)
+			log.V(4).Info("Enabling Metrics for Kyverno", "address", metricsAddr)
 
 			endpoint := otelCollector + metricsAddr
 			metricsConfig, pusher, err = NewOTLPGRPCConfig(

--- a/pkg/metrics/policychanges/policyChanges.go
+++ b/pkg/metrics/policychanges/policyChanges.go
@@ -21,11 +21,11 @@ func registerPolicyChangesMetric(
 	}
 	includeNamespaces, excludeNamespaces := m.Config.GetIncludeNamespaces(), m.Config.GetExcludeNamespaces()
 	if (policyNamespace != "" && policyNamespace != "-") && utils.ContainsString(excludeNamespaces, policyNamespace) {
-		m.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_policy_changes_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", policyNamespace, excludeNamespaces))
+		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_changes_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", policyNamespace, excludeNamespaces))
 		return nil
 	}
 	if (policyNamespace != "" && policyNamespace != "-") && len(includeNamespaces) > 0 && !utils.ContainsString(includeNamespaces, policyNamespace) {
-		m.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_policy_changes_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", policyNamespace, includeNamespaces))
+		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_changes_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", policyNamespace, includeNamespaces))
 		return nil
 	}
 

--- a/pkg/metrics/policychanges/policyChanges.go
+++ b/pkg/metrics/policychanges/policyChanges.go
@@ -21,11 +21,11 @@ func registerPolicyChangesMetric(
 	}
 	includeNamespaces, excludeNamespaces := m.Config.GetIncludeNamespaces(), m.Config.GetExcludeNamespaces()
 	if (policyNamespace != "" && policyNamespace != "-") && utils.ContainsString(excludeNamespaces, policyNamespace) {
-		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_changes_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", policyNamespace, excludeNamespaces))
+		m.Log.V(2).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_changes_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", policyNamespace, excludeNamespaces))
 		return nil
 	}
 	if (policyNamespace != "" && policyNamespace != "-") && len(includeNamespaces) > 0 && !utils.ContainsString(includeNamespaces, policyNamespace) {
-		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_changes_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", policyNamespace, includeNamespaces))
+		m.Log.V(2).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_changes_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", policyNamespace, includeNamespaces))
 		return nil
 	}
 

--- a/pkg/metrics/policyexecutionduration/policyExecutionDuration.go
+++ b/pkg/metrics/policyexecutionduration/policyExecutionDuration.go
@@ -32,11 +32,11 @@ func registerPolicyExecutionDurationMetric(
 	}
 	includeNamespaces, excludeNamespaces := m.Config.GetIncludeNamespaces(), m.Config.GetExcludeNamespaces()
 	if (resourceNamespace != "" && resourceNamespace != "-") && utils.ContainsString(excludeNamespaces, resourceNamespace) {
-		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_execution_duration_seconds metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
+		m.Log.V(2).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_execution_duration_seconds metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
 		return nil
 	}
 	if (resourceNamespace != "" && resourceNamespace != "-") && len(includeNamespaces) > 0 && !utils.ContainsString(includeNamespaces, resourceNamespace) {
-		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_execution_duration_seconds metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
+		m.Log.V(2).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_execution_duration_seconds metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
 		return nil
 	}
 

--- a/pkg/metrics/policyexecutionduration/policyExecutionDuration.go
+++ b/pkg/metrics/policyexecutionduration/policyExecutionDuration.go
@@ -32,11 +32,11 @@ func registerPolicyExecutionDurationMetric(
 	}
 	includeNamespaces, excludeNamespaces := m.Config.GetIncludeNamespaces(), m.Config.GetExcludeNamespaces()
 	if (resourceNamespace != "" && resourceNamespace != "-") && utils.ContainsString(excludeNamespaces, resourceNamespace) {
-		m.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_policy_execution_duration_seconds metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
+		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_execution_duration_seconds metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
 		return nil
 	}
 	if (resourceNamespace != "" && resourceNamespace != "-") && len(includeNamespaces) > 0 && !utils.ContainsString(includeNamespaces, resourceNamespace) {
-		m.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_policy_execution_duration_seconds metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
+		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_execution_duration_seconds metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
 		return nil
 	}
 

--- a/pkg/metrics/policyresults/policyResults.go
+++ b/pkg/metrics/policyresults/policyResults.go
@@ -27,11 +27,11 @@ func registerPolicyResultsMetric(
 	}
 	includeNamespaces, excludeNamespaces := m.Config.GetIncludeNamespaces(), m.Config.GetExcludeNamespaces()
 	if (resourceNamespace != "" && resourceNamespace != "-") && utils.ContainsString(excludeNamespaces, resourceNamespace) {
-		m.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_policy_results_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
+		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_results_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
 		return nil
 	}
 	if (resourceNamespace != "" && resourceNamespace != "-") && len(includeNamespaces) > 0 && !utils.ContainsString(includeNamespaces, resourceNamespace) {
-		m.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_policy_results_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
+		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_results_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
 		return nil
 	}
 

--- a/pkg/metrics/policyresults/policyResults.go
+++ b/pkg/metrics/policyresults/policyResults.go
@@ -27,11 +27,11 @@ func registerPolicyResultsMetric(
 	}
 	includeNamespaces, excludeNamespaces := m.Config.GetIncludeNamespaces(), m.Config.GetExcludeNamespaces()
 	if (resourceNamespace != "" && resourceNamespace != "-") && utils.ContainsString(excludeNamespaces, resourceNamespace) {
-		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_results_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
+		m.Log.V(2).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_results_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", resourceNamespace, excludeNamespaces))
 		return nil
 	}
 	if (resourceNamespace != "" && resourceNamespace != "-") && len(includeNamespaces) > 0 && !utils.ContainsString(includeNamespaces, resourceNamespace) {
-		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_results_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
+		m.Log.V(2).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_results_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", resourceNamespace, includeNamespaces))
 		return nil
 	}
 

--- a/pkg/metrics/policyruleinfo/policyRuleInfo.go
+++ b/pkg/metrics/policyruleinfo/policyRuleInfo.go
@@ -30,11 +30,11 @@ func registerPolicyRuleInfoMetric(
 	}
 	includeNamespaces, excludeNamespaces := m.Config.GetIncludeNamespaces(), m.Config.GetExcludeNamespaces()
 	if (policyNamespace != "" && policyNamespace != "-") && utils.ContainsString(excludeNamespaces, policyNamespace) {
-		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_rule_info_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", policyNamespace, excludeNamespaces))
+		m.Log.V(2).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_rule_info_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", policyNamespace, excludeNamespaces))
 		return nil
 	}
 	if (policyNamespace != "" && policyNamespace != "-") && len(includeNamespaces) > 0 && !utils.ContainsString(includeNamespaces, policyNamespace) {
-		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_rule_info_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", policyNamespace, includeNamespaces))
+		m.Log.V(2).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_rule_info_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", policyNamespace, includeNamespaces))
 		return nil
 	}
 	if policyType == metrics.Cluster {

--- a/pkg/metrics/policyruleinfo/policyRuleInfo.go
+++ b/pkg/metrics/policyruleinfo/policyRuleInfo.go
@@ -30,11 +30,11 @@ func registerPolicyRuleInfoMetric(
 	}
 	includeNamespaces, excludeNamespaces := m.Config.GetIncludeNamespaces(), m.Config.GetExcludeNamespaces()
 	if (policyNamespace != "" && policyNamespace != "-") && utils.ContainsString(excludeNamespaces, policyNamespace) {
-		m.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_policy_rule_info_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", policyNamespace, excludeNamespaces))
+		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_rule_info_total metric as the operation belongs to the namespace '%s' which is one of 'namespaces.exclude' %+v in values.yaml", policyNamespace, excludeNamespaces))
 		return nil
 	}
 	if (policyNamespace != "" && policyNamespace != "-") && len(includeNamespaces) > 0 && !utils.ContainsString(includeNamespaces, policyNamespace) {
-		m.Log.Info(fmt.Sprintf("Skipping the registration of kyverno_policy_rule_info_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", policyNamespace, includeNamespaces))
+		m.Log.V(3).Info(fmt.Sprintf("Skipping the registration of kyverno_policy_rule_info_total metric as the operation belongs to the namespace '%s' which is not one of 'namespaces.include' %+v in values.yaml", policyNamespace, includeNamespaces))
 		return nil
 	}
 	if policyType == metrics.Cluster {

--- a/pkg/openapi/validation.go
+++ b/pkg/openapi/validation.go
@@ -368,7 +368,7 @@ func (o *Controller) generateEmptyResource(kindSchema *openapiv2.Schema) interfa
 		return getBoolValue(kindSchema)
 	}
 
-	log.Log.V(4).Info("unknown type", types[0])
+	log.Log.V(2).Info("unknown type", types[0])
 	return nil
 }
 

--- a/pkg/openapi/validation.go
+++ b/pkg/openapi/validation.go
@@ -368,7 +368,7 @@ func (o *Controller) generateEmptyResource(kindSchema *openapiv2.Schema) interfa
 		return getBoolValue(kindSchema)
 	}
 
-	log.Log.Info("unknown type", types[0])
+	log.Log.V(4).Info("unknown type", types[0])
 	return nil
 }
 

--- a/pkg/policy/updaterequest.go
+++ b/pkg/policy/updaterequest.go
@@ -117,7 +117,7 @@ func (pc *PolicyController) handleUpdateRequest(ur *kyvernov1beta1.UpdateRequest
 			continue
 		}
 
-		pc.log.Info("creating new UR for generate")
+		pc.log.V(4).Info("creating new UR for generate")
 		_, err := pc.kyvernoClient.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace()).Create(context.TODO(), ur, metav1.CreateOptions{})
 		if err != nil {
 			return false, err

--- a/pkg/policy/updaterequest.go
+++ b/pkg/policy/updaterequest.go
@@ -59,7 +59,7 @@ func (pc *PolicyController) updateUR(policyKey string, policy kyvernov1.PolicyIn
 				if skip {
 					continue
 				}
-				pc.log.V(4).Info("successfully created UR on policy update", "policy", policy.GetName(), "rule", rule.Name, "rule type", ruleType,
+				pc.log.V(2).Info("successfully created UR on policy update", "policy", policy.GetName(), "rule", rule.Name, "rule type", ruleType,
 					"target", fmt.Sprintf("%s/%s/%s/%s", trigger.GetAPIVersion(), trigger.GetKind(), trigger.GetNamespace(), trigger.GetName()))
 			}
 		}
@@ -117,7 +117,7 @@ func (pc *PolicyController) handleUpdateRequest(ur *kyvernov1beta1.UpdateRequest
 			continue
 		}
 
-		pc.log.V(4).Info("creating new UR for generate")
+		pc.log.V(2).Info("creating new UR for generate")
 		_, err := pc.kyvernoClient.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace()).Create(context.TODO(), ur, metav1.CreateOptions{})
 		if err != nil {
 			return false, err

--- a/pkg/policyreport/reportcontroller.go
+++ b/pkg/policyreport/reportcontroller.go
@@ -232,7 +232,7 @@ func (g *ReportGenerator) deletePolicyReport(obj interface{}) {
 	if ok {
 		g.log.V(2).Info("PolicyReport deleted", "name", report.GetName())
 	} else {
-		g.log.Info("Failed to get deleted object", "obj", obj)
+		g.log.V(3).Info("Failed to get deleted object", "obj", obj)
 	}
 	g.ReconcileCh <- false
 }
@@ -299,7 +299,7 @@ func (g *ReportGenerator) processNextWorkItem() bool {
 	keyStr, ok := key.(string)
 	if !ok {
 		g.queue.Forget(key)
-		g.log.Info("incorrect type; expecting type 'string'", "obj", key)
+		g.log.V(4).Info("incorrect type; expecting type 'string'", "obj", key)
 		return true
 	}
 
@@ -367,7 +367,7 @@ func (g *ReportGenerator) syncHandler(key string) (aggregatedRequests interface{
 	report, err = g.reportLister.PolicyReports(namespace).Get(GeneratePolicyReportName(namespace, policyName))
 	if err == nil {
 		if val, ok := report.GetLabels()[inactiveLabelKey]; ok && val == inactiveLabelVal {
-			g.log.Info("got resourceExhausted error, please opt-in via \"splitPolicyReport\" to generate report per policy")
+			g.log.V(3).Info("got resourceExhausted error, please opt-in via \"splitPolicyReport\" to generate report per policy")
 			return aggregatedRequests, nil
 		}
 	}

--- a/pkg/policyreport/reportcontroller.go
+++ b/pkg/policyreport/reportcontroller.go
@@ -232,7 +232,7 @@ func (g *ReportGenerator) deletePolicyReport(obj interface{}) {
 	if ok {
 		g.log.V(2).Info("PolicyReport deleted", "name", report.GetName())
 	} else {
-		g.log.V(3).Info("Failed to get deleted object", "obj", obj)
+		g.log.V(2).Info("Failed to get deleted object", "obj", obj)
 	}
 	g.ReconcileCh <- false
 }
@@ -299,7 +299,7 @@ func (g *ReportGenerator) processNextWorkItem() bool {
 	keyStr, ok := key.(string)
 	if !ok {
 		g.queue.Forget(key)
-		g.log.V(4).Info("incorrect type; expecting type 'string'", "obj", key)
+		g.log.V(2).Info("incorrect type; expecting type 'string'", "obj", key)
 		return true
 	}
 
@@ -367,7 +367,7 @@ func (g *ReportGenerator) syncHandler(key string) (aggregatedRequests interface{
 	report, err = g.reportLister.PolicyReports(namespace).Get(GeneratePolicyReportName(namespace, policyName))
 	if err == nil {
 		if val, ok := report.GetLabels()[inactiveLabelKey]; ok && val == inactiveLabelVal {
-			g.log.V(3).Info("got resourceExhausted error, please opt-in via \"splitPolicyReport\" to generate report per policy")
+			g.log.V(2).Info("got resourceExhausted error, please opt-in via \"splitPolicyReport\" to generate report per policy")
 			return aggregatedRequests, nil
 		}
 	}

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -122,7 +122,7 @@ func isCRDInstalled(discoveryClient dclient.IDiscovery, kind string) bool {
 		return false
 	}
 
-	log.Log.Info("CRD found", "gvr", gvr.String())
+	log.Log.V(4).Info("CRD found", "gvr", gvr.String())
 	return true
 }
 

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -122,7 +122,7 @@ func isCRDInstalled(discoveryClient dclient.IDiscovery, kind string) bool {
 		return false
 	}
 
-	log.Log.V(4).Info("CRD found", "gvr", gvr.String())
+	log.Log.V(2).Info("CRD found", "gvr", gvr.String())
 	return true
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,7 +14,7 @@ var (
 
 // PrintVersionInfo displays the kyverno version - git version
 func PrintVersionInfo(log logr.Logger) {
-	log.Info("Kyverno", "Version", BuildVersion)
-	log.Info("Kyverno", "BuildHash", BuildHash)
-	log.Info("Kyverno", "BuildTime", BuildTime)
+	log.V(4).Info("Kyverno", "Version", BuildVersion)
+	log.V(4).Info("Kyverno", "BuildHash", BuildHash)
+	log.V(4).Info("Kyverno", "BuildTime", BuildTime)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,7 +14,7 @@ var (
 
 // PrintVersionInfo displays the kyverno version - git version
 func PrintVersionInfo(log logr.Logger) {
-	log.V(4).Info("Kyverno", "Version", BuildVersion)
-	log.V(4).Info("Kyverno", "BuildHash", BuildHash)
-	log.V(4).Info("Kyverno", "BuildTime", BuildTime)
+	log.V(2).Info("Kyverno", "Version", BuildVersion)
+	log.V(2).Info("Kyverno", "BuildHash", BuildHash)
+	log.V(2).Info("Kyverno", "BuildTime", BuildTime)
 }

--- a/pkg/webhookconfig/configmanager.go
+++ b/pkg/webhookconfig/configmanager.go
@@ -155,7 +155,7 @@ func (m *webhookConfigManager) deleteClusterPolicy(obj interface{}) {
 	p, ok := kubeutils.GetObjectWithTombstone(obj).(*kyvernov1.ClusterPolicy)
 	if !ok {
 		// utilruntime.HandleError(fmt.Errorf("error decoding object tombstone, invalid type"))
-		m.log.V(3).Info("Failed to get deleted object", "obj", obj)
+		m.log.V(2).Info("Failed to get deleted object", "obj", obj)
 		return
 	}
 	if hasWildcard(&p.Spec) {
@@ -189,7 +189,7 @@ func (m *webhookConfigManager) deletePolicy(obj interface{}) {
 	p, ok := kubeutils.GetObjectWithTombstone(obj).(*kyvernov1.Policy)
 	if !ok {
 		// utilruntime.HandleError(fmt.Errorf("error decoding object tombstone, invalid type"))
-		m.log.V(3).Info("Failed to get deleted object", "obj", obj)
+		m.log.V(2).Info("Failed to get deleted object", "obj", obj)
 		return
 	}
 	if hasWildcard(&p.Spec) {
@@ -202,7 +202,7 @@ func (m *webhookConfigManager) deleteMutatingWebhook(obj interface{}) {
 	m.log.WithName("deleteMutatingWebhook").Info("resource webhook configuration was deleted, recreating...")
 	webhook, ok := kubeutils.GetObjectWithTombstone(obj).(*admissionregistrationv1.MutatingWebhookConfiguration)
 	if !ok {
-		m.log.V(3).Info("Failed to get deleted object", "obj", obj)
+		m.log.V(2).Info("Failed to get deleted object", "obj", obj)
 		return
 	}
 	if webhook.GetName() == config.MutatingWebhookConfigurationName {
@@ -214,7 +214,7 @@ func (m *webhookConfigManager) deleteValidatingWebhook(obj interface{}) {
 	m.log.WithName("deleteMutatingWebhook").Info("resource webhook configuration was deleted, recreating...")
 	webhook, ok := kubeutils.GetObjectWithTombstone(obj).(*admissionregistrationv1.ValidatingWebhookConfiguration)
 	if !ok {
-		m.log.V(3).Info("Failed to get deleted object", "obj", obj)
+		m.log.V(2).Info("Failed to get deleted object", "obj", obj)
 		return
 	}
 	if webhook.GetName() == config.ValidatingWebhookConfigurationName {
@@ -249,8 +249,8 @@ func (m *webhookConfigManager) start() {
 	defer utilruntime.HandleCrash()
 	defer m.queue.ShutDown()
 
-	m.log.V(4).Info("starting")
-	defer m.log.V(4).Info("shutting down")
+	m.log.V(2).Info("starting")
+	defer m.log.V(2).Info("shutting down")
 
 	m.pInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    m.addClusterPolicy,

--- a/pkg/webhookconfig/configmanager.go
+++ b/pkg/webhookconfig/configmanager.go
@@ -155,7 +155,7 @@ func (m *webhookConfigManager) deleteClusterPolicy(obj interface{}) {
 	p, ok := kubeutils.GetObjectWithTombstone(obj).(*kyvernov1.ClusterPolicy)
 	if !ok {
 		// utilruntime.HandleError(fmt.Errorf("error decoding object tombstone, invalid type"))
-		m.log.Info("Failed to get deleted object", "obj", obj)
+		m.log.V(3).Info("Failed to get deleted object", "obj", obj)
 		return
 	}
 	if hasWildcard(&p.Spec) {
@@ -189,7 +189,7 @@ func (m *webhookConfigManager) deletePolicy(obj interface{}) {
 	p, ok := kubeutils.GetObjectWithTombstone(obj).(*kyvernov1.Policy)
 	if !ok {
 		// utilruntime.HandleError(fmt.Errorf("error decoding object tombstone, invalid type"))
-		m.log.Info("Failed to get deleted object", "obj", obj)
+		m.log.V(3).Info("Failed to get deleted object", "obj", obj)
 		return
 	}
 	if hasWildcard(&p.Spec) {
@@ -202,7 +202,7 @@ func (m *webhookConfigManager) deleteMutatingWebhook(obj interface{}) {
 	m.log.WithName("deleteMutatingWebhook").Info("resource webhook configuration was deleted, recreating...")
 	webhook, ok := kubeutils.GetObjectWithTombstone(obj).(*admissionregistrationv1.MutatingWebhookConfiguration)
 	if !ok {
-		m.log.Info("Failed to get deleted object", "obj", obj)
+		m.log.V(3).Info("Failed to get deleted object", "obj", obj)
 		return
 	}
 	if webhook.GetName() == config.MutatingWebhookConfigurationName {
@@ -214,7 +214,7 @@ func (m *webhookConfigManager) deleteValidatingWebhook(obj interface{}) {
 	m.log.WithName("deleteMutatingWebhook").Info("resource webhook configuration was deleted, recreating...")
 	webhook, ok := kubeutils.GetObjectWithTombstone(obj).(*admissionregistrationv1.ValidatingWebhookConfiguration)
 	if !ok {
-		m.log.Info("Failed to get deleted object", "obj", obj)
+		m.log.V(3).Info("Failed to get deleted object", "obj", obj)
 		return
 	}
 	if webhook.GetName() == config.ValidatingWebhookConfigurationName {
@@ -249,8 +249,8 @@ func (m *webhookConfigManager) start() {
 	defer utilruntime.HandleCrash()
 	defer m.queue.ShutDown()
 
-	m.log.Info("starting")
-	defer m.log.Info("shutting down")
+	m.log.V(4).Info("starting")
+	defer m.log.V(4).Info("shutting down")
 
 	m.pInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    m.addClusterPolicy,

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -415,7 +415,7 @@ func (wrc *Register) checkEndpoint() error {
 		}
 		for _, addr := range subset.Addresses {
 			if utils.ContainsString(ips, addr.IP) {
-				wrc.log.Info("Endpoint ready", "ns", config.KyvernoNamespace(), "name", config.KyvernoServiceName())
+				wrc.log.V(4).Info("Endpoint ready", "ns", config.KyvernoNamespace(), "name", config.KyvernoServiceName())
 				return nil
 			}
 		}

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -415,7 +415,7 @@ func (wrc *Register) checkEndpoint() error {
 		}
 		for _, addr := range subset.Addresses {
 			if utils.ContainsString(ips, addr.IP) {
-				wrc.log.V(4).Info("Endpoint ready", "ns", config.KyvernoNamespace(), "name", config.KyvernoServiceName())
+				wrc.log.V(2).Info("Endpoint ready", "ns", config.KyvernoNamespace(), "name", config.KyvernoServiceName())
 				return nil
 			}
 		}

--- a/pkg/webhooks/resource/utils.go
+++ b/pkg/webhooks/resource/utils.go
@@ -169,7 +169,7 @@ func convertResource(request *admissionv1.AdmissionRequest, resourceRaw []byte) 
 func blockRequest(engineReponses []*response.EngineResponse, failurePolicy kyvernov1.FailurePolicyType, log logr.Logger) bool {
 	for _, er := range engineReponses {
 		if engineutils2.BlockRequest(er, failurePolicy) {
-			log.V(4).Info("blocking admission request", "policy", er.PolicyResponse.Policy.Name)
+			log.V(2).Info("blocking admission request", "policy", er.PolicyResponse.Policy.Name)
 			return true
 		}
 	}

--- a/pkg/webhooks/resource/utils.go
+++ b/pkg/webhooks/resource/utils.go
@@ -169,7 +169,7 @@ func convertResource(request *admissionv1.AdmissionRequest, resourceRaw []byte) 
 func blockRequest(engineReponses []*response.EngineResponse, failurePolicy kyvernov1.FailurePolicyType, log logr.Logger) bool {
 	for _, er := range engineReponses {
 		if engineutils2.BlockRequest(er, failurePolicy) {
-			log.Info("blocking admission request", "policy", er.PolicyResponse.Policy.Name)
+			log.V(4).Info("blocking admission request", "policy", er.PolicyResponse.Policy.Name)
 			return true
 		}
 	}

--- a/pkg/webhooks/resource/validate_audit.go
+++ b/pkg/webhooks/resource/validate_audit.go
@@ -129,7 +129,7 @@ func (h *auditHandler) processNextWorkItem() bool {
 	request, ok := obj.(*admissionv1.AdmissionRequest)
 	if !ok {
 		h.queue.Forget(obj)
-		h.log.V(4).Info("incorrect type: expecting type 'AdmissionRequest'", "object", obj)
+		h.log.V(2).Info("incorrect type: expecting type 'AdmissionRequest'", "object", obj)
 		return true
 	}
 

--- a/pkg/webhooks/resource/validate_audit.go
+++ b/pkg/webhooks/resource/validate_audit.go
@@ -129,7 +129,7 @@ func (h *auditHandler) processNextWorkItem() bool {
 	request, ok := obj.(*admissionv1.AdmissionRequest)
 	if !ok {
 		h.queue.Forget(obj)
-		h.log.Info("incorrect type: expecting type 'AdmissionRequest'", "object", obj)
+		h.log.V(4).Info("incorrect type: expecting type 'AdmissionRequest'", "object", obj)
 		return true
 	}
 


### PR DESCRIPTION
Signed-off-by: anutosh491 <andersonbhat491@gmail.com>

## Explanation
As the issue points out.... a good chunk of logging in Kyverno is already set to some verbosity levels . Hence the pull request tries to add appropriate verbosity levels to remaining `log.Info()` calls wherever necessary.
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
#4181 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
`/kind feature`
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

According to my understanding of different logging levels .They operate like this
2 - **error**
3 - **warn**
4 - **information**

Hence I've mainly restricted the levels to these 3. 
1) I've used `3` for deprecation warning, skipping of objects and some failed to evaluate and related errors.

2) I've used `4` mainly when we encounter errors based on **types** or so something like `log.V(4).Info("Expected type int", "type", fmt.Sprintf("%T", value), "value", value)` and otherwise when some execution is successful like `Log.V(4).Info("Kyverno shutdown successful")`

3) I've just used 2 couple of times.

We can surely discuss if something needs to be changed in my approach . @JimBugwadia 


<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
