### PR TITLE
chore: use constant in cert manager controller

### DIFF
--- a/pkg/controllers/certmanager/log.go
+++ b/pkg/controllers/certmanager/log.go
@@ -2,4 +2,6 @@ package certmanager
 
 import "sigs.k8s.io/controller-runtime/pkg/log"
 
-var logger = log.Log.WithName("certmanager-controller")
+const controllerName = "certmanager-controller"
+
+var logger = log.Log.WithName(controllerName)


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charled.breteche@gmail.com>

## Explanation

This PR uses a constant in cert manager controller.
