### PR TITLE
fix: auto gen enabled when using names

### DIFF
--- a/pkg/autogen/autogen.go
+++ b/pkg/autogen/autogen.go
@@ -33,7 +33,7 @@ func isKindOtherthanPod(kinds []string) bool {
 
 func checkAutogenSupport(needed *bool, subjects ...kyvernov1.ResourceDescription) bool {
 	for _, subject := range subjects {
-		if subject.Name != "" || subject.Selector != nil || subject.Annotations != nil || isKindOtherthanPod(subject.Kinds) {
+		if subject.Name != "" || len(subject.Names) > 0 || subject.Selector != nil || subject.Annotations != nil || isKindOtherthanPod(subject.Kinds) {
 			return false
 		}
 		if needed != nil {

--- a/pkg/autogen/autogen_test.go
+++ b/pkg/autogen/autogen_test.go
@@ -72,6 +72,11 @@ func Test_CanAutoGen(t *testing.T) {
 			expectedControllers: "none",
 		},
 		{
+			name:                "rule-with-exclude-names",
+			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test-getcontrollers"},"spec":{"background":false,"rules":[{"name":"test-getcontrollers","match":{"resources":{"kinds":["Pod"]}},"exclude":{"resources":{"names":["test"]}}}]}}`),
+			expectedControllers: "none",
+		},
+		{
 			name:                "rule-with-exclude-selector",
 			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test-getcontrollers"},"spec":{"background":false,"rules":[{"name":"test-getcontrollers","match":{"resources":{"kinds":["Pod"]}},"exclude":{"resources":{"selector":{"matchLabels":{"foo":"bar"}}}}}]}}`),
 			expectedControllers: "none",


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR fixes a case where auto gen generates rules when names is used in `match` or `exclude`.

## Related issue

Fixes https://github.com/kyverno/kyverno/issues/4339