### PR TITLE
fix: make response order predictable

### DIFF
--- a/pkg/engine/validate/utils.go
+++ b/pkg/engine/validate/utils.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"container/list"
+	"sort"
 
 	commonAnchors "github.com/kyverno/kyverno/pkg/engine/anchor"
 )
@@ -34,7 +35,15 @@ func hasNestedAnchors(pattern interface{}) bool {
 // getSortedNestedAnchorResource - sorts anchors key
 func getSortedNestedAnchorResource(resources map[string]interface{}) *list.List {
 	sortedResourceKeys := list.New()
-	for k, v := range resources {
+
+	keys := make([]string, 0, len(resources))
+	for k := range resources {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := resources[k]
 		if commonAnchors.IsGlobalAnchor(k) {
 			sortedResourceKeys.PushFront(k)
 			continue

--- a/pkg/engine/validate/validate.go
+++ b/pkg/engine/validate/validate.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/go-logr/logr"
@@ -121,8 +122,15 @@ func validateMap(log logr.Logger, resourceMap, patternMap map[string]interface{}
 	// Phase 2 : Evaluate non-anchors
 	anchors, resources := anchor.GetAnchorsResourcesFromMap(patternMap)
 
+	keys := make([]string, 0, len(anchors))
+	for k := range anchors {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	// Evaluate anchors
-	for key, patternElement := range anchors {
+	for _, key := range keys {
+		patternElement := anchors[key]
 		// get handler for each pattern in the pattern
 		// - Conditional
 		// - Existence


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR makes engine response order predictable by sorting keys when iterating over maps.

## Related issue

Fixes #5057 
