### PR TITLE
[WIP] fix: generated downstream resource metadata/data sync with source

### DIFF
--- a/pkg/background/generate/generate.go
+++ b/pkg/background/generate/generate.go
@@ -549,6 +549,7 @@ func applyRule(log logr.Logger, client dclient.Interface, rule kyvernov1.Rule, r
 							return newGenResources, err
 						}
 					}
+
 				} else {
 					currentGeneratedResourcelabel := generatedObj.GetLabels()
 					currentSynclabel := currentGeneratedResourcelabel["policy.kyverno.io/synchronize"]


### PR DESCRIPTION
Signed-off-by: praddy26 <pradeep.vaishnav4@gmail.com>

## Explanation

This PR fixes the sync issue of generated downstream resource metadata/data with the source resource.

When additional metadata/data is added/deleted to/from the generated downstream resource, then this fix will ensure that it is synced with the source resource from the policy. 

## Related issue

Closes #5103
@prateekpandey14 

## Milestone of this PR

/milestone 1.8.2

## What type of PR is this

/kind bug

## Proposed Changes

The validation that was happening was checking only if all the metadata/data in the source(pattern) resource is present in the generated resource, but was not checking if any additional metadata/data has been added on the generated resource which was not present in the source(pattern) resource. 

In this fix an additional validation is performed on the generated resource metadata/data to check if there is any discrepancy with the source resource and accordingly updated.

### Proof Manifests

Please follow the steps mentioned in this [issue](https://github.com/kyverno/kyverno/issues/5103)

Additionally also test by adding new data in the generated(cloned) resource and verify that the generated resource will again sync with the source resource.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

