### PR TITLE
fix: typo

### DIFF
--- a/pkg/webhooks/handlers/admission.go
+++ b/pkg/webhooks/handlers/admission.go
@@ -74,9 +74,9 @@ func withAdmission(logger logr.Logger, inner AdmissionHandler) HttpHandler {
 			attribute.String("uid", string(admissionReview.Request.UID)),
 		)
 		defer span.End()
-		adminssionResponse := inner(ctx, logger, admissionReview.Request, startTime)
-		if adminssionResponse != nil {
-			admissionReview.Response = adminssionResponse
+		admissionResponse := inner(ctx, logger, admissionReview.Request, startTime)
+		if admissionResponse != nil {
+			admissionReview.Response = admissionResponse
 		}
 		responseJSON, err := json.Marshal(admissionReview)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR fixes a typo in a variable name `adminssionResponse` -> `admissionResponse`.
