### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/cli/kubectl-kyverno/jp/jp_command.go
+++ b/cmd/cli/kubectl-kyverno/jp/jp_command.go
@@ -3,7 +3,7 @@ package jp
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -37,7 +37,7 @@ func Command() *cobra.Command {
 			// https://github.com/jmespath/jp/blob/54882e03bd277fc4475a677fab1d35eaa478b839/jp.go
 			var expression string
 			if exprFile != "" {
-				byteExpr, err := ioutil.ReadFile(filepath.Clean(exprFile))
+				byteExpr, err := os.ReadFile(filepath.Clean(exprFile))
 				if err != nil {
 					return fmt.Errorf("error opening expression file: %w", err)
 				}
@@ -64,7 +64,7 @@ func Command() *cobra.Command {
 			}
 			var input interface{}
 			if filename != "" {
-				f, err := ioutil.ReadFile(filepath.Clean(filename))
+				f, err := os.ReadFile(filepath.Clean(filename))
 				if err != nil {
 					return fmt.Errorf("error opening input file: %w", err)
 				}
@@ -72,7 +72,7 @@ func Command() *cobra.Command {
 					return fmt.Errorf("error parsing input json: %w", err)
 				}
 			} else {
-				f, err := ioutil.ReadAll(os.Stdin)
+				f, err := io.ReadAll(os.Stdin)
 				if err != nil {
 					return fmt.Errorf("error opening input file: %w", err)
 				}

--- a/cmd/cli/kubectl-kyverno/test/test_command.go
+++ b/cmd/cli/kubectl-kyverno/test/test_command.go
@@ -3,7 +3,7 @@ package test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"path"
@@ -428,7 +428,7 @@ func testCommandExecute(dirPath []string, fileName string, gitBranch string, tes
 			if path.Base(file.Name()) == fileName {
 				testYamlCount++
 				policyresoucePath := strings.Trim(yamlFilePath, fileName)
-				bytes, err := ioutil.ReadAll(file)
+				bytes, err := io.ReadAll(file)
 				if err != nil {
 					errors = append(errors, sanitizederror.NewWithError("Error: failed to read file", err))
 					continue
@@ -483,7 +483,7 @@ func testCommandExecute(dirPath []string, fileName string, gitBranch string, tes
 func getLocalDirTestFiles(fs billy.Filesystem, path, fileName string, rc *resultCounts, testFiles *int, openAPIController *openapi.Controller, tf *testFilter, failOnly, removeColor bool) []error {
 	var errors []error
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return []error{fmt.Errorf("failed to read %v: %v", path, err.Error())}
 	}
@@ -495,7 +495,7 @@ func getLocalDirTestFiles(fs billy.Filesystem, path, fileName string, rc *result
 		if file.Name() == fileName {
 			*testFiles++
 			// We accept the risk of including files here as we read the test dir only.
-			yamlFile, err := ioutil.ReadFile(filepath.Join(path, file.Name())) // #nosec G304
+			yamlFile, err := os.ReadFile(filepath.Join(path, file.Name())) // #nosec G304
 			if err != nil {
 				errors = append(errors, sanitizederror.NewWithError("unable to read yaml", err))
 				continue

--- a/cmd/cli/kubectl-kyverno/utils/common/common.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common.go
@@ -1139,7 +1139,8 @@ func GetUserInfoFromPath(fs billy.Filesystem, path string, isGit bool, policyRes
 		}
 	} else {
 		var errors []error
-		bytes, err := os.ReadFile(filepath.Join(policyResourcePath, path))
+		pathname := filepath.Clean(filepath.Join(policyResourcePath, path))
+		bytes, err := os.ReadFile(pathname)
 		if err != nil {
 			errors = append(errors, sanitizederror.NewWithError("unable to read yaml", err))
 		}

--- a/cmd/cli/kubectl-kyverno/utils/common/common.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -105,7 +105,7 @@ func GetPolicies(paths []string) (policies []kyvernov1.PolicyInterface, errors [
 
 		// apply file from a directory is possible only if the path is not HTTP URL
 		if !isHTTPPath && fileDesc.IsDir() {
-			files, err := ioutil.ReadDir(path)
+			files, err := os.ReadDir(path)
 			if err != nil {
 				err := fmt.Errorf("failed to process %v: %v", path, err.Error())
 				errors = append(errors, err)
@@ -147,7 +147,7 @@ func GetPolicies(paths []string) (policies []kyvernov1.PolicyInterface, errors [
 					continue
 				}
 
-				fileBytes, err = ioutil.ReadAll(resp.Body)
+				fileBytes, err = io.ReadAll(resp.Body)
 				if err != nil {
 					err := fmt.Errorf("failed to process %v: %v", path, err.Error())
 					errors = append(errors, err)
@@ -156,7 +156,7 @@ func GetPolicies(paths []string) (policies []kyvernov1.PolicyInterface, errors [
 			} else {
 				path = filepath.Clean(path)
 				// We accept the risk of including a user provided file here.
-				fileBytes, err = ioutil.ReadFile(path) // #nosec G304
+				fileBytes, err = os.ReadFile(path) // #nosec G304
 				if err != nil {
 					err := fmt.Errorf("failed to process %v: %v", path, err.Error())
 					errors = append(errors, err)
@@ -267,13 +267,13 @@ func GetVariable(variablesString, valuesFile string, fs billy.Filesystem, isGit 
 			if err != nil {
 				fmt.Printf("Unable to open variable file: %s. error: %s", valuesFile, err)
 			}
-			yamlFile, err = ioutil.ReadAll(filep)
+			yamlFile, err = io.ReadAll(filep)
 			if err != nil {
 				fmt.Printf("Unable to read variable files: %s. error: %s \n", filep, err)
 			}
 		} else {
 			// We accept the risk of including a user provided file here.
-			yamlFile, err = ioutil.ReadFile(filepath.Join(policyResourcePath, valuesFile)) // #nosec G304
+			yamlFile, err = os.ReadFile(filepath.Join(policyResourcePath, valuesFile)) // #nosec G304
 			if err != nil {
 				fmt.Printf("\n Unable to open variable file: %s. error: %s \n", valuesFile, err)
 			}
@@ -621,7 +621,7 @@ func GetPoliciesFromPaths(fs billy.Filesystem, dirPath []string, isGit bool, pol
 				fmt.Printf("Error: file not available with path %s: %v", filep.Name(), err.Error())
 				continue
 			}
-			bytes, err := ioutil.ReadAll(filep)
+			bytes, err := io.ReadAll(filep)
 			if err != nil {
 				fmt.Printf("Error: failed to read file %s: %v", filep.Name(), err.Error())
 				continue
@@ -703,7 +703,7 @@ func GetResourceAccordingToResourcePath(fs billy.Filesystem, resourcePaths []str
 					return nil, err
 				}
 				if fileDesc.IsDir() {
-					files, err := ioutil.ReadDir(resourcePaths[0])
+					files, err := os.ReadDir(resourcePaths[0])
 					if err != nil {
 						return nil, sanitizederror.NewWithError(fmt.Sprintf("failed to parse %v", resourcePaths[0]), err)
 					}
@@ -1013,7 +1013,7 @@ func GetResourceFromPath(fs billy.Filesystem, path string, isGit bool, policyRes
 			if fileErr != nil {
 				fmt.Printf("Unable to open %s file: %s. \nerror: %s", resourceType, path, err)
 			}
-			resourceBytes, err = ioutil.ReadAll(filep)
+			resourceBytes, err = io.ReadAll(filep)
 		}
 	} else {
 		resourceBytes, err = getFileBytes(path)
@@ -1117,7 +1117,7 @@ func GetUserInfoFromPath(fs billy.Filesystem, path string, isGit bool, policyRes
 		if err != nil {
 			fmt.Printf("Unable to open userInfo file: %s. \nerror: %s", path, err)
 		}
-		bytes, err := ioutil.ReadAll(filep)
+		bytes, err := io.ReadAll(filep)
 		if err != nil {
 			fmt.Printf("Error: failed to read file %s: %v", filep.Name(), err.Error())
 		}
@@ -1139,7 +1139,7 @@ func GetUserInfoFromPath(fs billy.Filesystem, path string, isGit bool, policyRes
 		}
 	} else {
 		var errors []error
-		bytes, err := ioutil.ReadFile(filepath.Join(policyResourcePath, path))
+		bytes, err := os.ReadFile(filepath.Join(policyResourcePath, path))
 		if err != nil {
 			errors = append(errors, sanitizederror.NewWithError("unable to read yaml", err))
 		}

--- a/cmd/cli/kubectl-kyverno/utils/common/fetch.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/fetch.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -139,7 +140,7 @@ func GetResourcesWithTest(fs billy.Filesystem, policies []kyvernov1.PolicyInterf
 					fmt.Printf("Unable to open resource file: %s. error: %s", resourcePath, err)
 					continue
 				}
-				resourceBytes, _ = ioutil.ReadAll(filep)
+				resourceBytes, _ = io.ReadAll(filep)
 			} else {
 				resourceBytes, err = getFileBytes(resourcePath)
 			}
@@ -233,14 +234,14 @@ func getFileBytes(path string) ([]byte, error) {
 			return nil, err
 		}
 
-		file, err = ioutil.ReadAll(resp.Body)
+		file, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		path = filepath.Clean(path)
 		// We accept the risk of including a user provided file here.
-		file, err = ioutil.ReadFile(path) // #nosec G304
+		file, err = os.ReadFile(path) // #nosec G304
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/autogen/autogen_test.go
+++ b/pkg/autogen/autogen_test.go
@@ -3,7 +3,6 @@ package autogen
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -299,7 +298,7 @@ func Test_Any(t *testing.T) {
 	dir, err := os.Getwd()
 	baseDir := filepath.Dir(filepath.Dir(dir))
 	assert.NilError(t, err)
-	file, err := ioutil.ReadFile(baseDir + "/test/best_practices/disallow_bind_mounts.yaml")
+	file, err := os.ReadFile(baseDir + "/test/best_practices/disallow_bind_mounts.yaml")
 	if err != nil {
 		t.Log(err)
 	}
@@ -337,7 +336,7 @@ func Test_All(t *testing.T) {
 	dir, err := os.Getwd()
 	baseDir := filepath.Dir(filepath.Dir(dir))
 	assert.NilError(t, err)
-	file, err := ioutil.ReadFile(baseDir + "/test/best_practices/disallow_bind_mounts.yaml")
+	file, err := os.ReadFile(baseDir + "/test/best_practices/disallow_bind_mounts.yaml")
 	if err != nil {
 		t.Log(err)
 	}
@@ -376,7 +375,7 @@ func Test_Exclude(t *testing.T) {
 	dir, err := os.Getwd()
 	baseDir := filepath.Dir(filepath.Dir(dir))
 	assert.NilError(t, err)
-	file, err := ioutil.ReadFile(baseDir + "/test/best_practices/disallow_bind_mounts.yaml")
+	file, err := os.ReadFile(baseDir + "/test/best_practices/disallow_bind_mounts.yaml")
 	if err != nil {
 		t.Log(err)
 	}
@@ -410,7 +409,7 @@ func Test_CronJobOnly(t *testing.T) {
 	dir, err := os.Getwd()
 	baseDir := filepath.Dir(filepath.Dir(dir))
 	assert.NilError(t, err)
-	file, err := ioutil.ReadFile(baseDir + "/test/best_practices/disallow_bind_mounts.yaml")
+	file, err := os.ReadFile(baseDir + "/test/best_practices/disallow_bind_mounts.yaml")
 	if err != nil {
 		t.Log(err)
 	}
@@ -440,7 +439,7 @@ func Test_ForEachPod(t *testing.T) {
 	dir, err := os.Getwd()
 	baseDir := filepath.Dir(filepath.Dir(dir))
 	assert.NilError(t, err)
-	file, err := ioutil.ReadFile(baseDir + "/test/policy/mutate/policy_mutate_pod_foreach_with_context.yaml")
+	file, err := os.ReadFile(baseDir + "/test/policy/mutate/policy_mutate_pod_foreach_with_context.yaml")
 	if err != nil {
 		t.Log(err)
 	}
@@ -475,7 +474,7 @@ func Test_CronJob_hasExclude(t *testing.T) {
 	baseDir := filepath.Dir(filepath.Dir(dir))
 	assert.NilError(t, err)
 
-	file, err := ioutil.ReadFile(baseDir + "/test/best_practices/disallow_bind_mounts.yaml")
+	file, err := os.ReadFile(baseDir + "/test/best_practices/disallow_bind_mounts.yaml")
 	if err != nil {
 		t.Log(err)
 	}
@@ -512,7 +511,7 @@ func Test_CronJobAndDeployment(t *testing.T) {
 	dir, err := os.Getwd()
 	baseDir := filepath.Dir(filepath.Dir(dir))
 	assert.NilError(t, err)
-	file, err := ioutil.ReadFile(baseDir + "/test/best_practices/disallow_bind_mounts.yaml")
+	file, err := os.ReadFile(baseDir + "/test/best_practices/disallow_bind_mounts.yaml")
 	if err != nil {
 		t.Log(err)
 	}
@@ -543,7 +542,7 @@ func Test_UpdateVariablePath(t *testing.T) {
 	dir, err := os.Getwd()
 	baseDir := filepath.Dir(filepath.Dir(dir))
 	assert.NilError(t, err)
-	file, err := ioutil.ReadFile(baseDir + "/test/best_practices/select-secrets.yaml")
+	file, err := os.ReadFile(baseDir + "/test/best_practices/select-secrets.yaml")
 	if err != nil {
 		t.Log(err)
 	}
@@ -573,7 +572,7 @@ func Test_Deny(t *testing.T) {
 	dir, err := os.Getwd()
 	baseDir := filepath.Dir(filepath.Dir(dir))
 	assert.NilError(t, err)
-	file, err := ioutil.ReadFile(baseDir + "/test/policy/deny/policy.yaml")
+	file, err := os.ReadFile(baseDir + "/test/policy/deny/policy.yaml")
 	if err != nil {
 		t.Log(err)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,7 +2,6 @@ package config_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"testing"
@@ -70,7 +69,7 @@ func createMinimalKubeconfig(t *testing.T) string {
 
 func createCustomKubeConfig(t *testing.T, fileName string, hosts map[string]string, currentContext string) {
 	t.Helper()
-	err := ioutil.WriteFile(fileName, []byte(fmt.Sprintf(`
+	err := os.WriteFile(fileName, []byte(fmt.Sprintf(`
 apiVersion: v1
 clusters:
 - cluster:

--- a/pkg/registryclient/client.go
+++ b/pkg/registryclient/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	ecr "github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
@@ -48,7 +48,7 @@ func InitClient(options ...Option) (Client, error) {
 	baseKeychain := authn.NewMultiKeychain(
 		authn.DefaultKeychain,
 		google.Keychain,
-		authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(ioutil.Discard))),
+		authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(io.Discard))),
 		authn.NewKeychainFromHelper(credhelper.NewACRCredentialsHelper()),
 		github.Keychain,
 	)

--- a/pkg/testrunner/scenario.go
+++ b/pkg/testrunner/scenario.go
@@ -3,7 +3,6 @@ package testrunner
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	ospath "path"
 	"path/filepath"
@@ -119,7 +118,7 @@ func loadFile(t *testing.T, path string) ([]byte, error) {
 	}
 	path = filepath.Clean(path)
 	// We accept the risk of including a user provided file here.
-	return ioutil.ReadFile(path) // #nosec G304
+	return os.ReadFile(path) // #nosec G304
 }
 
 func runScenario(t *testing.T, s *Scenario) bool {

--- a/pkg/testrunner/scenario_test.go
+++ b/pkg/testrunner/scenario_test.go
@@ -1,7 +1,7 @@
 package testrunner
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/kyverno/kyverno/pkg/engine/response"
@@ -54,7 +54,7 @@ func Test_parse_file(t *testing.T) {
 
 func Test_parse_file2(t *testing.T) {
 	path := getRelativePath("test/scenarios/samples/best_practices/disallow_bind_mounts_fail.yaml")
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	assert.NilError(t, err)
 
 	strData := string(data)

--- a/pkg/testrunner/utils.go
+++ b/pkg/testrunner/utils.go
@@ -1,7 +1,6 @@
 package testrunner
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -16,7 +15,7 @@ func LoadFile(path string) ([]byte, error) {
 	}
 	path = filepath.Clean(path)
 	// We accept the risk of including a user provided file here.
-	return ioutil.ReadFile(path) // #nosec G304
+	return os.ReadFile(path) // #nosec G304
 }
 
 var kindToResource = map[string]string{

--- a/pkg/webhooks/handlers/admission.go
+++ b/pkg/webhooks/handlers/admission.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -28,7 +28,7 @@ func Admission(logger logr.Logger, inner AdmissionHandler) http.HandlerFunc {
 			return
 		}
 		defer request.Body.Close()
-		body, err := ioutil.ReadAll(request.Body)
+		body, err := io.ReadAll(request.Body)
 		if err != nil {
 			logger.Info("failed to read HTTP body", "req", request.URL.String())
 			http.Error(writer, "failed to read HTTP body", http.StatusBadRequest)


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

The `io/ioutil` package has been deprecated in Go 1.16, the same functionality is now provided by package io or package os (See https://pkg.go.dev/io/ioutil).

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR

/milestone 1.8.1

## What type of PR is this

/kind cleanup

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

Replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages:

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
