### PR TITLE
fix: make ldflags optional in .ko.yaml

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -2,14 +2,14 @@ builds:
 - id: initContainer
   main: ./cmd/initContainer
   ldflags:
-  - "{{ .Env.LD_FLAGS }}"
+  - '{{ if index .Env "LD_FLAGS" }}{{ .Env.LD_FLAGS }}{{ end }}'
 
 - id: kyverno
   main: ./cmd/kyverno
   ldflags:
-  - "{{ .Env.LD_FLAGS }}"
+  - '{{ if index .Env "LD_FLAGS" }}{{ .Env.LD_FLAGS }}{{ end }}'
 
 - id: cli
   main: ./cmd/cli
   ldflags:
-  - "{{ .Env.LD_FLAGS }}"
+  - '{{ if index .Env "LD_FLAGS" }}{{ .Env.LD_FLAGS }}{{ end }}'

--- a/Makefile
+++ b/Makefile
@@ -141,26 +141,32 @@ REPO_CLI            := $(REPO)/kyverno-cli
 
 .PHONY: ko-build-initContainer
 ko-build-initContainer: $(KO)
+	# @$(KO) login $(REGISTRY)
 	@LD_FLAGS=$(LD_FLAGS) KO_DOCKER_REPO=$(REPO_KYVERNOPRE) $(KO) build $(KYVERNOPRE_DIR) --bare --tags=latest,$(IMAGE_TAG) --platform=$(KO_PLATFORM)
 
 .PHONY: ko-build-kyverno
 ko-build-kyverno: $(KO)
+	# @$(KO) login $(REGISTRY)
 	@LD_FLAGS=$(LD_FLAGS) KO_DOCKER_REPO=$(REPO_KYVERNO) $(KO) build $(KYVERNO_DIR) --bare --tags=latest,$(IMAGE_TAG) --platform=$(KO_PLATFORM)
 
 .PHONY: ko-build-cli
 ko-build-cli: $(KO)
+	# @$(KO) login $(REGISTRY)
 	@LD_FLAGS=$(LD_FLAGS) KO_DOCKER_REPO=$(REPO_CLI) $(KO) build $(CLI_DIR) --bare --tags=latest,$(IMAGE_TAG) --platform=$(KO_PLATFORM)
 
 .PHONY: ko-build-initContainer-dev
 ko-build-initContainer-dev: $(KO)
+	@$(KO) login $(REGISTRY) --username "dummy" --password $(GITHUB_TOKEN)
 	@LD_FLAGS=$(LD_FLAGS_DEV) KO_DOCKER_REPO=$(REPO_KYVERNOPRE) $(KO) build $(KYVERNOPRE_DIR) --bare --tags=latest,$(IMAGE_TAG_DEV) --platform=$(KO_PLATFORM)
 
 .PHONY: ko-build-kyverno-dev
 ko-build-kyverno-dev: $(KO)
+	@$(KO) login $(REGISTRY) --username "dummy" --password $(GITHUB_TOKEN)
 	@LD_FLAGS=$(LD_FLAGS_DEV) KO_DOCKER_REPO=$(REPO_KYVERNO) $(KO) build $(KYVERNO_DIR) --bare --tags=latest,$(IMAGE_TAG_DEV) --platform=$(KO_PLATFORM)
 
 .PHONY: ko-build-cli-dev
 ko-build-cli-dev: $(KO)
+	@$(KO) login $(REGISTRY) --username "dummy" --password $(GITHUB_TOKEN)
 	@LD_FLAGS=$(LD_FLAGS_DEV) KO_DOCKER_REPO=$(REPO_CLI) $(KO) build $(CLI_DIR) --bare --tags=latest,$(IMAGE_TAG_DEV) --platform=$(KO_PLATFORM)
 
 .PHONY: ko-build-initContainer-local

--- a/test/cli/registry/resources.yaml
+++ b/test/cli/registry/resources.yaml
@@ -15,5 +15,5 @@ metadata:
 spec:
   containers:
   - name: kyverno
-    image: ghcr.io/kyverno/kyverno
+    image: ghcr.io/kyverno/kyverno:v1.7.3
 


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charled.breteche@gmail.com>

## Explanation

This PR makes `ldflags` optional in .ko.yaml to allow local builds that don't define the env var.