### PR TITLE
refactor: use context in openapi controller

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -402,7 +402,7 @@ func main() {
 	}
 
 	// the webhook server runs across all instances
-	openAPIController := startOpenAPIController(logger, dynamicClient, stopCh)
+	openAPIController := startOpenAPIController(signalCtx, logger, dynamicClient)
 
 	// WEBHOOK
 	// - https server to provide endpoints called based on rules defined in Mutating & Validation webhook configuration
@@ -536,7 +536,7 @@ func main() {
 	logger.V(2).Info("Kyverno shutdown successful")
 }
 
-func startOpenAPIController(logger logr.Logger, client dclient.Interface, stopCh <-chan struct{}) *openapi.Controller {
+func startOpenAPIController(ctx context.Context, logger logr.Logger, client dclient.Interface) *openapi.Controller {
 	logger = logger.WithName("open-api")
 	openAPIController, err := openapi.NewOpenAPIController()
 	if err != nil {
@@ -547,7 +547,7 @@ func startOpenAPIController(logger logr.Logger, client dclient.Interface, stopCh
 	openAPISync := openapi.NewCRDSync(client, openAPIController)
 	// start openAPI controller, this is used in admission review
 	// thus is required in each instance
-	openAPISync.Run(1, stopCh)
+	openAPISync.Run(ctx, 1)
 	return openAPIController
 }
 


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charled.breteche@gmail.com>

## Explanation

This PR uses context in openapi controller instead of chan.