### PR TITLE
Fixed issue-4655: verifyImages is executed before mutate

### DIFF
--- a/pkg/webhooks/resource/handlers.go
+++ b/pkg/webhooks/resource/handlers.go
@@ -181,6 +181,12 @@ func (h *handlers) Mutate(logger logr.Logger, request *admissionv1.AdmissionRequ
 		return admissionutils.ResponseFailure(err.Error())
 	}
 	newRequest := patchRequest(mutatePatches, request, logger)
+	// rebuild context to process images updated via mutate policies
+	policyContext, err = h.pcBuilder.Build(newRequest, mutatePolicies...)
+	if err != nil {
+		logger.Error(err, "failed to build policy context")
+		return admissionutils.ResponseFailure(err.Error())
+	}
 	ivh := imageverification.NewImageVerificationHandler(logger, h.eventGen)
 	imagePatches, imageVerifyWarnings, err := ivh.Handle(h.metricsConfig, newRequest, verifyImagesPolicies, policyContext)
 	if err != nil {

--- a/pkg/webhooks/resource/handlers_test.go
+++ b/pkg/webhooks/resource/handlers_test.go
@@ -133,6 +133,112 @@ var policyVerifySignature = `
 }
 `
 
+var policyMutateAndVerify = `
+{
+    "apiVersion": "kyverno.io/v1",
+    "kind": "ClusterPolicy",
+    "metadata": {
+        "name": "disallow-unsigned-images"
+    },
+    "spec": {
+        "validationFailureAction": "enforce",
+        "background": false,
+        "rules": [
+            {
+                "name": "replace-image-registry",
+                "match": {
+                    "any": [
+                        {
+                            "resources": {
+                                "kinds": [
+                                    "Pod"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "mutate": {
+                    "foreach": [
+                        {
+                            "list": "request.object.spec.containers",
+                            "patchStrategicMerge": {
+                                "spec": {
+                                    "containers": [
+                                        {
+                                            "name": "{{ element.name }}",
+                                            "image": "{{ regex_replace_all_literal('.*(.*)/', '{{element.image}}', 'ghcr.io/kyverno/' )}}"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "disallow-unsigned-images-rule",
+                "match": {
+                    "any": [
+                        {
+                            "resources": {
+                                "kinds": [
+                                    "Pod"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "verifyImages": [
+                    {
+                        "imageReferences": [
+                            "*"
+                        ],
+                        "verifyDigest": false,
+                        "required": null,
+                        "mutateDigest": false,
+                        "attestors": [
+                            {
+                                "count": 1,
+                                "entries": [
+                                    {
+                                        "keys": {
+                                            "publicKeys": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM\n5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==\n-----END PUBLIC KEY-----"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}
+`
+
+var resourceMutateAndVerify = `{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "labels": {
+            "run": "rewrite"
+        },
+        "name": "rewrite"
+    },
+    "spec": {
+        "containers": [
+            {
+                "image": "test-verify-image:signed",
+                "name": "rewrite",
+                "resources": {}
+            }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "OnFailure"
+    }
+}
+`
+
 var pod = `{
 	"apiVersion": "v1",
 	"kind": "Pod",
@@ -271,6 +377,36 @@ func Test_ImageVerify(t *testing.T) {
 
 	response = handlers.Mutate(logger, request, "", time.Now())
 	assert.Equal(t, response.Allowed, false)
+	assert.Equal(t, len(response.Warnings), 0)
+}
+
+func Test_MutateAndVerify(t *testing.T) {
+	policyCache := policycache.NewCache()
+	logger := log.WithName("Test_MutateAndVerify")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	handlers := NewFakeHandlers(ctx, policyCache)
+
+	var policy kyverno.ClusterPolicy
+	err := json.Unmarshal([]byte(policyMutateAndVerify), &policy)
+	assert.NilError(t, err)
+
+	key := makeKey(&policy)
+	policyCache.Set(key, &policy)
+
+	request := &v1.AdmissionRequest{
+		Operation: v1.Create,
+		Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+		Resource:  metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "Pod"},
+		Object: runtime.RawExtension{
+			Raw: []byte(resourceMutateAndVerify),
+		},
+	}
+
+	response := handlers.Mutate(logger, request, "", time.Now())
+	assert.Equal(t, response.Allowed, true)
 	assert.Equal(t, len(response.Warnings), 0)
 }
 


### PR DESCRIPTION
Signed-off-by: Pratik Shah <pratik@infracloud.io>

## Explanation

This PR sets mutation changes done for resource image in policy context. This verifies public key against mutated image.

## Related issue
Closes #4655 

## Milestone of this PR
/milestone 1.8.2

## What type of PR is this

/kind bug

## Proposed Changes
Added fix to build new policy context once images are mutated.

### Proof Manifests
Policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-unsigned-images
spec:
  validationFailureAction: enforce
  background: false
  rules:
    - name: replace-image-registry
      match:
        any:
          - resources:
              kinds:
                - Pod
      mutate:
        foreach:
          - list: "request.object.spec.containers"
            patchStrategicMerge:
              spec:
                containers:
                  - name: "{{ element.name }}"
                    image: "{{ regex_replace_all_literal('.*(.*)/', '{{element.image}}', 'pratikrshah/' )}}"
    - name: "disallow-unsigned-images-rule"
      match:
        any:
          - resources:
              kinds:
                - Pod
      verifyImages:
        - imageReferences:
            - "*"
          verifyDigest: false
          required:
          mutateDigest: false
          attestors:
            - count: 1
              entries:
                - keys:
                    publicKeys: |-
                      -----BEGIN PUBLIC KEY-----
                      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHsra9WSDxt9qv84KF4McNVCGjMFq
                      e96mWCQxGimL9Ltj6F3iXmlo8sUalKfJ7SBXpy8hwyBfXBBAmCalsp5xEw==
                      -----END PUBLIC KEY-----
```
Resource:
```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    run: rewrite
  name: rewrite
spec:
  containers:
  - image: nginx:latest
    name: rewrite
    resources: {}
  dnsPolicy: ClusterFirst
  restartPolicy: OnFailure
```
Create resource:
```bash
$ kubectl create -f resource.yaml
pod/rewrite created
```

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
