### PR TITLE
fix: lock in policy report mapper

### DIFF
--- a/pkg/policyreport/mapper.go
+++ b/pkg/policyreport/mapper.go
@@ -22,3 +22,7 @@ func (m concurrentMap) decrease(keyHash string) {
 		m.Set(ns, 0)
 	}
 }
+
+func newConcurrentMap() concurrentMap {
+	return concurrentMap{cmap.New()}
+}


### PR DESCRIPTION
## Explanation

This PR adds a lock around policy report mapper.
Access to the mapper needs to be properly synchronized to be used reliably.