### PR TITLE
feat: add metrics server and kube-prometheus-stack to argocd lab

### DIFF
--- a/scripts/labs/argocd/README.md
+++ b/scripts/labs/argocd/README.md
@@ -2,7 +2,7 @@
 
 This lab sets up the following components:
 - A [kind](https://kind.sigs.k8s.io) cluster
-- [nginx-ingress](https://github.com/kubernetes/ingress-nginx)
+- [ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 - [ArgoCD](https://argo-cd.readthedocs.io)
 - ArgoCD application to deploy [kyverno](https://kyverno.io)
 - ArgoCD application to deploy [kyverno-policies](https://artifacthub.io/packages/helm/kyverno/kyverno-policies)

--- a/scripts/labs/argocd/README.md
+++ b/scripts/labs/argocd/README.md
@@ -8,6 +8,14 @@ This lab sets up the following components:
 - ArgoCD application to deploy kyverno-policies
 - ArgoCD application to deploy policy-reporter
 
+## Install
+
+Run the command below to install the lab:
+
+```shell
+./kind-argo.sh
+```
+
 ## Accessing ArgoCD
 
 ArgoCD should be available at http://localhost/argocd.
@@ -15,3 +23,7 @@ ArgoCD should be available at http://localhost/argocd.
 Login credentials:
 - User name: `admin`
 - Password: `kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d`
+
+## Accessing policy-reporter
+
+policy-reporter should be available at http://localhost/policy-reporter.

--- a/scripts/labs/argocd/README.md
+++ b/scripts/labs/argocd/README.md
@@ -6,6 +6,7 @@ This lab sets up the following components:
 - ArgoCD
 - ArgoCD application to deploy kyverno
 - ArgoCD application to deploy kyverno-policies
+- ArgoCD application to deploy policy-reporter
 
 ## Accessing ArgoCD
 

--- a/scripts/labs/argocd/README.md
+++ b/scripts/labs/argocd/README.md
@@ -12,7 +12,7 @@ This lab sets up the following components:
 
 Run the command below to install the lab:
 
-```shell
+```console
 ./kind-argo.sh
 ```
 

--- a/scripts/labs/argocd/README.md
+++ b/scripts/labs/argocd/README.md
@@ -7,6 +7,10 @@ This lab sets up the following components:
 - ArgoCD application to deploy [kyverno](https://kyverno.io)
 - ArgoCD application to deploy [kyverno-policies](https://artifacthub.io/packages/helm/kyverno/kyverno-policies)
 - ArgoCD application to deploy [policy-reporter](https://kyverno.github.io/policy-reporter)
+- ArgoCD application to deploy [metrics-server](https://github.com/kubernetes-sigs/metrics-server)
+- ArgoCD application to deploy [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
+
+> **Note**: Unfortunately kube-prometheus-stack fails to sync the first time it is deployed hence we need to make it pass by hand.
 
 ## Install
 
@@ -27,3 +31,19 @@ Login credentials:
 ## Accessing policy-reporter
 
 policy-reporter should be available at http://localhost/policy-reporter.
+
+## Accessing prometheus
+
+prometheus should be available at http://localhost/prometheus.
+
+## Accessing alertmanager
+
+alertmanager should be available at http://localhost/alertmanager.
+
+## Accessing grafana
+
+grafana should be available at http://localhost/grafana.
+
+Login credentials:
+- User name: `admin`
+- Password: `admin`

--- a/scripts/labs/argocd/README.md
+++ b/scripts/labs/argocd/README.md
@@ -1,12 +1,12 @@
 # ArgoCD lab
 
 This lab sets up the following components:
-- A kind cluster
-- nginx-ingress
-- ArgoCD
-- ArgoCD application to deploy kyverno
-- ArgoCD application to deploy kyverno-policies
-- ArgoCD application to deploy policy-reporter
+- A [kind](https://kind.sigs.k8s.io) cluster
+- [nginx-ingress](https://github.com/kubernetes/ingress-nginx)
+- [ArgoCD](https://argo-cd.readthedocs.io)
+- ArgoCD application to deploy [kyverno](https://kyverno.io)
+- ArgoCD application to deploy [kyverno-policies](https://artifacthub.io/packages/helm/kyverno/kyverno-policies)
+- ArgoCD application to deploy [policy-reporter](https://kyverno.github.io/policy-reporter)
 
 ## Install
 

--- a/scripts/labs/argocd/kind-argo.sh
+++ b/scripts/labs/argocd/kind-argo.sh
@@ -16,10 +16,26 @@ kind delete cluster --name $NAME || true
 kind create cluster --name $NAME --image $KIND_IMAGE --config - <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+  - |-
+    kind: ClusterConfiguration
+    controllerManager:
+      extraArgs:
+        bind-address: 0.0.0.0
+    etcd:
+      local:
+        extraArgs:
+          listen-metrics-urls: http://0.0.0.0:2381
+    scheduler:
+      extraArgs:
+        bind-address: 0.0.0.0
+  - |-
+    kind: KubeProxyConfiguration
+    metricsBindAddress: 0.0.0.0
 nodes:
   - role: control-plane
     kubeadmConfigPatches:
-      - |
+      - |-
         kind: InitConfiguration
         nodeRegistration:
           kubeletExtraArgs:
@@ -31,6 +47,9 @@ nodes:
       - containerPort: 443
         hostPort: 443
         protocol: TCP
+  - role: worker
+  - role: worker
+  - role: worker
 EOF
 
 # DEPLOY INGRESS-NGINX
@@ -87,6 +106,110 @@ server:
       - /argocd
 EOF
 
+# CREATE METRICS-SERVER APP
+
+kubectl apply -f - <<EOF
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metrics-server
+  namespace: argocd
+spec:
+  destination:
+    namespace: kube-system
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    chart: metrics-server
+    repoURL: https://charts.bitnami.com/bitnami
+    targetRevision: 6.2.1
+    helm:
+      values: |
+        extraArgs:
+          - --kubelet-insecure-tls=true
+        apiService:
+          create: true
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+EOF
+
+# CREATE KUBE-PROMETHEUS-STASK APP
+
+kubectl apply -f - <<EOF
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-prometheus-stack
+  namespace: argocd
+spec:
+  destination:
+    namespace: monitoring
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    chart: kube-prometheus-stack
+    repoURL: https://prometheus-community.github.io/helm-charts
+    targetRevision: 41.4.1
+    helm:
+      values: |
+        kubeEtcd:
+          service:
+            enabled: true
+            targetPort: 2381
+        defaultRules:
+          create: true
+        alertmanager:
+          alertmanagerSpec:
+            routePrefix: /alertmanager
+            alertmanagerConfigSelector:
+              matchLabels: {}
+            alertmanagerConfigNamespaceSelector:
+              matchLabels: {}
+          ingress:
+            enabled: true
+            pathType: Prefix
+        prometheus:
+          prometheusSpec:
+            externalUrl: /prometheus
+            routePrefix: /prometheus
+            ruleSelectorNilUsesHelmValues: false
+            serviceMonitorSelectorNilUsesHelmValues: false
+            podMonitorSelectorNilUsesHelmValues: false
+            probeSelectorNilUsesHelmValues: false
+          ingress:
+            enabled: true
+            pathType: Prefix
+        grafana:
+          enabled: true
+          adminPassword: admin
+          sidecar:
+            enableUniqueFilenames: true
+            dashboards:
+              enabled: true
+              searchNamespace: ALL
+              provider:
+                foldersFromFilesStructure: true
+            datasources:
+              enabled: true
+              searchNamespace: ALL
+          grafana.ini:
+            server:
+              root_url: "%(protocol)s://%(domain)s:%(http_port)s/grafana"
+              serve_from_sub_path: true
+          ingress:
+            enabled: true
+            path: /grafana
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - Replace=true
+EOF
+
 # CREATE KYVERNO APP
 
 kubectl apply -f - <<EOF
@@ -104,6 +227,10 @@ spec:
     chart: kyverno
     repoURL: https://kyverno.github.io/kyverno
     targetRevision: 2.6.0
+    helm:
+      values: |
+        serviceMonitor:
+          enabled: true
   syncPolicy:
     automated:
       prune: true
@@ -180,9 +307,14 @@ spec:
       - CreateNamespace=true
 EOF
 
+echo "---------------------------------------------------------------------------------"
+
 ARGOCD_PASSWORD=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
 
-echo "---------------------------------------------------------------------------------"
-echo "ArgoCD is running and available at http://localhost/argocd"
+echo "ARGOCD is running and available at            http://localhost/argocd"
 echo "- log in with admin / $ARGOCD_PASSWORD"
-echo "policy-reporter is running and available at http://localhost/policy-reporter"
+echo "POLICY-REPORTER is running and available at   http://localhost/policy-reporter"
+echo "PROMETHEUS is running and available at        http://localhost/prometheus"
+echo "ALERTMANAGER is running and available at      http://localhost/alertmanager"
+echo "GRAFANA is running and available at           http://localhost/grafana"
+echo "- log in with admin / admin"

--- a/scripts/labs/argocd/kind-argo.sh
+++ b/scripts/labs/argocd/kind-argo.sh
@@ -135,7 +135,7 @@ spec:
       selfHeal: true
 EOF
 
-# CREATE KUBE-PROMETHEUS-STASK APP
+# CREATE KUBE-PROMETHEUS-STACK APP
 
 kubectl apply -f - <<EOF
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
## Explanation

This PR adds metrics server and kube-prometheus-stack to argocd lab.
Unfortunately kube-prometheus-stack fails to sync the first time it is deployed hence we need to make it pass by hand.