### PR TITLE
allow PSa validation with no exceptions

### DIFF
--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -260,14 +260,15 @@ func (v *validator) validate() *response.RuleResponse {
 
 		return ruleResponse
 	}
-	if v.podSecurity.Exclude != nil {
+
+	if v.podSecurity != nil {
 		if !isDeleteRequest(v.ctx) {
 			ruleResponse := v.validatePodSecurity()
 			return ruleResponse
 		}
 	}
 
-	v.log.V(2).Info("invalid validation rule: either patterns or deny conditions are expected")
+	v.log.V(2).Info("invalid validation rule: podSecurity, patterns, or deny expected")
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Jim Bugwadia <jim@nirmata.com>

## Explanation

Apply `validate.podSecurity` even when no `exclude` elements are specified.

## Related issue


## Milestone of this PR

1.8

## What type of PR is this

 /kind bug

## Proposed Changes

Remove check for `exclude`

### Proof Manifests

Configure policy:

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: pod-security
spec:
  validationFailureAction: enforce
  rules:
  - name: restricted
    match:
      all:
      - resources:
          kinds:
            - Pod
    validate:
      podSecurity:
        level: restricted
        version: v1.24
```

Run an insecure image:

```sh
❯ kubectl run nginx --image nginx
Error from server: admission webhook "validate.kyverno.svc-fail" denied the request:

policy Pod/default/nginx for resource violation:

pod-security:
  restricted: |
    Validation rule 'restricted' failed. It violates PodSecurity "restricted:v1.24": ({Allowed:false ForbiddenReason:allowPrivilegeEscalation != false ForbiddenDetail:container "nginx" must set securityContext.allowPrivilegeEscalation=false})
    ({Allowed:false ForbiddenReason:unrestricted capabilities ForbiddenDetail:container "nginx" must set securityContext.capabilities.drop=["ALL"]})
    ({Allowed:false ForbiddenReason:runAsNonRoot != true ForbiddenDetail:pod or container "nginx" must set securityContext.runAsNonRoot=true})
    ({Allowed:false ForbiddenReason:seccompProfile ForbiddenDetail:pod or container "nginx" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost"})

```


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
