### PR TITLE
Add reconciling logic for creating cronjobs whenever a new cleanup policy is created

### DIFF
--- a/api/kyverno/v1alpha1/cleanup_policy_interface.go
+++ b/api/kyverno/v1alpha1/cleanup_policy_interface.go
@@ -14,5 +14,5 @@ type CleanupPolicyInterface interface {
 	GetStatus() *CleanupPolicyStatus
 	Validate(sets.String) field.ErrorList
 	GetKind() string
-	GetSchedule() string
+	GetAPIVersion() string
 }

--- a/api/kyverno/v1alpha1/cleanup_policy_types.go
+++ b/api/kyverno/v1alpha1/cleanup_policy_types.go
@@ -31,6 +31,8 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:resource:shortName=cleanpol,categories=kyverno;all
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=".spec.schedule"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
@@ -58,20 +60,21 @@ func (p *CleanupPolicy) GetStatus() *CleanupPolicyStatus {
 	return &p.Status
 }
 
-// GetSchedule returns the schedule from the policy spec
-func (p *CleanupPolicy) GetSchedule() string {
-	return p.Spec.Schedule
-}
-
-func (p *CleanupPolicy) GetKind() string {
-	return p.Kind
-}
-
 // Validate implements programmatic validation
 func (p *CleanupPolicy) Validate(clusterResources sets.String) (errs field.ErrorList) {
 	errs = append(errs, kyvernov1.ValidatePolicyName(field.NewPath("metadata").Child("name"), p.Name)...)
 	errs = append(errs, p.Spec.Validate(field.NewPath("spec"), clusterResources, true)...)
 	return errs
+}
+
+// GetKind returns the resource kind
+func (p *CleanupPolicy) GetKind() string {
+	return p.Kind
+}
+
+// GetAPIVersion returns the resource kind
+func (p *CleanupPolicy) GetAPIVersion() string {
+	return p.APIVersion
 }
 
 // +kubebuilder:object:root=true
@@ -88,6 +91,8 @@ type CleanupPolicyList struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:resource:scope=Cluster,shortName=cleancpol,categories=kyverno;all
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=".spec.schedule"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
@@ -115,13 +120,14 @@ func (p *ClusterCleanupPolicy) GetStatus() *CleanupPolicyStatus {
 	return &p.Status
 }
 
-// GetSchedule returns the schedule from the policy spec
-func (p *ClusterCleanupPolicy) GetSchedule() string {
-	return p.Spec.Schedule
-}
-
+// GetKind returns the resource kind
 func (p *ClusterCleanupPolicy) GetKind() string {
 	return p.Kind
+}
+
+// GetAPIVersion returns the resource kind
+func (p *ClusterCleanupPolicy) GetAPIVersion() string {
+	return p.APIVersion
 }
 
 // Validate implements programmatic validation

--- a/api/kyverno/v1alpha1/cleanup_policy_types.go
+++ b/api/kyverno/v1alpha1/cleanup_policy_types.go
@@ -92,7 +92,7 @@ type CleanupPolicyList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
-// +kubebuilder:resource:scope=Cluster,shortName=cleancpol,categories=kyverno;all
+// +kubebuilder:resource:scope=Cluster,shortName=ccleanpol,categories=kyverno;all
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=".spec.schedule"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/charts/kyverno/templates/cleanup-controller/clusterrole.yaml
+++ b/charts/kyverno/templates/cleanup-controller/clusterrole.yaml
@@ -22,4 +22,15 @@ rules:
     - update
     - watch
     - deletecollection
+- apiGroups:
+    - batch
+  resources:
+    - cronjobs
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - update
+    - watch
 {{- end }}

--- a/charts/kyverno/templates/crds.yaml
+++ b/charts/kyverno/templates/crds.yaml
@@ -1965,7 +1965,7 @@ spec:
     listKind: ClusterCleanupPolicyList
     plural: clustercleanuppolicies
     shortNames:
-    - cleancpol
+    - ccleanpol
     singular: clustercleanuppolicy
   scope: Cluster
   versions:

--- a/charts/kyverno/templates/crds.yaml
+++ b/charts/kyverno/templates/crds.yaml
@@ -512,9 +512,14 @@ metadata:
 spec:
   group: kyverno.io
   names:
+    categories:
+    - kyverno
+    - all
     kind: CleanupPolicy
     listKind: CleanupPolicyList
     plural: cleanuppolicies
+    shortNames:
+    - cleanpol
     singular: cleanuppolicy
   scope: Namespaced
   versions:
@@ -1953,11 +1958,16 @@ metadata:
 spec:
   group: kyverno.io
   names:
+    categories:
+    - kyverno
+    - all
     kind: ClusterCleanupPolicy
     listKind: ClusterCleanupPolicyList
     plural: clustercleanuppolicies
+    shortNames:
+    - cleancpol
     singular: clustercleanuppolicy
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.schedule

--- a/cmd/cleanup-controller/controller.go
+++ b/cmd/cleanup-controller/controller.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/kyverno/kyverno/pkg/controllers/cleanup"
+)
+
+type controller struct {
+	name       string
+	controller cleanup.Controller
+	workers    int
+}
+
+func newController(name string, c cleanup.Controller, w int) controller {
+	return controller{
+		name:       name,
+		controller: c,
+		workers:    w,
+	}
+}
+
+func (c controller) run(ctx context.Context, logger logr.Logger, wg *sync.WaitGroup) {
+	wg.Add(1)
+	go func(logger logr.Logger) {
+		logger.Info("starting controller", "workers", c.workers)
+		defer logger.Info("controller stopped")
+		defer wg.Done()
+		c.controller.Run(ctx, c.workers)
+	}(logger.WithValues("name", c.name))
+}

--- a/cmd/cleanup-controller/logger/log.go
+++ b/cmd/cleanup-controller/logger/log.go
@@ -1,5 +1,7 @@
 package logger
 
-import "github.com/kyverno/kyverno/pkg/logging"
+import (
+	"github.com/kyverno/kyverno/pkg/logging"
+)
 
 var Logger = logging.WithName("cleanuppolicywebhooks")

--- a/cmd/cleanup-controller/main.go
+++ b/cmd/cleanup-controller/main.go
@@ -120,6 +120,14 @@ func main() {
 		logger.Error(err, "failed to create dynamic client")
 		os.Exit(1)
 	}
+	kubeKyvernoInformer := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod, kubeinformers.WithNamespace(config.KyvernoNamespace()))
+	kyvernoInformer := kyvernoinformer.NewSharedInformerFactory(kyvernoClient, resyncPeriod)
+	cleanupController := cleanup.NewController(
+		kubeClient,
+		kyvernoInformer.Kyverno().V1alpha1().ClusterCleanupPolicies(),
+		kyvernoInformer.Kyverno().V1alpha1().CleanupPolicies(),
+	)
+	controller := newController(cleanup.ControllerName, *cleanupController, cleanup.Workers)
 	policyHandlers := NewHandlers(
 		dClient,
 	)

--- a/cmd/cleanup-controller/main.go
+++ b/cmd/cleanup-controller/main.go
@@ -120,12 +120,14 @@ func main() {
 		logger.Error(err, "failed to create dynamic client")
 		os.Exit(1)
 	}
+	kubeInformer := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod)
 	kubeKyvernoInformer := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod, kubeinformers.WithNamespace(config.KyvernoNamespace()))
 	kyvernoInformer := kyvernoinformer.NewSharedInformerFactory(kyvernoClient, resyncPeriod)
 	cleanupController := cleanup.NewController(
 		kubeClient,
 		kyvernoInformer.Kyverno().V1alpha1().ClusterCleanupPolicies(),
 		kyvernoInformer.Kyverno().V1alpha1().CleanupPolicies(),
+		kubeInformer.Batch().V1().CronJobs(),
 	)
 	controller := newController(cleanup.ControllerName, *cleanupController, cleanup.Workers)
 	policyHandlers := NewHandlers(

--- a/config/crds/kyverno.io_cleanuppolicies.yaml
+++ b/config/crds/kyverno.io_cleanuppolicies.yaml
@@ -9,9 +9,14 @@ metadata:
 spec:
   group: kyverno.io
   names:
+    categories:
+    - kyverno
+    - all
     kind: CleanupPolicy
     listKind: CleanupPolicyList
     plural: cleanuppolicies
+    shortNames:
+    - cleanpol
     singular: cleanuppolicy
   scope: Namespaced
   versions:

--- a/config/crds/kyverno.io_clustercleanuppolicies.yaml
+++ b/config/crds/kyverno.io_clustercleanuppolicies.yaml
@@ -9,11 +9,16 @@ metadata:
 spec:
   group: kyverno.io
   names:
+    categories:
+    - kyverno
+    - all
     kind: ClusterCleanupPolicy
     listKind: ClusterCleanupPolicyList
     plural: clustercleanuppolicies
+    shortNames:
+    - cleancpol
     singular: clustercleanuppolicy
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.schedule

--- a/config/crds/kyverno.io_clustercleanuppolicies.yaml
+++ b/config/crds/kyverno.io_clustercleanuppolicies.yaml
@@ -16,7 +16,7 @@ spec:
     listKind: ClusterCleanupPolicyList
     plural: clustercleanuppolicies
     shortNames:
-    - cleancpol
+    - ccleanpol
     singular: clustercleanuppolicy
   scope: Cluster
   versions:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -678,9 +678,14 @@ metadata:
 spec:
   group: kyverno.io
   names:
+    categories:
+    - kyverno
+    - all
     kind: CleanupPolicy
     listKind: CleanupPolicyList
     plural: cleanuppolicies
+    shortNames:
+    - cleanpol
     singular: cleanuppolicy
   scope: Namespaced
   versions:
@@ -2767,11 +2772,16 @@ metadata:
 spec:
   group: kyverno.io
   names:
+    categories:
+    - kyverno
+    - all
     kind: ClusterCleanupPolicy
     listKind: ClusterCleanupPolicyList
     plural: clustercleanuppolicies
+    shortNames:
+    - cleancpol
     singular: clustercleanuppolicy
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.schedule

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -2779,7 +2779,7 @@ spec:
     listKind: ClusterCleanupPolicyList
     plural: clustercleanuppolicies
     shortNames:
-    - cleancpol
+    - ccleanpol
     singular: clustercleanuppolicy
   scope: Cluster
   versions:

--- a/config/install_debug.yaml
+++ b/config/install_debug.yaml
@@ -2772,7 +2772,7 @@ spec:
     listKind: ClusterCleanupPolicyList
     plural: clustercleanuppolicies
     shortNames:
-    - cleancpol
+    - ccleanpol
     singular: clustercleanuppolicy
   scope: Cluster
   versions:

--- a/config/install_debug.yaml
+++ b/config/install_debug.yaml
@@ -674,9 +674,14 @@ metadata:
 spec:
   group: kyverno.io
   names:
+    categories:
+    - kyverno
+    - all
     kind: CleanupPolicy
     listKind: CleanupPolicyList
     plural: cleanuppolicies
+    shortNames:
+    - cleanpol
     singular: cleanuppolicy
   scope: Namespaced
   versions:
@@ -2760,11 +2765,16 @@ metadata:
 spec:
   group: kyverno.io
   names:
+    categories:
+    - kyverno
+    - all
     kind: ClusterCleanupPolicy
     listKind: ClusterCleanupPolicyList
     plural: clustercleanuppolicies
+    shortNames:
+    - cleancpol
     singular: clustercleanuppolicy
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.schedule

--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -80,9 +80,9 @@ func (c *Controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 	}
 
 	cronjob := getCronJobForTriggerResource(policy)
-	_, err = c.client.BatchV1().CronJobs("default").Create(ctx, cronjob, metav1.CreateOptions{})
+	_, err = c.client.BatchV1().CronJobs(cronjob.GetNamespace()).Create(ctx, cronjob, metav1.CreateOptions{})
 	if err != nil {
-		logger.Error(err, "unable to create the resource of kind CronJob for CleanupPolicy %s", name)
+		logger.Error(err, "unable to create the resource of kind CronJob", "policy", policy)
 		return err
 	}
 	return nil

--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -9,6 +9,7 @@ import (
 	kyvernov1alpha1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1alpha1"
 	kyvernov1alpha1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1alpha1"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/workqueue"
@@ -71,6 +72,9 @@ func (c *Controller) getPolicy(namespace, name string) (kyvernov1alpha1.CleanupP
 func (c *Controller) reconcile(ctx context.Context, logger logr.Logger, key, namespace, name string) error {
 	policy, err := c.getPolicy(namespace, name)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		logger.Error(err, "unable to get the policy from policy informer")
 		return err
 	}

--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -76,6 +76,7 @@ func (c *Controller) getPolicy(namespace, name string) (kyvernov1alpha1.CleanupP
 		return policy, nil
 	}
 }
+
 func (c *Controller) getCronjob(namespace, name string) (*batchv1.CronJob, error) {
 	cj, err := c.cjLister.CronJobs(namespace).Get(name)
 	if err != nil {

--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -1,0 +1,77 @@
+package cleanup
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	kyvernov1alpha1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1alpha1"
+	kyvernov1alpha1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1alpha1"
+	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type Controller struct {
+	client kubernetes.Clientset
+	// listers
+	cpolLister kyvernov1alpha1listers.ClusterCleanupPolicyLister
+	polLister  kyvernov1alpha1listers.CleanupPolicyLister
+
+	// queue
+	queue workqueue.RateLimitingInterface
+}
+
+const (
+	MaxRetries = 10
+	Workers    = 3
+)
+
+func NewController(kubeClient kubernetes.Clientset, cpolInformer kyvernov1alpha1informers.ClusterCleanupPolicyInformer, polInformer kyvernov1alpha1informers.CleanupPolicyInformer) *Controller {
+	c := &Controller{
+		client:     kubeClient,
+		cpolLister: cpolInformer.Lister(),
+		polLister:  polInformer.Lister(),
+		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cleanup-controller"),
+	}
+
+	cpolInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: c.enqueue,
+		UpdateFunc: func(_, obj interface{}) {
+			c.enqueue(obj)
+		},
+	})
+	polInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: c.enqueue,
+		UpdateFunc: func(_, obj interface{}) {
+			c.enqueue(obj)
+		},
+	})
+	return c
+}
+
+func (c *Controller) enqueue(obj interface{}) {
+	c.queue.Add(obj)
+}
+
+func (c *Controller) Run(ctx context.Context, workers int) {
+	controllerutils.Run(ctx, logger.V(3), ControllerName, time.Second, c.queue, Workers, MaxRetries, c.reconcile)
+}
+
+func (c *Controller) reconcile(ctx context.Context, logger logr.Logger, key, namespace, name string) error {
+	policy, err := c.getPolicy(namespace, name)
+	if err != nil {
+		logger.Error(err, "unable to get the policy from policy informer")
+		return err
+	}
+
+	cronjob := getCronJobForTriggerResource(policy)
+	_, err = c.client.BatchV1().CronJobs("default").Create(ctx, cronjob, metav1.CreateOptions{})
+	if err != nil {
+		logger.Error(err, "unable to create the resource of kind CronJob for CleanupPolicy %s", name)
+		return err
+	}
+	return nil
+}

--- a/pkg/controllers/cleanup/log.go
+++ b/pkg/controllers/cleanup/log.go
@@ -1,0 +1,7 @@
+package cleanup
+
+import "sigs.k8s.io/controller-runtime/pkg/log"
+
+const ControllerName = "cleanup-controller"
+
+var logger = log.Log.WithName(ControllerName)

--- a/pkg/controllers/cleanup/log.go
+++ b/pkg/controllers/cleanup/log.go
@@ -1,7 +1,5 @@
 package cleanup
 
-import "sigs.k8s.io/controller-runtime/pkg/log"
+import "github.com/kyverno/kyverno/pkg/logging"
 
-const ControllerName = "cleanup-controller"
-
-var logger = log.Log.WithName(ControllerName)
+var logger = logging.WithName(ControllerName)

--- a/pkg/controllers/cleanup/utils.go
+++ b/pkg/controllers/cleanup/utils.go
@@ -9,8 +9,12 @@ import (
 
 func getCronJobForTriggerResource(pol kyvernov1alpha1.CleanupPolicyInterface) *batchv1.CronJob {
 	namespace := pol.GetNamespace()
+	// TODO: find a better way to do that, it looks like resources returned by WATCH don't have the GVK
+	apiVersion := "kyverno.io/v1alpha1"
+	kind := "CleanupPolicy"
 	if namespace == "" {
 		namespace = "kyverno"
+		kind = "ClusterCleanupPolicy"
 	}
 	cronjob := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
@@ -18,8 +22,8 @@ func getCronJobForTriggerResource(pol kyvernov1alpha1.CleanupPolicyInterface) *b
 			Namespace: namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: pol.GetAPIVersion(),
-					Kind:       pol.GetKind(),
+					APIVersion: apiVersion,
+					Kind:       kind,
 					Name:       pol.GetName(),
 					UID:        pol.GetUID(),
 				},

--- a/pkg/controllers/cleanup/utils.go
+++ b/pkg/controllers/cleanup/utils.go
@@ -7,22 +7,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (c *Controller) getPolicy(namespace, name string) (kyvernov1alpha1.CleanupPolicyInterface, error) {
-	if namespace == "" {
-		cpolicy, err := c.cpolLister.Get(name)
-		if err != nil {
-			return nil, err
-		}
-		return cpolicy, nil
-	} else {
-		policy, err := c.polLister.CleanupPolicies(namespace).Get(name)
-		if err != nil {
-			return nil, err
-		}
-		return policy, nil
-	}
-}
-
 func getCronJobForTriggerResource(pol kyvernov1alpha1.CleanupPolicyInterface) *batchv1.CronJob {
 	cronjob := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/cleanup/utils.go
+++ b/pkg/controllers/cleanup/utils.go
@@ -14,10 +14,12 @@ func getCronJobForTriggerResource(pol kyvernov1alpha1.CleanupPolicyInterface) *b
 			Namespace: "default",
 		},
 		Spec: batchv1.CronJobSpec{
+			Schedule: pol.GetSpec().Schedule,
 			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
+							RestartPolicy: corev1.RestartPolicyOnFailure,
 							Containers: []corev1.Container{
 								{
 									Name:  "cleanup",

--- a/pkg/controllers/cleanup/utils.go
+++ b/pkg/controllers/cleanup/utils.go
@@ -8,18 +8,15 @@ import (
 )
 
 func getCronJobForTriggerResource(pol kyvernov1alpha1.CleanupPolicyInterface) *batchv1.CronJob {
-	namespace := pol.GetNamespace()
 	// TODO: find a better way to do that, it looks like resources returned by WATCH don't have the GVK
 	apiVersion := "kyverno.io/v1alpha1"
 	kind := "CleanupPolicy"
-	if namespace == "" {
-		namespace = "kyverno"
+	if pol.GetNamespace() == "" {
 		kind = "ClusterCleanupPolicy"
 	}
 	cronjob := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      string(pol.GetUID()),
-			Namespace: namespace,
+			Name: string(pol.GetUID()),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: apiVersion,

--- a/pkg/controllers/cleanup/utils.go
+++ b/pkg/controllers/cleanup/utils.go
@@ -1,0 +1,55 @@
+package cleanup
+
+import (
+	kyvernov1alpha1 "github.com/kyverno/kyverno/api/kyverno/v1alpha1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (c *Controller) getPolicy(namespace, name string) (kyvernov1alpha1.CleanupPolicyInterface, error) {
+	if namespace == "" {
+		cpolicy, err := c.cpolLister.Get(name)
+		if err != nil {
+			return nil, err
+		}
+		return cpolicy, nil
+	} else {
+		policy, err := c.polLister.CleanupPolicies(namespace).Get(name)
+		if err != nil {
+			return nil, err
+		}
+		return policy, nil
+	}
+}
+
+func getCronJobForTriggerResource(pol kyvernov1alpha1.CleanupPolicyInterface) *batchv1.CronJob {
+	cronjob := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cleanupcj",
+			Namespace: "default",
+		},
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "cleanup",
+									Image: "bitnami/kubectl:latest",
+									Args: []string{
+										"/bin/sh",
+										"-c",
+										`echo "Hello World"`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return cronjob
+}

--- a/pkg/controllers/cleanup/utils.go
+++ b/pkg/controllers/cleanup/utils.go
@@ -8,10 +8,22 @@ import (
 )
 
 func getCronJobForTriggerResource(pol kyvernov1alpha1.CleanupPolicyInterface) *batchv1.CronJob {
+	namespace := pol.GetNamespace()
+	if namespace == "" {
+		namespace = "kyverno"
+	}
 	cronjob := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cleanupcj",
-			Namespace: "default",
+			Name:      string(pol.GetUID()),
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: pol.GetAPIVersion(),
+					Kind:       pol.GetKind(),
+					Name:       pol.GetName(),
+					UID:        pol.GetUID(),
+				},
+			},
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule: pol.GetSpec().Schedule,


### PR DESCRIPTION
Signed-off-by: Nikhil Sharma <nikhilsharma230303@gmail.com>

## Explanation
This PR adds reconciling logic for creating CronJob whenever a new cleanup policy is created.
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.
