### PR TITLE
refactor: move validation audit out of webhooks package

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/webhooks"
 	webhookspolicy "github.com/kyverno/kyverno/pkg/webhooks/policy"
 	webhooksresource "github.com/kyverno/kyverno/pkg/webhooks/resource"
+	"github.com/kyverno/kyverno/pkg/webhooks/resource/audit"
 	webhookgenerate "github.com/kyverno/kyverno/pkg/webhooks/updaterequest"
 	_ "go.uber.org/automaxprocs" // #nosec
 	kubeinformers "k8s.io/client-go/informers"
@@ -361,7 +362,7 @@ func main() {
 	policyCache := policycache.NewCache()
 	policyCacheController := policycachecontroller.NewController(policyCache, kyvernoV1.ClusterPolicies(), kyvernoV1.Policies())
 
-	auditHandler := webhooksresource.NewValidateAuditHandler(
+	auditHandler := audit.NewValidateAuditHandler(
 		policyCache,
 		eventGenerator,
 		reportReqGen,

--- a/pkg/webhooks/resource/audit/validate_audit.go
+++ b/pkg/webhooks/resource/audit/validate_audit.go
@@ -1,4 +1,4 @@
-package resource
+package audit
 
 import (
 	"strings"

--- a/pkg/webhooks/resource/fake.go
+++ b/pkg/webhooks/resource/fake.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/policycache"
 	"github.com/kyverno/kyverno/pkg/policyreport"
 	"github.com/kyverno/kyverno/pkg/webhooks"
+	"github.com/kyverno/kyverno/pkg/webhooks/resource/audit"
 	"github.com/kyverno/kyverno/pkg/webhooks/updaterequest"
 	webhookutils "github.com/kyverno/kyverno/pkg/webhooks/utils"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -56,7 +57,7 @@ func NewFakeHandlers(ctx context.Context, policyCache policycache.Cache) webhook
 	}
 }
 
-func newFakeAuditHandler() AuditHandler {
+func newFakeAuditHandler() audit.AuditHandler {
 	return &fakeAuditHandler{}
 }
 

--- a/pkg/webhooks/resource/handlers.go
+++ b/pkg/webhooks/resource/handlers.go
@@ -27,6 +27,7 @@ import (
 	engineutils "github.com/kyverno/kyverno/pkg/utils/engine"
 	jsonutils "github.com/kyverno/kyverno/pkg/utils/json"
 	"github.com/kyverno/kyverno/pkg/webhooks"
+	"github.com/kyverno/kyverno/pkg/webhooks/resource/audit"
 	"github.com/kyverno/kyverno/pkg/webhooks/resource/validation"
 	webhookgenerate "github.com/kyverno/kyverno/pkg/webhooks/updaterequest"
 	webhookutils "github.com/kyverno/kyverno/pkg/webhooks/utils"
@@ -59,7 +60,7 @@ type handlers struct {
 	prGenerator       policyreport.GeneratorInterface
 	urGenerator       webhookgenerate.Generator
 	eventGen          event.Interface
-	auditHandler      AuditHandler
+	auditHandler      audit.AuditHandler
 	openAPIController openapi.ValidateInterface
 	pcBuilder         webhookutils.PolicyContextBuilder
 	urUpdater         webhookutils.UpdateRequestUpdater
@@ -78,7 +79,7 @@ func NewHandlers(
 	prGenerator policyreport.GeneratorInterface,
 	urGenerator webhookgenerate.Generator,
 	eventGen event.Interface,
-	auditHandler AuditHandler,
+	auditHandler audit.AuditHandler,
 	openAPIController openapi.ValidateInterface,
 ) webhooks.Handlers {
 	return &handlers{


### PR DESCRIPTION
## Explanation

This PR move validation audit handler out of webhooks package.