### PR TITLE
fix: fetch history in pre-checks job

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -19,15 +19,17 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+      - name: Checkout
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+
       - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
           go-version: '1.18'
-      -
-        name: Generate Code Coverage Report
+
+      - name: Generate Code Coverage Report
         run: make code-cov-report
-      -
-        name: Upload Report to Codecov
+
+      - name: Upload Report to Codecov
         uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2.1.0
         with:
           file: ./coverage.out

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -11,12 +11,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+      - name: Checkout
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+
       - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
           go-version: "^1.18.x"
-      - run: go version
-      # Runs a set of commands to initialize and analyze with FOSSA
+
       - name: run FOSSA analysis
         env:
           # FOSSA Push-Only API Token

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
         with:
           fetch-depth: 0
-          
+
       - name: Install Helm
         uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1.1
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
 
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
       # see https://michaelheap.com/ensure-github-actions-pinned-sha/
       - name: Ensure SHA pinned actions
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@6ca5574367befbc9efdb2fa25978084159c5902d # pin@v1.3.0


### PR DESCRIPTION
## Explanation

This PR fetches history in pre-checks job.
This is to avoid:
```
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
```