### PR TITLE
refactor: client wrappers

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -192,7 +192,7 @@ func main() {
 	// informer factories
 	kubeInformer := kubeinformers.NewSharedInformerFactory(kubeClient, resyncPeriod)
 	kubeKyvernoInformer := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod, kubeinformers.WithNamespace(config.KyvernoNamespace()))
-	kyvernoInformer := kyvernoinformer.NewSharedInformerFactory(kyvernoClient.VersionedClient(), policyControllerResyncPeriod)
+	kyvernoInformer := kyvernoinformer.NewSharedInformerFactory(kyvernoClient, policyControllerResyncPeriod)
 
 	// utils
 	kyvernoV1 := kyvernoInformer.Kyverno().V1()

--- a/pkg/background/common/status.go
+++ b/pkg/background/common/status.go
@@ -3,8 +3,8 @@ package common
 import (
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1beta1"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 )
 
 // StatusControlInterface provides interface to update status subresource
@@ -16,11 +16,11 @@ type StatusControlInterface interface {
 
 // statusControl is default implementaation of GRStatusControlInterface
 type statusControl struct {
-	client   kyvernoclient.Interface
+	client   versioned.Interface
 	urLister kyvernov1beta1listers.UpdateRequestNamespaceLister
 }
 
-func NewStatusControl(client kyvernoclient.Interface, urLister kyvernov1beta1listers.UpdateRequestNamespaceLister) StatusControlInterface {
+func NewStatusControl(client versioned.Interface, urLister kyvernov1beta1listers.UpdateRequestNamespaceLister) StatusControlInterface {
 	return &statusControl{
 		client:   client,
 		urLister: urLister,

--- a/pkg/background/common/util.go
+++ b/pkg/background/common/util.go
@@ -6,8 +6,8 @@ import (
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1beta1"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 	"github.com/kyverno/kyverno/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -22,7 +22,7 @@ var DefaultRetry = wait.Backoff{
 	Jitter:   0.1,
 }
 
-func Update(client kyvernoclient.Interface, urLister kyvernov1beta1listers.UpdateRequestNamespaceLister, name string, mutator func(*kyvernov1beta1.UpdateRequest)) (*kyvernov1beta1.UpdateRequest, error) {
+func Update(client versioned.Interface, urLister kyvernov1beta1listers.UpdateRequestNamespaceLister, name string, mutator func(*kyvernov1beta1.UpdateRequest)) (*kyvernov1beta1.UpdateRequest, error) {
 	var ur *kyvernov1beta1.UpdateRequest
 	err := retry.RetryOnConflict(DefaultRetry, func() error {
 		ur, err := urLister.Get(name)
@@ -46,7 +46,7 @@ func Update(client kyvernoclient.Interface, urLister kyvernov1beta1listers.Updat
 	return ur, err
 }
 
-func UpdateStatus(client kyvernoclient.Interface, urLister kyvernov1beta1listers.UpdateRequestNamespaceLister, name string, state kyvernov1beta1.UpdateRequestState, message string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error) {
+func UpdateStatus(client versioned.Interface, urLister kyvernov1beta1listers.UpdateRequestNamespaceLister, name string, state kyvernov1beta1.UpdateRequestState, message string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error) {
 	var ur *kyvernov1beta1.UpdateRequest
 	err := retry.RetryOnConflict(DefaultRetry, func() error {
 		ur, err := urLister.Get(name)

--- a/pkg/background/generate/generate.go
+++ b/pkg/background/generate/generate.go
@@ -15,10 +15,10 @@ import (
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/autogen"
 	"github.com/kyverno/kyverno/pkg/background/common"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1"
 	kyvernov1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 	pkgcommon "github.com/kyverno/kyverno/pkg/common"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/engine"
@@ -39,7 +39,7 @@ import (
 type GenerateController struct {
 	// clients
 	client        dclient.Interface
-	kyvernoClient kyvernoclient.Interface
+	kyvernoClient versioned.Interface
 	statusControl common.StatusControlInterface
 
 	// listers
@@ -57,7 +57,7 @@ type GenerateController struct {
 // NewGenerateController returns an instance of the Generate-Request Controller
 func NewGenerateController(
 	client dclient.Interface,
-	kyvernoClient kyvernoclient.Interface,
+	kyvernoClient versioned.Interface,
 	statusControl common.StatusControlInterface,
 	policyLister kyvernov1listers.ClusterPolicyLister,
 	npolicyLister kyvernov1listers.PolicyLister,

--- a/pkg/background/update_request_controller.go
+++ b/pkg/background/update_request_controller.go
@@ -10,12 +10,12 @@ import (
 	common "github.com/kyverno/kyverno/pkg/background/common"
 	"github.com/kyverno/kyverno/pkg/background/generate"
 	"github.com/kyverno/kyverno/pkg/background/mutate"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1"
 	kyvernov1beta1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1beta1"
 	kyvernov1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1"
 	kyvernov1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 	pkgCommon "github.com/kyverno/kyverno/pkg/common"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/event"
@@ -45,7 +45,7 @@ type Controller interface {
 type controller struct {
 	// clients
 	client        dclient.Interface
-	kyvernoClient kyvernoclient.Interface
+	kyvernoClient versioned.Interface
 
 	// listers
 	cpolLister kyvernov1listers.ClusterPolicyLister
@@ -65,7 +65,7 @@ type controller struct {
 
 // NewController returns an instance of the Generate-Request Controller
 func NewController(
-	kyvernoClient kyvernoclient.Interface,
+	kyvernoClient versioned.Interface,
 	client dclient.Interface,
 	cpolInformer kyvernov1informers.ClusterPolicyInformer,
 	polInformer kyvernov1informers.PolicyInformer,

--- a/pkg/clients/wrappers/clientset.go
+++ b/pkg/clients/wrappers/clientset.go
@@ -2,81 +2,54 @@ package kyvernoclient
 
 import (
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
-	kyvernov1 "github.com/kyverno/kyverno/pkg/clients/wrappers/kyverno/v1"
-	kyvernov1alpha2 "github.com/kyverno/kyverno/pkg/clients/wrappers/kyverno/v1alpha2"
-	kyvernov1beta1 "github.com/kyverno/kyverno/pkg/clients/wrappers/kyverno/v1beta1"
-	wgpolicyk8sv1alpha2 "github.com/kyverno/kyverno/pkg/clients/wrappers/policyreport/v1alpha2"
+	versionedkyvernov1 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1"
+	versionedkyvernov1alpha2 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1alpha2"
+	versionedkyvernov1beta1 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1beta1"
+	versionedpolicyreportv1alpha2 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/policyreport/v1alpha2"
+	wrappedkyvernov1 "github.com/kyverno/kyverno/pkg/clients/wrappers/kyverno/v1"
+	wrappedkyvernov1alpha2 "github.com/kyverno/kyverno/pkg/clients/wrappers/kyverno/v1alpha2"
+	wrappedkyvernov1beta1 "github.com/kyverno/kyverno/pkg/clients/wrappers/kyverno/v1beta1"
+	wrappedwgpolicyk8sv1alpha2 "github.com/kyverno/kyverno/pkg/clients/wrappers/policyreport/v1alpha2"
 	"github.com/kyverno/kyverno/pkg/clients/wrappers/utils"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	"k8s.io/client-go/rest"
 )
 
-type Interface interface {
-	VersionedClient() versioned.Interface
-	KyvernoV1() kyvernov1.KyvernoV1Interface
-	KyvernoV1beta1() kyvernov1beta1.KyvernoV1beta1Interface
-	KyvernoV1alpha2() kyvernov1alpha2.KyvernoV1alpha2Interface
-	Wgpolicyk8sV1alpha2() wgpolicyk8sv1alpha2.Wgpolicyk8sV1alpha2Interface
+type clientset struct {
+	versioned.Interface
+	kyvernoV1           versionedkyvernov1.KyvernoV1Interface
+	kyvernoV1beta1      versionedkyvernov1beta1.KyvernoV1beta1Interface
+	kyvernoV1alpha2     versionedkyvernov1alpha2.KyvernoV1alpha2Interface
+	wgpolicyk8sV1alpha2 versionedpolicyreportv1alpha2.Wgpolicyk8sV1alpha2Interface
 }
 
-type Clientset struct {
-	versionedClient     versioned.Interface
-	kyvernoV1           *kyvernov1.KyvernoV1Client
-	kyvernoV1beta1      *kyvernov1beta1.KyvernoV1beta1Client
-	kyvernoV1alpha2     *kyvernov1alpha2.KyvernoV1alpha2Client
-	wgpolicyk8sV1alpha2 *wgpolicyk8sv1alpha2.Wgpolicyk8sV1alpha2Client
-}
-
-func (c *Clientset) VersionedClient() versioned.Interface {
-	return c.versionedClient
-}
-
-func (c *Clientset) KyvernoV1() kyvernov1.KyvernoV1Interface {
+func (c *clientset) KyvernoV1() versionedkyvernov1.KyvernoV1Interface {
 	return c.kyvernoV1
 }
 
-func (c *Clientset) KyvernoV1beta1() kyvernov1beta1.KyvernoV1beta1Interface {
+func (c *clientset) KyvernoV1beta1() versionedkyvernov1beta1.KyvernoV1beta1Interface {
 	return c.kyvernoV1beta1
 }
 
-func (c *Clientset) KyvernoV1alpha2() kyvernov1alpha2.KyvernoV1alpha2Interface {
+func (c *clientset) KyvernoV1alpha2() versionedkyvernov1alpha2.KyvernoV1alpha2Interface {
 	return c.kyvernoV1alpha2
 }
 
-func (c *Clientset) Wgpolicyk8sV1alpha2() wgpolicyk8sv1alpha2.Wgpolicyk8sV1alpha2Interface {
+func (c *clientset) Wgpolicyk8sV1alpha2() versionedpolicyreportv1alpha2.Wgpolicyk8sV1alpha2Interface {
 	return c.wgpolicyk8sV1alpha2
 }
 
-func NewForConfig(c *rest.Config, m *metrics.MetricsConfig) (*Clientset, error) {
-	var cs Clientset
+func NewForConfig(c *rest.Config, m *metrics.MetricsConfig) (versioned.Interface, error) {
 	clientQueryMetric := utils.NewClientQueryMetric(m)
-
 	kClientset, err := versioned.NewForConfig(c)
 	if err != nil {
 		return nil, err
 	}
-
-	cs.versionedClient = kClientset
-
-	cs.kyvernoV1 = kyvernov1.NewForConfig(
-		kClientset.KyvernoV1().RESTClient(),
-		kClientset.KyvernoV1(),
-		clientQueryMetric)
-
-	cs.kyvernoV1beta1 = kyvernov1beta1.NewForConfig(
-		kClientset.KyvernoV1beta1().RESTClient(),
-		kClientset.KyvernoV1beta1(),
-		clientQueryMetric)
-
-	cs.kyvernoV1alpha2 = kyvernov1alpha2.NewForConfig(
-		kClientset.KyvernoV1alpha2().RESTClient(),
-		kClientset.KyvernoV1alpha2(),
-		clientQueryMetric)
-
-	cs.wgpolicyk8sV1alpha2 = wgpolicyk8sv1alpha2.NewForConfig(
-		kClientset.Wgpolicyk8sV1alpha2().RESTClient(),
-		kClientset.Wgpolicyk8sV1alpha2(),
-		clientQueryMetric)
-
-	return &cs, nil
+	return &clientset{
+		Interface:           kClientset,
+		kyvernoV1:           wrappedkyvernov1.Wrap(kClientset.KyvernoV1(), clientQueryMetric),
+		kyvernoV1beta1:      wrappedkyvernov1beta1.Wrap(kClientset.KyvernoV1beta1(), clientQueryMetric),
+		kyvernoV1alpha2:     wrappedkyvernov1alpha2.Wrap(kClientset.KyvernoV1alpha2(), clientQueryMetric),
+		wgpolicyk8sV1alpha2: wrappedwgpolicyk8sv1alpha2.Wrap(kClientset.Wgpolicyk8sV1alpha2(), clientQueryMetric),
+	}, nil
 }

--- a/pkg/clients/wrappers/kyverno/v1/clusterpolicy.go
+++ b/pkg/clients/wrappers/kyverno/v1/clusterpolicy.go
@@ -4,86 +4,67 @@ import (
 	"context"
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
-	versionedkyvernov1 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1"
+	v1 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/clients/wrappers/utils"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/rest"
 )
 
-type ClusterPoliciesGetter interface {
-	ClusterPolicies() ClusterPoliciesControlInterface
-}
-
-type ClusterPoliciesControlInterface interface {
-	Create(ctx context.Context, clusterPolicy *kyvernov1.ClusterPolicy, opts metav1.CreateOptions) (*kyvernov1.ClusterPolicy, error)
-	Update(ctx context.Context, clusterPolicy *kyvernov1.ClusterPolicy, opts metav1.UpdateOptions) (*kyvernov1.ClusterPolicy, error)
-	UpdateStatus(ctx context.Context, clusterPolicy *kyvernov1.ClusterPolicy, opts metav1.UpdateOptions) (*kyvernov1.ClusterPolicy, error)
-	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
-	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*kyvernov1.ClusterPolicy, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*kyvernov1.ClusterPolicyList, error)
-	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *kyvernov1.ClusterPolicy, err error)
-}
-
-type clusterPoliciesControl struct {
-	client            rest.Interface
-	cpolClient        versionedkyvernov1.ClusterPoliciesGetter
+type clusterPolicies struct {
+	inner             v1.ClusterPolicyInterface
 	clientQueryMetric utils.ClientQueryMetric
 }
 
-func newClusterPolicies(c *KyvernoV1Client) *clusterPoliciesControl {
-	return &clusterPoliciesControl{
-		client:            c.RESTClient(),
-		cpolClient:        c.kyvernov1Interface,
-		clientQueryMetric: c.clientQueryMetric,
+func wrapClusterPolicies(c v1.ClusterPolicyInterface, m utils.ClientQueryMetric) v1.ClusterPolicyInterface {
+	return &clusterPolicies{
+		inner:             c,
+		clientQueryMetric: m,
 	}
 }
 
-func (c *clusterPoliciesControl) Create(ctx context.Context, clusterPolicy *kyvernov1.ClusterPolicy, opts metav1.CreateOptions) (*kyvernov1.ClusterPolicy, error) {
+func (c *clusterPolicies) Create(ctx context.Context, clusterPolicy *kyvernov1.ClusterPolicy, opts metav1.CreateOptions) (*kyvernov1.ClusterPolicy, error) {
 	c.clientQueryMetric.Record(metrics.ClientCreate, metrics.KyvernoClient, "ClusterPolicy", "")
-	return c.cpolClient.ClusterPolicies().Create(ctx, clusterPolicy, opts)
+	return c.inner.Create(ctx, clusterPolicy, opts)
 }
 
-func (c *clusterPoliciesControl) Update(ctx context.Context, clusterPolicy *kyvernov1.ClusterPolicy, opts metav1.UpdateOptions) (*kyvernov1.ClusterPolicy, error) {
+func (c *clusterPolicies) Update(ctx context.Context, clusterPolicy *kyvernov1.ClusterPolicy, opts metav1.UpdateOptions) (*kyvernov1.ClusterPolicy, error) {
 	c.clientQueryMetric.Record(metrics.ClientUpdate, metrics.KyvernoClient, "ClusterPolicy", "")
-	return c.cpolClient.ClusterPolicies().Update(ctx, clusterPolicy, opts)
+	return c.inner.Update(ctx, clusterPolicy, opts)
 }
 
-func (c *clusterPoliciesControl) UpdateStatus(ctx context.Context, clusterPolicy *kyvernov1.ClusterPolicy, opts metav1.UpdateOptions) (*kyvernov1.ClusterPolicy, error) {
+func (c *clusterPolicies) UpdateStatus(ctx context.Context, clusterPolicy *kyvernov1.ClusterPolicy, opts metav1.UpdateOptions) (*kyvernov1.ClusterPolicy, error) {
 	c.clientQueryMetric.Record(metrics.ClientUpdateStatus, metrics.KyvernoClient, "ClusterPolicy", "")
-	return c.cpolClient.ClusterPolicies().UpdateStatus(ctx, clusterPolicy, opts)
+	return c.inner.UpdateStatus(ctx, clusterPolicy, opts)
 }
 
-func (c *clusterPoliciesControl) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+func (c *clusterPolicies) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDelete, metrics.KyvernoClient, "ClusterPolicy", "")
-	return c.cpolClient.ClusterPolicies().Delete(ctx, name, opts)
+	return c.inner.Delete(ctx, name, opts)
 }
 
-func (c *clusterPoliciesControl) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+func (c *clusterPolicies) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDeleteCollection, metrics.KyvernoClient, "ClusterPolicy", "")
-	return c.cpolClient.ClusterPolicies().DeleteCollection(ctx, opts, listOpts)
+	return c.inner.DeleteCollection(ctx, opts, listOpts)
 }
 
-func (c *clusterPoliciesControl) Get(ctx context.Context, name string, opts metav1.GetOptions) (*kyvernov1.ClusterPolicy, error) {
+func (c *clusterPolicies) Get(ctx context.Context, name string, opts metav1.GetOptions) (*kyvernov1.ClusterPolicy, error) {
 	c.clientQueryMetric.Record(metrics.ClientGet, metrics.KyvernoClient, "ClusterPolicy", "")
-	return c.cpolClient.ClusterPolicies().Get(ctx, name, opts)
+	return c.inner.Get(ctx, name, opts)
 }
 
-func (c *clusterPoliciesControl) List(ctx context.Context, opts metav1.ListOptions) (*kyvernov1.ClusterPolicyList, error) {
+func (c *clusterPolicies) List(ctx context.Context, opts metav1.ListOptions) (*kyvernov1.ClusterPolicyList, error) {
 	c.clientQueryMetric.Record(metrics.ClientList, metrics.KyvernoClient, "ClusterPolicy", "")
-	return c.cpolClient.ClusterPolicies().List(ctx, opts)
+	return c.inner.List(ctx, opts)
 }
 
-func (c *clusterPoliciesControl) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+func (c *clusterPolicies) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	c.clientQueryMetric.Record(metrics.ClientWatch, metrics.KyvernoClient, "ClusterPolicy", "")
-	return c.cpolClient.ClusterPolicies().Watch(ctx, opts)
+	return c.inner.Watch(ctx, opts)
 }
 
-func (c *clusterPoliciesControl) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *kyvernov1.ClusterPolicy, err error) {
+func (c *clusterPolicies) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *kyvernov1.ClusterPolicy, err error) {
 	c.clientQueryMetric.Record(metrics.ClientPatch, metrics.KyvernoClient, "ClusterPolicy", "")
-	return c.cpolClient.ClusterPolicies().Patch(ctx, name, pt, data, opts, subresources...)
+	return c.inner.Patch(ctx, name, pt, data, opts, subresources...)
 }

--- a/pkg/clients/wrappers/kyverno/v1/kyverno_client.go
+++ b/pkg/clients/wrappers/kyverno/v1/kyverno_client.go
@@ -1,40 +1,23 @@
 package v1
 
 import (
-	kyvernov1 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1"
+	v1 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/clients/wrappers/utils"
-	"k8s.io/client-go/rest"
 )
 
-type KyvernoV1Interface interface {
-	RESTClient() rest.Interface
-	ClusterPoliciesGetter
-	PoliciesGetter
+type client struct {
+	v1.KyvernoV1Interface
+	clientQueryMetric utils.ClientQueryMetric
 }
 
-type KyvernoV1Client struct {
-	restClient         rest.Interface
-	kyvernov1Interface kyvernov1.KyvernoV1Interface
-	clientQueryMetric  utils.ClientQueryMetric
+func (c *client) ClusterPolicies() v1.ClusterPolicyInterface {
+	return wrapClusterPolicies(c.KyvernoV1Interface.ClusterPolicies(), c.clientQueryMetric)
 }
 
-func (c *KyvernoV1Client) ClusterPolicies() ClusterPoliciesControlInterface {
-	return newClusterPolicies(c)
+func (c *client) Policies(namespace string) v1.PolicyInterface {
+	return wrapPolicies(c.KyvernoV1Interface.Policies(namespace), c.clientQueryMetric, namespace)
 }
 
-func (c *KyvernoV1Client) Policies(namespace string) PoliciesControlInterface {
-	return newPolicies(c, namespace)
-}
-
-// RESTClient returns a RESTClient that is used to communicate
-// with API server by this client implementation.
-func (c *KyvernoV1Client) RESTClient() rest.Interface {
-	if c == nil {
-		return nil
-	}
-	return c.restClient
-}
-
-func NewForConfig(restClient rest.Interface, kyvernov1Interface kyvernov1.KyvernoV1Interface, m utils.ClientQueryMetric) *KyvernoV1Client {
-	return &KyvernoV1Client{restClient, kyvernov1Interface, m}
+func Wrap(inner v1.KyvernoV1Interface, m utils.ClientQueryMetric) v1.KyvernoV1Interface {
+	return &client{inner, m}
 }

--- a/pkg/clients/wrappers/kyverno/v1/policy.go
+++ b/pkg/clients/wrappers/kyverno/v1/policy.go
@@ -4,88 +4,69 @@ import (
 	"context"
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
-	versionedv1 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1"
+	v1 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/clients/wrappers/utils"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/rest"
 )
 
-type PoliciesGetter interface {
-	Policies(namespace string) PoliciesControlInterface
-}
-
-type PoliciesControlInterface interface {
-	Create(ctx context.Context, policy *kyvernov1.Policy, opts metav1.CreateOptions) (*kyvernov1.Policy, error)
-	Update(ctx context.Context, policy *kyvernov1.Policy, opts metav1.UpdateOptions) (*kyvernov1.Policy, error)
-	UpdateStatus(ctx context.Context, policy *kyvernov1.Policy, opts metav1.UpdateOptions) (*kyvernov1.Policy, error)
-	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
-	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*kyvernov1.Policy, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*kyvernov1.PolicyList, error)
-	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *kyvernov1.Policy, err error)
-}
-
-type policiesControl struct {
-	client            rest.Interface
-	polClient         versionedv1.PoliciesGetter
+type policies struct {
+	inner             v1.PolicyInterface
 	clientQueryMetric utils.ClientQueryMetric
 	ns                string
 }
 
-func newPolicies(c *KyvernoV1Client, namespace string) *policiesControl {
-	return &policiesControl{
-		client:            c.RESTClient(),
-		polClient:         c.kyvernov1Interface,
-		clientQueryMetric: c.clientQueryMetric,
+func wrapPolicies(c v1.PolicyInterface, m utils.ClientQueryMetric, namespace string) v1.PolicyInterface {
+	return &policies{
+		inner:             c,
+		clientQueryMetric: m,
 		ns:                namespace,
 	}
 }
 
-func (c *policiesControl) Create(ctx context.Context, policy *kyvernov1.Policy, opts metav1.CreateOptions) (*kyvernov1.Policy, error) {
+func (c *policies) Create(ctx context.Context, policy *kyvernov1.Policy, opts metav1.CreateOptions) (*kyvernov1.Policy, error) {
 	c.clientQueryMetric.Record(metrics.ClientCreate, metrics.KyvernoClient, "Policy", c.ns)
-	return c.polClient.Policies(c.ns).Create(ctx, policy, opts)
+	return c.inner.Create(ctx, policy, opts)
 }
 
-func (c *policiesControl) Update(ctx context.Context, policy *kyvernov1.Policy, opts metav1.UpdateOptions) (*kyvernov1.Policy, error) {
+func (c *policies) Update(ctx context.Context, policy *kyvernov1.Policy, opts metav1.UpdateOptions) (*kyvernov1.Policy, error) {
 	c.clientQueryMetric.Record(metrics.ClientUpdate, metrics.KyvernoClient, "Policy", c.ns)
-	return c.polClient.Policies(c.ns).Update(ctx, policy, opts)
+	return c.inner.Update(ctx, policy, opts)
 }
 
-func (c *policiesControl) UpdateStatus(ctx context.Context, policy *kyvernov1.Policy, opts metav1.UpdateOptions) (*kyvernov1.Policy, error) {
+func (c *policies) UpdateStatus(ctx context.Context, policy *kyvernov1.Policy, opts metav1.UpdateOptions) (*kyvernov1.Policy, error) {
 	c.clientQueryMetric.Record(metrics.ClientUpdateStatus, metrics.KyvernoClient, "Policy", c.ns)
-	return c.polClient.Policies(c.ns).UpdateStatus(ctx, policy, opts)
+	return c.inner.UpdateStatus(ctx, policy, opts)
 }
 
-func (c *policiesControl) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+func (c *policies) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDelete, metrics.KyvernoClient, "Policy", c.ns)
-	return c.polClient.Policies(c.ns).Delete(ctx, name, opts)
+	return c.inner.Delete(ctx, name, opts)
 }
 
-func (c *policiesControl) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+func (c *policies) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDeleteCollection, metrics.KyvernoClient, "Policy", c.ns)
-	return c.polClient.Policies(c.ns).DeleteCollection(ctx, opts, listOpts)
+	return c.inner.DeleteCollection(ctx, opts, listOpts)
 }
 
-func (c *policiesControl) Get(ctx context.Context, name string, opts metav1.GetOptions) (*kyvernov1.Policy, error) {
+func (c *policies) Get(ctx context.Context, name string, opts metav1.GetOptions) (*kyvernov1.Policy, error) {
 	c.clientQueryMetric.Record(metrics.ClientGet, metrics.KyvernoClient, "Policy", c.ns)
-	return c.polClient.Policies(c.ns).Get(ctx, name, opts)
+	return c.inner.Get(ctx, name, opts)
 }
 
-func (c *policiesControl) List(ctx context.Context, opts metav1.ListOptions) (*kyvernov1.PolicyList, error) {
+func (c *policies) List(ctx context.Context, opts metav1.ListOptions) (*kyvernov1.PolicyList, error) {
 	c.clientQueryMetric.Record(metrics.ClientList, metrics.KyvernoClient, "Policy", c.ns)
-	return c.polClient.Policies(c.ns).List(ctx, opts)
+	return c.inner.List(ctx, opts)
 }
 
-func (c *policiesControl) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+func (c *policies) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	c.clientQueryMetric.Record(metrics.ClientWatch, metrics.KyvernoClient, "Policy", c.ns)
-	return c.polClient.Policies(c.ns).Watch(ctx, opts)
+	return c.inner.Watch(ctx, opts)
 }
 
-func (c *policiesControl) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *kyvernov1.Policy, err error) {
+func (c *policies) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *kyvernov1.Policy, err error) {
 	c.clientQueryMetric.Record(metrics.ClientPatch, metrics.KyvernoClient, "Policy", c.ns)
-	return c.polClient.Policies(c.ns).Patch(ctx, name, pt, data, opts, subresources...)
+	return c.inner.Patch(ctx, name, pt, data, opts, subresources...)
 }

--- a/pkg/clients/wrappers/kyverno/v1alpha2/clusterreportchangerequest.go
+++ b/pkg/clients/wrappers/kyverno/v1alpha2/clusterreportchangerequest.go
@@ -3,81 +3,63 @@ package v1alpha2
 import (
 	"context"
 
-	"github.com/kyverno/kyverno/api/kyverno/v1alpha2"
-	kyvernov1alpha2 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1alpha2"
+	kyvernov1alpha2 "github.com/kyverno/kyverno/api/kyverno/v1alpha2"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1alpha2"
 	"github.com/kyverno/kyverno/pkg/clients/wrappers/utils"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/rest"
 )
 
-type ClusterReportChangeRequestsGetter interface {
-	ClusterReportChangeRequests() ClusterReportChangeRequestControlInterface
-}
-
-type ClusterReportChangeRequestControlInterface interface {
-	Create(ctx context.Context, clusterReportChangeRequest *v1alpha2.ClusterReportChangeRequest, opts metav1.CreateOptions) (*v1alpha2.ClusterReportChangeRequest, error)
-	Update(ctx context.Context, clusterReportChangeRequest *v1alpha2.ClusterReportChangeRequest, opts metav1.UpdateOptions) (*v1alpha2.ClusterReportChangeRequest, error)
-	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
-	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1alpha2.ClusterReportChangeRequest, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1alpha2.ClusterReportChangeRequestList, error)
-	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1alpha2.ClusterReportChangeRequest, err error)
-}
-
-type clusterReportChangeRequestControl struct {
-	client            rest.Interface
-	crcrClient        kyvernov1alpha2.ClusterReportChangeRequestsGetter
+type clusterReportChangeRequest struct {
+	inner             v1alpha2.ClusterReportChangeRequestInterface
 	clientQueryMetric utils.ClientQueryMetric
 }
 
-func newClusterReportChangeRequests(c *KyvernoV1alpha2Client) *clusterReportChangeRequestControl {
-	return &clusterReportChangeRequestControl{
-		client:            c.RESTClient(),
-		crcrClient:        c.kyvernov1alpha2Interface,
-		clientQueryMetric: c.clientQueryMetric,
+func wrapClusterReportChangeRequests(c v1alpha2.ClusterReportChangeRequestInterface, m utils.ClientQueryMetric) v1alpha2.ClusterReportChangeRequestInterface {
+	return &clusterReportChangeRequest{
+		inner:             c,
+		clientQueryMetric: m,
 	}
 }
 
-func (c *clusterReportChangeRequestControl) Create(ctx context.Context, clusterReportChangeRequest *v1alpha2.ClusterReportChangeRequest, opts metav1.CreateOptions) (*v1alpha2.ClusterReportChangeRequest, error) {
+func (c *clusterReportChangeRequest) Create(ctx context.Context, clusterReportChangeRequest *kyvernov1alpha2.ClusterReportChangeRequest, opts metav1.CreateOptions) (*kyvernov1alpha2.ClusterReportChangeRequest, error) {
 	c.clientQueryMetric.Record(metrics.ClientCreate, metrics.KyvernoClient, "ClusterReportChangeRequest", "")
-	return c.crcrClient.ClusterReportChangeRequests().Create(ctx, clusterReportChangeRequest, opts)
+	return c.inner.Create(ctx, clusterReportChangeRequest, opts)
 }
 
-func (c *clusterReportChangeRequestControl) Update(ctx context.Context, clusterReportChangeRequest *v1alpha2.ClusterReportChangeRequest, opts metav1.UpdateOptions) (*v1alpha2.ClusterReportChangeRequest, error) {
+func (c *clusterReportChangeRequest) Update(ctx context.Context, clusterReportChangeRequest *kyvernov1alpha2.ClusterReportChangeRequest, opts metav1.UpdateOptions) (*kyvernov1alpha2.ClusterReportChangeRequest, error) {
 	c.clientQueryMetric.Record(metrics.ClientUpdate, metrics.KyvernoClient, "ClusterReportChangeRequest", "")
-	return c.crcrClient.ClusterReportChangeRequests().Update(ctx, clusterReportChangeRequest, opts)
+	return c.inner.Update(ctx, clusterReportChangeRequest, opts)
 }
 
-func (c *clusterReportChangeRequestControl) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+func (c *clusterReportChangeRequest) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDelete, metrics.KyvernoClient, "ClusterReportChangeRequest", "")
-	return c.crcrClient.ClusterReportChangeRequests().Delete(ctx, name, opts)
+	return c.inner.Delete(ctx, name, opts)
 }
 
-func (c *clusterReportChangeRequestControl) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+func (c *clusterReportChangeRequest) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDeleteCollection, metrics.KyvernoClient, "ClusterReportChangeRequest", "")
-	return c.crcrClient.ClusterReportChangeRequests().DeleteCollection(ctx, opts, listOpts)
+	return c.inner.DeleteCollection(ctx, opts, listOpts)
 }
 
-func (c *clusterReportChangeRequestControl) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1alpha2.ClusterReportChangeRequest, error) {
+func (c *clusterReportChangeRequest) Get(ctx context.Context, name string, opts metav1.GetOptions) (*kyvernov1alpha2.ClusterReportChangeRequest, error) {
 	c.clientQueryMetric.Record(metrics.ClientGet, metrics.KyvernoClient, "ClusterReportChangeRequest", "")
-	return c.crcrClient.ClusterReportChangeRequests().Get(ctx, name, opts)
+	return c.inner.Get(ctx, name, opts)
 }
 
-func (c *clusterReportChangeRequestControl) List(ctx context.Context, opts metav1.ListOptions) (*v1alpha2.ClusterReportChangeRequestList, error) {
+func (c *clusterReportChangeRequest) List(ctx context.Context, opts metav1.ListOptions) (*kyvernov1alpha2.ClusterReportChangeRequestList, error) {
 	c.clientQueryMetric.Record(metrics.ClientList, metrics.KyvernoClient, "ClusterReportChangeRequest", "")
-	return c.crcrClient.ClusterReportChangeRequests().List(ctx, opts)
+	return c.inner.List(ctx, opts)
 }
 
-func (c *clusterReportChangeRequestControl) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+func (c *clusterReportChangeRequest) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	c.clientQueryMetric.Record(metrics.ClientWatch, metrics.KyvernoClient, "ClusterReportChangeRequest", "")
-	return c.crcrClient.ClusterReportChangeRequests().Watch(ctx, opts)
+	return c.inner.Watch(ctx, opts)
 }
 
-func (c *clusterReportChangeRequestControl) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1alpha2.ClusterReportChangeRequest, err error) {
+func (c *clusterReportChangeRequest) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *kyvernov1alpha2.ClusterReportChangeRequest, err error) {
 	c.clientQueryMetric.Record(metrics.ClientPatch, metrics.KyvernoClient, "ClusterReportChangeRequest", "")
-	return c.crcrClient.ClusterReportChangeRequests().Patch(ctx, name, pt, data, opts, subresources...)
+	return c.inner.Patch(ctx, name, pt, data, opts, subresources...)
 }

--- a/pkg/clients/wrappers/kyverno/v1alpha2/kyverno_client.go
+++ b/pkg/clients/wrappers/kyverno/v1alpha2/kyverno_client.go
@@ -1,40 +1,23 @@
 package v1alpha2
 
 import (
-	kyvernov1alpha2 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1alpha2"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1alpha2"
 	"github.com/kyverno/kyverno/pkg/clients/wrappers/utils"
-	"k8s.io/client-go/rest"
 )
 
-type KyvernoV1alpha2Interface interface {
-	RESTClient() rest.Interface
-	ClusterReportChangeRequestsGetter
-	ReportChangeRequestsGetter
+type client struct {
+	v1alpha2.KyvernoV1alpha2Interface
+	clientQueryMetric utils.ClientQueryMetric
 }
 
-type KyvernoV1alpha2Client struct {
-	restClient               rest.Interface
-	kyvernov1alpha2Interface kyvernov1alpha2.KyvernoV1alpha2Interface
-	clientQueryMetric        utils.ClientQueryMetric
+func (c *client) ClusterReportChangeRequests() v1alpha2.ClusterReportChangeRequestInterface {
+	return wrapClusterReportChangeRequests(c.KyvernoV1alpha2Interface.ClusterReportChangeRequests(), c.clientQueryMetric)
 }
 
-func (c *KyvernoV1alpha2Client) ClusterReportChangeRequests() ClusterReportChangeRequestControlInterface {
-	return newClusterReportChangeRequests(c)
+func (c *client) ReportChangeRequests(namespace string) v1alpha2.ReportChangeRequestInterface {
+	return wrapReportChangeRequests(c.KyvernoV1alpha2Interface.ReportChangeRequests(namespace), c.clientQueryMetric, namespace)
 }
 
-func (c *KyvernoV1alpha2Client) ReportChangeRequests(namespace string) ReportChangeRequestControlInterface {
-	return newReportChangeRequests(c, namespace)
-}
-
-// RESTClient returns a RESTClient that is used to communicate
-// with API server by this client implementation.
-func (c *KyvernoV1alpha2Client) RESTClient() rest.Interface {
-	if c == nil {
-		return nil
-	}
-	return c.restClient
-}
-
-func NewForConfig(restClient rest.Interface, kyvernov1alpha2Interface kyvernov1alpha2.KyvernoV1alpha2Interface, m utils.ClientQueryMetric) *KyvernoV1alpha2Client {
-	return &KyvernoV1alpha2Client{restClient, kyvernov1alpha2Interface, m}
+func Wrap(inner v1alpha2.KyvernoV1alpha2Interface, m utils.ClientQueryMetric) v1alpha2.KyvernoV1alpha2Interface {
+	return &client{inner, m}
 }

--- a/pkg/clients/wrappers/kyverno/v1alpha2/reportchangerequest.go
+++ b/pkg/clients/wrappers/kyverno/v1alpha2/reportchangerequest.go
@@ -3,83 +3,65 @@ package v1alpha2
 import (
 	"context"
 
-	"github.com/kyverno/kyverno/api/kyverno/v1alpha2"
-	kyvernov1alpha2 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1alpha2"
+	kyvernov1alpha2 "github.com/kyverno/kyverno/api/kyverno/v1alpha2"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1alpha2"
 	"github.com/kyverno/kyverno/pkg/clients/wrappers/utils"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/rest"
 )
 
-type ReportChangeRequestsGetter interface {
-	ReportChangeRequests(namespace string) ReportChangeRequestControlInterface
-}
-
-type ReportChangeRequestControlInterface interface {
-	Create(ctx context.Context, creportChangeRequest *v1alpha2.ReportChangeRequest, opts metav1.CreateOptions) (*v1alpha2.ReportChangeRequest, error)
-	Update(ctx context.Context, creportChangeRequest *v1alpha2.ReportChangeRequest, opts metav1.UpdateOptions) (*v1alpha2.ReportChangeRequest, error)
-	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
-	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1alpha2.ReportChangeRequest, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1alpha2.ReportChangeRequestList, error)
-	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1alpha2.ReportChangeRequest, err error)
-}
-
 type reportChangeRequestControl struct {
-	client            rest.Interface
-	rcrClient         kyvernov1alpha2.ReportChangeRequestsGetter
+	inner             v1alpha2.ReportChangeRequestInterface
 	clientQueryMetric utils.ClientQueryMetric
 	ns                string
 }
 
-func newReportChangeRequests(c *KyvernoV1alpha2Client, namespace string) *reportChangeRequestControl {
+func wrapReportChangeRequests(c v1alpha2.ReportChangeRequestInterface, m utils.ClientQueryMetric, namespace string) v1alpha2.ReportChangeRequestInterface {
 	return &reportChangeRequestControl{
-		client:            c.RESTClient(),
-		rcrClient:         c.kyvernov1alpha2Interface,
-		clientQueryMetric: c.clientQueryMetric,
+		inner:             c,
+		clientQueryMetric: m,
 		ns:                namespace,
 	}
 }
 
-func (c *reportChangeRequestControl) Create(ctx context.Context, reportChangeRequest *v1alpha2.ReportChangeRequest, opts metav1.CreateOptions) (*v1alpha2.ReportChangeRequest, error) {
+func (c *reportChangeRequestControl) Create(ctx context.Context, reportChangeRequest *kyvernov1alpha2.ReportChangeRequest, opts metav1.CreateOptions) (*kyvernov1alpha2.ReportChangeRequest, error) {
 	c.clientQueryMetric.Record(metrics.ClientCreate, metrics.KyvernoClient, "ReportChangeRequest", c.ns)
-	return c.rcrClient.ReportChangeRequests(c.ns).Create(ctx, reportChangeRequest, opts)
+	return c.inner.Create(ctx, reportChangeRequest, opts)
 }
 
-func (c *reportChangeRequestControl) Update(ctx context.Context, reportChangeRequest *v1alpha2.ReportChangeRequest, opts metav1.UpdateOptions) (*v1alpha2.ReportChangeRequest, error) {
+func (c *reportChangeRequestControl) Update(ctx context.Context, reportChangeRequest *kyvernov1alpha2.ReportChangeRequest, opts metav1.UpdateOptions) (*kyvernov1alpha2.ReportChangeRequest, error) {
 	c.clientQueryMetric.Record(metrics.ClientUpdate, metrics.KyvernoClient, "ReportChangeRequest", c.ns)
-	return c.rcrClient.ReportChangeRequests(c.ns).Update(ctx, reportChangeRequest, opts)
+	return c.inner.Update(ctx, reportChangeRequest, opts)
 }
 
 func (c *reportChangeRequestControl) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDelete, metrics.KyvernoClient, "ReportChangeRequest", c.ns)
-	return c.rcrClient.ReportChangeRequests(c.ns).Delete(ctx, name, opts)
+	return c.inner.Delete(ctx, name, opts)
 }
 
 func (c *reportChangeRequestControl) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDeleteCollection, metrics.KyvernoClient, "ReportChangeRequest", c.ns)
-	return c.rcrClient.ReportChangeRequests(c.ns).DeleteCollection(ctx, opts, listOpts)
+	return c.inner.DeleteCollection(ctx, opts, listOpts)
 }
 
-func (c *reportChangeRequestControl) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1alpha2.ReportChangeRequest, error) {
+func (c *reportChangeRequestControl) Get(ctx context.Context, name string, opts metav1.GetOptions) (*kyvernov1alpha2.ReportChangeRequest, error) {
 	c.clientQueryMetric.Record(metrics.ClientGet, metrics.KyvernoClient, "ReportChangeRequest", c.ns)
-	return c.rcrClient.ReportChangeRequests(c.ns).Get(ctx, name, opts)
+	return c.inner.Get(ctx, name, opts)
 }
 
-func (c *reportChangeRequestControl) List(ctx context.Context, opts metav1.ListOptions) (*v1alpha2.ReportChangeRequestList, error) {
+func (c *reportChangeRequestControl) List(ctx context.Context, opts metav1.ListOptions) (*kyvernov1alpha2.ReportChangeRequestList, error) {
 	c.clientQueryMetric.Record(metrics.ClientList, metrics.KyvernoClient, "ReportChangeRequest", c.ns)
-	return c.rcrClient.ReportChangeRequests(c.ns).List(ctx, opts)
+	return c.inner.List(ctx, opts)
 }
 
 func (c *reportChangeRequestControl) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	c.clientQueryMetric.Record(metrics.ClientWatch, metrics.KyvernoClient, "ReportChangeRequest", c.ns)
-	return c.rcrClient.ReportChangeRequests(c.ns).Watch(ctx, opts)
+	return c.inner.Watch(ctx, opts)
 }
 
-func (c *reportChangeRequestControl) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1alpha2.ReportChangeRequest, err error) {
+func (c *reportChangeRequestControl) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *kyvernov1alpha2.ReportChangeRequest, err error) {
 	c.clientQueryMetric.Record(metrics.ClientPatch, metrics.KyvernoClient, "ReportChangeRequest", c.ns)
-	return c.rcrClient.ReportChangeRequests(c.ns).Patch(ctx, name, pt, data, opts, subresources...)
+	return c.inner.Patch(ctx, name, pt, data, opts, subresources...)
 }

--- a/pkg/clients/wrappers/kyverno/v1beta1/kyverno_client.go
+++ b/pkg/clients/wrappers/kyverno/v1beta1/kyverno_client.go
@@ -1,33 +1,19 @@
 package v1beta1
 
 import (
-	kyvernov1beta1 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1beta1"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/clients/wrappers/utils"
-	"k8s.io/client-go/rest"
 )
 
-type KyvernoV1beta1Interface interface {
-	RESTClient() rest.Interface
-	UpdateRequestsGetter
+type client struct {
+	v1beta1.KyvernoV1beta1Interface
+	clientQueryMetric utils.ClientQueryMetric
 }
 
-type KyvernoV1beta1Client struct {
-	restClient              rest.Interface
-	kyvernov1beta1Interface kyvernov1beta1.KyvernoV1beta1Interface
-	clientQueryMetric       utils.ClientQueryMetric
+func (c *client) UpdateRequests(namespace string) v1beta1.UpdateRequestInterface {
+	return wrapUpdateRequests(c.KyvernoV1beta1Interface.UpdateRequests(namespace), c.clientQueryMetric, namespace)
 }
 
-func (c *KyvernoV1beta1Client) UpdateRequests(namespace string) UpdateRequestControlInterface {
-	return newUpdateRequests(c, namespace)
-}
-
-func (c *KyvernoV1beta1Client) RESTClient() rest.Interface {
-	if c == nil {
-		return nil
-	}
-	return c.restClient
-}
-
-func NewForConfig(restClient rest.Interface, kyvernov1beta1Interface kyvernov1beta1.KyvernoV1beta1Interface, m utils.ClientQueryMetric) *KyvernoV1beta1Client {
-	return &KyvernoV1beta1Client{restClient, kyvernov1beta1Interface, m}
+func Wrap(inner v1beta1.KyvernoV1beta1Interface, m utils.ClientQueryMetric) v1beta1.KyvernoV1beta1Interface {
+	return &client{inner, m}
 }

--- a/pkg/clients/wrappers/kyverno/v1beta1/updaterequest.go
+++ b/pkg/clients/wrappers/kyverno/v1beta1/updaterequest.go
@@ -3,89 +3,70 @@ package v1beta1
 import (
 	"context"
 
-	"github.com/kyverno/kyverno/api/kyverno/v1beta1"
-	kyvernov1beta1 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1beta1"
+	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/clients/wrappers/utils"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/rest"
 )
 
-type UpdateRequestsGetter interface {
-	UpdateRequests(namespace string) UpdateRequestControlInterface
-}
-
-type UpdateRequestControlInterface interface {
-	Create(ctx context.Context, updateRequest *v1beta1.UpdateRequest, opts metav1.CreateOptions) (*v1beta1.UpdateRequest, error)
-	Update(ctx context.Context, updateRequest *v1beta1.UpdateRequest, opts metav1.UpdateOptions) (*v1beta1.UpdateRequest, error)
-	UpdateStatus(ctx context.Context, updateRequest *v1beta1.UpdateRequest, opts metav1.UpdateOptions) (*v1beta1.UpdateRequest, error)
-	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
-	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1beta1.UpdateRequest, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1beta1.UpdateRequestList, error)
-	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1beta1.UpdateRequest, err error)
-}
-
-type updateRequestsControl struct {
-	client            rest.Interface
-	urClient          kyvernov1beta1.UpdateRequestsGetter
+type updateRequests struct {
+	inner             v1beta1.UpdateRequestInterface
 	clientQueryMetric utils.ClientQueryMetric
 	ns                string
 }
 
-func newUpdateRequests(c *KyvernoV1beta1Client, namespace string) *updateRequestsControl {
-	return &updateRequestsControl{
-		client:            c.RESTClient(),
-		urClient:          c.kyvernov1beta1Interface,
-		clientQueryMetric: c.clientQueryMetric,
+func wrapUpdateRequests(c v1beta1.UpdateRequestInterface, m utils.ClientQueryMetric, namespace string) v1beta1.UpdateRequestInterface {
+	return &updateRequests{
+		inner:             c,
+		clientQueryMetric: m,
 		ns:                namespace,
 	}
 }
 
-func (c *updateRequestsControl) Create(ctx context.Context, updateRequest *v1beta1.UpdateRequest, opts metav1.CreateOptions) (*v1beta1.UpdateRequest, error) {
+func (c *updateRequests) Create(ctx context.Context, updateRequest *kyvernov1beta1.UpdateRequest, opts metav1.CreateOptions) (*kyvernov1beta1.UpdateRequest, error) {
 	c.clientQueryMetric.Record(metrics.ClientCreate, metrics.KyvernoClient, "UpdateRequest", c.ns)
-	return c.urClient.UpdateRequests(c.ns).Create(ctx, updateRequest, opts)
+	return c.inner.Create(ctx, updateRequest, opts)
 }
 
-func (c *updateRequestsControl) Update(ctx context.Context, updateRequest *v1beta1.UpdateRequest, opts metav1.UpdateOptions) (*v1beta1.UpdateRequest, error) {
+func (c *updateRequests) Update(ctx context.Context, updateRequest *kyvernov1beta1.UpdateRequest, opts metav1.UpdateOptions) (*kyvernov1beta1.UpdateRequest, error) {
 	c.clientQueryMetric.Record(metrics.ClientUpdate, metrics.KyvernoClient, "UpdateRequest", c.ns)
-	return c.urClient.UpdateRequests(c.ns).Update(ctx, updateRequest, opts)
+	return c.inner.Update(ctx, updateRequest, opts)
 }
 
-func (c *updateRequestsControl) UpdateStatus(ctx context.Context, updateRequest *v1beta1.UpdateRequest, opts metav1.UpdateOptions) (*v1beta1.UpdateRequest, error) {
+func (c *updateRequests) UpdateStatus(ctx context.Context, updateRequest *kyvernov1beta1.UpdateRequest, opts metav1.UpdateOptions) (*kyvernov1beta1.UpdateRequest, error) {
 	c.clientQueryMetric.Record(metrics.ClientUpdateStatus, metrics.KyvernoClient, "UpdateRequest", c.ns)
-	return c.urClient.UpdateRequests(c.ns).UpdateStatus(ctx, updateRequest, opts)
+	return c.inner.UpdateStatus(ctx, updateRequest, opts)
 }
 
-func (c *updateRequestsControl) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+func (c *updateRequests) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDelete, metrics.KyvernoClient, "UpdateRequest", c.ns)
-	return c.urClient.UpdateRequests(c.ns).Delete(ctx, name, opts)
+	return c.inner.Delete(ctx, name, opts)
 }
 
-func (c *updateRequestsControl) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+func (c *updateRequests) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDeleteCollection, metrics.KyvernoClient, "UpdateRequest", c.ns)
-	return c.urClient.UpdateRequests(c.ns).DeleteCollection(ctx, opts, listOpts)
+	return c.inner.DeleteCollection(ctx, opts, listOpts)
 }
 
-func (c *updateRequestsControl) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1beta1.UpdateRequest, error) {
+func (c *updateRequests) Get(ctx context.Context, name string, opts metav1.GetOptions) (*kyvernov1beta1.UpdateRequest, error) {
 	c.clientQueryMetric.Record(metrics.ClientGet, metrics.KyvernoClient, "UpdateRequest", c.ns)
-	return c.urClient.UpdateRequests(c.ns).Get(ctx, name, opts)
+	return c.inner.Get(ctx, name, opts)
 }
 
-func (c *updateRequestsControl) List(ctx context.Context, opts metav1.ListOptions) (*v1beta1.UpdateRequestList, error) {
+func (c *updateRequests) List(ctx context.Context, opts metav1.ListOptions) (*kyvernov1beta1.UpdateRequestList, error) {
 	c.clientQueryMetric.Record(metrics.ClientCreate, metrics.KyvernoClient, "UpdateRequest", c.ns)
-	return c.urClient.UpdateRequests(c.ns).List(ctx, opts)
+	return c.inner.List(ctx, opts)
 }
 
-func (c *updateRequestsControl) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+func (c *updateRequests) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	c.clientQueryMetric.Record(metrics.ClientWatch, metrics.KyvernoClient, "UpdateRequest", c.ns)
-	return c.urClient.UpdateRequests(c.ns).Watch(ctx, opts)
+	return c.inner.Watch(ctx, opts)
 }
 
-func (c *updateRequestsControl) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1beta1.UpdateRequest, err error) {
+func (c *updateRequests) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *kyvernov1beta1.UpdateRequest, err error) {
 	c.clientQueryMetric.Record(metrics.ClientPatch, metrics.KyvernoClient, "UpdateRequest", c.ns)
-	return c.urClient.UpdateRequests(c.ns).Patch(ctx, name, pt, data, opts, subresources...)
+	return c.inner.Patch(ctx, name, pt, data, opts, subresources...)
 }

--- a/pkg/clients/wrappers/policyreport/v1alpha2/clusterpolicyreport.go
+++ b/pkg/clients/wrappers/policyreport/v1alpha2/clusterpolicyreport.go
@@ -3,81 +3,63 @@ package v1alpha2
 import (
 	"context"
 
-	"github.com/kyverno/kyverno/api/policyreport/v1alpha2"
-	policyreportv1alpha2 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/policyreport/v1alpha2"
+	policyreportv1alpha2 "github.com/kyverno/kyverno/api/policyreport/v1alpha2"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/policyreport/v1alpha2"
 	"github.com/kyverno/kyverno/pkg/clients/wrappers/utils"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/rest"
 )
 
-type ClusterPolicyReportsGetter interface {
-	ClusterPolicyReports() ClusterPolicyReportControlInterface
-}
-
-type ClusterPolicyReportControlInterface interface {
-	Create(ctx context.Context, clusterPolicyReport *v1alpha2.ClusterPolicyReport, opts metav1.CreateOptions) (*v1alpha2.ClusterPolicyReport, error)
-	Update(ctx context.Context, clusterPolicyReport *v1alpha2.ClusterPolicyReport, opts metav1.UpdateOptions) (*v1alpha2.ClusterPolicyReport, error)
-	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
-	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1alpha2.ClusterPolicyReport, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1alpha2.ClusterPolicyReportList, error)
-	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1alpha2.ClusterPolicyReport, err error)
-}
-
-type clusterPolicyReportsControl struct {
-	client            rest.Interface
-	cpolrClient       policyreportv1alpha2.ClusterPolicyReportsGetter
+type clusterPolicyReports struct {
+	inner             v1alpha2.ClusterPolicyReportInterface
 	clientQueryMetric utils.ClientQueryMetric
 }
 
-func newClusterPolicyReports(c *Wgpolicyk8sV1alpha2Client) *clusterPolicyReportsControl {
-	return &clusterPolicyReportsControl{
-		client:            c.RESTClient(),
-		cpolrClient:       c.wgpolicyk8sV1alpha2Interface,
-		clientQueryMetric: c.clientQueryMetric,
+func wrapClusterPolicyReports(c v1alpha2.ClusterPolicyReportInterface, m utils.ClientQueryMetric) v1alpha2.ClusterPolicyReportInterface {
+	return &clusterPolicyReports{
+		inner:             c,
+		clientQueryMetric: m,
 	}
 }
 
-func (c *clusterPolicyReportsControl) Create(ctx context.Context, clusterPolicyReport *v1alpha2.ClusterPolicyReport, opts metav1.CreateOptions) (*v1alpha2.ClusterPolicyReport, error) {
+func (c *clusterPolicyReports) Create(ctx context.Context, clusterPolicyReport *policyreportv1alpha2.ClusterPolicyReport, opts metav1.CreateOptions) (*policyreportv1alpha2.ClusterPolicyReport, error) {
 	c.clientQueryMetric.Record(metrics.ClientCreate, metrics.PolicyReportClient, "ClusterPolicyReport", "")
-	return c.cpolrClient.ClusterPolicyReports().Create(ctx, clusterPolicyReport, opts)
+	return c.inner.Create(ctx, clusterPolicyReport, opts)
 }
 
-func (c *clusterPolicyReportsControl) Update(ctx context.Context, clusterPolicyReport *v1alpha2.ClusterPolicyReport, opts metav1.UpdateOptions) (*v1alpha2.ClusterPolicyReport, error) {
+func (c *clusterPolicyReports) Update(ctx context.Context, clusterPolicyReport *policyreportv1alpha2.ClusterPolicyReport, opts metav1.UpdateOptions) (*policyreportv1alpha2.ClusterPolicyReport, error) {
 	c.clientQueryMetric.Record(metrics.ClientUpdate, metrics.PolicyReportClient, "ClusterPolicyReport", "")
-	return c.cpolrClient.ClusterPolicyReports().Update(ctx, clusterPolicyReport, opts)
+	return c.inner.Update(ctx, clusterPolicyReport, opts)
 }
 
-func (c *clusterPolicyReportsControl) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+func (c *clusterPolicyReports) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDelete, metrics.PolicyReportClient, "ClusterPolicyReport", "")
-	return c.cpolrClient.ClusterPolicyReports().Delete(ctx, name, opts)
+	return c.inner.Delete(ctx, name, opts)
 }
 
-func (c *clusterPolicyReportsControl) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+func (c *clusterPolicyReports) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDeleteCollection, metrics.PolicyReportClient, "ClusterPolicyReport", "")
-	return c.cpolrClient.ClusterPolicyReports().DeleteCollection(ctx, opts, listOpts)
+	return c.inner.DeleteCollection(ctx, opts, listOpts)
 }
 
-func (c *clusterPolicyReportsControl) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1alpha2.ClusterPolicyReport, error) {
+func (c *clusterPolicyReports) Get(ctx context.Context, name string, opts metav1.GetOptions) (*policyreportv1alpha2.ClusterPolicyReport, error) {
 	c.clientQueryMetric.Record(metrics.ClientGet, metrics.PolicyReportClient, "ClusterPolicyReport", "")
-	return c.cpolrClient.ClusterPolicyReports().Get(ctx, name, opts)
+	return c.inner.Get(ctx, name, opts)
 }
 
-func (c *clusterPolicyReportsControl) List(ctx context.Context, opts metav1.ListOptions) (*v1alpha2.ClusterPolicyReportList, error) {
+func (c *clusterPolicyReports) List(ctx context.Context, opts metav1.ListOptions) (*policyreportv1alpha2.ClusterPolicyReportList, error) {
 	c.clientQueryMetric.Record(metrics.ClientList, metrics.PolicyReportClient, "ClusterPolicyReport", "")
-	return c.cpolrClient.ClusterPolicyReports().List(ctx, opts)
+	return c.inner.List(ctx, opts)
 }
 
-func (c *clusterPolicyReportsControl) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+func (c *clusterPolicyReports) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	c.clientQueryMetric.Record(metrics.ClientWatch, metrics.PolicyReportClient, "ClusterPolicyReport", "")
-	return c.cpolrClient.ClusterPolicyReports().Watch(ctx, opts)
+	return c.inner.Watch(ctx, opts)
 }
 
-func (c *clusterPolicyReportsControl) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1alpha2.ClusterPolicyReport, err error) {
+func (c *clusterPolicyReports) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *policyreportv1alpha2.ClusterPolicyReport, err error) {
 	c.clientQueryMetric.Record(metrics.ClientPatch, metrics.PolicyReportClient, "ClusterPolicyReport", "")
-	return c.cpolrClient.ClusterPolicyReports().Patch(ctx, name, pt, data, opts, subresources...)
+	return c.inner.Patch(ctx, name, pt, data, opts, subresources...)
 }

--- a/pkg/clients/wrappers/policyreport/v1alpha2/policyreport.go
+++ b/pkg/clients/wrappers/policyreport/v1alpha2/policyreport.go
@@ -3,84 +3,65 @@ package v1alpha2
 import (
 	"context"
 
-	"github.com/kyverno/kyverno/api/policyreport/v1alpha2"
-	policyreportv1alpha2 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/policyreport/v1alpha2"
+	policyreportv1alpha2 "github.com/kyverno/kyverno/api/policyreport/v1alpha2"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/policyreport/v1alpha2"
 	"github.com/kyverno/kyverno/pkg/clients/wrappers/utils"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/rest"
 )
 
-type PolicyReportsGetter interface {
-	PolicyReports(namespace string) PolicyReportControlInterface
-}
-
-type PolicyReportControlInterface interface {
-	Create(ctx context.Context, policyReport *v1alpha2.PolicyReport, opts metav1.CreateOptions) (*v1alpha2.PolicyReport, error)
-	Update(ctx context.Context, policyReport *v1alpha2.PolicyReport, opts metav1.UpdateOptions) (*v1alpha2.PolicyReport, error)
-	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
-	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1alpha2.PolicyReport, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1alpha2.PolicyReportList, error)
-	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1alpha2.PolicyReport, err error)
-}
-
-type policyReportsControl struct {
-	client            rest.Interface
-	polrClient        policyreportv1alpha2.PolicyReportsGetter
+type policyReports struct {
+	inner             v1alpha2.PolicyReportInterface
 	clientQueryMetric utils.ClientQueryMetric
 	ns                string
 }
 
-// newPolicyReports returns a PolicyReports
-func newPolicyReports(c *Wgpolicyk8sV1alpha2Client, namespace string) *policyReportsControl {
-	return &policyReportsControl{
-		client:            c.RESTClient(),
-		polrClient:        c.wgpolicyk8sV1alpha2Interface,
-		clientQueryMetric: c.clientQueryMetric,
+func wrapPolicyReports(c v1alpha2.PolicyReportInterface, m utils.ClientQueryMetric, namespace string) v1alpha2.PolicyReportInterface {
+	return &policyReports{
+		inner:             c,
+		clientQueryMetric: m,
 		ns:                namespace,
 	}
 }
 
-func (c *policyReportsControl) Create(ctx context.Context, policyReport *v1alpha2.PolicyReport, opts metav1.CreateOptions) (*v1alpha2.PolicyReport, error) {
+func (c *policyReports) Create(ctx context.Context, policyReport *policyreportv1alpha2.PolicyReport, opts metav1.CreateOptions) (*policyreportv1alpha2.PolicyReport, error) {
 	c.clientQueryMetric.Record(metrics.ClientCreate, metrics.PolicyReportClient, "PolicyReport", c.ns)
-	return c.polrClient.PolicyReports(c.ns).Create(ctx, policyReport, opts)
+	return c.inner.Create(ctx, policyReport, opts)
 }
 
-func (c *policyReportsControl) Update(ctx context.Context, policyReport *v1alpha2.PolicyReport, opts metav1.UpdateOptions) (*v1alpha2.PolicyReport, error) {
+func (c *policyReports) Update(ctx context.Context, policyReport *policyreportv1alpha2.PolicyReport, opts metav1.UpdateOptions) (*policyreportv1alpha2.PolicyReport, error) {
 	c.clientQueryMetric.Record(metrics.ClientUpdate, metrics.PolicyReportClient, "PolicyReport", c.ns)
-	return c.polrClient.PolicyReports(c.ns).Update(ctx, policyReport, opts)
+	return c.inner.Update(ctx, policyReport, opts)
 }
 
-func (c *policyReportsControl) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+func (c *policyReports) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDelete, metrics.PolicyReportClient, "PolicyReport", c.ns)
-	return c.polrClient.PolicyReports(c.ns).Delete(ctx, name, opts)
+	return c.inner.Delete(ctx, name, opts)
 }
 
-func (c *policyReportsControl) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+func (c *policyReports) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	c.clientQueryMetric.Record(metrics.ClientDeleteCollection, metrics.PolicyReportClient, "PolicyReport", c.ns)
-	return c.polrClient.PolicyReports(c.ns).DeleteCollection(ctx, opts, listOpts)
+	return c.inner.DeleteCollection(ctx, opts, listOpts)
 }
 
-func (c *policyReportsControl) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1alpha2.PolicyReport, error) {
+func (c *policyReports) Get(ctx context.Context, name string, opts metav1.GetOptions) (*policyreportv1alpha2.PolicyReport, error) {
 	c.clientQueryMetric.Record(metrics.ClientGet, metrics.PolicyReportClient, "PolicyReport", c.ns)
-	return c.polrClient.PolicyReports(c.ns).Get(ctx, name, opts)
+	return c.inner.Get(ctx, name, opts)
 }
 
-func (c *policyReportsControl) List(ctx context.Context, opts metav1.ListOptions) (*v1alpha2.PolicyReportList, error) {
+func (c *policyReports) List(ctx context.Context, opts metav1.ListOptions) (*policyreportv1alpha2.PolicyReportList, error) {
 	c.clientQueryMetric.Record(metrics.ClientList, metrics.PolicyReportClient, "PolicyReport", c.ns)
-	return c.polrClient.PolicyReports(c.ns).List(ctx, opts)
+	return c.inner.List(ctx, opts)
 }
 
-func (c *policyReportsControl) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+func (c *policyReports) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	c.clientQueryMetric.Record(metrics.ClientWatch, metrics.PolicyReportClient, "PolicyReport", c.ns)
-	return c.polrClient.PolicyReports(c.ns).Watch(ctx, opts)
+	return c.inner.Watch(ctx, opts)
 }
 
-func (c *policyReportsControl) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1alpha2.PolicyReport, err error) {
+func (c *policyReports) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *policyreportv1alpha2.PolicyReport, err error) {
 	c.clientQueryMetric.Record(metrics.ClientPatch, metrics.PolicyReportClient, "PolicyReport", c.ns)
-	return c.polrClient.PolicyReports(c.ns).Patch(ctx, name, pt, data, opts, subresources...)
+	return c.inner.Patch(ctx, name, pt, data, opts, subresources...)
 }

--- a/pkg/clients/wrappers/policyreport/v1alpha2/policyreport_client.go
+++ b/pkg/clients/wrappers/policyreport/v1alpha2/policyreport_client.go
@@ -1,38 +1,23 @@
 package v1alpha2
 
 import (
-	policyreportv1alpha2 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/policyreport/v1alpha2"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/typed/policyreport/v1alpha2"
 	"github.com/kyverno/kyverno/pkg/clients/wrappers/utils"
-	"k8s.io/client-go/rest"
 )
 
-type Wgpolicyk8sV1alpha2Interface interface {
-	RESTClient() rest.Interface
-	ClusterPolicyReportsGetter
-	PolicyReportsGetter
+type client struct {
+	v1alpha2.Wgpolicyk8sV1alpha2Interface
+	clientQueryMetric utils.ClientQueryMetric
 }
 
-type Wgpolicyk8sV1alpha2Client struct {
-	restClient                   rest.Interface
-	wgpolicyk8sV1alpha2Interface policyreportv1alpha2.Wgpolicyk8sV1alpha2Interface
-	clientQueryMetric            utils.ClientQueryMetric
+func (c *client) ClusterPolicyReports() v1alpha2.ClusterPolicyReportInterface {
+	return wrapClusterPolicyReports(c.Wgpolicyk8sV1alpha2Interface.ClusterPolicyReports(), c.clientQueryMetric)
 }
 
-func (c *Wgpolicyk8sV1alpha2Client) ClusterPolicyReports() ClusterPolicyReportControlInterface {
-	return newClusterPolicyReports(c)
+func (c *client) PolicyReports(namespace string) v1alpha2.PolicyReportInterface {
+	return wrapPolicyReports(c.Wgpolicyk8sV1alpha2Interface.PolicyReports(namespace), c.clientQueryMetric, namespace)
 }
 
-func (c *Wgpolicyk8sV1alpha2Client) PolicyReports(namespace string) PolicyReportControlInterface {
-	return newPolicyReports(c, namespace)
-}
-
-func (c *Wgpolicyk8sV1alpha2Client) RESTClient() rest.Interface {
-	if c == nil {
-		return nil
-	}
-	return c.restClient
-}
-
-func NewForConfig(restClient rest.Interface, wgpolicyk8sV1alpha2Interface policyreportv1alpha2.Wgpolicyk8sV1alpha2Interface, m utils.ClientQueryMetric) *Wgpolicyk8sV1alpha2Client {
-	return &Wgpolicyk8sV1alpha2Client{restClient, wgpolicyk8sV1alpha2Interface, m}
+func Wrap(inner v1alpha2.Wgpolicyk8sV1alpha2Interface, m utils.ClientQueryMetric) v1alpha2.Wgpolicyk8sV1alpha2Interface {
+	return &client{inner, m}
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 	enginutils "github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -79,7 +79,7 @@ func RetryFunc(retryInterval, timeout time.Duration, run func() error, msg strin
 	}
 }
 
-func ProcessDeletePolicyForCloneGenerateRule(policy kyvernov1.PolicyInterface, client dclient.Interface, kyvernoClient kyvernoclient.Interface, urlister kyvernov1beta1listers.UpdateRequestNamespaceLister, pName string, logger logr.Logger) bool {
+func ProcessDeletePolicyForCloneGenerateRule(policy kyvernov1.PolicyInterface, client dclient.Interface, kyvernoClient versioned.Interface, urlister kyvernov1beta1listers.UpdateRequestNamespaceLister, pName string, logger logr.Logger) bool {
 	generatePolicyWithClone := false
 	for _, rule := range policy.GetSpec().Rules {
 		clone, sync := rule.GetCloneSyncForGenerate()

--- a/pkg/policy/policy_controller.go
+++ b/pkg/policy/policy_controller.go
@@ -15,13 +15,13 @@ import (
 	utilscommon "github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/utils/common"
 	"github.com/kyverno/kyverno/pkg/autogen"
 	common "github.com/kyverno/kyverno/pkg/background/common"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/scheme"
 	kyvernov1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1"
 	kyvernov1beta1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1beta1"
 	kyvernov1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1"
 	kyvernov1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/event"
 	"github.com/kyverno/kyverno/pkg/metrics"
@@ -56,7 +56,7 @@ const (
 // in the system with the corresponding policy violations
 type PolicyController struct {
 	client        dclient.Interface
-	kyvernoClient kyvernoclient.Interface
+	kyvernoClient versioned.Interface
 	pInformer     kyvernov1informers.ClusterPolicyInformer
 	npInformer    kyvernov1informers.PolicyInformer
 
@@ -100,7 +100,7 @@ type PolicyController struct {
 
 // NewPolicyController create a new PolicyController
 func NewPolicyController(
-	kyvernoClient kyvernoclient.Interface,
+	kyvernoClient versioned.Interface,
 	client dclient.Interface,
 	pInformer kyvernov1informers.ClusterPolicyInformer,
 	npInformer kyvernov1informers.PolicyInformer,
@@ -509,7 +509,7 @@ func generateTriggers(client dclient.Interface, rule kyvernov1.Rule, log logr.Lo
 	return convertlist(list.Items)
 }
 
-func updateUR(kyvernoClient kyvernoclient.Interface, urLister kyvernov1beta1listers.UpdateRequestNamespaceLister, policyKey string, urList []*kyvernov1beta1.UpdateRequest, logger logr.Logger) {
+func updateUR(kyvernoClient versioned.Interface, urLister kyvernov1beta1listers.UpdateRequestNamespaceLister, policyKey string, urList []*kyvernov1beta1.UpdateRequest, logger logr.Logger) {
 	for _, ur := range urList {
 		if policyKey == ur.Spec.Policy {
 			_, err := common.Update(kyvernoClient, urLister, ur.GetName(), func(ur *kyvernov1beta1.UpdateRequest) {

--- a/pkg/policy/report.go
+++ b/pkg/policy/report.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/kyverno/kyverno/api/policyreport/v1alpha2"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1alpha2listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1alpha2"
 	policyreportv1alpha2listers "github.com/kyverno/kyverno/pkg/client/listers/policyreport/v1alpha2"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/engine/response"
 	"github.com/kyverno/kyverno/pkg/event"
@@ -114,7 +114,7 @@ func (pc *PolicyController) forceReconciliation(reconcileCh <-chan bool, cleanup
 	}
 }
 
-func cleanupReportChangeRequests(pclient kyvernoclient.Interface, rcrLister kyvernov1alpha2listers.ReportChangeRequestLister, crcrLister kyvernov1alpha2listers.ClusterReportChangeRequestLister, nslabels map[string]string) error {
+func cleanupReportChangeRequests(pclient versioned.Interface, rcrLister kyvernov1alpha2listers.ReportChangeRequestLister, crcrLister kyvernov1alpha2listers.ClusterReportChangeRequestLister, nslabels map[string]string) error {
 	var errors []string
 	var gracePeriod int64 = 0
 	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
@@ -138,7 +138,7 @@ func cleanupReportChangeRequests(pclient kyvernoclient.Interface, rcrLister kyve
 	return fmt.Errorf("%v", strings.Join(errors, ";"))
 }
 
-func eraseResultEntries(pclient kyvernoclient.Interface, reportLister policyreportv1alpha2listers.PolicyReportLister, clusterReportLister policyreportv1alpha2listers.ClusterPolicyReportLister, ns *string) error {
+func eraseResultEntries(pclient versioned.Interface, reportLister policyreportv1alpha2listers.PolicyReportLister, clusterReportLister policyreportv1alpha2listers.ClusterPolicyReportLister, ns *string) error {
 	selector, err := metav1.LabelSelectorAsSelector(policyreport.LabelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to erase results entries %v", err)
@@ -217,7 +217,7 @@ func eraseResultEntries(pclient kyvernoclient.Interface, reportLister policyrepo
 	return fmt.Errorf("failed to erase results entries %v", strings.Join(errors, ";"))
 }
 
-func eraseSplitResultEntries(pclient kyvernoclient.Interface, ns *string, selector labels.Selector) error {
+func eraseSplitResultEntries(pclient versioned.Interface, ns *string, selector labels.Selector) error {
 	var errors []string
 
 	if ns != nil {

--- a/pkg/policyreport/changerequestcreator.go
+++ b/pkg/policyreport/changerequestcreator.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/toggle"
 	"github.com/patrickmn/go-cache"
@@ -26,7 +26,7 @@ type creator interface {
 }
 
 type changeRequestCreator struct {
-	client kyvernoclient.Interface
+	client versioned.Interface
 
 	// addCache preserves requests that are to be added to report
 	RCRCache *cache.Cache
@@ -45,7 +45,7 @@ type changeRequestCreator struct {
 	log logr.Logger
 }
 
-func newChangeRequestCreator(client kyvernoclient.Interface, tickerInterval time.Duration, log logr.Logger) creator {
+func newChangeRequestCreator(client versioned.Interface, tickerInterval time.Duration, log logr.Logger) creator {
 	return &changeRequestCreator{
 		client:         client,
 		RCRCache:       cache.New(0, 24*time.Hour),

--- a/pkg/policyreport/policyreport.go
+++ b/pkg/policyreport/policyreport.go
@@ -10,9 +10,9 @@ import (
 	"github.com/cornelk/hashmap"
 	kyvernov1alpha2 "github.com/kyverno/kyverno/api/kyverno/v1alpha2"
 	policyreportv1alpha2 "github.com/kyverno/kyverno/api/policyreport/v1alpha2"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1alpha2listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1alpha2"
 	policyreportv1alpha2listers "github.com/kyverno/kyverno/pkg/client/listers/policyreport/v1alpha2"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 	"github.com/kyverno/kyverno/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -25,8 +25,8 @@ type PolicyReportEraser interface {
 }
 
 type (
-	CleanupReportChangeRequests = func(pclient kyvernoclient.Interface, rcrLister kyvernov1alpha2listers.ReportChangeRequestLister, crcrLister kyvernov1alpha2listers.ClusterReportChangeRequestLister, labels map[string]string) error
-	EraseResultEntries          = func(pclient kyvernoclient.Interface, reportLister policyreportv1alpha2listers.PolicyReportLister, clusterReportLister policyreportv1alpha2listers.ClusterPolicyReportLister, ns *string) error
+	CleanupReportChangeRequests = func(pclient versioned.Interface, rcrLister kyvernov1alpha2listers.ReportChangeRequestLister, crcrLister kyvernov1alpha2listers.ClusterReportChangeRequestLister, labels map[string]string) error
+	EraseResultEntries          = func(pclient versioned.Interface, reportLister policyreportv1alpha2listers.PolicyReportLister, clusterReportLister policyreportv1alpha2listers.ClusterPolicyReportLister, ns *string) error
 )
 
 func (g *ReportGenerator) CleanupReportChangeRequests(cleanup CleanupReportChangeRequests, labels map[string]string) error {
@@ -225,7 +225,7 @@ func mapToStruct(in, out interface{}) error {
 	return json.Unmarshal(jsonBytes, out)
 }
 
-func CleanupPolicyReport(client kyvernoclient.Interface) error {
+func CleanupPolicyReport(client versioned.Interface) error {
 	var errors []string
 	var gracePeriod int64 = 0
 

--- a/pkg/policyreport/reportcontroller.go
+++ b/pkg/policyreport/reportcontroller.go
@@ -10,11 +10,11 @@ import (
 	"github.com/go-logr/logr"
 	kyvernov1alpha2 "github.com/kyverno/kyverno/api/kyverno/v1alpha2"
 	policyreportv1alpha2 "github.com/kyverno/kyverno/api/policyreport/v1alpha2"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1alpha2informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1alpha2"
 	policyreportv1alpha2informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/policyreport/v1alpha2"
 	kyvernov1alpha2listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1alpha2"
 	policyreportv1alpha2listers "github.com/kyverno/kyverno/pkg/client/listers/policyreport/v1alpha2"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/toggle"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
@@ -54,7 +54,7 @@ var LabelSelector = &metav1.LabelSelector{
 
 // ReportGenerator creates policy report
 type ReportGenerator struct {
-	pclient kyvernoclient.Interface
+	pclient versioned.Interface
 
 	clusterReportInformer    policyreportv1alpha2informers.ClusterPolicyReportInformer
 	reportInformer           policyreportv1alpha2informers.PolicyReportInformer
@@ -82,7 +82,7 @@ type ReportGenerator struct {
 
 // NewReportGenerator returns a new instance of policy report generator
 func NewReportGenerator(
-	pclient kyvernoclient.Interface,
+	pclient versioned.Interface,
 	clusterReportInformer policyreportv1alpha2informers.ClusterPolicyReportInformer,
 	reportInformer policyreportv1alpha2informers.PolicyReportInformer,
 	reportReqInformer kyvernov1alpha2informers.ReportChangeRequestInformer,

--- a/pkg/policyreport/reportrequest.go
+++ b/pkg/policyreport/reportrequest.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1"
 	kyvernov1alpha2informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1alpha2"
 	kyvernov1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1"
 	kyvernov1alpha2listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1alpha2"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 	"github.com/kyverno/kyverno/pkg/engine/response"
 	cmap "github.com/orcaman/concurrent-map"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -60,7 +60,7 @@ type Generator struct {
 }
 
 // NewReportChangeRequestGenerator returns a new instance of report request generator
-func NewReportChangeRequestGenerator(client kyvernoclient.Interface,
+func NewReportChangeRequestGenerator(client versioned.Interface,
 	reportReqInformer kyvernov1alpha2informers.ReportChangeRequestInformer,
 	clusterReportReqInformer kyvernov1alpha2informers.ClusterReportChangeRequestInformer,
 	cpolInformer kyvernov1informers.ClusterPolicyInformer,

--- a/pkg/webhookconfig/configmanager.go
+++ b/pkg/webhookconfig/configmanager.go
@@ -10,10 +10,10 @@ import (
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/autogen"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1"
 	kyvernov1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	"github.com/kyverno/kyverno/pkg/toggle"
@@ -42,7 +42,7 @@ type webhookConfigManager struct {
 	// clients
 	discoveryClient dclient.IDiscovery
 	kubeClient      kubernetes.Interface
-	kyvernoClient   kyvernoclient.Interface
+	kyvernoClient   versioned.Interface
 
 	// informers
 	pInformer        kyvernov1informers.ClusterPolicyInformer
@@ -82,7 +82,7 @@ type manage interface {
 func newWebhookConfigManager(
 	discoveryClient dclient.IDiscovery,
 	kubeClient kubernetes.Interface,
-	kyvernoClient kyvernoclient.Interface,
+	kyvernoClient versioned.Interface,
 	pInformer kyvernov1informers.ClusterPolicyInformer,
 	npInformer kyvernov1informers.PolicyInformer,
 	mwcInformer admissionregistrationv1informers.MutatingWebhookConfigurationInformer,

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	"github.com/kyverno/kyverno/pkg/utils"
@@ -42,7 +42,7 @@ const (
 type Register struct {
 	// clients
 	kubeClient    kubernetes.Interface
-	kyvernoClient kyvernoclient.Interface
+	kyvernoClient versioned.Interface
 	clientConfig  *rest.Config
 
 	// listers
@@ -72,7 +72,7 @@ func NewRegister(
 	clientConfig *rest.Config,
 	client dclient.Interface,
 	kubeClient kubernetes.Interface,
-	kyvernoClient kyvernoclient.Interface,
+	kyvernoClient versioned.Interface,
 	mwcInformer admissionregistrationv1informers.MutatingWebhookConfigurationInformer,
 	vwcInformer admissionregistrationv1informers.ValidatingWebhookConfigurationInformer,
 	kDeplInformer appsv1informers.DeploymentInformer,

--- a/pkg/webhooks/resource/handlers.go
+++ b/pkg/webhooks/resource/handlers.go
@@ -8,9 +8,9 @@ import (
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 	"github.com/kyverno/kyverno/pkg/common"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/engine"
@@ -40,7 +40,7 @@ import (
 type handlers struct {
 	// clients
 	client        dclient.Interface
-	kyvernoClient kyvernoclient.Interface
+	kyvernoClient versioned.Interface
 
 	// config
 	configuration config.Configuration
@@ -65,7 +65,7 @@ type handlers struct {
 
 func NewHandlers(
 	client dclient.Interface,
-	kyvernoClient kyvernoclient.Interface,
+	kyvernoClient versioned.Interface,
 	configuration config.Configuration,
 	metricsConfig *metrics.MetricsConfig,
 	pCache policycache.Cache,

--- a/pkg/webhooks/updaterequest/generator.go
+++ b/pkg/webhooks/updaterequest/generator.go
@@ -7,9 +7,9 @@ import (
 	backoff "github.com/cenkalti/backoff"
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/background/common"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1beta1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1beta1"
 	kyvernov1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1beta1"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/clients/wrappers"
 	"github.com/kyverno/kyverno/pkg/config"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,14 +24,14 @@ type Generator interface {
 // generator defines the implementation to manage update request resource
 type generator struct {
 	// clients
-	client kyvernoclient.Interface
+	client versioned.Interface
 
 	// listers
 	urLister kyvernov1beta1listers.UpdateRequestNamespaceLister
 }
 
 // NewGenerator returns a new instance of UpdateRequest resource generator
-func NewGenerator(client kyvernoclient.Interface, urInformer kyvernov1beta1informers.UpdateRequestInformer) Generator {
+func NewGenerator(client versioned.Interface, urInformer kyvernov1beta1informers.UpdateRequestInformer) Generator {
 	return &generator{
 		client:   client,
 		urLister: urInformer.Lister().UpdateRequests(config.KyvernoNamespace()),


### PR DESCRIPTION
## Explanation

This PR refactors our client wrappers.
It removes unnecessary interface definitions, simplifies the way we wrap clients, and makes types private when possible.