### PR TITLE
fix: resource schema validation in policies under any/all match

### DIFF
--- a/pkg/openapi/manager.go
+++ b/pkg/openapi/manager.go
@@ -124,6 +124,16 @@ func (o *manager) ValidatePolicyMutation(policy kyvernov1.PolicyInterface) error
 			for _, kind := range rule.MatchResources.Kinds {
 				kindToRules[kind] = append(kindToRules[kind], rule)
 			}
+			for _, resourceFilter := range rule.MatchResources.Any {
+				for _, kind := range resourceFilter.Kinds {
+					kindToRules[kind] = append(kindToRules[kind], rule)
+				}
+			}
+			for _, resourceFilter := range rule.MatchResources.All {
+				for _, kind := range resourceFilter.Kinds {
+					kindToRules[kind] = append(kindToRules[kind], rule)
+				}
+			}
 		}
 	}
 

--- a/pkg/openapi/manager_test.go
+++ b/pkg/openapi/manager_test.go
@@ -13,31 +13,57 @@ func Test_ValidateMutationPolicy(t *testing.T) {
 	tcs := []struct {
 		description string
 		policy      []byte
-		errMessage  string
+		mustSucceed bool
 	}{
 		{
 			description: "Policy with mutating imagePullPolicy Overlay",
 			policy:      []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"set-image-pull-policy-2"},"spec":{"rules":[{"name":"set-image-pull-policy-2","match":{"resources":{"kinds":["Pod"]}},"mutate":{"patchStrategicMerge":{"spec":{"containers":[{"(name)":"*","imagePullPolicy":"Always"}]}}}}]}}`),
+			mustSucceed: true,
 		},
 		{
 			description: "Policy with mutating imagePullPolicy Overlay, type of value is different (does not throw error since all numbers are also strings according to swagger)",
 			policy:      []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"set-image-pull-policy-2"},"spec":{"rules":[{"name":"set-image-pull-policy-2","match":{"resources":{"kinds":["Pod"]}},"mutate":{"patchStrategicMerge":{"spec":{"containers":[{"(image)":"*","imagePullPolicy":80}]}}}}]}}`),
+			mustSucceed: true,
 		},
 		{
 			description: "Policy with patches",
 			policy:      []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"policy-endpoints"},"spec":{"rules":[{"name":"pEP","match":{"resources":{"kinds":["Endpoints"],"selector":{"matchLabels":{"label":"test"}}}},"mutate":{"patches": "[{\"path\":\"/subsets/0/ports/0/port\",\"op\":\"replace\",\"value\":9663},{\"path\":\"/metadata/labels/isMutated\",\"op\":\"add\",\"value\":\"true\"}]}}]" }}`),
+			mustSucceed: true,
 		},
 		{
 			description: "Dealing with nested variables",
 			policy:      []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"add-ns-access-controls","annotations":{"policies.kyverno.io/category":"Workload Isolation","policies.kyverno.io/description":"Create roles and role bindings for a new namespace"}},"spec":{"background":false,"rules":[{"name":"add-sa-annotation","match":{"resources":{"kinds":["Namespace"]}},"mutate":{"overlay":{"metadata":{"annotations":{"nirmata.io/ns-creator":"{{serviceAccountName-{{something}}}}"}}}}},{"name":"generate-owner-role","match":{"resources":{"kinds":["Namespace"]}},"preconditions":[{"key":"{{request.userInfo.username}}","operator":"NotEqual","value":""},{"key":"{{serviceAccountName}}","operator":"NotEqual","value":""},{"key":"{{serviceAccountNamespace}}","operator":"NotEqual","value":""}],"generate":{"kind":"ClusterRole","name":"ns-owner-{{request.object.metadata.name{{something}}}}-{{request.userInfo.username}}","data":{"metadata":{"annotations":{"nirmata.io/ns-creator":"{{serviceAccountName}}"}},"rules":[{"apiGroups":[""],"resources":["namespaces"],"verbs":["delete"],"resourceNames":["{{request.object.metadata.name}}"]}]}}},{"name":"generate-owner-role-binding","match":{"resources":{"kinds":["Namespace"]}},"preconditions":[{"key":"{{request.userInfo.username}}","operator":"NotEqual","value":""},{"key":"{{serviceAccountName}}","operator":"NotEqual","value":""},{"key":"{{serviceAccountNamespace}}","operator":"NotEqual","value":""}],"generate":{"kind":"ClusterRoleBinding","name":"ns-owner-{{request.object.metadata.name}}-{{request.userInfo.username}}-binding","data":{"metadata":{"annotations":{"nirmata.io/ns-creator":"{{serviceAccountName}}"}},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"ns-owner-{{request.object.metadata.name}}-{{request.userInfo.username}}"},"subjects":[{"kind":"ServiceAccount","name":"{{serviceAccountName}}","namespace":"{{serviceAccountNamespace}}"}]}}},{"name":"generate-admin-role-binding","match":{"resources":{"kinds":["Namespace"]}},"preconditions":[{"key":"{{request.userInfo.username}}","operator":"NotEqual","value":""},{"key":"{{serviceAccountName}}","operator":"NotEqual","value":""},{"key":"{{serviceAccountNamespace}}","operator":"NotEqual","value":""}],"generate":{"kind":"RoleBinding","name":"ns-admin-{{request.object.metadata.name}}-{{request.userInfo.username}}-binding","namespace":"{{request.object.metadata.name}}","data":{"metadata":{"annotations":{"nirmata.io/ns-creator":"{{serviceAccountName}}"}},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"admin"},"subjects":[{"kind":"ServiceAccount","name":"{{serviceAccountName}}","namespace":"{{serviceAccountNamespace}}"}]}}}]}}`),
+			mustSucceed: true,
 		},
 		{
 			description: "Policy with patchesJson6902 and added element at the beginning of a list",
 			policy:      []byte(`{"apiVersion": "kyverno.io/v1","kind": "ClusterPolicy","metadata": {"name": "pe"},"spec": {"rules": [{"name": "pe","match": {"resources": {"kinds": ["Endpoints"]}},"mutate": {"patchesJson6902": "- path: \"/subsets/0/addresses/0\"\n  op: add\n  value: {\"ip\":\"123\"}\n- path: \"/subsets/1/addresses/0\"\n  op: add\n  value: {\"ip\":\"123\"}"}}]}}`),
+			mustSucceed: true,
 		},
 		{
 			description: "Policy with patchesJson6902 and added element at the end of a list",
 			policy:      []byte(`{"apiVersion": "kyverno.io/v1","kind": "ClusterPolicy","metadata": {"name": "pe"},"spec": {"rules": [{"name": "pe","match": {"resources": {"kinds": ["Endpoints"]}},"mutate": {"patchesJson6902": "- path: \"/subsets/0/addresses/-\"\n  op: add\n  value: {\"ip\":\"123\"}\n- path: \"/subsets/1/addresses/-\"\n  op: add\n  value: {\"ip\":\"123\"}"}}]}}`),
+			mustSucceed: true,
+		},
+		{
+			description: "Invalid policy with patchStrategicMerge and new match schema(any)",
+			policy:      []byte(`{"apiVersion":"kyverno.io\/v1","kind":"ClusterPolicy","metadata":{"name":"mutate-pod"},"spec":{"rules":[{"name":"mutate-pod","match":{"any":[{"resources":{"kinds":["Pod"]}}]},"mutate":{"patchStrategicMerge":{"spec":{"pod":"incorrect"}}}}]}}`),
+			mustSucceed: false,
+		},
+		{
+			description: "Invalid policy with patchStrategicMerge and new match schema(all)",
+			policy:      []byte(`{"apiVersion":"kyverno.io\/v1","kind":"ClusterPolicy","metadata":{"name":"mutate-pod"},"spec":{"rules":[{"name":"mutate-pod","match":{"all":[{"resources":{"kinds":["Pod"]}}]},"mutate":{"patchStrategicMerge":{"spec":{"pod":"incorrect"}}}}]}}`),
+			mustSucceed: false,
+		},
+		{
+			description: "Valid policy with patchStrategicMerge and new match schema(any)",
+			policy:      []byte(`{"apiVersion":"kyverno.io\/v1","kind":"ClusterPolicy","metadata":{"name":"set-image-pull-policy"},"spec":{"rules":[{"name":"set-image-pull-policy","match":{"any":[{"resources":{"kinds":["Pod"]}}]},"mutate":{"patchStrategicMerge":{"spec":{"containers":[{"(image)":"*:latest","imagePullPolicy":"IfNotPresent"}]}}}}]}}`),
+			mustSucceed: true,
+		},
+		{
+			description: "Valid policy with patchStrategicMerge and new match schema(all)",
+			policy:      []byte(`{"apiVersion":"kyverno.io\/v1","kind":"ClusterPolicy","metadata":{"name":"set-image-pull-policy"},"spec":{"rules":[{"name":"set-image-pull-policy","match":{"all":[{"resources":{"kinds":["Pod"]}}]},"mutate":{"patchStrategicMerge":{"spec":{"containers":[{"(image)":"*:latest","imagePullPolicy":"IfNotPresent"}]}}}}]}}`),
+			mustSucceed: true,
 		},
 	}
 
@@ -46,15 +72,15 @@ func Test_ValidateMutationPolicy(t *testing.T) {
 	for i, tc := range tcs {
 		policy := v1.ClusterPolicy{}
 		_ = json.Unmarshal(tc.policy, &policy)
-
 		var errMessage string
 		err := o.ValidatePolicyMutation(&policy)
 		if err != nil {
 			errMessage = err.Error()
 		}
-
-		if errMessage != tc.errMessage {
-			t.Errorf("\nTestcase [%v] failed:\nExpected Error:  %v\nGot Error:  %v", i+1, tc.errMessage, errMessage)
+		if tc.mustSucceed {
+			assert.NilError(t, err, "\nTestcase [%v] failed: Expected no error, Got error:  %v", i+1, errMessage)
+		} else {
+			assert.Assert(t, err != nil, "\nTestcase [%v] failed: Expected error to have occurred", i+1)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Sandesh More <sandesh.more@infracloud.io>

## Explanation

currently validating the resource's schema when using any|all match conditions is skipped.
This PR will validate resource schema when any|all match conditions are used.

## Related issue
closes: #4440

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
bug

## Proposed Changes

### Proof Manifests
#### Apply manifest that uses any/all match condition in the policy rules

```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: mutate-pod
spec:
  rules:
    - name: mutate-pod
      match:
        any:
        - resources:
            kinds:
              - Pod
      mutate:
        patchStrategicMerge:
          spec:
            pod: incorrect
```

```
$ k apply -f second.yaml 
Error from server: error when creating "second.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: mutate result violates resource schema: ValidationError(io.k8s.api.apps.v1.DaemonSet.spec.template.spec): unknown field "pod" in io.k8s.api.core.v1.PodSpec
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
