### PR TITLE
bump golang 1.18.5 version digest in Dockerfile

### DIFF
--- a/cmd/cli/kubectl-kyverno/Dockerfile
+++ b/cmd/cli/kubectl-kyverno/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage docker build
 # Build stage
-FROM --platform=${BUILDPLATFORM} golang@sha256:724abf4dd44985d060f7aa91af5211eb2052491424bd497ba3ddc31f7cee969d AS base
+FROM --platform=${BUILDPLATFORM} golang@sha256:5540a6a6b3b612c382accc545b3f6702de21e77b15d89ad947116c94b5f42993 AS base
 WORKDIR /src
 LABEL maintainer="Kyverno"
 

--- a/cmd/initContainer/Dockerfile
+++ b/cmd/initContainer/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage docker build
 # Build stage
-FROM --platform=${BUILDPLATFORM} golang@sha256:724abf4dd44985d060f7aa91af5211eb2052491424bd497ba3ddc31f7cee969d AS base
+FROM --platform=${BUILDPLATFORM} golang@sha256:5540a6a6b3b612c382accc545b3f6702de21e77b15d89ad947116c94b5f42993 AS base
 WORKDIR /src
 LABEL maintainer="Kyverno"
 

--- a/cmd/kyverno/Dockerfile
+++ b/cmd/kyverno/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Kyverno"
 
 RUN apk add --no-cache ca-certificates
 
-FROM --platform=${BUILDPLATFORM} golang@sha256:724abf4dd44985d060f7aa91af5211eb2052491424bd497ba3ddc31f7cee969d AS base
+FROM --platform=${BUILDPLATFORM} golang@sha256:5540a6a6b3b612c382accc545b3f6702de21e77b15d89ad947116c94b5f42993 AS base
 WORKDIR /src
 LABEL maintainer="Kyverno"
 


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Explanation

bump golang 1.18.5 version digest in Dockerfile as part of  #4408 PR to bump the overall go version to 1.18. 

Note: Earlier 1.17.9 golang image digest has been used

```sh
$ crane config golang@sha256:724abf4dd44985d060f7aa91af5211eb2052491424bd497ba3ddc31f7cee969d | jq
{
  "architecture": "amd64",
  "config": {
    "Hostname": "",
    "Domainname": "",
    "User": "",
    "AttachStdin": false,
    "AttachStdout": false,
    "AttachStderr": false,
    "Tty": false,
    "OpenStdin": false,
    "StdinOnce": false,
    "Env": [
      "PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
      "GOLANG_VERSION=1.17.9",
      "GOPATH=/go"

```

```sh
$ crane digest golang:1.18.5
sha256:5540a6a6b3b612c382accc545b3f6702de21e77b15d89ad947116c94b5f42993

$  mquery golang@sha256:5540a6a6b3b612c382accc545b3f6702de21e77b15d89ad947116c94b5f42993
Image: golang@sha256:5540a6a6b3b612c382accc545b3f6702de21e77b15d89ad947116c94b5f42993 (digest: sha256:5540a6a6b3b612c382accc545b3f6702de21e77b15d89ad947116c94b5f42993)
 * Manifest List: Yes (Image type: application/vnd.docker.distribution.manifest.list.v2+json)
 * Supported platforms:
   - linux/amd64
   - linux/arm/v5
   - linux/arm/v7
   - linux/arm64/v8
   - linux/386
   - linux/mips64le
   - linux/ppc64le
   - linux/s390x
   - windows/amd64:10.0.20348.887
   - windows/amd64:10.0.17763.3287

```