### PR TITLE
Fix issue where CLI test command ignores failures

### DIFF
--- a/cmd/cli/kubectl-kyverno/test/test_command.go
+++ b/cmd/cli/kubectl-kyverno/test/test_command.go
@@ -68,7 +68,7 @@ applying 1 policy to 2 resources...
 kyverno test .
 
 Executing limit-containers-per-pod...
-applying 1 policy to 4 resources... 
+applying 1 policy to 4 resources...
 
 │───│──────────────────────────│──────────────────────────────────────│─────────────────────────────│────────│
 │ # │ POLICY                   │ RULE                                 │ RESOURCE                    │ RESULT │
@@ -85,7 +85,7 @@ Test Summary: 4 tests passed and 0 tests failed
 kyverno test . --test-case-selector "policy=disallow-latest-tag, rule=require-image-tag, resource=test-require-image-tag-pass"
 
 Executing test-simple...
-applying 1 policy to 1 resource... 
+applying 1 policy to 1 resource...
 
 │───│─────────────────────│───────────────────│─────────────────────────────────────────│────────│
 │ # │ POLICY              │ RULE              │ RESOURCE                                │ RESULT │
@@ -788,9 +788,7 @@ func getAndCompareResource(path string, engineResource unstructured.Unstructured
 	if err != nil {
 		log.Log.V(3).Info(resourceType+" mismatch", "error", err.Error())
 		status = "fail"
-	}
-
-	if matched == "" {
+	} else if matched == "" {
 		status = "pass"
 	}
 	return status


### PR DESCRIPTION
## Explanation

The test command was resetting the return value to "pass", even if it was already marked failed due to validation failures, in some cases. This solves by moving the "pass" into an else-if clause.

## Related issue

Closes #5187 

## Milestone of this PR

N/A

## What type of PR is this

/kind bug

## Proposed Changes

This may cause some end-users who have previously had passing unit tests, to now have failing unit tests, and may require some communication. I am not sure.

### Proof Manifests

Same as in the issue:

`kyverno-test.yaml`:

```yaml
name: sgp-inject
policies:
- policy.yaml
resources:
- resource.yaml
variables: variables.yaml
results:
  - policy: inject-sg
    rule: inject-sg
    resource: my-sgp
    kind: SecurityGroupPolicy
    patchedResource: mutated.yaml
    result: pass
```

`mutated.yaml`:

```yaml
apiVersion: vpcresources.k8s.aws/v1beta1
kind: SecurityGroupPolicy
metadata:
  annotations:
    my-annotations/sgs: a
  name: my-sgp
spec:
  securityGroups:
    groupIds:
    - sg-1
    - sg-a
```

`policy.yaml`:

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: inject-sg
spec:
  rules:
  - name: inject-sg
    match:
      resources:
        kinds:
        - SecurityGroupPolicy
      annotations:
        my-annotations/sgs: "*"
    context:
    - name: annotation
      variable:
        jmesPath: request.object.metadata.annotations."my-annotations/sgs"
    - name: sg_lookup
      configMap:
        name: sg-lookup
        namespace: default
    mutate:
      foreach:
        - list: annotation
          patchStrategicMerge:
            spec:
              securityGroups:
                groupIds:
                - "{{ sg_lookup.data.{{element}} }}"
```

`resource.yaml`:

```yaml
apiVersion: vpcresources.k8s.aws/v1beta1
kind: SecurityGroupPolicy
metadata:
  annotations:
    my-annotations/sgs: a
  name: my-sgp
spec:
  securityGroups:
    groupIds:
    - sg-1
```

`variables.yaml`:

```yaml
policies:
  - name: inject-sg
    rules:
    - name: inject-sg
      values:
        sg_lookup.data:
          a: sg-a
          b: sg-b
          c: sg-c
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

I understand this as a bugfix, not requiring documentation.