### PR TITLE
fix: prevent installing helm chart in namespace kube-system

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -30,3 +30,5 @@ annotations:
       description: Added possibility to define additional init and sidecar container
     - kind: added
       description: Added ability to remove namespaces from default resourceFilters list
+    - kind: added
+      description: Prevent installing Kyverno in namespace kube-system.

--- a/charts/kyverno/templates/validate.yaml
+++ b/charts/kyverno/templates/validate.yaml
@@ -7,3 +7,7 @@
     {{ fail "Kyverno does not support running with 2 replicas. For a highly-available deployment, select 3 replicas or for standalone select 1 replica." }}
   {{- end }}
 {{- end }}
+
+{{- if eq (include "kyverno.namespace" .) "kube-system" }}
+    {{ fail "Kyverno cannot be installed in namespace kube-system." }}
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charled.breteche@gmail.com>

## Explanation

Installing kyverno in `kube-system` namespace is not supported.
This PR adds a check in the helm chart and fails if the user tries to install in `kube-system`.
