### PR TITLE
fix: reduce startup probe delay

### DIFF
--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -240,9 +240,9 @@ startupProbe:
     path: /health/liveness
     port: 9443
     scheme: HTTPS
-  failureThreshold: 12
-  initialDelaySeconds: 30
-  periodSeconds: 10
+  failureThreshold: 20
+  initialDelaySeconds: 2
+  periodSeconds: 6
 
 # -- Liveness probe.
 # The block is directly forwarded into the deployment, so you can use whatever livenessProbe configuration you want.

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -29242,13 +29242,13 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         startupProbe:
-          failureThreshold: 12
+          failureThreshold: 20
           httpGet:
             path: /health/liveness
             port: 9443
             scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 10
+          initialDelaySeconds: 2
+          periodSeconds: 6
         volumeMounts:
         - mountPath: /.sigstore
           name: sigstore

--- a/config/manifest/deployment.yaml
+++ b/config/manifest/deployment.yaml
@@ -128,9 +128,9 @@ spec:
               path: /health/liveness
               port: 9443
               scheme: HTTPS
-            failureThreshold: 12
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            failureThreshold: 20
+            initialDelaySeconds: 2
+            periodSeconds: 6
           livenessProbe:
             httpGet:
               path: /health/liveness


### PR DESCRIPTION
## Explanation

This PR reduces startup probe delay.
30 seconds is unnecessarily long.
