### PR TITLE
fix: non watchable resources in report controller

### DIFF
--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -132,6 +132,8 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 		apiResource, gvr, err := c.client.Discovery().FindResource(apiVersion, kind)
 		if err != nil {
 			logger.Error(err, "failed to get gvr from kind", "kind", kind)
+		} else if apiVersion == "" && kind == "Event" {
+			logger.Info("Event cannot be an owner, skipping", "apiVersion", apiVersion, "kind", kind)
 		} else {
 			if pkgutils.ContainsString(apiResource.Verbs, "list") && pkgutils.ContainsString(apiResource.Verbs, "watch") {
 				gvrs[kind] = gvr

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -11,7 +11,9 @@ import (
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/controllers"
 	"github.com/kyverno/kyverno/pkg/controllers/report/utils"
+	pkgutils "github.com/kyverno/kyverno/pkg/utils"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -126,11 +128,16 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 	kinds := utils.BuildKindSet(logger, utils.RemoveNonBackgroundPolicies(logger, append(clusterPolicies, policies...)...)...)
 	gvrs := map[string]schema.GroupVersionResource{}
 	for _, kind := range kinds.List() {
-		gvr, err := c.client.Discovery().GetGVRFromKind(kind)
-		if err == nil {
-			gvrs[kind] = gvr
-		} else {
+		apiVersion, kind := kubeutils.GetKindFromGVK(kind)
+		apiResource, gvr, err := c.client.Discovery().FindResource(apiVersion, kind)
+		if err != nil {
 			logger.Error(err, "failed to get gvr from kind", "kind", kind)
+		} else {
+			if pkgutils.ContainsString(apiResource.Verbs, "list") && pkgutils.ContainsString(apiResource.Verbs, "watch") {
+				gvrs[kind] = gvr
+			} else {
+				logger.Info("list/watch not supported for kind", "kind", kind)
+			}
 		}
 	}
 	dynamicWatchers := map[schema.GroupVersionResource]*watcher{}


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR fixes non watchable resources in report controller.
Before starting the watcher we make sure that api resource supports watch and list verbs.

This also fixes an issue with Events that are not allowed to be an owner (hence we can't attach background scan reports).

## Related issues

Fixes #4889 