### PR TITLE
fix: hardening policy validation for generate cloneList 

### DIFF
--- a/pkg/policy/generate/validate.go
+++ b/pkg/policy/generate/validate.go
@@ -55,6 +55,13 @@ func (g *Generate) Validate() (string, error) {
 		if kind == "" {
 			return "kind", fmt.Errorf("kind cannot be empty")
 		}
+	} else {
+		if name != "" {
+			return "name", fmt.Errorf("with cloneList, generate.name. should not be specified.")
+		}
+		if kind != "" {
+			return "kind", fmt.Errorf("with cloneList, generate.kind. should not be specified.")
+		}
 	}
 
 	if rule.CloneList.Selector != nil {


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Explanation

Hardening policy validation for generate cloneList. Optional fields like `generate.name` and `generate.kind` can not be specified if cloneList has been used in policy.

## Related issue

N/A

## Milestone of this PR
`/milestone 1.8.1`.


## What type of PR is this
> /kind bug

### Proof Manifests
1. If `generate.name` has been specified with cloneList
  ```yaml
    generate:
      namespace: "{{request.object.metadata.name}}"
      synchronize : true
      name: generate-secret
      cloneList:
        namespace: stagging
        kinds:
          - v1/Secret
          - v1/ConfigMap
        selector:
          matchLabels:
            allowedToBeCloned: "true"
```
```sh
$ kubectl apply -f multi-clone-policy.yaml 
Error from server: error when creating "multi-clone-policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: path: spec.rules[0].generate.name.: with cloneList, generate.name should not be specified.
```

2. If `generate.kind` has been specified
  ```yaml
    generate:
      namespace: "{{request.object.metadata.name}}"
      synchronize : true
      kind: Secret
      cloneList:
        namespace: stagging
        kinds:
          - v1/Secret
          - v1/ConfigMap
        selector:
          matchLabels:
            allowedToBeCloned: "true"
```

```sh
$ kubectl apply -f multi-clone-policy.yaml 
Error from server: error when creating "multi-clone-policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: path: spec.rules[0].generate.kind.: with cloneList, generate.kind should not be specified.
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
