### PR TITLE
refactor: use context in controllers instead of chan

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -464,7 +464,7 @@ func main() {
 			os.Exit(1)
 		}
 		webhookCfg.UpdateWebhookChan <- true
-		go certManager.Run(stopCh)
+		go certManager.Run(signalCtx)
 		go policyCtrl.Run(2, stopCh)
 
 		reportControllers := setupReportControllers(
@@ -481,7 +481,7 @@ func main() {
 		metadataInformer.WaitForCacheSync(stopCh)
 
 		for _, controller := range reportControllers {
-			go controller.Run(stopCh)
+			go controller.Run(signalCtx)
 		}
 	}
 
@@ -516,10 +516,10 @@ func main() {
 
 	// init events handlers
 	// start Kyverno controllers
-	go policyCacheController.Run(stopCh)
+	go policyCacheController.Run(signalCtx)
 	go urc.Run(genWorkers, stopCh)
 	go le.Run(signalCtx)
-	go configurationController.Run(stopCh)
+	go configurationController.Run(signalCtx)
 	go eventGenerator.Run(3, stopCh)
 	if !debug {
 		go webhookMonitor.Run(webhookCfg, certRenewer, eventGenerator, stopCh)

--- a/pkg/controllers/certmanager/controller.go
+++ b/pkg/controllers/certmanager/controller.go
@@ -1,12 +1,14 @@
 package certmanager
 
 import (
+	"context"
 	"os"
 	"reflect"
 	"time"
 
 	"github.com/kyverno/kyverno/pkg/common"
 	"github.com/kyverno/kyverno/pkg/config"
+	"github.com/kyverno/kyverno/pkg/controllers"
 	"github.com/kyverno/kyverno/pkg/tls"
 	corev1 "k8s.io/api/core/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
@@ -15,9 +17,7 @@ import (
 )
 
 type Controller interface {
-	// Run starts the certManager
-	Run(stopCh <-chan struct{})
-
+	controllers.Controller
 	// GetTLSPemPair gets the existing TLSPemPair from the secret
 	GetTLSPemPair() ([]byte, []byte, error)
 }
@@ -44,6 +44,29 @@ func NewController(secretInformer corev1informers.SecretInformer, certRenewer *t
 		UpdateFunc: manager.updateSecretFunc,
 	})
 	return manager, nil
+}
+
+func (m *controller) Run(ctx context.Context) {
+	logger.Info("start managing certificate")
+	certsRenewalTicker := time.NewTicker(tls.CertRenewalInterval)
+	defer certsRenewalTicker.Stop()
+	for {
+		select {
+		case <-certsRenewalTicker.C:
+			if err := m.renewCertificates(); err != nil {
+				logger.Error(err, "unable to renew certificates, force restarting")
+				os.Exit(1)
+			}
+		case <-m.secretQueue:
+			if err := m.renewCertificates(); err != nil {
+				logger.Error(err, "unable to renew certificates, force restarting")
+				os.Exit(1)
+			}
+		case <-ctx.Done():
+			logger.V(2).Info("stopping cert renewer")
+			return
+		}
+	}
 }
 
 func (m *controller) addSecretFunc(obj interface{}) {
@@ -97,27 +120,4 @@ func (m *controller) GetCAPem() ([]byte, error) {
 		result = secret.Data[tls.RootCAKey]
 	}
 	return result, nil
-}
-
-func (m *controller) Run(stopCh <-chan struct{}) {
-	logger.Info("start managing certificate")
-	certsRenewalTicker := time.NewTicker(tls.CertRenewalInterval)
-	defer certsRenewalTicker.Stop()
-	for {
-		select {
-		case <-certsRenewalTicker.C:
-			if err := m.renewCertificates(); err != nil {
-				logger.Error(err, "unable to renew certificates, force restarting")
-				os.Exit(1)
-			}
-		case <-m.secretQueue:
-			if err := m.renewCertificates(); err != nil {
-				logger.Error(err, "unable to renew certificates, force restarting")
-				os.Exit(1)
-			}
-		case <-stopCh:
-			logger.V(2).Info("stopping cert renewer")
-			return
-		}
-	}
 }

--- a/pkg/controllers/config/controller.go
+++ b/pkg/controllers/config/controller.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 	"github.com/kyverno/kyverno/pkg/config"
+	"github.com/kyverno/kyverno/pkg/controllers"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
 	"k8s.io/apimachinery/pkg/api/errors"
 	corev1informers "k8s.io/client-go/informers/core/v1"
@@ -29,7 +32,7 @@ type controller struct {
 	queue workqueue.RateLimitingInterface
 }
 
-func NewController(configuration config.Configuration, configmapInformer corev1informers.ConfigMapInformer) *controller {
+func NewController(configuration config.Configuration, configmapInformer corev1informers.ConfigMapInformer) controllers.Controller {
 	c := controller{
 		configuration:   configuration,
 		configmapLister: configmapInformer.Lister(),
@@ -41,8 +44,8 @@ func NewController(configuration config.Configuration, configmapInformer corev1i
 	return &c
 }
 
-func (c *controller) Run(stopCh <-chan struct{}) {
-	controllerutils.Run(controllerName, logger.V(3), c.queue, workers, maxRetries, c.reconcile, stopCh, c.configmapSynced)
+func (c *controller) Run(ctx context.Context) {
+	controllerutils.Run(ctx, controllerName, logger.V(3), c.queue, workers, maxRetries, c.reconcile, c.configmapSynced)
 }
 
 func (c *controller) reconcile(logger logr.Logger, key, namespace, name string) error {

--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -1,6 +1,8 @@
 package controllers
 
+import "context"
+
 type Controller interface {
 	// Run starts the controller
-	Run(stopCh <-chan struct{})
+	Run(context.Context)
 }

--- a/pkg/controllers/policycache/controller.go
+++ b/pkg/controllers/policycache/controller.go
@@ -1,6 +1,8 @@
 package policycache
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1"
@@ -78,8 +80,8 @@ func (c *controller) WarmUp() error {
 	return nil
 }
 
-func (c *controller) Run(stopCh <-chan struct{}) {
-	controllerutils.Run(controllerName, logger.V(3), c.queue, workers, maxRetries, c.reconcile, stopCh, c.cpolSynced, c.polSynced)
+func (c *controller) Run(ctx context.Context) {
+	controllerutils.Run(ctx, controllerName, logger.V(3), c.queue, workers, maxRetries, c.reconcile, c.cpolSynced, c.polSynced)
 }
 
 func (c *controller) reconcile(logger logr.Logger, key, namespace, name string) error {

--- a/pkg/controllers/report/admission/controller.go
+++ b/pkg/controllers/report/admission/controller.go
@@ -62,7 +62,7 @@ func NewController(
 	return &c
 }
 
-func (c *controller) Run(stopCh <-chan struct{}) {
+func (c *controller) Run(ctx context.Context) {
 	c.metadataCache.AddEventHandler(func(uid types.UID, _ schema.GroupVersionKind, _ resource.Resource) {
 		selector, err := reportutils.SelectorResourceUidEquals(uid)
 		if err != nil {
@@ -72,7 +72,7 @@ func (c *controller) Run(stopCh <-chan struct{}) {
 			logger.Error(err, "failed to enqueue")
 		}
 	})
-	controllerutils.Run(controllerName, logger.V(3), c.queue, workers, maxRetries, c.reconcile, stopCh)
+	controllerutils.Run(ctx, controllerName, logger.V(3), c.queue, workers, maxRetries, c.reconcile)
 }
 
 func (c *controller) enqueue(selector labels.Selector) error {

--- a/pkg/controllers/report/aggregate/controller.go
+++ b/pkg/controllers/report/aggregate/controller.go
@@ -81,8 +81,8 @@ func NewController(
 	return &c
 }
 
-func (c *controller) Run(stopCh <-chan struct{}) {
-	controllerutils.Run(controllerName, logger.V(3), c.queue, workers, maxRetries, c.reconcile, stopCh)
+func (c *controller) Run(ctx context.Context) {
+	controllerutils.Run(ctx, controllerName, logger.V(3), c.queue, workers, maxRetries, c.reconcile)
 }
 
 func (c *controller) listAdmissionReports(namespace string) ([]kyvernov1alpha2.ReportInterface, error) {

--- a/pkg/controllers/report/background/controller.go
+++ b/pkg/controllers/report/background/controller.go
@@ -85,7 +85,7 @@ func NewController(
 	return &c
 }
 
-func (c *controller) Run(stopCh <-chan struct{}) {
+func (c *controller) Run(ctx context.Context) {
 	c.metadataCache.AddEventHandler(func(uid types.UID, _ schema.GroupVersionKind, resource resource.Resource) {
 		selector, err := reportutils.SelectorResourceUidEquals(uid)
 		if err != nil {
@@ -100,7 +100,7 @@ func (c *controller) Run(stopCh <-chan struct{}) {
 			c.queue.Add(resource.Namespace + "/" + string(uid))
 		}
 	})
-	controllerutils.Run(controllerName, logger.V(3), c.queue, workers, maxRetries, c.reconcile, stopCh)
+	controllerutils.Run(ctx, controllerName, logger.V(3), c.queue, workers, maxRetries, c.reconcile)
 }
 
 func (c *controller) addPolicy(obj interface{}) {

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -84,8 +84,8 @@ func NewController(
 	return &c
 }
 
-func (c *controller) Run(stopCh <-chan struct{}) {
-	controllerutils.Run(controllerName, logger.V(3), c.queue, workers, maxRetries, c.reconcile, stopCh)
+func (c *controller) Run(ctx context.Context) {
+	controllerutils.Run(ctx, controllerName, logger.V(3), c.queue, workers, maxRetries, c.reconcile)
 }
 
 func (c *controller) GetResourceHash(uid types.UID) (Resource, schema.GroupVersionKind, bool) {


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charled.breteche@gmail.com>

## Explanation

This PR uses context in controllers instead of chan.
The advantage is that we can easily forward the context to reconciliation funcs and use it in api calls instead of `TODO` contexts that are completely ignoring the parent context...