### PR TITLE
fix: remove /approve from prow actions

### DIFF
--- a/.github/workflows/comment-commands.yaml
+++ b/.github/workflows/comment-commands.yaml
@@ -16,7 +16,6 @@ jobs:
           prow-commands: '/assign 
             /unassign
             /lgtm 
-            /milestone
-            /approve'
+            /milestone'
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR removes `/approve` from prow actions.
`/approve` in its current form allows PR authors to approve their own PRs.
