### PR TITLE
feat: add flag to configure the number of background scan workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.8.1-rc3
+
+### Note
+
+- A new flag `backgroundScanWorkers` to configure the number of background scan workers (default value is `2`).
+
 ## v1.8.0-rc3
 
 ### Note

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -93,6 +93,7 @@ var (
 	backgroundScan             bool
 	admissionReports           bool
 	reportsChunkSize           int
+	backgroundScanWorkers      int
 	logFormat                  string
 	// DEPRECATED: remove in 1.9
 	splitPolicyReport bool
@@ -126,6 +127,7 @@ func parseFlags() error {
 	flag.BoolVar(&backgroundScan, "backgroundScan", true, "Enable or disable backgound scan.")
 	flag.BoolVar(&admissionReports, "admissionReports", true, "Enable or disable admission reports.")
 	flag.IntVar(&reportsChunkSize, "reportsChunkSize", 1000, "Max number of results in generated reports, reports will be split accordingly if there are more results to be stored.")
+	flag.IntVar(&backgroundScanWorkers, "backgroundScanWorkers", backgroundscancontroller.Workers, "Configure the number of background scan workers.")
 	// DEPRECATED: remove in 1.9
 	flag.BoolVar(&splitPolicyReport, "splitPolicyReport", false, "This is deprecated, please don't use it, will be removed in v1.9.")
 	if err := flag.Set("v", "2"); err != nil {
@@ -410,7 +412,7 @@ func createReportControllers(
 					kubeInformer.Core().V1().Namespaces(),
 					resourceReportController,
 				),
-				backgroundscancontroller.Workers,
+				backgroundScanWorkers,
 			))
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR adds a flag to configure the number of background scan workers.
