### PR TITLE
Fixed issue-4782: Starting controller locally throws panic

### DIFF
--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -279,12 +279,14 @@ func (wrc *Register) UpdateWebhookConfigurations(configHandler config.Configurat
 		logger.V(4).Info("received the signal to update webhook configurations")
 
 		retry := false
-		deploy, err := wrc.GetKubePolicyDeployment()
-		if err != nil {
-			retry = true
-		}
-		if tlsutils.IsKyvernoInRollingUpdate(deploy) {
-			retry = true
+		if wrc.serverIP == "" {
+			deploy, err := wrc.GetKubePolicyDeployment()
+			if err != nil {
+				retry = true
+			}
+			if tlsutils.IsKyvernoInRollingUpdate(deploy) {
+				retry = true
+			}
 		}
 
 		if !retry {


### PR DESCRIPTION
## Explanation

Currently running controller locally is throwing panic as deployment details are not present. This PR adds a check to decide whether to get the details of deployment or not.

## Related issue
Closes 4782

## What type of PR is this
/kind bug

## Proposed Changes
This PR adds a check to decide whether to get deployment details or not. This prevents panic and starts controller properly.

### Proof Manifests
Controller starts properly
![Screenshot from 2022-10-03 11-29-14](https://user-images.githubusercontent.com/8165377/193510275-27f9a126-e227-4b69-a9b2-c226e0812f6e.png)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->