### PR TITLE
fix: the entry length validation for the verify image rule

### DIFF
--- a/api/kyverno/v1/image_verification_test.go
+++ b/api/kyverno/v1/image_verification_test.go
@@ -180,6 +180,28 @@ func Test_ImageVerification(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "multiple entries",
+			subject: ImageVerification{
+				ImageReferences: []string{"*"},
+				Attestors: []AttestorSet{
+					{
+						Entries: []Attestor{
+							{
+								Keys: &StaticKeyAttestor{
+									PublicKeys: "key1",
+								},
+							},
+							{
+								Keys: &StaticKeyAttestor{
+									PublicKeys: "key2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/api/kyverno/v1/image_verification_types.go
+++ b/api/kyverno/v1/image_verification_types.go
@@ -256,8 +256,6 @@ func validateAttestorSet(as *AttestorSet, path *field.Path) (errs field.ErrorLis
 
 	if len(as.Entries) == 0 {
 		errs = append(errs, field.Invalid(path, as, "An entry is required"))
-	} else if len(as.Entries) > 1 {
-		errs = append(errs, field.Invalid(path, as, "Only one entry is currently supported"))
 	}
 
 	entriesPath := path.Child("entries")

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -293,13 +293,6 @@ func Validate(policy kyvernov1.PolicyInterface, client dclient.Interface, mock b
 				}
 			}
 
-			if rule.HasVerifyImages() {
-				verifyImagePath := rulePath.Child("verifyImages")
-				for index, i := range rule.VerifyImages {
-					errs = append(errs, i.Validate(verifyImagePath.Index(index))...)
-				}
-			}
-
 			if len(errs) != 0 {
 				return warnings, errs.ToAggregate()
 			}


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Explanation

A verifyImage policy specifying multiple `entries` should be allowed to create. Prior to this PR the policy creation is blocked.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #5379.

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
1.9.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
The policy with multiple entries can be created/updated successfully.

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: verify-image-with-multi-keys
  annotations:
    policies.kyverno.io/title: Verify Image with Multiple Keys
    policies.kyverno.io/category: Sample
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod
    policies.kyverno.io/minversion: 1.7.0
    kyverno.io/kyverno-version: 1.7.2
    kyverno.io/kubernetes-version: "1.23"
    policies.kyverno.io/description: >-
      There may be multiple keys used to sign images based on
      the parties involved in the creation process. This image
      verification policy requires the named image be signed by
      two separate keys. It will search for a global "production"
      key in a ConfigMap called `key` in the `default` Namespace
      and also a Namespace key in the same ConfigMap.
spec:
  validationFailureAction: enforce
  background: false
  rules:
    - name: check-image-with-two-keys
      match:
        any:
        - resources:
            kinds:
              - Pod
      context:
      - name: keys
        configMap:
          name: keys
          namespace: default
      verifyImages:
      - imageReferences:
        - "ghcr.io/myorg/myimage*"
        required: true
        attestors:
        - count: 1
          entries:
          - keys: 
              publicKeys: "{{ keys.data.production }}"
          - keys: 
              publicKeys: "{{ keys.data.{{request.namespace}} }}"
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
