### PR TITLE
chore: add workflow to ensure github actions are pinned to a commit SHA

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   push-init-kyverno:
-    uses: kyverno/kyverno/.github/workflows/reuse.yaml@main
+    uses: ./.github/workflows/reuse.yaml
     with:
       publish_command: docker-publish-initContainer
       digest_command: docker-get-initContainer-digest
@@ -23,7 +23,7 @@ jobs:
       registry_password: ${{ secrets.CR_PAT }}
 
   push-kyverno:
-    uses: kyverno/kyverno/.github/workflows/reuse.yaml@main
+    uses: ./.github/workflows/reuse.yaml
     with:
       publish_command: docker-publish-kyverno
       digest_command: docker-get-kyverno-digest
@@ -34,7 +34,7 @@ jobs:
       registry_password: ${{ secrets.CR_PAT }}
 
   push-kyverno-cli:
-    uses: kyverno/kyverno/.github/workflows/reuse.yaml@main
+    uses: ./.github/workflows/reuse.yaml
     with:
       publish_command: docker-publish-cli
       digest_command: docker-get-cli-digest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    uses: kyverno/kyverno/.github/workflows/reuse.yaml@main
+    uses: ./.github/workflows/reuse.yaml
     with:
       publish_command: docker-publish-initContainer
       digest_command: docker-get-initContainer-digest
@@ -26,7 +26,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    uses: kyverno/kyverno/.github/workflows/reuse.yaml@main
+    uses: ./.github/workflows/reuse.yaml
     with:
       publish_command: docker-publish-kyverno
       digest_command: docker-get-kyverno-digest
@@ -42,7 +42,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    uses: kyverno/kyverno/.github/workflows/reuse.yaml@main
+    uses: ./.github/workflows/reuse.yaml
     with:
       publish_command: docker-publish-cli
       digest_command: docker-get-cli-digest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,28 +9,32 @@ on:
       - 'main'
       - 'release*'
 
-permissions: 
+permissions:
   contents: read
   packages: write
-  id-token: write 
+  id-token: write
 
 jobs:
   pre-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # pin@v2.4.0
+
+      # see https://michaelheap.com/ensure-github-actions-pinned-sha/
+      - name: Ensure SHA pinned actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@6ca5574367befbc9efdb2fa25978084159c5902d # pin@v1.3.0
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
+        uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # pin@v2.1.5
         with:
           go-version: 1.17
 
       - name: Cache Go modules
-        uses: actions/cache@d9747005de0f7240e5d35a68dca96b3f41b8b340 # v1.2.0
+        uses: actions/cache@d9747005de0f7240e5d35a68dca96b3f41b8b340 # pin@v1.2.0
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -58,7 +62,7 @@ jobs:
           fi
 
       - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@02bcf8c1a9febe8620f1ca523b18dd64f82296db # v1.25.0
+        uses: reviewdog/action-golangci-lint@02bcf8c1a9febe8620f1ca523b18dd64f82296db # pin@v1.25.0
         with:
           fail_on_error: true
 
@@ -77,23 +81,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        autogen-internals: [true, false]
+        autogen-internals: [ true, false ]
     runs-on: ubuntu-latest
     needs: pre-checks
     steps:
       - name: Checkout
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # pin@v2.4.0
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
+        uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # pin@v2.1.5
         with:
           go-version: 1.17
 
       - name: Cache Go modules
-        uses: actions/cache@d9747005de0f7240e5d35a68dca96b3f41b8b340 # v1.2.0
+        uses: actions/cache@d9747005de0f7240e5d35a68dca96b3f41b8b340 # pin@v1.2.0
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charled.breteche@gmail.com>

## Explanation

Pinning github actions to commit sha makes them more secure (using tag or branches, actions are mutable, with commit SHA they are immutable).
See https://michaelheap.com/ensure-github-actions-pinned-sha/
Pinning GH actions https://github.com/mheap/pin-github-action

This PR adds a verification step to make sure all github actions used are pinned.
