### PR TITLE
fix: jmespath divide func

### DIFF
--- a/pkg/engine/jmespath/arithmetic.go
+++ b/pkg/engine/jmespath/arithmetic.go
@@ -303,19 +303,7 @@ func (op1 Scalar) Divide(op2 interface{}) (interface{}, error) {
 
 		return resource.NewDecimalQuantity(quo, v.Format).String(), nil
 	case Duration:
-		var quo float64
-		if op1.float64 == 0 {
-			return nil, fmt.Errorf(undefinedQuoError, divide)
-		}
-
-		quo = op1.float64 / v.Seconds()
-
-		res, err := time.ParseDuration(fmt.Sprintf("%.9fs", quo))
-		if err != nil {
-			return nil, err
-		}
-
-		return res.String(), nil
+		return nil, fmt.Errorf(invalidArgumentTypeError, divide, 2, "Real")
 	}
 
 	return nil, nil

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -849,7 +849,7 @@ func Test_Divide(t *testing.T) {
 			err:  true,
 		},
 		{
-			test: "divide('12s', `2`)",
+			test: "divide(`12`, '2s')",
 			err:  true,
 		},
 		{
@@ -858,7 +858,7 @@ func Test_Divide(t *testing.T) {
 			retFloat:       true,
 		},
 		{
-			test:           "divide(`12`, '2s')",
+			test:           "divide('12s', `2`)",
 			expectedResult: `6s`,
 		},
 		{

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -853,6 +853,10 @@ func Test_Divide(t *testing.T) {
 			err:  true,
 		},
 		{
+			test: "divide(`360`, '-2s')",
+			err:  true,
+		},
+		{
 			test:           "divide(`25`, `2`)",
 			expectedResult: 12.5,
 			retFloat:       true,
@@ -870,10 +874,6 @@ func Test_Divide(t *testing.T) {
 			test:           "divide('25m0s', '2s')",
 			expectedResult: 750.0,
 			retFloat:       true,
-		},
-		{
-			test:           "divide(`360`, '-2s')",
-			expectedResult: `-3m0s`,
 		},
 		{
 			test:           "divide(`13312`, '1Ki')",
@@ -923,87 +923,87 @@ func Test_Modulo(t *testing.T) {
 		err            bool
 		retFloat       bool
 	}{
-		// {
-		// 	test: "modulo('12', '13s')",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo('12Ki', '13s')",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo('12s', '13')",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo('12s', '13Ki')",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo('12s', `0`)",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo('12s', '0s')",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo(`12`, '0s')",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo('12M', '0Mi')",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo('12K', `0`)",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo('12K', '0m')",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo('12Ki', '0G')",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo('12Mi', '0Gi')",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo('12Mi', `0`)",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo(`12`, '0Gi')",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo(`12`, '0K')",
-		// 	err:  true,
-		// },
-		// {
-		// 	test: "modulo(`12`, `0`)",
-		// 	err:  true,
-		// },
-		// {
-		// 	test:           "modulo(`25`, `2`)",
-		// 	expectedResult: 1.0,
-		// 	retFloat:       true,
-		// },
-		// {
-		// 	test:           "modulo(`13`, '2s')",
-		// 	expectedResult: `1s`,
-		// },
-		// {
-		// 	test:           "modulo('25m13s', '32s')",
-		// 	expectedResult: `9s`,
-		// },
-		// {
-		// 	test:           "modulo(`371`, '-13s')",
-		// 	expectedResult: `7s`,
-		// },
+		{
+			test: "modulo('12', '13s')",
+			err:  true,
+		},
+		{
+			test: "modulo('12Ki', '13s')",
+			err:  true,
+		},
+		{
+			test: "modulo('12s', '13')",
+			err:  true,
+		},
+		{
+			test: "modulo('12s', '13Ki')",
+			err:  true,
+		},
+		{
+			test: "modulo('12s', `0`)",
+			err:  true,
+		},
+		{
+			test: "modulo('12s', '0s')",
+			err:  true,
+		},
+		{
+			test: "modulo(`12`, '0s')",
+			err:  true,
+		},
+		{
+			test: "modulo('12M', '0Mi')",
+			err:  true,
+		},
+		{
+			test: "modulo('12K', `0`)",
+			err:  true,
+		},
+		{
+			test: "modulo('12K', '0m')",
+			err:  true,
+		},
+		{
+			test: "modulo('12Ki', '0G')",
+			err:  true,
+		},
+		{
+			test: "modulo('12Mi', '0Gi')",
+			err:  true,
+		},
+		{
+			test: "modulo('12Mi', `0`)",
+			err:  true,
+		},
+		{
+			test: "modulo(`12`, '0Gi')",
+			err:  true,
+		},
+		{
+			test: "modulo(`12`, '0K')",
+			err:  true,
+		},
+		{
+			test: "modulo(`12`, `0`)",
+			err:  true,
+		},
+		{
+			test:           "modulo(`25`, `2`)",
+			expectedResult: 1.0,
+			retFloat:       true,
+		},
+		{
+			test:           "modulo(`13`, '2s')",
+			expectedResult: `1s`,
+		},
+		{
+			test:           "modulo('25m13s', '32s')",
+			expectedResult: `9s`,
+		},
+		{
+			test:           "modulo(`371`, '-13s')",
+			expectedResult: `7s`,
+		},
 		{
 			test:           "modulo(`13312`, '513')",
 			expectedResult: `487`,

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -849,6 +849,10 @@ func Test_Divide(t *testing.T) {
 			err:  true,
 		},
 		{
+			test: "divide('12s', `2`)",
+			err:  true,
+		},
+		{
 			test:           "divide(`25`, `2`)",
 			expectedResult: 12.5,
 			retFloat:       true,
@@ -856,6 +860,11 @@ func Test_Divide(t *testing.T) {
 		{
 			test:           "divide(`12`, '2s')",
 			expectedResult: `6s`,
+		},
+		{
+			test:           "divide('12s', '2s')",
+			expectedResult: 6.0,
+			retFloat:       true,
 		},
 		{
 			test:           "divide('25m0s', '2s')",
@@ -914,87 +923,87 @@ func Test_Modulo(t *testing.T) {
 		err            bool
 		retFloat       bool
 	}{
-		{
-			test: "modulo('12', '13s')",
-			err:  true,
-		},
-		{
-			test: "modulo('12Ki', '13s')",
-			err:  true,
-		},
-		{
-			test: "modulo('12s', '13')",
-			err:  true,
-		},
-		{
-			test: "modulo('12s', '13Ki')",
-			err:  true,
-		},
-		{
-			test: "modulo('12s', `0`)",
-			err:  true,
-		},
-		{
-			test: "modulo('12s', '0s')",
-			err:  true,
-		},
-		{
-			test: "modulo(`12`, '0s')",
-			err:  true,
-		},
-		{
-			test: "modulo('12M', '0Mi')",
-			err:  true,
-		},
-		{
-			test: "modulo('12K', `0`)",
-			err:  true,
-		},
-		{
-			test: "modulo('12K', '0m')",
-			err:  true,
-		},
-		{
-			test: "modulo('12Ki', '0G')",
-			err:  true,
-		},
-		{
-			test: "modulo('12Mi', '0Gi')",
-			err:  true,
-		},
-		{
-			test: "modulo('12Mi', `0`)",
-			err:  true,
-		},
-		{
-			test: "modulo(`12`, '0Gi')",
-			err:  true,
-		},
-		{
-			test: "modulo(`12`, '0K')",
-			err:  true,
-		},
-		{
-			test: "modulo(`12`, `0`)",
-			err:  true,
-		},
-		{
-			test:           "modulo(`25`, `2`)",
-			expectedResult: 1.0,
-			retFloat:       true,
-		},
-		{
-			test:           "modulo(`13`, '2s')",
-			expectedResult: `1s`,
-		},
-		{
-			test:           "modulo('25m13s', '32s')",
-			expectedResult: `9s`,
-		},
-		{
-			test:           "modulo(`371`, '-13s')",
-			expectedResult: `7s`,
-		},
+		// {
+		// 	test: "modulo('12', '13s')",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo('12Ki', '13s')",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo('12s', '13')",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo('12s', '13Ki')",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo('12s', `0`)",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo('12s', '0s')",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo(`12`, '0s')",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo('12M', '0Mi')",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo('12K', `0`)",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo('12K', '0m')",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo('12Ki', '0G')",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo('12Mi', '0Gi')",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo('12Mi', `0`)",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo(`12`, '0Gi')",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo(`12`, '0K')",
+		// 	err:  true,
+		// },
+		// {
+		// 	test: "modulo(`12`, `0`)",
+		// 	err:  true,
+		// },
+		// {
+		// 	test:           "modulo(`25`, `2`)",
+		// 	expectedResult: 1.0,
+		// 	retFloat:       true,
+		// },
+		// {
+		// 	test:           "modulo(`13`, '2s')",
+		// 	expectedResult: `1s`,
+		// },
+		// {
+		// 	test:           "modulo('25m13s', '32s')",
+		// 	expectedResult: `9s`,
+		// },
+		// {
+		// 	test:           "modulo(`371`, '-13s')",
+		// 	expectedResult: `7s`,
+		// },
 		{
 			test:           "modulo(`13312`, '513')",
 			expectedResult: `487`,


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR fixes jmespath divide func when a scalar is divided by a duration, it should trigger an error.
Example:
```
divide(`12`, '2s') -> should trigger an error, not `6s`
```

Related to #3168 
