### PR TITLE
ci: Use the Docker login action for GHCR auth

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,27 +140,30 @@ jobs:
           file: config/.release/install.yaml
           asset_name: install.yaml
           tag: ${{ github.ref }}
-      
+
+      - name: Login to GHCR
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push manifests to GHCR with Flux
         env:
           CR_PAT_ARTIFACTS:  ${{ secrets.CR_PAT_ARTIFACTS }}
         run: |
-            set -e
-            cd config/.release/ && \
-            flux push artifact oci://ghcr.io/${{ github.repository_owner }}/manifests/kyverno:$(git rev-parse --short HEAD) \
-              --path="." \
-              --source="$(git config --get remote.origin.url)" \
-              --revision="$(git tag --points-at HEAD)/$(git rev-parse HEAD)"
-              --creds flux:${CR_PAT_ARTIFACTS}
-      
+          set -e
+          cd config/.release/ && \
+          flux push artifact oci://ghcr.io/${{ github.repository_owner }}/manifests/kyverno:$(git rev-parse --short HEAD) \
+            --path="." \
+            --source="$(git config --get remote.origin.url)" \
+            --revision="$(git tag --points-at HEAD)/$(git rev-parse HEAD)"
+
       - name: Sign manifests in GHCR with Cosign
         env:
           COSIGN_EXPERIMENTAL: 1
-          CR_PAT_ARTIFACTS:  ${{ secrets.CR_PAT_ARTIFACTS }}
         run: |
-            set -e
-            cosign login --username ${GITHUB_ACTOR} --password ${CR_PAT_ARTIFACTS} ghcr.io
-            cosign sign ghcr.io/${{ github.repository_owner }}/manifests/kyverno:$(git rev-parse --short HEAD)
+          cosign sign ghcr.io/${{ github.repository_owner }}/manifests/kyverno:$(git rev-parse --short HEAD)
 
   release-cli-via-krew:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use the `docker/login-action` action and the default `GITHUB_TOKEN` for setting up the GHCR credentials for Flux and Cosign to be able to push OCI artifacts to ` ghcr.io/kyverno/manifests/kyverno`.