### PR TITLE
enable autogen for validate.podsecurity with no exclude

### DIFF
--- a/pkg/autogen/autogen.go
+++ b/pkg/autogen/autogen.go
@@ -220,12 +220,16 @@ func generateRules(spec *kyvernov1.Spec, controllers string) []kyvernov1.Rule {
 		if genRule := createRule(generateRuleForControllers(&spec.Rules[i], stripCronJob(controllers))); genRule != nil {
 			if convRule, err := convertRule(*genRule, "Pod"); err == nil {
 				rules = append(rules, *convRule)
+			} else {
+				logger.Error(err, "failed to create rule")
 			}
 		}
 		// handle CronJob, it appends an additional rule
 		if genRule := createRule(generateCronJobRule(&spec.Rules[i], controllers)); genRule != nil {
 			if convRule, err := convertRule(*genRule, "Cronjob"); err == nil {
 				rules = append(rules, *convRule)
+			} else {
+				logger.Error(err, "failed to create Cronjob rule")
 			}
 		}
 	}

--- a/pkg/autogen/autogen_test.go
+++ b/pkg/autogen/autogen_test.go
@@ -228,6 +228,11 @@ func Test_GetSupportedControllers(t *testing.T) {
 			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"require-network-policy","match":{"resources":{"kinds":["Pod"]}},"validate":{"message":"testpolicy","podSecurity": {"level": "baseline","version":"v1.24","exclude":[{"controlName":"SELinux","restrictedField":"spec.containers[*].securityContext.seLinuxOptions.role","images":["nginx"],"values":["baz"]}, {"controlName":"SELinux","restrictedField":"spec.initContainers[*].securityContext.seLinuxOptions.role","images":["nodejs"],"values":["init-baz"]}]}}}]}}`),
 			expectedControllers: PodControllers,
 		},
+		{
+			name:                "rule-with-validate-podsecurity",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"pod-security"},"spec":{"validationFailureAction":"enforce","rules":[{"name":"restricted","match":{"all":[{"resources":{"kinds":["Pod"]}}]},"validate":{"podSecurity":{"level":"restricted","version":"v1.24"}}}]}}`),
+			expectedControllers: PodControllers,
+		},
 	}
 
 	for _, test := range testCases {
@@ -816,4 +821,14 @@ kA==
 		rules := computeRules(policies[0])
 		assert.DeepEqual(t, test.expectedRules, rules)
 	}
+}
+
+func Test_PodSecurityWithNoExceptions(t *testing.T) {
+	policy := []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"pod-security"},"spec":{"validationFailureAction":"enforce","rules":[{"name":"restricted","match":{"all":[{"resources":{"kinds":["Pod"]}}]},"validate":{"podSecurity":{"level":"restricted","version":"v1.24"}}}]}}`)
+	policies, err := yamlutils.GetPolicy([]byte(policy))
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(policies))
+
+	rules := computeRules(policies[0])
+	assert.Equal(t, 3, len(rules))
 }

--- a/pkg/autogen/rule.go
+++ b/pkg/autogen/rule.go
@@ -149,7 +149,7 @@ func generateRule(name string, rule *kyvernov1.Rule, tplKey, shift string, kinds
 		rule.Validation = deny
 		return rule
 	}
-	if rule.Validation.PodSecurity != nil && len(rule.Validation.PodSecurity.Exclude) > 0 {
+	if rule.Validation.PodSecurity != nil {
 		newExclude := make([]kyvernov1.PodSecurityStandard, len(rule.Validation.PodSecurity.Exclude))
 		copy(newExclude, rule.Validation.PodSecurity.Exclude)
 		podSecurity := kyvernov1.Validation{


### PR DESCRIPTION
Signed-off-by: Jim Bugwadia <jim@nirmata.com>

## Explanation

Fix AutoGen for `validate.podsecurity` when no exclude is configured
 
## Related issue

n/a

## Milestone of this PR

1.8

## What type of PR is this

/kind bug

## Proposed Changes

Allow autogen for pod security rules that have no exclude elements configured

### Proof Manifests

Configure a policy like this:

```yaml

apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: pod-security
spec:
  validationFailureAction: enforce
  rules:
  - name: restricted
    match:
      all:
      - resources:
          kinds:
            - Pod
    validate:
      podSecurity:
        level: restricted
        version: v1.24
          
```

Apply it to a cluster. You should see autogen rules in the `status` block.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
