### PR TITLE
fix: detection of kyverno going down

### DIFF
--- a/pkg/utils/runtime/utils.go
+++ b/pkg/utils/runtime/utils.go
@@ -94,6 +94,9 @@ func (c *runtime) IsGoingDown() bool {
 	if err != nil {
 		return apierrors.IsNotFound(err)
 	}
+	if deployment.GetDeletionTimestamp() != nil {
+		return true
+	}
 	if deployment.Spec.Replicas != nil {
 		return *deployment.Spec.Replicas == 0
 	}


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR fixes a case for detection of kyverno going down.
We were not checking the deletion timestamp of the deployment.
