### PR TITLE
fix: split policy report flag

### DIFF
--- a/pkg/policyreport/changerequestcreator.go
+++ b/pkg/policyreport/changerequestcreator.go
@@ -37,9 +37,6 @@ type changeRequestCreator struct {
 	mutex sync.RWMutex
 	queue []string
 
-	// splitPolicyReport enable/disable the PolicyReport split-up per policy feature
-	splitPolicyReport bool
-
 	tickerInterval time.Duration
 
 	log logr.Logger
@@ -126,7 +123,7 @@ func (c *changeRequestCreator) run(stopChan <-chan struct{}) {
 		case <-ticker.C:
 			var requests []*unstructured.Unstructured
 			var size int
-			if c.splitPolicyReport {
+			if toggle.SplitPolicyReport.Enabled() {
 				requests, size = c.mergeRequestsPerPolicy()
 			} else {
 				requests, size = c.mergeRequests()


### PR DESCRIPTION
## Explanation

This PR fixes split policy report flag not applied correctly.
The code used a field that was never set, I suspect it should look at the feature flag instead.
