### PR TITLE
fix: set operation in context when necessary

### DIFF
--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -47,15 +47,16 @@ func (s *scanner) ScanResource(resource unstructured.Unstructured, nsLabels map[
 
 func (s *scanner) scan(resource unstructured.Unstructured, nsLabels map[string]string, policy kyvernov1.PolicyInterface) (*response.EngineResponse, error) {
 	ctx := context.NewContext()
-	err := ctx.AddResource(resource.Object)
-	if err != nil {
+	if err := ctx.AddResource(resource.Object); err != nil {
 		return nil, err
 	}
-	err = ctx.AddNamespace(resource.GetNamespace())
-	if err != nil {
+	if err := ctx.AddNamespace(resource.GetNamespace()); err != nil {
 		return nil, err
 	}
 	if err := ctx.AddImageInfos(&resource); err != nil {
+		return nil, err
+	}
+	if err := ctx.AddOperation("CREATE"); err != nil {
 		return nil, err
 	}
 	policyCtx := &engine.PolicyContext{

--- a/pkg/engine/context/context.go
+++ b/pkg/engine/context/context.go
@@ -52,6 +52,9 @@ type Interface interface {
 	// AddTargetResource merges resource json under target
 	AddTargetResource(data map[string]interface{}) error
 
+	// AddOperation merges operation under request.operation
+	AddOperation(data string) error
+
 	// AddUserInfo merges userInfo json under kyverno.userInfo
 	AddUserInfo(userInfo kyvernov1beta1.RequestInfo) error
 
@@ -171,6 +174,11 @@ func (ctx *context) AddOldResource(data map[string]interface{}) error {
 // AddTargetResource adds data at path: target
 func (ctx *context) AddTargetResource(data map[string]interface{}) error {
 	return addToContext(ctx, data, "target")
+}
+
+// AddOperation data at path: request.operation
+func (ctx *context) AddOperation(data string) error {
+	return addToContext(ctx, data, "request", "operation")
 }
 
 // AddUserInfo adds userInfo at path request.userInfo

--- a/pkg/policy/apply.go
+++ b/pkg/policy/apply.go
@@ -52,6 +52,10 @@ func applyPolicy(policy kyvernov1.PolicyInterface, resource unstructured.Unstruc
 		logger.Error(err, "unable to add image info to variables context")
 	}
 
+	if err := ctx.AddOperation("CREATE"); err != nil {
+		logger.Error(err, "unable to set operation in context")
+	}
+
 	engineResponseMutation, err = mutation(policy, resource, logger, ctx, namespaceLabels)
 	if err != nil {
 		logger.Error(err, "failed to process mutation rule")


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR sets operation in context when necessary (background scan and evaluating against existing resources).

## Related issue

Fixes https://github.com/kyverno/kyverno/issues/4870