### PR TITLE
Fixed issue-3709: Image verify rule gives error for non-existing configmap

### DIFF
--- a/pkg/engine/imageVerifyValidate.go
+++ b/pkg/engine/imageVerifyValidate.go
@@ -19,6 +19,13 @@ func processImageValidationRule(log logr.Logger, ctx *PolicyContext, rule *kyver
 	}
 
 	log = log.WithValues("rule", rule.Name)
+	matchingImages, _, err := extractMatchingImages(ctx, rule)
+	if err != nil {
+		return ruleResponse(*rule, response.Validation, err.Error(), response.RuleStatusError, nil)
+	}
+	if len(matchingImages) == 0 {
+		return ruleResponse(*rule, response.Validation, "image verified", response.RuleStatusSkip, nil)
+	}
 	if err := LoadContext(log, rule.Context, ctx, rule.Name); err != nil {
 		if _, ok := err.(gojmespath.NotFoundError); ok {
 			log.V(3).Info("failed to load context", "reason", err.Error())

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -501,6 +501,11 @@ func ruleForbiddenSectionsHaveVariables(rule *kyvernov1.Rule) error {
 		return fmt.Errorf("rule \"%s\" should not have variables in match section", rule.Name)
 	}
 
+	err = imageRefHasVariables(rule.VerifyImages)
+	if err != nil {
+		return fmt.Errorf("rule \"%s\" should not have variables in image reference section", rule.Name)
+	}
+
 	return nil
 }
 
@@ -548,6 +553,19 @@ func objectHasVariables(object interface{}) error {
 		return fmt.Errorf("invalid variables")
 	}
 
+	return nil
+}
+
+func imageRefHasVariables(verifyImages []kyvernov1.ImageVerification) error {
+	for _, verifyImage := range verifyImages {
+		verifyImage = *verifyImage.Convert()
+		for _, imageRef := range verifyImage.ImageReferences {
+			matches := variables.RegexVariables.FindAllString(imageRef, -1)
+			if len(matches) > 0 {
+				return fmt.Errorf("variables are not allowed in image reference")
+			}
+		}
+	}
 	return nil
 }
 

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/01-policy.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/01-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- policy.yaml
+assert:
+- policy-ready.yaml

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/02-create-good-pod.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/02-create-good-pod.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- namespace.yaml
+- good-pod.yaml
+assert:
+- good-pod.yaml

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/03-create-bad-pod.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/03-create-bad-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    if kubectl apply -f bad-pod.yaml
+    then 
+      echo "Tested failed. Pod was created when it shouldn't have been."
+      exit 1 
+    else 
+      echo "Test succeeded. Pod was not created as intended."
+      exit 0
+    fi

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/04-update-policy.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/04-update-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- update-policy.yaml
+assert:
+- update-policy.yaml

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/05-create-pod-with-configmap.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/05-create-pod-with-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- pod-with-configmap.yaml
+assert:
+- pod-with-configmap-ready.yaml

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/99-cleanup.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/99-cleanup.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete -f policy.yaml,good-pod.yaml,pod-with-configmap.yaml,namespace.yaml --force --wait=true --ignore-not-found=true

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/README.md
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/README.md
@@ -1,0 +1,13 @@
+## Description
+
+This test verifies that resource creation is not blocked if resource image is different than policy image.
+
+## Expected Behavior
+
+This test should create a policy with missing configmap, a pod with different image than policy image. This shouldn't block pod creation.
+When pod is created with same image as policy image, pod creation should be blocked.
+When test tries to update any field in a policy, it should get updated properly.
+
+## Reference Issue(s)
+
+3709

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/bad-pod.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/bad-pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-fail
+  namespace: mynamespace
+spec:
+  containers:
+  - image: ghcr.io/kyverno/test-verify-image:signed
+    name: test-fail

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/good-pod.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/good-pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-success
+  namespace: mynamespace
+spec:
+  containers:
+  - image: nginx:latest
+    name: test-success

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/namespace.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mynamespace

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/pod-with-configmap-ready.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/pod-with-configmap-ready.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-with-configmap
+  namespace: mynamespace
+spec:
+  containers:
+  - image: ghcr.io/kyverno/test-verify-image:signed
+    name: test-with-configmap

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/pod-with-configmap.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/pod-with-configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: myconfigmap1
+  namespace: mynamespace
+data:
+  configmapkey: |
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
+    5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
+    -----END PUBLIC KEY-----
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-with-configmap
+  namespace: mynamespace
+spec:
+  containers:
+  - image: ghcr.io/kyverno/test-verify-image:signed
+    name: test-with-configmap

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/policy-ready.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/policy-ready.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: image-verify-polset
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/policy.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/policy.yaml
@@ -1,0 +1,32 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+  name: image-verify-polset
+spec:
+  background: false
+  failurePolicy: Fail
+  rules:
+    - context:
+        - configMap:
+            name: myconfigmap
+            namespace: mynamespace
+          name: myconfigmap
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      name: image-verify-pol1
+      verifyImages:
+        - imageReferences:
+            - ghcr.io/*
+          mutateDigest: false
+          verifyDigest: false
+          attestors:
+            - entries:
+                - keys:
+                    publicKeys: '{{myconfigmap.data.configmapkey}}'
+  validationFailureAction: Audit
+  webhookTimeoutSeconds: 30

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/update-policy.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/noconfigmap-diffimage-success/update-policy.yaml
@@ -1,0 +1,32 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+  name: image-verify-polset
+spec:
+  background: false
+  failurePolicy: Fail
+  rules:
+    - context:
+        - configMap:
+            name: myconfigmap1
+            namespace: mynamespace
+          name: myconfigmap1
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      name: image-verify-pol1
+      verifyImages:
+        - imageReferences:
+            - ghcr.io/*
+          mutateDigest: false
+          verifyDigest: false
+          attestors:
+            - entries:
+                - keys:
+                    publicKeys: '{{myconfigmap1.data.configmapkey}}'
+  validationFailureAction: Audit
+  webhookTimeoutSeconds: 30


### PR DESCRIPTION
Signed-off-by: Pratik Shah <pratik@infracloud.io>

## Explanation
This PR doesn't verify resource images which are different from policy images. This allows user to create resources even if there are image verification errors.

## Related issue
Closes #3709 

## What type of PR is this
/kind bug

## Proposed Changes
This PR adds `requireValidation` function which executes following checks.
- checks for variables. if any variables are present in imageRef, function will return `true` so that regular workflow of image verification takes place. if we block variables here, we might not allow user to provide variables for imageRef at all.
- next, function will take images from `policyContext` and if imageExtractors are present in rule, it will generate custom images and replace `images` variable with images from imageExtractors
- then, with images we get, function will check if there are any matching images.
- if image passed for resource doesn't match with imageRef in policy, then skip image verification.

### Proof Manifests
Policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  annotations:
    pod-policies.kyverno.io/autogen-controllers: none
  name: image-verify-polset
spec:
  background: false
  failurePolicy: Fail
  rules:
  - context:
    - configMap:
        name: myconfigmap
        namespace: somens
      name: myconfigmap
    match:
      resources:
        kinds:
        - Pod
    name: image-verify-pol1
    verifyImages:
    - image: ghcr.io/*
      key: '{{myconfigmap.data.configmapkey}}'
  validationFailureAction: audit
  webhookTimeoutSeconds: 30
```
NOTE: we haven't created configmap mentioned in the policy
Resource:
```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    run: test
  name: test
spec:
  containers:
  - image: ghcr.io/kyverno/test-verify-image:signed
    name: test
    resources: {}
```
On resource creation (this should fail)
```bash
$ kubectl create -f ../resource.yaml 
Error from server: error when creating "../resource.yaml": admission webhook "mutate.kyverno.svc-fail" denied the request: 

policy Pod/default/test for resource error: 

image-verify-polset:
  image-verify-pol1: 'failed to load context: failed to retrieve config map for context
    entry myconfigmap: failed to get configmap somens/myconfigmap : configmaps "myconfigmap"
    not found'
```
Change image field in resource.yaml to nginx:latest
```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    run: test
  name: test
spec:
  containers:
  - image: nginx:latest
    name: test
    resources: {}
```
Create resource (this should create test pod)
```bash
$ kubectl create -f ../resource.yaml 
pod/test created
```
To verify policy update:
```bash
$ kubectl edit cpol image-verify-polset
change configmap name from myconfigmap to myconfigmap1

$ kubectl describe cpol image-verify-polset
Name:         image-verify-polset
Namespace:    
Labels:       <none>
Annotations:  pod-policies.kyverno.io/autogen-controllers: none
API Version:  kyverno.io/v1
Kind:         ClusterPolicy
Metadata:
  Creation Timestamp:  2022-11-14T07:39:51Z
  Generation:          2
  Managed Fields:
    API Version:  kyverno.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        .:
        f:autogen:
        f:conditions:
        f:ready:
        f:rulecount:
          .:
          f:generate:
          f:mutate:
          f:validate:
          f:verifyimages:
    Manager:      __debug_bin
    Operation:    Update
    Subresource:  status
    Time:         2022-11-14T07:39:51Z
    API Version:  kyverno.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:pod-policies.kyverno.io/autogen-controllers:
      f:spec:
        .:
        f:background:
        f:failurePolicy:
        f:validationFailureAction:
        f:webhookTimeoutSeconds:
    Manager:      kubectl-create
    Operation:    Update
    Time:         2022-11-14T07:39:51Z
    API Version:  kyverno.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        f:rules:
    Manager:         kubectl-edit
    Operation:       Update
    Time:            2022-11-14T08:31:12Z
  Resource Version:  22348
  UID:               2542f112-52d0-4312-a0b2-9339bb5fe7b8
Spec:
  Background:      false
  Failure Policy:  Fail
  Rules:
    Context:
      Config Map:
        Name:       myconfigmap1
        Namespace:  somens
      Name:         myconfigmap1
    Match:
      Resources:
        Kinds:
          Pod
    Name:  image-verify-pol1
    Verify Images:
      Image:                  ghcr.io/*
      Key:                    {{myconfigmap1.data.configmapkey}}
      Mutate Digest:          true
      Required:               true
      Verify Digest:          true
  Validation Failure Action:  Audit
  Webhook Timeout Seconds:    30
Status:
  Autogen:
  Conditions:
    Last Transition Time:  2022-11-14T08:30:00Z
    Message:               
    Reason:                Succeeded
    Status:                True
    Type:                  Ready
  Ready:                   true
  Rulecount:
    Generate:      0
    Mutate:        0
    Validate:      0
    Verifyimages:  1
Events:            <none>
```
## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
