### PR TITLE
fix: update github action to use current workflow path

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   push-init-kyverno:
-    uses: kyverno/kyverno/.github/workflows/reuse.yaml@main
+    uses: ./.github/workflows/reuse.yaml
     with:
       publish_command: docker-publish-initContainer
       digest_command: docker-get-initContainer-digest
@@ -23,7 +23,7 @@ jobs:
       registry_password: ${{ secrets.CR_PAT }}
 
   push-kyverno:
-    uses: kyverno/kyverno/.github/workflows/reuse.yaml@main
+    uses: ./.github/workflows/reuse.yaml
     with:
       publish_command: docker-publish-kyverno
       digest_command: docker-get-kyverno-digest
@@ -34,7 +34,7 @@ jobs:
       registry_password: ${{ secrets.CR_PAT }}
 
   push-kyverno-cli:
-    uses: kyverno/kyverno/.github/workflows/reuse.yaml@main
+    uses: ./.github/workflows/reuse.yaml
     with:
       publish_command: docker-publish-cli
       digest_command: docker-get-cli-digest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    uses: kyverno/kyverno/.github/workflows/reuse.yaml@main
+    uses: ./.github/workflows/reuse.yaml
     with:
       publish_command: docker-publish-initContainer
       digest_command: docker-get-initContainer-digest
@@ -26,7 +26,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    uses: kyverno/kyverno/.github/workflows/reuse.yaml@main
+    uses: ./.github/workflows/reuse.yaml
     with:
       publish_command: docker-publish-kyverno
       digest_command: docker-get-kyverno-digest
@@ -42,7 +42,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    uses: kyverno/kyverno/.github/workflows/reuse.yaml@main
+    uses: ./.github/workflows/reuse.yaml
     with:
       publish_command: docker-publish-cli
       digest_command: docker-get-cli-digest


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Explanation

Update github action to use current workflow path, earlier it was pointing to `main` which has been updated with latest changes.

https://github.com/kyverno/kyverno/actions/runs/3128643227/workflow