### PR TITLE
feat: Add container registry setting on Helm Chart (cherry-pick #4281)

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -42,3 +42,5 @@ annotations:
       description: Self signed certificates not using SANs.
     - kind: added
       description: Extra args support for init container.
+    - kind: added
+      description: Added possibility to define custom image registries

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -107,15 +107,18 @@ The command removes all the Kubernetes components associated with the chart and 
 | rbac.serviceAccount.create | bool | `true` | Create a ServiceAccount |
 | rbac.serviceAccount.name | string | `nil` | The ServiceAccount name |
 | rbac.serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
+| image.registry | string | `nil` | Image registry |
 | image.repository | string | `"ghcr.io/kyverno/kyverno"` | Image repository |
 | image.tag | string | `nil` | Image tag Defaults to appVersion in Chart.yaml if omitted |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |
+| initImage.registry | string | `nil` | Image registry |
 | initImage.repository | string | `"ghcr.io/kyverno/kyvernopre"` | Image repository |
 | initImage.tag | string | `nil` | Image tag If initImage.tag is missing, defaults to image.tag |
 | initImage.pullPolicy | string | `nil` | Image pull policy If initImage.pullPolicy is missing, defaults to image.pullPolicy |
 | initContainer.extraArgs | list | `["--loggingFormat=text"]` | Extra arguments to give to the kyvernopre binary. |
-| testImage.repository | string | `nil` | Image repository Defaults to `busybox` if omitted |
+| testImage.registry | string | `nil` | Image registry |
+| testImage.repository | string | `"busybox"` | Image repository |
 | testImage.tag | string | `nil` | Image tag Defaults to `latest` if omitted |
 | testImage.pullPolicy | string | `nil` | Image pull policy Defaults to image.pullPolicy if omitted |
 | replicaCount | int | `nil` | Desired number of pods |

--- a/charts/kyverno/ci/imageRegistry-values.yaml
+++ b/charts/kyverno/ci/imageRegistry-values.yaml
@@ -1,0 +1,9 @@
+testImage:
+  registry: docker.io
+  repository: busybox
+image:
+  registry: ko.local
+  repository: github.com/kyverno/kyverno/cmd/kyverno
+initImage:
+  registry: ko.local
+  repository: github.com/kyverno/kyverno/cmd/initcontainer

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -125,6 +125,13 @@ maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
 {{- printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" .registry (printf "%s:%s" .username .password | b64enc) | b64enc }}
 {{- end }}
 
+{{- define "kyverno.image" -}}
+  {{- if .image.registry -}}
+{{ .image.registry }}/{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+  {{- else -}}
+{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+  {{- end -}}
+{{- end }}
 
 {{- define "kyverno.resourceFilters" -}}
 {{- $resourceFilters := .Values.config.resourceFilters }}

--- a/charts/kyverno/templates/deployment.yaml
+++ b/charts/kyverno/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         {{- toYaml .Values.extraInitContainers | nindent 8 }}
       {{- end }}
         - name: kyverno-pre
-          image: {{ .Values.initImage.repository }}:{{ default .Chart.AppVersion (default .Values.image.tag .Values.initImage.tag) }}
+          image: {{ include "kyverno.image" (dict "image" .Values.initImage "defaultTag" (default .Chart.AppVersion .Values.image.tag)) | quote }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.initImage.pullPolicy }}
           {{- if .Values.initContainer.extraArgs }}
           args:
@@ -102,7 +102,7 @@ spec:
         {{- toYaml .Values.extraContainers | nindent 8 }}
       {{- end }}
         - name: kyverno
-          image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
+          image: {{ include "kyverno.image" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if or .Values.extraArgs .Values.imagePullSecrets }}
           args:

--- a/charts/kyverno/templates/tests/test.yaml
+++ b/charts/kyverno/templates/tests/test.yaml
@@ -10,7 +10,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: wget
-      image: {{ .Values.testImage.repository | default "busybox" }}{{- if .Values.testImage.tag }}:{{ .Values.testImage.tag }}{{- end }}
+      image: {{ include "kyverno.image" (dict "image" .Values.testImage "defaultTag" "latest") | quote }}
       imagePullPolicy: {{ default .Values.image.pullPolicy .Values.testImage.pullPolicy }}
       {{- with .Values.testResources }}
       resources: {{ tpl (toYaml .) $ | nindent 8 }}
@@ -24,7 +24,7 @@ spec:
         - |
           sleep 20 ; wget -O- -S --no-check-certificate https://{{ template "kyverno.serviceName" . }}:{{ .Values.service.port }}/health/liveness
     - name: wget-metrics
-      image: {{ .Values.testImage.repository | default "busybox" }}{{- if .Values.testImage.tag }}:{{ .Values.testImage.tag }}{{- end }}
+      image: {{ include "kyverno.image" (dict "image" .Values.testImage "defaultTag" "latest") | quote }}
       imagePullPolicy: {{ default .Values.image.pullPolicy .Values.testImage.pullPolicy }}
       {{- with .Values.testResources }}
       resources: {{ tpl (toYaml .) $ | nindent 8 }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -23,6 +23,11 @@ rbac:
       # example.com/annotation: value
 
 image:
+  # -- Image registry
+  registry:
+  # If you want to manage the registry you should remove it from the repository
+  # registry: ghcr.io
+  # repository: kyverno/kyverno
   # -- Image repository
   repository: ghcr.io/kyverno/kyverno  # kyverno: replaced in e2e tests
   # -- Image tag
@@ -35,6 +40,11 @@ image:
   # - secretName
 
 initImage:
+  # -- Image registry
+  registry:
+  # If you want to manage the registry you should remove it from the repository
+  # registry: ghcr.io
+  # repository: kyverno/kyvernopre
   # -- Image repository
   repository: ghcr.io/kyverno/kyvernopre  # init: replaced in e2e tests
   # -- Image tag
@@ -51,9 +61,10 @@ initContainer:
 
 
 testImage:
+  # -- Image registry
+  registry:
   # -- Image repository
-  # Defaults to `busybox` if omitted
-  repository:
+  repository: busybox
   # -- Image tag
   # Defaults to `latest` if omitted
   tag:


### PR DESCRIPTION
This is cherry-pick of #4281 

To make the customization of the container registries easier, eg. a custom private registry, this change adds a new property on the images configuration to allow setting a custom image registry without needing to customize the repository of the image.

Signed-off-by: Samuel Torres <samuelpirestorres@gmail.com>
Signed-off-by: Trey Dockendorf <tdockendorf@osc.edu>