### PR TITLE
fix: use default retry with retryfunc for a conflict

### DIFF
--- a/pkg/background/common/util.go
+++ b/pkg/background/common/util.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"time"
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
@@ -11,20 +10,12 @@ import (
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/logging"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
 
-var DefaultRetry = wait.Backoff{
-	Steps:    15,
-	Duration: 100 * time.Millisecond,
-	Factor:   1.0,
-	Jitter:   0.1,
-}
-
 func Update(client versioned.Interface, urLister kyvernov1beta1listers.UpdateRequestNamespaceLister, name string, mutator func(*kyvernov1beta1.UpdateRequest)) (*kyvernov1beta1.UpdateRequest, error) {
 	var ur *kyvernov1beta1.UpdateRequest
-	err := retry.RetryOnConflict(DefaultRetry, func() error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		ur, err := urLister.Get(name)
 		if err != nil {
 			logging.Error(err, "[ATTEMPT] failed to fetch update request", "name", name)
@@ -48,7 +39,7 @@ func Update(client versioned.Interface, urLister kyvernov1beta1listers.UpdateReq
 
 func UpdateStatus(client versioned.Interface, urLister kyvernov1beta1listers.UpdateRequestNamespaceLister, name string, state kyvernov1beta1.UpdateRequestState, message string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error) {
 	var ur *kyvernov1beta1.UpdateRequest
-	err := retry.RetryOnConflict(DefaultRetry, func() error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		ur, err := urLister.Get(name)
 		if err != nil {
 			logging.Error(err, "[ATTEMPT] failed to fetch update request", "name", name)

--- a/pkg/background/update_request_controller.go
+++ b/pkg/background/update_request_controller.go
@@ -373,7 +373,7 @@ func (c *controller) processUR(ur *kyvernov1beta1.UpdateRequest) error {
 
 func (c *controller) acquireUR(ur *kyvernov1beta1.UpdateRequest) (*kyvernov1beta1.UpdateRequest, bool, error) {
 	name := ur.GetName()
-	err := retry.RetryOnConflict(common.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var err error
 		ur, err = c.urLister.Get(name)
 		if err != nil {
@@ -395,7 +395,7 @@ func (c *controller) acquireUR(ur *kyvernov1beta1.UpdateRequest) (*kyvernov1beta
 }
 
 func (c *controller) releaseUR(ur *kyvernov1beta1.UpdateRequest) (*kyvernov1beta1.UpdateRequest, error) {
-	err := retry.RetryOnConflict(common.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var err error
 		ur, err = c.urLister.Get(ur.GetName())
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Explanation
DefaultRetry is the recommended retry for a conflict where multiple clients are making changes to the same resource. 
Earlier parameters were to aggressive , which was causing update conflicts. 

The news defaults parameters are

```go
var DefaultRetry = wait.Backoff{
	Steps:    5,
	Duration: 10 * time.Millisecond,
	Factor:   1.0,
	Jitter:   0.1,
}


```


Fixes: https://github.com/kyverno/kyverno/issues/4265
