### PR TITLE
fix: check resource version on update notification

### DIFF
--- a/pkg/controllers/report/background/controller.go
+++ b/pkg/controllers/report/background/controller.go
@@ -85,8 +85,8 @@ func NewController(
 		cbgscanEnqueue: controllerutils.AddDefaultEventHandlers(logger, cbgscanr.Informer(), queue),
 		metadataCache:  metadataCache,
 	}
-	controllerutils.AddEventHandlers(polInformer.Informer(), c.addPolicy, c.updatePolicy, c.deletePolicy)
-	controllerutils.AddEventHandlers(cpolInformer.Informer(), c.addPolicy, c.updatePolicy, c.deletePolicy)
+	controllerutils.AddEventHandlersT(polInformer.Informer(), c.addPolicy, c.updatePolicy, c.deletePolicy)
+	controllerutils.AddEventHandlersT(cpolInformer.Informer(), c.addPolicy, c.updatePolicy, c.deletePolicy)
 	c.metadataCache.AddEventHandler(func(uid types.UID, _ schema.GroupVersionKind, resource resource.Resource) {
 		selector, err := reportutils.SelectorResourceUidEquals(uid)
 		if err != nil {
@@ -108,8 +108,8 @@ func (c *controller) Run(ctx context.Context, workers int) {
 	controllerutils.Run(ctx, logger, ControllerName, time.Second, c.queue, workers, maxRetries, c.reconcile)
 }
 
-func (c *controller) addPolicy(obj interface{}) {
-	selector, err := reportutils.SelectorPolicyDoesNotExist(obj.(kyvernov1.PolicyInterface))
+func (c *controller) addPolicy(obj kyvernov1.PolicyInterface) {
+	selector, err := reportutils.SelectorPolicyDoesNotExist(obj)
 	if err != nil {
 		logger.Error(err, "failed to create label selector")
 	}
@@ -118,18 +118,20 @@ func (c *controller) addPolicy(obj interface{}) {
 	}
 }
 
-func (c *controller) updatePolicy(_, obj interface{}) {
-	selector, err := reportutils.SelectorPolicyNotEquals(obj.(kyvernov1.PolicyInterface))
-	if err != nil {
-		logger.Error(err, "failed to create label selector")
-	}
-	if err := c.enqueue(selector); err != nil {
-		logger.Error(err, "failed to enqueue")
+func (c *controller) updatePolicy(old, obj kyvernov1.PolicyInterface) {
+	if old.GetResourceVersion() != obj.GetResourceVersion() {
+		selector, err := reportutils.SelectorPolicyNotEquals(obj)
+		if err != nil {
+			logger.Error(err, "failed to create label selector")
+		}
+		if err := c.enqueue(selector); err != nil {
+			logger.Error(err, "failed to enqueue")
+		}
 	}
 }
 
-func (c *controller) deletePolicy(obj interface{}) {
-	selector, err := reportutils.SelectorPolicyExists(obj.(kyvernov1.PolicyInterface))
+func (c *controller) deletePolicy(obj kyvernov1.PolicyInterface) {
+	selector, err := reportutils.SelectorPolicyExists(obj)
 	if err != nil {
 		logger.Error(err, "failed to create label selector")
 	}


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR checks resource version on update notification.
This is to avoid unnecessary calculations if resource didn't change (on informer resync).

## Related issue

Fixes https://github.com/kyverno/kyverno/issues/5129
