### PR TITLE
filter validation policies using ValidationFailureActionOverride

### DIFF
--- a/pkg/policycache/cache.go
+++ b/pkg/policycache/cache.go
@@ -2,6 +2,7 @@ package policycache
 
 import (
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	kyvernoutils "github.com/kyverno/kyverno/pkg/utils"
 )
 
 // Cache get method use for to get policy names and mostly use to test cache testcases
@@ -42,5 +43,47 @@ func (c *cache) GetPolicies(pkey PolicyType, kind, nspace string) []kyvernov1.Po
 		result = append(result, c.store.get(pkey, kind, nspace)...)
 		result = append(result, c.store.get(pkey, "*", nspace)...)
 	}
+
+	if pkey == ValidateAudit { // also get policies with ValidateEnforce
+		result = append(result, c.store.get(ValidateEnforce, kind, "")...)
+		result = append(result, c.store.get(ValidateEnforce, "*", "")...)
+	}
+
+	if pkey == ValidateAudit || pkey == ValidateEnforce {
+		result = filterPolicies(pkey, result, nspace, kind)
+	}
+
 	return result
+}
+
+// Filter cluster policies using validationFailureAction override
+func filterPolicies(pkey PolicyType, result []kyvernov1.PolicyInterface, nspace, kind string) []kyvernov1.PolicyInterface {
+	var policies []kyvernov1.PolicyInterface
+	for _, policy := range result {
+		keepPolicy := true
+		switch pkey {
+		case ValidateAudit:
+			keepPolicy = checkValidationFailureActionOverrides(kyvernov1.Audit, nspace, policy)
+		case ValidateEnforce:
+			keepPolicy = checkValidationFailureActionOverrides(kyvernov1.Enforce, nspace, policy)
+		}
+		if keepPolicy { // add policy to result
+			policies = append(policies, policy)
+		}
+	}
+	return policies
+}
+
+func checkValidationFailureActionOverrides(requestedAction kyvernov1.ValidationFailureAction, ns string, policy kyvernov1.PolicyInterface) bool {
+	validationFailureAction := policy.GetSpec().ValidationFailureAction
+	validationFailureActionOverrides := policy.GetSpec().ValidationFailureActionOverrides
+	if validationFailureAction != requestedAction && (ns == "" || len(validationFailureActionOverrides) == 0) {
+		return false
+	}
+	for _, action := range validationFailureActionOverrides {
+		if action.Action != requestedAction && kyvernoutils.ContainsNamepace(action.Namespaces, ns) {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/policycache/cache_test.go
+++ b/pkg/policycache/cache_test.go
@@ -1159,3 +1159,105 @@ func Test_Validate_Enforce_Policy(t *testing.T) {
 		t.Errorf("removing: expected 0 validate audit policy, found %v", len(validateAudit))
 	}
 }
+
+func Test_Get_Policies(t *testing.T) {
+	cache := NewCache()
+	policy := newPolicy(t)
+	key, _ := kubecache.MetaNamespaceKeyFunc(policy)
+	cache.Set(key, policy)
+
+	validateAudit := cache.GetPolicies(ValidateAudit, "Namespace", "")
+	if len(validateAudit) != 0 {
+		t.Errorf("expected 0 validate audit policy, found %v", len(validateAudit))
+	}
+
+	validateAudit = cache.GetPolicies(ValidateAudit, "Pod", "test")
+	if len(validateAudit) != 0 {
+		t.Errorf("expected 0 validate audit policy, found %v", len(validateAudit))
+	}
+
+	validateEnforce := cache.GetPolicies(ValidateEnforce, "Namespace", "")
+	if len(validateEnforce) != 1 {
+		t.Errorf("expected 1 validate enforce policy, found %v", len(validateEnforce))
+	}
+
+	mutate := cache.GetPolicies(Mutate, "Pod", "")
+	if len(mutate) != 1 {
+		t.Errorf("expected 1 mutate policy, found %v", len(mutate))
+	}
+
+	generate := cache.GetPolicies(Generate, "Pod", "")
+	if len(generate) != 1 {
+		t.Errorf("expected 1 generate policy, found %v", len(generate))
+	}
+
+}
+
+func Test_Get_Policies_Ns(t *testing.T) {
+	cache := NewCache()
+	policy := newNsPolicy(t)
+	key, _ := kubecache.MetaNamespaceKeyFunc(policy)
+	cache.Set(key, policy)
+	nspace := policy.GetNamespace()
+
+	validateAudit := cache.GetPolicies(ValidateAudit, "Pod", nspace)
+	if len(validateAudit) != 0 {
+		t.Errorf("expected 0 validate audit policy, found %v", len(validateAudit))
+	}
+
+	validateEnforce := cache.GetPolicies(ValidateEnforce, "Pod", nspace)
+	if len(validateEnforce) != 1 {
+		t.Errorf("expected 1 validate enforce policy, found %v", len(validateEnforce))
+	}
+
+	mutate := cache.GetPolicies(Mutate, "Pod", nspace)
+	if len(mutate) != 1 {
+		t.Errorf("expected 1 mutate policy, found %v", len(mutate))
+	}
+
+	generate := cache.GetPolicies(Generate, "Pod", nspace)
+	if len(generate) != 1 {
+		t.Errorf("expected 1 generate policy, found %v", len(generate))
+	}
+}
+
+func Test_Get_Policies_Validate_Failure_Action_Overrides(t *testing.T) {
+	cache := NewCache()
+	policy1 := newValidateAuditPolicy(t)
+	policy2 := newValidateEnforcePolicy(t)
+	key1, _ := kubecache.MetaNamespaceKeyFunc(policy1)
+	cache.Set(key1, policy1)
+	key2, _ := kubecache.MetaNamespaceKeyFunc(policy2)
+	cache.Set(key2, policy2)
+
+	validateAudit := cache.GetPolicies(ValidateAudit, "Pod", "")
+	if len(validateAudit) != 1 {
+		t.Errorf("expected 1 validate audit policy, found %v", len(validateAudit))
+	}
+
+	validateEnforce := cache.GetPolicies(ValidateEnforce, "Pod", "")
+	if len(validateEnforce) != 1 {
+		t.Errorf("expected 1 validate enforce policy, found %v", len(validateEnforce))
+	}
+
+	validateAudit = cache.GetPolicies(ValidateAudit, "Pod", "test")
+	if len(validateAudit) != 2 {
+		t.Errorf("expected 2 validate audit policy, found %v", len(validateAudit))
+	}
+
+	validateEnforce = cache.GetPolicies(ValidateEnforce, "Pod", "test")
+	if len(validateEnforce) != 0 {
+		t.Errorf("expected 0 validate enforce policy, found %v", len(validateEnforce))
+	}
+
+	validateAudit = cache.GetPolicies(ValidateAudit, "Pod", "default")
+	if len(validateAudit) != 0 {
+		t.Errorf("expected 0 validate audit policy, found %v", len(validateAudit))
+	}
+
+	validateEnforce = cache.GetPolicies(ValidateEnforce, "Pod", "default")
+	if len(validateEnforce) != 2 {
+		t.Errorf("expected 2 validate enforce policy, found %v", len(validateEnforce))
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Sandesh More <sandesh.more@infracloud.io>

## Explanation
currently when validation policy is created with ValidationFailureActionOverride and has enforce action defined for atleast one namespace, then validation always happens in validation webhook handler and even when it has action audit for a namespace. 

This PR will add filter policies for audit/enforce considering resource namespace and ValidationFailureActionOverride.

## Related issue

closes: #3058 part 1

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/kind bug


## Proposed Changes
filter policies for validation policies considering requested resource namespace and action/namespace defined in ValidationFailureActionOverride for more granularity.


### Proof Manifests
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: check-label-app-test
spec:
  validationFailureAction: enforce
  validationFailureActionOverrides:
    - action: enforce
      namespaces:
        - default
    - action: audit
      namespaces:
        - test
  rules:
    - name: check-label-app
      match:
        resources:
          kinds:
          - Pod
      validate:
        message: "The label `app` is required."
        pattern:
          metadata:
            labels:
              app: "?*"
```

#### Apply above policy and create pod in ```test``` namespace
```
~$ k apply -f check-label-app-test.yaml
clusterpolicy.kyverno.io/check-label-app-test created
~$ k -n test run ng --image nginx
pod/ng created
```

#### controller logs
```
I0920 11:55:04.230591  220006 validation.go:90] ValidateAuditHandler "msg"="validation failed" "action"="validate" "gvk"="/v1, Kind=Pod" "operation"="CREATE" "resource"="test/Pod/ng" "failed rules"=["check-label-app"] "policy"="check-label-app-test"
```
Here request for POD in  namespace ```test``` was handle in ```ValidateAuditHandler``` instead of validation ```webhook handler```.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
