### PR TITLE
fix: kyverno Dockerfile base image tag and sha256 hash

### DIFF
--- a/cmd/kyverno/localDockerfile
+++ b/cmd/kyverno/localDockerfile
@@ -1,4 +1,4 @@
-FROM golang@sha256:992d5fea982526ce265a0631a391e3c94694f4d15190fd170f35d91b2e6cb0ba
+FROM golang:alpine@sha256:e4dcdac3ed37d8c2b3b8bcef2909573b2ad9c2ab53ba53c608909e8b89ccee36
 ADD kyverno /kyverno
 RUN apk add --no-cache ca-certificates
 USER 10001


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Explanation

fix kyverno localDockerfile base image tag and sha256 hash , which get changed as part of [PR](https://github.com/kyverno/kyverno/pull/5168) to pin the hash. 
