### PR TITLE
Attempt to fix a cosign issue - Bump cosign version to 1.11.0

### DIFF
--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@116dc6872c0a067bcb78758f18955414cdbf918f # v1.4.1
         with:
-          cosign-release: 'v1.4.1'
+          cosign-release: 'v1.11.0'
 
       - name: Cache Go modules
         uses: actions/cache@d9747005de0f7240e5d35a68dca96b3f41b8b340 # v1.2.0


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Explanation
All CI jobs failed due to this cosign failure https://github.com/kyverno/kyverno/runs/7995970752?check_suite_focus=true.

Bump to the latest version 1.11.0 to see if it fixes the issue.

Slack conv https://sigstore.slack.com/archives/C02K0T1LNPQ/p1661350000528639.
