### PR TITLE
chore: preserve pr title in cherry picks

### DIFF
--- a/.github/cherry-pick-bot.yml
+++ b/.github/cherry-pick-bot.yml
@@ -1,1 +1,2 @@
 enabled: true
+preservePullRequestTitle: true


### PR DESCRIPTION
## Explanation

This PR preserves pr title in cherry picks.

See https://github.com/googleapis/repo-automation-bots/pull/4357