### PR TITLE
chore: add cli binary to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ gh-pages/public
 _output
 coverage.txt
 .idea
+cmd/cli/kubectl-kyverno/kubectl-kyverno
 cmd/initContainer/kyvernopre
 cmd/kyverno/kyverno
 cmd/cleanup-controller/cleanup-controller


### PR DESCRIPTION
## Explanation

This PR adds the cli binary to gitignore.
