### PR TITLE
fix: duration metrics precision

### DIFF
--- a/pkg/webhooks/resource/generation.go
+++ b/pkg/webhooks/resource/generation.go
@@ -29,7 +29,7 @@ func (h *handlers) handleGenerate(
 	request *admissionv1.AdmissionRequest,
 	policies []kyvernov1.PolicyInterface,
 	policyContext *engine.PolicyContext,
-	admissionRequestTimestamp int64,
+	admissionRequestTimestamp time.Time,
 	latencySender *chan int64,
 	generateEngineResponsesSenderForAdmissionReviewDurationMetric *chan []*response.EngineResponse,
 	generateEngineResponsesSenderForAdmissionRequestsCountMetric *chan []*response.EngineResponse,
@@ -80,7 +80,7 @@ func (h *handlers) handleGenerate(
 	}
 
 	// sending the admission request latency to other goroutine (reporting the metrics) over the channel
-	admissionReviewLatencyDuration := int64(time.Since(time.Unix(admissionRequestTimestamp, 0)))
+	admissionReviewLatencyDuration := int64(time.Since(admissionRequestTimestamp))
 	*latencySender <- admissionReviewLatencyDuration
 	*generateEngineResponsesSenderForAdmissionReviewDurationMetric <- engineResponses
 	*generateEngineResponsesSenderForAdmissionRequestsCountMetric <- engineResponses

--- a/pkg/webhooks/resource/updaterequest.go
+++ b/pkg/webhooks/resource/updaterequest.go
@@ -14,7 +14,7 @@ import (
 )
 
 // createUpdateRequests applies generate and mutateExisting policies, and creates update requests for background reconcile
-func (h *handlers) createUpdateRequests(logger logr.Logger, request *admissionv1.AdmissionRequest, policyContext *engine.PolicyContext, generatePolicies, mutatePolicies []kyvernov1.PolicyInterface, ts int64) {
+func (h *handlers) createUpdateRequests(logger logr.Logger, request *admissionv1.AdmissionRequest, policyContext *engine.PolicyContext, generatePolicies, mutatePolicies []kyvernov1.PolicyInterface, ts time.Time) {
 	admissionReviewCompletionLatencyChannel := make(chan int64, 1)
 	generateEngineResponsesSenderForAdmissionReviewDurationMetric := make(chan []*response.EngineResponse, 1)
 	generateEngineResponsesSenderForAdmissionRequestsCountMetric := make(chan []*response.EngineResponse, 1)
@@ -26,7 +26,7 @@ func (h *handlers) createUpdateRequests(logger logr.Logger, request *admissionv1
 	go h.registerAdmissionRequestsMetricGenerate(logger, string(request.Operation), &generateEngineResponsesSenderForAdmissionRequestsCountMetric)
 }
 
-func (h *handlers) handleMutateExisting(logger logr.Logger, request *admissionv1.AdmissionRequest, policies []kyvernov1.PolicyInterface, policyContext *engine.PolicyContext, admissionRequestTimestamp int64) {
+func (h *handlers) handleMutateExisting(logger logr.Logger, request *admissionv1.AdmissionRequest, policies []kyvernov1.PolicyInterface, policyContext *engine.PolicyContext, admissionRequestTimestamp time.Time) {
 	logger.V(4).Info("update request")
 
 	if request.Operation == admissionv1.Delete {
@@ -73,7 +73,7 @@ func (h *handlers) handleMutateExisting(logger logr.Logger, request *admissionv1
 		}
 	}
 
-	admissionReviewLatencyDuration := int64(time.Since(time.Unix(admissionRequestTimestamp, 0)))
+	admissionReviewLatencyDuration := int64(time.Since(admissionRequestTimestamp))
 	go h.registerAdmissionReviewDurationMetricMutate(logger, string(request.Operation), engineResponses, admissionReviewLatencyDuration)
 	go h.registerAdmissionRequestsMetricMutate(logger, string(request.Operation), engineResponses)
 }

--- a/pkg/webhooks/resource/validate_audit.go
+++ b/pkg/webhooks/resource/validate_audit.go
@@ -143,7 +143,7 @@ func (h *auditHandler) process(request *admissionv1.AdmissionRequest) error {
 	var roles, clusterRoles []string
 	var err error
 	// time at which the corresponding the admission request's processing got initiated
-	admissionRequestTimestamp := time.Now().Unix()
+	admissionRequestTimestamp := time.Now()
 	logger := h.log.WithName("process")
 
 	policies := h.pCache.GetPolicies(policycache.ValidateAudit, request.Kind.Kind, request.Namespace)

--- a/pkg/webhooks/resource/validation.go
+++ b/pkg/webhooks/resource/validation.go
@@ -32,7 +32,7 @@ func (v *validationHandler) handleValidation(
 	policies []kyvernov1.PolicyInterface,
 	policyContext *engine.PolicyContext,
 	namespaceLabels map[string]string,
-	admissionRequestTimestamp int64,
+	admissionRequestTimestamp time.Time,
 ) (bool, string, []string) {
 	if len(policies) == 0 {
 		return true, "", nil
@@ -123,8 +123,8 @@ func (v *validationHandler) generateReportChangeRequests(request *admissionv1.Ad
 	}
 }
 
-func (v *validationHandler) generateMetrics(request *admissionv1.AdmissionRequest, admissionRequestTimestamp int64, engineResponses []*response.EngineResponse, metricsConfig *metrics.MetricsConfig, logger logr.Logger) {
-	admissionReviewLatencyDuration := int64(time.Since(time.Unix(admissionRequestTimestamp, 0)))
+func (v *validationHandler) generateMetrics(request *admissionv1.AdmissionRequest, admissionRequestTimestamp time.Time, engineResponses []*response.EngineResponse, metricsConfig *metrics.MetricsConfig, logger logr.Logger) {
+	admissionReviewLatencyDuration := int64(time.Since(admissionRequestTimestamp))
 	go registerAdmissionReviewDurationMetricValidate(logger, metricsConfig, string(request.Operation), engineResponses, admissionReviewLatencyDuration)
 	go registerAdmissionRequestsMetricValidate(logger, metricsConfig, string(request.Operation), engineResponses)
 }


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charled.breteche@gmail.com>

## Explanation

Duration metrics are computed from admission request timestamp, but this timestamp was rounded to the nearest second.
This PR keeps the full admission request timestamp precision.

## Related issue

Closes #4320 
