### PR TITLE
fix: workaround for request.operation

### DIFF
--- a/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.yaml
@@ -46,7 +46,7 @@ spec:
       preconditions:
         {{- if .all }}
         all:
-        - key: "{{`{{ request.operation }}`}}"
+        - key: "{{`{{ request.operation || 'BACKGROUND' }}`}}"
           operator: NotEquals
           value: DELETE
         {{- toYaml .all | nindent 8 }}
@@ -57,7 +57,7 @@ spec:
       {{- else }}
       preconditions:
         all:
-        - key: "{{`{{ request.operation }}`}}"
+        - key: "{{`{{ request.operation || 'BACKGROUND' }}`}}"
           operator: NotEquals
           value: DELETE
       {{- end }}
@@ -88,7 +88,7 @@ spec:
       preconditions:
         {{- if .all }}
         all:
-        - key: "{{`{{ request.operation }}`}}"
+        - key: "{{`{{ request.operation || 'BACKGROUND' }}`}}"
           operator: NotEquals
           value: DELETE
         {{- toYaml .all | nindent 8 }}
@@ -99,7 +99,7 @@ spec:
       {{- else }}
       preconditions:
         all:
-        - key: "{{`{{ request.operation }}`}}"
+        - key: "{{`{{ request.operation || 'BACKGROUND' }}`}}"
           operator: NotEquals
           value: DELETE
       {{- end }}


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR fixes `request.operation` not being set when running in background.