### PR TITLE
fix: configure idle timeout in server

### DIFF
--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -102,6 +102,7 @@ func NewServer(
 			ReadTimeout:       30 * time.Second,
 			WriteTimeout:      30 * time.Second,
 			ReadHeaderTimeout: 30 * time.Second,
+			IdleTimeout:       5 * time.Minute,
 		},
 		mwcClient:   mwcClient,
 		vwcClient:   vwcClient,


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR configures idle timeout in our webhooks server.
This is an attempt to fix the errors below:
```
I1019 09:06:18.509751       1 server.go:70]  "msg"="2022/10/19 09:06:18 http: TLS handshake error from 172.18.0.6:61457: EOF" 
```
