### PR TITLE
fix: background scan labels

### DIFF
--- a/pkg/utils/report/labels.go
+++ b/pkg/utils/report/labels.go
@@ -20,8 +20,8 @@ const (
 	LabelResourceHash = "audit.kyverno.io/resource.hash"
 	LabelResourceUid  = "audit.kyverno.io/resource.uid"
 	//	policy labels
-	LabelDomainClusterPolicy = "pol.kyverno.io"
-	LabelDomainPolicy        = "cpol.kyverno.io"
+	LabelDomainClusterPolicy = "cpol.kyverno.io"
+	LabelDomainPolicy        = "pol.kyverno.io"
 	LabelPrefixClusterPolicy = LabelDomainClusterPolicy + "/"
 	LabelPrefixPolicy        = LabelDomainPolicy + "/"
 )


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR fixes background scan labels inverted between policies and cluster policies.
