### PR TITLE
[Bug] [CLI] With results[].resources[] test summary table does not show individual line numbers

### DIFF
--- a/cmd/cli/kubectl-kyverno/test/test_command.go
+++ b/cmd/cli/kubectl-kyverno/test/test_command.go
@@ -1037,9 +1037,13 @@ func printTestResult(resps map[string]policyreportv1alpha2.PolicyReportResult, t
 	boldFgCyan := color.New(color.FgCyan).Add(color.Bold)
 
 	var countDeprecatedResource int
-	for i, v := range testResults {
+	testCount := 1
+	for _, v := range testResults {
 		res := new(Table)
-		res.ID = i + 1
+		res.ID = testCount
+		if v.Resources == nil {
+			testCount++
+		}
 		if !removeColor {
 			res.Policy = boldFgCyan.Sprintf(v.Policy)
 			res.Rule = boldFgCyan.Sprintf(v.Rule)
@@ -1050,6 +1054,8 @@ func printTestResult(resps map[string]policyreportv1alpha2.PolicyReportResult, t
 
 		if v.Resources != nil {
 			for _, resource := range v.Resources {
+				res.ID = testCount
+				testCount++
 				if !removeColor {
 					res.Resource = boldFgCyan.Sprintf(v.Namespace) + "/" + boldFgCyan.Sprintf(v.Kind) + "/" + boldFgCyan.Sprintf(resource)
 				} else {


### PR DESCRIPTION
Signed-off-by: Anant Vijay <anantvijay3@gmail.com>

## Explanation
Currently on running tests with `results[].resources[]` instead of `results[].resource` leads to unintended "groupings" on the line numbers in the test summary table, this is due to how the `results[].resources[]` declarations are handled by the cli, as it assigns each `resource` in `results[].resources[]` the same id, adding counter increments will get rid of the undesired behaviour.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #4589 @chipzoller 

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/kind bug

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Modify the counter which loops over and assigns each row it's id, moreover add counter increments when `results[].resources[]` is iterated over.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
### Test Manifest
```yaml
name: disallow-privileged-containers
policies:
  - disallow-privileged-containers.yaml
resources:
  - resource.yaml
results:
###### Pods - Bad
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resources:
    - badpod01
    - badpod02
    - badpod03
    - badpod04
    - badpod05
    kind: Pod
    result: fail
###### Pods - Good
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resources:
    - goodpod01
    - goodpod02
    - goodpod03
    - goodpod04
    - goodpod05
    - goodpod06
    kind: Pod
    result: pass
###### Deployments - Bad
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resources:
    - baddeployment01
    - baddeployment02
    - baddeployment03
    - baddeployment04
    - baddeployment05
    kind: Deployment
    result: fail
###### Deployments - Good
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resources:
    - gooddeployment01
    - gooddeployment02
    - gooddeployment03
    - gooddeployment04
    - gooddeployment05
    - gooddeployment06
    kind: Deployment
    result: pass
###### CronJobs - Bad
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resources:
    - badcronjob01
    - badcronjob02
    - badcronjob03
    - badcronjob04
    - badcronjob05
    kind: CronJob
    result: fail
###### CronJobs - Good
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resources:
    - goodcronjob01
    - goodcronjob02
    - goodcronjob03
    - goodcronjob04
    - goodcronjob05
    - goodcronjob06
    kind: CronJob
    result: pass
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
