### PR TITLE
fix: add replicaset and replicationController kinds in podsecurity validation

### DIFF
--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -456,7 +456,7 @@ func (v *validator) getDenyMessage(deny bool) string {
 func getSpec(v *validator) (podSpec *corev1.PodSpec, metadata *metav1.ObjectMeta, err error) {
 	kind := v.ctx.NewResource.GetKind()
 
-	if kind == "DaemonSet" || kind == "Deployment" || kind == "Job" || kind == "StatefulSet" {
+	if kind == "DaemonSet" || kind == "Deployment" || kind == "Job" || kind == "StatefulSet" || kind == "ReplicaSet" || kind == "ReplicationController" {
 		var deployment appsv1.Deployment
 
 		resourceBytes, err := v.ctx.NewResource.MarshalJSON()


### PR DESCRIPTION


Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Explanation

Add missing `Replicaset` and `Replicationcontroller` kinds  while validating PodSecurity policies added as part of PR
https://github.com/kyverno/kyverno/pull/4975 