### PR TITLE
fix: exclude autogen rules when autogen internals is enabled

### DIFF
--- a/pkg/autogen/autogen.go
+++ b/pkg/autogen/autogen.go
@@ -296,7 +296,11 @@ func computeRules(p kyvernov1.PolicyInterface) []kyvernov1.Rule {
 		return spec.Rules
 	}
 	var out []kyvernov1.Rule
-	out = append(out, spec.Rules...)
+	for _, rule := range spec.Rules {
+		if !isAutogenRuleName(rule.Name) {
+			out = append(out, rule)
+		}
+	}
 	out = append(out, genRules...)
 	return out
 }


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charled.breteche@gmail.com>

## Explanation

When enabling autogen internals, previously auto generated rules must be discarded.
This PR ignores auto generated rules in the policy spec when autogen internals is enabled.