### PR TITLE
chore: bump minimum go version

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go 
         uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
-          go-version: 1.18
+          go-version: ~1.18.6
 
       - name: Cache Go modules
         uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # pin@v3

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
-          go-version: '1.18'
+          go-version: ~1.18.6
 
       - name: Generate Code Coverage Report
         run: make code-cov-report

--- a/.github/workflows/e2e-autogen-internals.yaml
+++ b/.github/workflows/e2e-autogen-internals.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go 
         uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
-          go-version: 1.18
+          go-version: ~1.18.6
 
       - name: Set up Helm
         uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1.1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go 
         uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
-          go-version: 1.18
+          go-version: ~1.18.6
 
       - name: Set up Helm
         uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1.1

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
-          go-version: "^1.18.x"
+          go-version: ~1.18.6
 
       - name: run FOSSA analysis
         env:

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
-          go-version: 1.18
+          go-version: ~1.18.6
 
       - name: Cache Go modules
         uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # pin@v3
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
-          go-version: 1.18
+          go-version: ~1.18.6
 
       - name: Cache Go modules
         uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # pin@v3
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
-          go-version: 1.18
+          go-version: ~1.18.6
 
       - name: Cache Go modules
         uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # pin@v3
@@ -140,7 +140,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
-          go-version: 1.18
+          go-version: ~1.18.6
 
       - name: Cache Go modules
         uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # pin@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
-          go-version: 1.18
+          go-version: ~1.18.6
 
       - name: Cache Go modules
         uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # pin@v3

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
-          go-version: 1.18
+          go-version: ~1.18.6
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@116dc6872c0a067bcb78758f18955414cdbf918f # v1.4.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # pin@v3
         with:
-          go-version: 1.18
+          go-version: ~1.18.6
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc # pin@v3
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # pin@v2.1.5
         with:
-          go-version: 1.18
+          go-version: ~1.18.6
 
       - name: Cache Go modules
         uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # pin@v3

--- a/.github/workflows/verify-codegen.yaml
+++ b/.github/workflows/verify-codegen.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go 
         uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
         with:
-          go-version: 1.18
+          go-version: ~1.18.6
 
       - name: Set up Helm
         uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1.1


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charled.breteche@gmail.com>

## Explanation

This PR bumps minimum go version to `1.18.6`, fixing CVE CVE-2022-27664.

## Related issue

Fixes #4676
