### PR TITLE
feat: add webhook server logger

### DIFF
--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"io"
+	stdlog "log"
 	"os"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
@@ -128,4 +131,18 @@ func Background() context.Context {
 // TODO calls IntoContext with the global logger and a TODO context.
 func TODO() context.Context {
 	return IntoContext(context.TODO(), GlobalLogger())
+}
+
+type writerAdapter struct {
+	io.Writer
+	logger logr.Logger
+}
+
+func (a *writerAdapter) Write(p []byte) (int, error) {
+	a.logger.Info(strings.TrimSuffix(string(p), "\n"))
+	return len(p), nil
+}
+
+func StdLogger(logger logr.Logger, prefix string) *stdlog.Logger {
+	return stdlog.New(&writerAdapter{logger: logger}, prefix, stdlog.LstdFlags)
 }

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/config"
+	"github.com/kyverno/kyverno/pkg/logging"
 	"github.com/kyverno/kyverno/pkg/toggle"
 	"github.com/kyverno/kyverno/pkg/utils"
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
@@ -102,6 +103,7 @@ func NewServer(
 			ReadTimeout:       30 * time.Second,
 			WriteTimeout:      30 * time.Second,
 			ReadHeaderTimeout: 30 * time.Second,
+			ErrorLog:          logging.StdLogger(logger.WithName("server"), ""),
 		},
 		mwcClient:   mwcClient,
 		vwcClient:   vwcClient,


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR adds webhook server logger support.
Basically it provides a `log.Logger` wrapper around a `logr.Logger` and uses that in the webhook server.