### PR TITLE
fix: replace AbsPath with RequestURI to support query params

### DIFF
--- a/pkg/clients/dclient/client.go
+++ b/pkg/clients/dclient/client.go
@@ -145,7 +145,7 @@ func (c *client) RawAbsPath(path string) ([]byte, error) {
 	if c.restClient == nil {
 		return nil, errors.New("rest client not supported")
 	}
-	return c.restClient.Get().AbsPath(path).DoRaw(context.TODO())
+	return c.restClient.Get().RequestURI(path).DoRaw(context.TODO())
 }
 
 // PatchResource patches the resource


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR replaces AbsPath with RequestURI to support query params.

## Related issue

Fixes #4848 

Tried with:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: limits
spec:
  validationFailureAction: enforce
  rules:
  - name: limit-lb-svc
    match:
      any:
      - resources:
          kinds:
          - Service
    context:
    - name: serviceCount
      apiCall:
        urlPath: "/api/v1/namespaces/{{ request.namespace }}/services?limit=1"
        jmesPath: "items[?spec.type == 'LoadBalancer'] | length(@)"    
    preconditions:
      any:
      - key: "{{ request.operation }}"
        operator: Equals
        value: CREATE
    validate:
      message: "Only one LoadBalancer service is allowed per namespace"
      deny:
        conditions:
          any:
          - key: "{{ serviceCount }}"
            operator: GreaterThan
            value: 1
```

I see no error in the logs (there was an error when using `AbsPath`).