### PR TITLE
fix: use constants defined in openapi controller

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -332,7 +332,7 @@ func createNonLeaderControllers(
 	)
 	return []controller{
 			newController(policycachecontroller.ControllerName, policyCacheController, policycachecontroller.Workers),
-			newController("openapi-controller", openApiController, 1),
+			newController(openapicontroller.ControllerName, openApiController, openapicontroller.Workers),
 			newController(configcontroller.ControllerName, configurationController, configcontroller.Workers),
 			newController("update-request-controller", updateRequestController, genWorkers),
 		},


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR makes use constants defined in openapi controller.
