### PR TITLE
fix: add user info in admission request logs

### DIFF
--- a/pkg/webhooks/handlers/admission.go
+++ b/pkg/webhooks/handlers/admission.go
@@ -51,6 +51,7 @@ func Admission(logger logr.Logger, inner AdmissionHandler) http.HandlerFunc {
 			"name", admissionReview.Request.Name,
 			"operation", admissionReview.Request.Operation,
 			"uid", admissionReview.Request.UID,
+			"user", admissionReview.Request.UserInfo,
 		)
 		admissionReview.Response = &admissionv1.AdmissionResponse{
 			Allowed: true,


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR adds user info in admission request logs.
This is useful for troubleshooting an abnormal quantity of admission requests.