### PR TITLE
test: add rbac kuttl test

### DIFF
--- a/test/conformance/kuttl/kuttl-test.yaml
+++ b/test/conformance/kuttl/kuttl-test.yaml
@@ -22,6 +22,8 @@ testDirs:
 # Report tests
 - ./test/conformance/kuttl/reports/admission
 - ./test/conformance/kuttl/reports/background
+# RBAC
+- ./test/conformance/kuttl/rbac
 # Webhooks
 - ./test/conformance/kuttl/webhooks
 startKIND: false

--- a/test/conformance/kuttl/rbac/aggregate-to-admin/00-cluster-role.yaml
+++ b/test/conformance/kuttl/rbac/aggregate-to-admin/00-cluster-role.yaml
@@ -1,0 +1,8 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+assert:
+- admin-generaterequest.yaml
+- admin-policies.yaml
+- admin-policyreport.yaml
+- admin-reports.yaml
+- admin-updaterequest.yaml

--- a/test/conformance/kuttl/rbac/aggregate-to-admin/README.md
+++ b/test/conformance/kuttl/rbac/aggregate-to-admin/README.md
@@ -1,0 +1,3 @@
+## Description
+
+This test verifies that kyverno admin cluster roles exist in the cluster and are labelled correctly to be aggregated to the `admin` cluster role.

--- a/test/conformance/kuttl/rbac/aggregate-to-admin/admin-generaterequest.yaml
+++ b/test/conformance/kuttl/rbac/aggregate-to-admin/admin-generaterequest.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: kyverno:admin-generaterequest
+rules:
+- apiGroups:
+  - kyverno.io
+  resources:
+  - generaterequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/test/conformance/kuttl/rbac/aggregate-to-admin/admin-policies.yaml
+++ b/test/conformance/kuttl/rbac/aggregate-to-admin/admin-policies.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: kyverno:admin-policies
+rules:
+- apiGroups:
+  - kyverno.io
+  resources:
+  - policies
+  - clusterpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/test/conformance/kuttl/rbac/aggregate-to-admin/admin-policyreport.yaml
+++ b/test/conformance/kuttl/rbac/aggregate-to-admin/admin-policyreport.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: kyverno:admin-policyreport
+rules:
+- apiGroups:
+  - wgpolicyk8s.io
+  resources:
+  - policyreports
+  - clusterpolicyreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/test/conformance/kuttl/rbac/aggregate-to-admin/admin-reports.yaml
+++ b/test/conformance/kuttl/rbac/aggregate-to-admin/admin-reports.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: kyverno:admin-reports
+rules:
+- apiGroups:
+  - kyverno.io
+  resources:
+  - admissionreports
+  - clusteradmissionreports
+  - backgroundscanreports
+  - clusterbackgroundscanreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/test/conformance/kuttl/rbac/aggregate-to-admin/admin-updaterequest.yaml
+++ b/test/conformance/kuttl/rbac/aggregate-to-admin/admin-updaterequest.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: kyverno:admin-updaterequest
+rules:
+- apiGroups:
+  - kyverno.io
+  resources:
+  - updaterequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR adds rbac kuttl test.
It checks the necessary cluster roles that will be aggregated in the `admin` cluster role.