### PR TITLE
added kubeconfig and context flag to kyverno apply

### DIFF
--- a/cmd/cli/kubectl-kyverno/apply/apply_command.go
+++ b/cmd/cli/kubectl-kyverno/apply/apply_command.go
@@ -13,12 +13,12 @@ import (
 	sanitizederror "github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/utils/sanitizedError"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/utils/store"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/openapi"
 	policy2 "github.com/kyverno/kyverno/pkg/policy"
 	"github.com/kyverno/kyverno/pkg/policyreport"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	log "sigs.k8s.io/controller-runtime/pkg/log"
 	yaml1 "sigs.k8s.io/yaml"
@@ -41,6 +41,22 @@ type Values struct {
 type SkippedInvalidPolicies struct {
 	skipped []string
 	invalid []string
+}
+
+type ApplyCommandConfig struct {
+	KubeConfig      string
+	Context         string
+	Namespace       string
+	MutateLogPath   string
+	VariablesString string
+	ValuesFile      string
+	UserInfoPath    string
+	Cluster         bool
+	PolicyReport    bool
+	Stdin           bool
+	RegistryAccess  bool
+	ResourcePaths   []string
+	PolicyPaths     []string
 }
 
 var applyHelp = `
@@ -110,9 +126,7 @@ More info: https://kyverno.io/docs/kyverno-cli/
 
 func Command() *cobra.Command {
 	var cmd *cobra.Command
-	var resourcePaths []string
-	var cluster, policyReport, stdin, registryAccess bool
-	var mutateLogPath, variablesString, valuesFile, namespace, userInfoPath string
+	applyCommandConfig := &ApplyCommandConfig{}
 	cmd = &cobra.Command{
 		Use:     "apply",
 		Short:   "applies policies on resources",
@@ -126,43 +140,43 @@ func Command() *cobra.Command {
 					}
 				}
 			}()
-
-			rc, resources, skipInvalidPolicies, pvInfos, err := applyCommandHelper(resourcePaths, userInfoPath, cluster, policyReport, mutateLogPath, variablesString, valuesFile, namespace, policyPaths, stdin, registryAccess)
+			applyCommandConfig.PolicyPaths = policyPaths
+			rc, resources, skipInvalidPolicies, pvInfos, err := applyCommandConfig.applyCommandHelper()
 			if err != nil {
 				return err
 			}
 
-			PrintReportOrViolation(policyReport, rc, resourcePaths, len(resources), skipInvalidPolicies, stdin, pvInfos)
+			PrintReportOrViolation(applyCommandConfig.PolicyReport, rc, applyCommandConfig.ResourcePaths, len(resources), skipInvalidPolicies, applyCommandConfig.Stdin, pvInfos)
 			return nil
 		},
 	}
-	cmd.Flags().StringArrayVarP(&resourcePaths, "resource", "r", []string{}, "Path to resource files")
-	cmd.Flags().BoolVarP(&cluster, "cluster", "c", false, "Checks if policies should be applied to cluster in the current context")
-	cmd.Flags().StringVarP(&mutateLogPath, "output", "o", "", "Prints the mutated resources in provided file/directory")
+	cmd.Flags().StringArrayVarP(&applyCommandConfig.ResourcePaths, "resource", "r", []string{}, "Path to resource files")
+	cmd.Flags().BoolVarP(&applyCommandConfig.Cluster, "cluster", "c", false, "Checks if policies should be applied to cluster in the current context")
+	cmd.Flags().StringVarP(&applyCommandConfig.MutateLogPath, "output", "o", "", "Prints the mutated resources in provided file/directory")
 	// currently `set` flag supports variable for single policy applied on single resource
-	cmd.Flags().StringVarP(&userInfoPath, "userinfo", "u", "", "Admission Info including Roles, Cluster Roles and Subjects")
-	cmd.Flags().StringVarP(&variablesString, "set", "s", "", "Variables that are required")
-	cmd.Flags().StringVarP(&valuesFile, "values-file", "f", "", "File containing values for policy variables")
-	cmd.Flags().BoolVarP(&policyReport, "policy-report", "p", false, "Generates policy report when passed (default policyviolation)")
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Optional Policy parameter passed with cluster flag")
-	cmd.Flags().BoolVarP(&stdin, "stdin", "i", false, "Optional mutate policy parameter to pipe directly through to kubectl")
-	cmd.Flags().BoolVarP(&registryAccess, "registry", "", false, "If set to true, access the image registry using local docker credentials to populate external data")
+	cmd.Flags().StringVarP(&applyCommandConfig.UserInfoPath, "userinfo", "u", "", "Admission Info including Roles, Cluster Roles and Subjects")
+	cmd.Flags().StringVarP(&applyCommandConfig.VariablesString, "set", "s", "", "Variables that are required")
+	cmd.Flags().StringVarP(&applyCommandConfig.ValuesFile, "values-file", "f", "", "File containing values for policy variables")
+	cmd.Flags().BoolVarP(&applyCommandConfig.PolicyReport, "policy-report", "p", false, "Generates policy report when passed (default policyviolation)")
+	cmd.Flags().StringVarP(&applyCommandConfig.Namespace, "namespace", "n", "", "Optional Policy parameter passed with cluster flag")
+	cmd.Flags().BoolVarP(&applyCommandConfig.Stdin, "stdin", "i", false, "Optional mutate policy parameter to pipe directly through to kubectl")
+	cmd.Flags().BoolVarP(&applyCommandConfig.RegistryAccess, "registry", "", false, "If set to true, access the image registry using local docker credentials to populate external data")
+	cmd.Flags().StringVarP(&applyCommandConfig.KubeConfig, "kubeconfig", "", "", "path to kubeconfig file with authorization and master location information")
+	cmd.Flags().StringVarP(&applyCommandConfig.Context, "context", "", "", "The name of the kubeconfig context to use")
 	return cmd
 }
 
-func applyCommandHelper(resourcePaths []string, userInfoPath string, cluster bool, policyReport bool, mutateLogPath string,
-	variablesString string, valuesFile string, namespace string, policyPaths []string, stdin bool, registryAccess bool,
-) (rc *common.ResultCounts, resources []*unstructured.Unstructured, skipInvalidPolicies SkippedInvalidPolicies, pvInfos []policyreport.Info, err error) {
+func (c *ApplyCommandConfig) applyCommandHelper() (rc *common.ResultCounts, resources []*unstructured.Unstructured, skipInvalidPolicies SkippedInvalidPolicies, pvInfos []policyreport.Info, err error) {
 	store.SetMock(true)
-	store.SetRegistryAccess(registryAccess)
-	kubernetesConfig := genericclioptions.NewConfigFlags(true)
+	store.SetRegistryAccess(c.RegistryAccess)
+
 	fs := memfs.New()
 
-	if valuesFile != "" && variablesString != "" {
+	if c.ValuesFile != "" && c.VariablesString != "" {
 		return rc, resources, skipInvalidPolicies, pvInfos, sanitizederror.NewWithError("pass the values either using set flag or values_file flag", err)
 	}
 
-	variables, globalValMap, valuesMap, namespaceSelectorMap, err := common.GetVariable(variablesString, valuesFile, fs, false, "")
+	variables, globalValMap, valuesMap, namespaceSelectorMap, err := common.GetVariable(c.VariablesString, c.ValuesFile, fs, false, "")
 	if err != nil {
 		if !sanitizederror.IsErrorSanitized(err) {
 			return rc, resources, skipInvalidPolicies, pvInfos, sanitizederror.NewWithError("failed to decode yaml", err)
@@ -176,8 +190,8 @@ func applyCommandHelper(resourcePaths []string, userInfoPath string, cluster boo
 	}
 
 	var dClient dclient.Interface
-	if cluster {
-		restConfig, err := kubernetesConfig.ToRESTConfig()
+	if c.Cluster {
+		restConfig, err := config.CreateClientConfigWithContext(c.KubeConfig, c.Context)
 		if err != nil {
 			return rc, resources, skipInvalidPolicies, pvInfos, err
 		}
@@ -191,25 +205,25 @@ func applyCommandHelper(resourcePaths []string, userInfoPath string, cluster boo
 		}
 	}
 
-	if len(policyPaths) == 0 {
+	if len(c.PolicyPaths) == 0 {
 		return rc, resources, skipInvalidPolicies, pvInfos, sanitizederror.NewWithError("require policy", err)
 	}
 
-	if (len(policyPaths) > 0 && policyPaths[0] == "-") && len(resourcePaths) > 0 && resourcePaths[0] == "-" {
+	if (len(c.PolicyPaths) > 0 && c.PolicyPaths[0] == "-") && len(c.ResourcePaths) > 0 && c.ResourcePaths[0] == "-" {
 		return rc, resources, skipInvalidPolicies, pvInfos, sanitizederror.NewWithError("a stdin pipe can be used for either policies or resources, not both", err)
 	}
 
-	policies, err := common.GetPoliciesFromPaths(fs, policyPaths, false, "")
+	policies, err := common.GetPoliciesFromPaths(fs, c.PolicyPaths, false, "")
 	if err != nil {
 		fmt.Printf("Error: failed to load policies\nCause: %s\n", err)
 		os.Exit(1)
 	}
 
-	if len(resourcePaths) == 0 && !cluster {
+	if len(c.ResourcePaths) == 0 && !c.Cluster {
 		return rc, resources, skipInvalidPolicies, pvInfos, sanitizederror.NewWithError("resource file(s) or cluster required", err)
 	}
 
-	mutateLogPathIsDir, err := checkMutateLogPath(mutateLogPath)
+	mutateLogPathIsDir, err := checkMutateLogPath(c.MutateLogPath)
 	if err != nil {
 		if !sanitizederror.IsErrorSanitized(err) {
 			return rc, resources, skipInvalidPolicies, pvInfos, sanitizederror.NewWithError("failed to create file/folder", err)
@@ -219,13 +233,13 @@ func applyCommandHelper(resourcePaths []string, userInfoPath string, cluster boo
 
 	// empty the previous contents of the file just in case if the file already existed before with some content(so as to perform overwrites)
 	// the truncation of files for the case when mutateLogPath is dir, is handled under pkg/kyverno/apply/common.go
-	if !mutateLogPathIsDir && mutateLogPath != "" {
-		mutateLogPath = filepath.Clean(mutateLogPath)
+	if !mutateLogPathIsDir && c.MutateLogPath != "" {
+		c.MutateLogPath = filepath.Clean(c.MutateLogPath)
 		// Necessary for us to include the file via variable as it is part of the CLI.
-		_, err := os.OpenFile(mutateLogPath, os.O_TRUNC|os.O_WRONLY, 0o600) // #nosec G304
+		_, err := os.OpenFile(c.MutateLogPath, os.O_TRUNC|os.O_WRONLY, 0o600) // #nosec G304
 		if err != nil {
 			if !sanitizederror.IsErrorSanitized(err) {
-				return rc, resources, skipInvalidPolicies, pvInfos, sanitizederror.NewWithError("failed to truncate the existing file at "+mutateLogPath, err)
+				return rc, resources, skipInvalidPolicies, pvInfos, sanitizederror.NewWithError("failed to truncate the existing file at "+c.MutateLogPath, err)
 			}
 			return rc, resources, skipInvalidPolicies, pvInfos, err
 		}
@@ -243,21 +257,21 @@ func applyCommandHelper(resourcePaths []string, userInfoPath string, cluster boo
 		return rc, resources, skipInvalidPolicies, pvInfos, sanitizederror.NewWithError("failed to marsal mutated policy", err)
 	}
 
-	resources, err = common.GetResourceAccordingToResourcePath(fs, resourcePaths, cluster, mutatedPolicies, dClient, namespace, policyReport, false, "")
+	resources, err = common.GetResourceAccordingToResourcePath(fs, c.ResourcePaths, c.Cluster, mutatedPolicies, dClient, c.Namespace, c.PolicyReport, false, "")
 	if err != nil {
 		fmt.Printf("Error: failed to load resources\nCause: %s\n", err)
 		os.Exit(1)
 	}
 
-	if (len(resources) > 1 || len(mutatedPolicies) > 1) && variablesString != "" {
+	if (len(resources) > 1 || len(mutatedPolicies) > 1) && c.VariablesString != "" {
 		return rc, resources, skipInvalidPolicies, pvInfos, sanitizederror.NewWithError("currently `set` flag supports variable for single policy applied on single resource ", nil)
 	}
 
 	// get the user info as request info from a different file
 	var userInfo v1beta1.RequestInfo
 	var subjectInfo store.Subject
-	if userInfoPath != "" {
-		userInfo, subjectInfo, err = common.GetUserInfoFromPath(fs, userInfoPath, false, "")
+	if c.UserInfoPath != "" {
+		userInfo, subjectInfo, err = common.GetUserInfoFromPath(fs, c.UserInfoPath, false, "")
 		if err != nil {
 			fmt.Printf("Error: failed to load request info\nCause: %s\n", err)
 			os.Exit(1)
@@ -265,7 +279,7 @@ func applyCommandHelper(resourcePaths []string, userInfoPath string, cluster boo
 		store.SetSubjects(subjectInfo)
 	}
 
-	if variablesString != "" {
+	if c.VariablesString != "" {
 		variables = common.SetInStoreContext(mutatedPolicies, variables)
 	}
 
@@ -293,7 +307,7 @@ func applyCommandHelper(resourcePaths []string, userInfoPath string, cluster boo
 	}
 
 	if len(mutatedPolicies) > 0 && len(resources) > 0 {
-		if !stdin {
+		if !c.Stdin {
 			if mutatedPolicyRulesCount > policyRulesCount {
 				fmt.Printf("\nauto-generated pod policies\nApplying %s to %s...\n", msgPolicyRules, msgResources)
 			} else {
@@ -324,7 +338,7 @@ func applyCommandHelper(resourcePaths []string, userInfoPath string, cluster boo
 		if len(variable) > 0 {
 			if len(variables) == 0 {
 				// check policy in variable file
-				if valuesFile == "" || valuesMap[policy.GetName()] == nil {
+				if c.ValuesFile == "" || valuesMap[policy.GetName()] == nil {
 					skipInvalidPolicies.skipped = append(skipInvalidPolicies.skipped, policy.GetName())
 					continue
 				}
@@ -339,7 +353,7 @@ func applyCommandHelper(resourcePaths []string, userInfoPath string, cluster boo
 				return rc, resources, skipInvalidPolicies, pvInfos, sanitizederror.NewWithError(fmt.Sprintf("policy `%s` have variables. pass the values for the variables for resource `%s` using set/values_file flag", policy.GetName(), resource.GetName()), err)
 			}
 
-			_, info, err := common.ApplyPolicyOnResource(policy, resource, mutateLogPath, mutateLogPathIsDir, thisPolicyResourceValues, userInfo, policyReport, namespaceSelectorMap, stdin, rc, true, nil)
+			_, info, err := common.ApplyPolicyOnResource(policy, resource, c.MutateLogPath, mutateLogPathIsDir, thisPolicyResourceValues, userInfo, c.PolicyReport, namespaceSelectorMap, c.Stdin, rc, true, nil)
 			if err != nil {
 				return rc, resources, skipInvalidPolicies, pvInfos, sanitizederror.NewWithError(fmt.Errorf("failed to apply policy %v on resource %v", policy.GetName(), resource.GetName()).Error(), err)
 			}

--- a/cmd/cli/kubectl-kyverno/apply/apply_command_test.go
+++ b/cmd/cli/kubectl-kyverno/apply/apply_command_test.go
@@ -12,12 +12,16 @@ func Test_Apply(t *testing.T) {
 		PolicyPaths           []string
 		ResourcePaths         []string
 		expectedPolicyReports []preport.PolicyReport
+		config                ApplyCommandConfig
 	}
 
 	testcases := []TestCase{
 		{
-			PolicyPaths:   []string{"../../../../test/best_practices/disallow_latest_tag.yaml"},
-			ResourcePaths: []string{"../../../../test/resources/pod_with_version_tag.yaml"},
+			config: ApplyCommandConfig{
+				PolicyPaths:   []string{"../../../../test/best_practices/disallow_latest_tag.yaml"},
+				ResourcePaths: []string{"../../../../test/resources/pod_with_version_tag.yaml"},
+				PolicyReport:  true,
+			},
 			expectedPolicyReports: []preport.PolicyReport{
 				{
 					Summary: preport.PolicyReportSummary{
@@ -31,8 +35,11 @@ func Test_Apply(t *testing.T) {
 			},
 		},
 		{
-			PolicyPaths:   []string{"../../../../test/best_practices/disallow_latest_tag.yaml"},
-			ResourcePaths: []string{"../../../../test/resources/pod_with_latest_tag.yaml"},
+			config: ApplyCommandConfig{
+				PolicyPaths:   []string{"../../../../test/best_practices/disallow_latest_tag.yaml"},
+				ResourcePaths: []string{"../../../../test/resources/pod_with_latest_tag.yaml"},
+				PolicyReport:  true,
+			},
 			expectedPolicyReports: []preport.PolicyReport{
 				{
 					Summary: preport.PolicyReportSummary{
@@ -46,8 +53,11 @@ func Test_Apply(t *testing.T) {
 			},
 		},
 		{
-			PolicyPaths:   []string{"../../../../test/cli/apply/policies"},
-			ResourcePaths: []string{"../../../../test/cli/apply/resource"},
+			config: ApplyCommandConfig{
+				PolicyPaths:   []string{"../../../../test/cli/apply/policies"},
+				ResourcePaths: []string{"../../../../test/cli/apply/resource"},
+				PolicyReport:  true,
+			},
 			expectedPolicyReports: []preport.PolicyReport{
 				{
 					Summary: preport.PolicyReportSummary{
@@ -71,7 +81,7 @@ func Test_Apply(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		_, _, _, info, _ := applyCommandHelper(tc.ResourcePaths, "", false, true, "", "", "", "", tc.PolicyPaths, false, false)
+		_, _, _, info, _ := tc.config.applyCommandHelper()
 		resps := buildPolicyReports(info)
 		for i, resp := range resps {
 			compareSummary(tc.expectedPolicyReports[i].Summary, resp.UnstructuredContent()["summary"].(map[string]interface{}))

--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	rest "k8s.io/client-go/rest"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
 )
@@ -31,4 +32,13 @@ func createClientConfig(kubeconfig string) (*rest.Config, error) {
 	}
 	logger.V(4).Info("Using specified kubeconfig", "kubeconfig", kubeconfig)
 	return clientcmd.BuildConfigFromFlags("", kubeconfig)
+}
+
+// CreateClientConfigWithContext creates client config from custom kubeconfig file and context
+// Used for cli commands
+func CreateClientConfigWithContext(kubeconfig string, context string) (*rest.Config, error) {
+	kubernetesConfig := genericclioptions.NewConfigFlags(true)
+	kubernetesConfig.KubeConfig = &kubeconfig
+	kubernetesConfig.Context = &context
+	return kubernetesConfig.ToRESTConfig()
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,8 @@
 package config_test
 
 import (
+	"fmt"
+	"io/ioutil"
 	"math"
 	"os"
 	"testing"
@@ -64,4 +66,124 @@ func createMinimalKubeconfig(t *testing.T) string {
 	assert.NilError(t, f.Close())
 
 	return f.Name()
+}
+
+func createCustomKubeConfig(t *testing.T, fileName string, hosts map[string]string, currentContext string) {
+	t.Helper()
+	err := ioutil.WriteFile(fileName, []byte(fmt.Sprintf(`
+apiVersion: v1
+clusters:
+- cluster:
+    server: %s
+  name: dev
+- cluster:
+    server: %s
+  name: qa
+contexts:
+- context:
+    cluster: dev
+    user: dev
+  name: dev
+- context:
+    cluster: qa
+    user: qa
+  name: qa
+current-context: %s
+kind: Config
+preferences: {}
+users:
+- name: dev
+  user: {}
+- name: qa
+  user: {}
+
+`, hosts["dev"], hosts["qa"], currentContext)), os.FileMode(0755))
+	assert.NilError(t, err)
+}
+
+func Test_CreateCustomClientConfig_WithContext(t *testing.T) {
+	pwd, _ := os.Getwd()
+	customKubeConfig := pwd + "/kubeConfig"
+	hosts := map[string]string{
+		"dev": "http://127.0.0.1:8081",
+		"qa":  "http://127.0.0.2:8082",
+	}
+	currentContext := "dev"
+	createCustomKubeConfig(t, customKubeConfig, hosts, currentContext)
+	defer os.Remove(customKubeConfig)
+
+	testCases := []struct {
+		testName   string
+		kubeConfig string
+		context    string
+		host       string
+	}{
+		{
+			testName:   "default kubeconfig",
+			kubeConfig: "",
+			context:    "",
+		},
+		{
+			testName:   "custom kubeconfig file with current-context as dev",
+			kubeConfig: customKubeConfig,
+			context:    "",
+			host:       hosts["dev"],
+		},
+		{
+			testName:   "custom kubeconfig file with custom context as qa",
+			kubeConfig: customKubeConfig,
+			context:    "qa",
+			host:       hosts["qa"],
+		},
+	}
+
+	for _, test := range testCases {
+		restConfig, err := config.CreateClientConfigWithContext(test.kubeConfig, test.context)
+		assert.NilError(t, err, fmt.Sprintf("test %s failed", test.testName))
+		if test.host != "" {
+			assert.Equal(t, restConfig.Host, test.host, fmt.Sprintf("test %s failed", test.testName))
+		}
+	}
+
+	t.Setenv("KUBECONFIG", customKubeConfig) // use custom kubeconfig instead of ~/.kube/config
+	newCustomKubeConfig := pwd + "/newkubeConfig"
+	newHosts := map[string]string{
+		"dev": "http://127.0.0.1:8083",
+		"qa":  "http://127.0.0.2:8084",
+	}
+	createCustomKubeConfig(t, newCustomKubeConfig, newHosts, currentContext)
+	defer os.Remove(newCustomKubeConfig)
+	testCases = []struct {
+		testName   string
+		kubeConfig string
+		context    string
+		host       string
+	}{
+		{
+			testName:   "kubeconfig file from env with current-context as dev",
+			kubeConfig: "",
+			context:    "",
+			host:       hosts["dev"],
+		},
+		{
+			testName:   "kubeconfig file from env with custom context as qa",
+			kubeConfig: "",
+			context:    "qa",
+			host:       hosts["qa"],
+		},
+		{
+			testName:   "override kubeconfig from env with new kubeconfig and custom context as qa",
+			kubeConfig: newCustomKubeConfig,
+			context:    "qa",
+			host:       newHosts["qa"],
+		},
+	}
+
+	for _, test := range testCases {
+		restConfig, err := config.CreateClientConfigWithContext(test.kubeConfig, test.context)
+		assert.NilError(t, err, fmt.Sprintf("test %s failed", test.testName))
+		if test.host != "" {
+			assert.Equal(t, restConfig.Host, test.host, fmt.Sprintf("test %s failed", test.testName))
+		}
+	}
 }


### PR DESCRIPTION
Signed-off-by: Sandesh More <sandesh.more@infracloud.io>

## Explanation

previously ```kyverno apply``` command only supported default kubeconfig file or kubeconfig file from KUBECONFIG env variable with current-context. This PR intends to add  flags to kyverno apply command to support use of seperate kubeconfig file and context.

## Related issue

closes: #2317

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

add cli flags namely ```kubeconfig``` and ```context``` in ```kyverno apply``` command while creating kubeclient

### Proof Manifests
for testing i have two kubeconfig files 

#### default kubeconfig
```
$ kubectl config get-contexts
CURRENT   NAME                CLUSTER     AUTHINFO    NAMESPACE
          developer-context
          kind-c1             kind-c1     kind-c1
*         kind-kind           kind-kind   kind-kind   default
````
#### seperate kubeconfig
```
$ kubectl --kubeconfig ~/newkubeconfig config get-contexts
CURRENT   NAME      CLUSTER   AUTHINFO   NAMESPACE
*         kind-c2   kind-c2   kind-c2
          kind-c3   kind-c3   kind-c3  
```

i have each cluster-context with one pod in default namespace failing for policy check-for-labels

https://raw.githubusercontent.com/kyverno/policies/main/best-practices/require_labels/require_labels.yaml

to switch different context and kubeconfig with flags introduced in this PR:

#### change only context
```
$ ./cmd/cli/kubectl-kyverno/kubectl-kyverno  apply --context kind-c1 /home/sandesh/require-labels-pol.yaml --cluster --namespace default
Applying 1 policy rule to 1 resource...
policy require-labels -> resource default/Pod/c1-nginx failed:
1. check-for-labels: validation error: label '[app.kubernetes.io/name](http://app.kubernetes.io/name)' is required. rule check-for-labels failed at path /metadata/labels/app.kubernetes.io/name/
pass: 0, fail: 1, warn: 0, error: 0, skip: 2
```
here policy failed for pod ```c1-nginx``` from cluster ```kind-c1``` as i specified --context ```kind-c1``` in command

#### change kubeconfig
```
$ ./cmd/cli/kubectl-kyverno/kubectl-kyverno  apply --kubeconfig /home/sandesh/newkubeconfig  /home/sandesh/require-labels-pol.yaml --cluster --namespace default
Applying 1 policy rule to 1 resource...
policy require-labels -> resource default/Pod/c2-nginx failed:
1. check-for-labels: validation error: label 'app.kubernetes.io/name' is required. rule check-for-labels failed at path /metadata/labels/app.kubernetes.io/name/
pass: 0, fail: 1, warn: 0, error: 0, skip: 2
```
here policy failed for pod ```c2-nginx``` from cluster ```kind-c2``` as i specified kubeconfig where current-context is ```kind-c2``` cluster

#### change both kubeconfig and context
```
$ ./cmd/cli/kubectl-kyverno/kubectl-kyverno  apply --kubeconfig /home/sandesh/newkubeconfig --context kind-c3 /home/sandesh/require-labels-pol.yaml --cluster --namespace default
Applying 1 policy rule to 1 resource...
policy require-labels -> resource default/Pod/c3-nginx failed:
1. check-for-labels: validation error: label 'app.kubernetes.io/name' is required. rule check-for-labels failed at path /metadata/labels/app.kubernetes.io/name/
pass: 0, fail: 1, warn: 0, error: 0, skip: 2
```
here policy failed for pod ```c3-nginx``` from cluster ```kind-c3``` as i specified kubeconfig with cluster ```kind-c3``` in command

Note: kubeconfig file set with ```KUBECONFIG``` env varibale will be overriden by cli flag ```--kubeconfig```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
