### PR TITLE
fix: admission reports stacking up

### DIFF
--- a/api/kyverno/v1alpha2/admission_report_types.go
+++ b/api/kyverno/v1alpha2/admission_report_types.go
@@ -49,6 +49,7 @@ type AdmissionReportSpec struct {
 // +kubebuilder:printcolumn:name="Skip",type=integer,JSONPath=".spec.summary.skip"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Hash",type=string,JSONPath=".metadata.labels['audit\\.kyverno\\.io/resource\\.hash']",priority=1
+// +kubebuilder:printcolumn:name="AGGREGATE",type=string,JSONPath=".metadata.labels['audit\\.kyverno\\.io/report\\.aggregate']",priority=1
 
 // AdmissionReport is the Schema for the AdmissionReports API
 type AdmissionReport struct {
@@ -85,6 +86,7 @@ func (r *AdmissionReport) SetSummary(summary policyreportv1alpha2.PolicyReportSu
 // +kubebuilder:printcolumn:name="Skip",type=integer,JSONPath=".spec.summary.skip"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Hash",type=string,JSONPath=".metadata.labels['audit\\.kyverno\\.io/resource\\.hash']",priority=1
+// +kubebuilder:printcolumn:name="AGGREGATE",type=string,JSONPath=".metadata.labels['audit\\.kyverno\\.io/report\\.aggregate']",priority=1
 
 // ClusterAdmissionReport is the Schema for the ClusterAdmissionReports API
 type ClusterAdmissionReport struct {

--- a/charts/kyverno/templates/crds.yaml
+++ b/charts/kyverno/templates/crds.yaml
@@ -64,6 +64,10 @@ spec:
       name: Hash
       priority: 1
       type: string
+    - jsonPath: .metadata.labels['audit\.kyverno\.io/report\.aggregate']
+      name: AGGREGATE
+      priority: 1
+      type: string
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -1503,6 +1507,10 @@ spec:
       type: date
     - jsonPath: .metadata.labels['audit\.kyverno\.io/resource\.hash']
       name: Hash
+      priority: 1
+      type: string
+    - jsonPath: .metadata.labels['audit\.kyverno\.io/report\.aggregate']
+      name: AGGREGATE
       priority: 1
       type: string
     name: v1alpha2

--- a/config/crds/kyverno.io_admissionreports.yaml
+++ b/config/crds/kyverno.io_admissionreports.yaml
@@ -55,6 +55,10 @@ spec:
       name: Hash
       priority: 1
       type: string
+    - jsonPath: .metadata.labels['audit\.kyverno\.io/report\.aggregate']
+      name: AGGREGATE
+      priority: 1
+      type: string
     name: v1alpha2
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno.io_clusteradmissionreports.yaml
+++ b/config/crds/kyverno.io_clusteradmissionreports.yaml
@@ -55,6 +55,10 @@ spec:
       name: Hash
       priority: 1
       type: string
+    - jsonPath: .metadata.labels['audit\.kyverno\.io/report\.aggregate']
+      name: AGGREGATE
+      priority: 1
+      type: string
     name: v1alpha2
     schema:
       openAPIV3Schema:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -72,6 +72,10 @@ spec:
       name: Hash
       priority: 1
       type: string
+    - jsonPath: .metadata.labels['audit\.kyverno\.io/report\.aggregate']
+      name: AGGREGATE
+      priority: 1
+      type: string
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -2158,6 +2162,10 @@ spec:
       type: date
     - jsonPath: .metadata.labels['audit\.kyverno\.io/resource\.hash']
       name: Hash
+      priority: 1
+      type: string
+    - jsonPath: .metadata.labels['audit\.kyverno\.io/report\.aggregate']
+      name: AGGREGATE
       priority: 1
       type: string
     name: v1alpha2

--- a/config/install_debug.yaml
+++ b/config/install_debug.yaml
@@ -70,6 +70,10 @@ spec:
       name: Hash
       priority: 1
       type: string
+    - jsonPath: .metadata.labels['audit\.kyverno\.io/report\.aggregate']
+      name: AGGREGATE
+      priority: 1
+      type: string
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -2153,6 +2157,10 @@ spec:
       type: date
     - jsonPath: .metadata.labels['audit\.kyverno\.io/resource\.hash']
       name: Hash
+      priority: 1
+      type: string
+    - jsonPath: .metadata.labels['audit\.kyverno\.io/report\.aggregate']
+      name: AGGREGATE
       priority: 1
       type: string
     name: v1alpha2

--- a/pkg/controllers/report/admission/controller.go
+++ b/pkg/controllers/report/admission/controller.go
@@ -2,20 +2,24 @@ package admission
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	"github.com/go-logr/logr"
 	kyvernov1alpha2 "github.com/kyverno/kyverno/api/kyverno/v1alpha2"
+	policyreportv1alpha2 "github.com/kyverno/kyverno/api/policyreport/v1alpha2"
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	"github.com/kyverno/kyverno/pkg/controllers"
 	"github.com/kyverno/kyverno/pkg/controllers/report/resource"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
+	"go.uber.org/multierr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	metadatainformers "k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -37,9 +41,7 @@ type controller struct {
 	cadmrLister cache.GenericLister
 
 	// queue
-	queue        workqueue.RateLimitingInterface
-	admrEnqueue  controllerutils.EnqueueFunc
-	cadmrEnqueue controllerutils.EnqueueFunc
+	queue workqueue.RateLimitingInterface
 
 	// cache
 	metadataCache resource.MetadataCache
@@ -58,19 +60,21 @@ func NewController(
 		admrLister:    admrInformer.Lister(),
 		cadmrLister:   cadmrInformer.Lister(),
 		queue:         queue,
-		admrEnqueue:   controllerutils.AddDefaultEventHandlers(logger, admrInformer.Informer(), queue),
-		cadmrEnqueue:  controllerutils.AddDefaultEventHandlers(logger, cadmrInformer.Informer(), queue),
 		metadataCache: metadataCache,
 	}
-	c.metadataCache.AddEventHandler(func(uid types.UID, _ schema.GroupVersionKind, _ resource.Resource) {
-		selector, err := reportutils.SelectorResourceUidEquals(uid)
-		if err != nil {
-			logger.Error(err, "failed to create label selector")
-		}
-		if err := c.enqueue(selector); err != nil {
-			logger.Error(err, "failed to enqueue")
-		}
-	})
+	c.metadataCache.AddEventHandler(func(uid types.UID, _ schema.GroupVersionKind, _ resource.Resource) { queue.Add(cache.ExplicitKey(uid)) })
+	controllerutils.AddEventHandlersT(
+		admrInformer.Informer(),
+		func(obj metav1.Object) { queue.Add(cache.ExplicitKey(reportutils.GetResourceUid(obj))) },
+		func(old, obj metav1.Object) { queue.Add(cache.ExplicitKey(reportutils.GetResourceUid(old))) },
+		func(obj metav1.Object) { queue.Add(cache.ExplicitKey(reportutils.GetResourceUid(obj))) },
+	)
+	controllerutils.AddEventHandlersT(
+		cadmrInformer.Informer(),
+		func(obj metav1.Object) { queue.Add(cache.ExplicitKey(reportutils.GetResourceUid(obj))) },
+		func(old, obj metav1.Object) { queue.Add(cache.ExplicitKey(reportutils.GetResourceUid(old))) },
+		func(obj metav1.Object) { queue.Add(cache.ExplicitKey(reportutils.GetResourceUid(obj))) },
+	)
 	return &c
 }
 
@@ -78,31 +82,30 @@ func (c *controller) Run(ctx context.Context, workers int) {
 	controllerutils.Run(ctx, logger, ControllerName, time.Second, c.queue, workers, maxRetries, c.reconcile)
 }
 
-func (c *controller) enqueue(selector labels.Selector) error {
+func (c *controller) getReports(uid types.UID) ([]metav1.Object, error) {
+	selector, err := reportutils.SelectorResourceUidEquals(uid)
+	if err != nil {
+		return nil, err
+	}
+	var results []metav1.Object
 	admrs, err := c.admrLister.List(selector)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	for _, adm := range admrs {
-		err = c.admrEnqueue(adm)
-		if err != nil {
-			logger.Error(err, "failed to enqueue")
-		}
+	for _, admr := range admrs {
+		results = append(results, admr.(metav1.Object))
 	}
 	cadmrs, err := c.cadmrLister.List(selector)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for _, cadmr := range cadmrs {
-		err = c.admrEnqueue(cadmr)
-		if err != nil {
-			logger.Error(err, "failed to enqueue")
-		}
+		results = append(results, cadmr.(metav1.Object))
 	}
-	return nil
+	return results, nil
 }
 
-func (c *controller) getMeta(namespace, name string) (metav1.Object, error) {
+func (c *controller) getReportMetadata(namespace, name string) (metav1.Object, error) {
 	if namespace == "" {
 		obj, err := c.cadmrLister.Get(name)
 		if err != nil {
@@ -134,44 +137,161 @@ func (c *controller) getReport(ctx context.Context, namespace, name string) (kyv
 	}
 }
 
-func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, namespace, name string) error {
-	// try to find meta from the cache
-	meta, err := c.getMeta(namespace, name)
+// reportsAreIdentical we expect reports are sorted before comparing them
+func reportsAreIdentical(before, after kyvernov1alpha2.ReportInterface) bool {
+	bLabels := sets.NewString()
+	aLabels := sets.NewString()
+	for key := range before.GetLabels() {
+		bLabels.Insert(key)
+	}
+	for key := range after.GetLabels() {
+		aLabels.Insert(key)
+	}
+	if !aLabels.Equal(bLabels) {
+		return false
+	}
+	b := before.GetResults()
+	a := after.GetResults()
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		a := a[i]
+		b := b[i]
+		a.Timestamp = metav1.Timestamp{}
+		b.Timestamp = metav1.Timestamp{}
+		if !reflect.DeepEqual(&a, &b) {
+			return false
+		}
+	}
+	return true
+}
+
+func mergeReports(accumulator map[string]policyreportv1alpha2.PolicyReportResult, reports ...kyvernov1alpha2.ReportInterface) {
+	for _, report := range reports {
+		if len(report.GetOwnerReferences()) == 1 {
+			ownerRef := report.GetOwnerReferences()[0]
+			objectRefs := []corev1.ObjectReference{{
+				APIVersion: ownerRef.APIVersion,
+				Kind:       ownerRef.Kind,
+				Namespace:  report.GetNamespace(),
+				Name:       ownerRef.Name,
+				UID:        ownerRef.UID,
+			}}
+			for _, result := range report.GetResults() {
+				key := result.Policy + "/" + result.Rule + "/" + string(ownerRef.UID)
+				result.Resources = objectRefs
+				if rule, exists := accumulator[key]; !exists {
+					accumulator[key] = result
+				} else if rule.Timestamp.Seconds < result.Timestamp.Seconds {
+					accumulator[key] = result
+				}
+			}
+		}
+	}
+}
+
+func (c *controller) aggregateReports(ctx context.Context, uid types.UID, gvk schema.GroupVersionKind, res resource.Resource, reports ...metav1.Object) error {
+	merged := map[string]policyreportv1alpha2.PolicyReportResult{}
+	var toDelete []metav1.Object
+	for _, report := range reports {
+		if reportutils.GetResourceHash(report) == res.Hash {
+			// TODO: see if we can use List instead of fetching reports one by one
+			report, err := c.getReport(ctx, report.GetNamespace(), report.GetName())
+			if err != nil {
+				return err
+			}
+			mergeReports(merged, report)
+		}
+		if report.GetName() != string(uid) {
+			if reportutils.GetResourceHash(report) == res.Hash || report.GetCreationTimestamp().Add(time.Minute*2).Before(time.Now()) {
+				toDelete = append(toDelete, report)
+			} else {
+				c.queue.AddAfter(cache.ExplicitKey(uid), time.Minute*2)
+			}
+		}
+	}
+	var results []policyreportv1alpha2.PolicyReportResult
+	for _, result := range merged {
+		results = append(results, result)
+	}
+	before, err := c.getReport(ctx, res.Namespace, string(uid))
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil
+			if len(results) == 0 {
+				return nil
+			}
+			report := reportutils.EmptyAdmissionReport(uid, res.Namespace, res.Name, metav1.GroupVersionKind(gvk))
+			controllerutils.SetOwner(report, gvk.GroupVersion().String(), gvk.Kind, res.Name, uid)
+			controllerutils.SetLabel(report, reportutils.LabelResourceHash, res.Hash)
+			controllerutils.SetLabel(report, reportutils.LabelAggregatedReport, res.Hash)
+			reportutils.SetResults(report, results...)
+			_, err := reportutils.CreateReport(ctx, report, c.client)
+			return err
 		}
 		return err
 	}
-	// try to find resource from the cache
-	uid := reportutils.GetResourceUid(meta)
-	resource, gvk, found := c.metadataCache.GetResourceHash(uid)
-	// set owner if not done yet
-	if found && len(meta.GetOwnerReferences()) == 0 {
-		report, err := c.getReport(ctx, namespace, name)
+	after := reportutils.DeepCopy(before)
+	controllerutils.SetLabel(after, reportutils.LabelResourceHash, res.Hash)
+	controllerutils.SetLabel(after, reportutils.LabelAggregatedReport, res.Hash)
+	reportutils.SetResults(after, results...)
+	if !reportsAreIdentical(before, after) {
+		_, err = reportutils.UpdateReport(ctx, after, c.client)
 		if err != nil {
 			return err
 		}
-		controllerutils.SetOwner(report, gvk.GroupVersion().String(), gvk.Kind, resource.Name, uid)
-		_, err = reportutils.UpdateReport(ctx, report, c.client)
+	}
+	var errs []error
+	for _, report := range toDelete {
+		if err := c.deleteReport(ctx, report.GetNamespace(), report.GetName()); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return multierr.Combine(errs...)
+}
+
+func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, _, _ string) error {
+	resourceUid := types.UID(key)
+	// find related reports
+	reports, err := c.getReports(resourceUid)
+	if err != nil {
 		return err
-	}
-	// cleanup old reports
-	// if they are not the same version as the current resource version
-	// and were created more than 2 minutes ago
-	if !found {
-		// if we didn't find the resource, either no policy exist for this kind
-		// or the resource was never created, we delete the report if it has no owner
-		// and was created more than 2 minutes ago
-		if len(meta.GetOwnerReferences()) == 0 && meta.GetCreationTimestamp().Add(time.Minute*2).Before(time.Now()) {
-			return c.deleteReport(ctx, namespace, name)
-		}
 	} else {
-		// if hashes don't match and the report was created more than 2
-		// minutes ago we consider it obsolete and delete the report
-		if !reportutils.CompareHash(meta, resource.Hash) && meta.GetCreationTimestamp().Add(time.Minute*2).Before(time.Now()) {
-			return c.deleteReport(ctx, namespace, name)
+		var toDelete []metav1.Object
+		for _, report := range reports {
+			if report.GetName() != string(resourceUid) {
+				if report.GetCreationTimestamp().Add(time.Minute * 2).Before(time.Now()) {
+					toDelete = append(toDelete, report)
+				}
+			}
+		}
+		var errs []error
+		for _, report := range toDelete {
+			if err := c.deleteReport(ctx, report.GetNamespace(), report.GetName()); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		if err := multierr.Combine(errs...); err != nil {
+			return err
 		}
 	}
-	return nil
+	// is the resource known
+	resource, gvk, found := c.metadataCache.GetResourceHash(resourceUid)
+	if !found {
+		return nil
+	}
+	// set orphan reports an owner
+	for _, report := range reports {
+		if len(report.GetOwnerReferences()) == 0 {
+			report, err := c.getReport(ctx, report.GetNamespace(), report.GetName())
+			if err != nil {
+				return err
+			}
+			controllerutils.SetOwner(report, gvk.GroupVersion().String(), gvk.Kind, resource.Name, resourceUid)
+			_, err = reportutils.UpdateReport(ctx, report, c.client)
+			return err
+		}
+	}
+	// build an aggregated report
+	return c.aggregateReports(ctx, resourceUid, gvk, resource, reports...)
 }

--- a/pkg/controllers/report/admission/controller.go
+++ b/pkg/controllers/report/admission/controller.go
@@ -227,7 +227,7 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, _, 
 	// is the resource known
 	resource, gvk, found := c.metadataCache.GetResourceHash(uid)
 	if !found {
-		return c.cleanupReports(ctx, uid, "", reports...)
+		return c.cleanupReports(ctx, "", "", reports...)
 	}
 	// set orphan reports an owner
 	for _, report := range reports {

--- a/pkg/controllers/report/aggregate/controller.go
+++ b/pkg/controllers/report/aggregate/controller.go
@@ -100,6 +100,7 @@ func NewController(
 	controllerutils.AddDelayedExplicitEventHandlers(logger, bgscanrInformer.Informer(), c.queue, delay, keyFunc)
 	controllerutils.AddDelayedExplicitEventHandlers(logger, cbgscanrInformer.Informer(), c.queue, delay, keyFunc)
 	enqueueFromAdmr := func(obj metav1.Object) {
+		// no need to consider non aggregated reports
 		if controllerutils.HasLabel(obj, reportutils.LabelAggregatedReport) {
 			c.queue.AddAfter(keyFunc(obj), delay)
 		}
@@ -128,6 +129,7 @@ func (c *controller) mergeAdmissionReports(ctx context.Context, namespace string
 		next := ""
 		for {
 			cadms, err := c.client.KyvernoV1alpha2().ClusterAdmissionReports().List(ctx, metav1.ListOptions{
+				// no need to consider non aggregated reports
 				LabelSelector: reportutils.LabelAggregatedReport,
 				Limit:         mergeLimit,
 				Continue:      next,
@@ -147,6 +149,7 @@ func (c *controller) mergeAdmissionReports(ctx context.Context, namespace string
 		next := ""
 		for {
 			adms, err := c.client.KyvernoV1alpha2().AdmissionReports(namespace).List(ctx, metav1.ListOptions{
+				// no need to consider non aggregated reports
 				LabelSelector: reportutils.LabelAggregatedReport,
 				Limit:         mergeLimit,
 				Continue:      next,

--- a/pkg/controllers/report/aggregate/controller.go
+++ b/pkg/controllers/report/aggregate/controller.go
@@ -98,10 +98,25 @@ func NewController(
 	delay := 15 * time.Second
 	controllerutils.AddDelayedExplicitEventHandlers(logger, polrInformer.Informer(), c.queue, delay, keyFunc)
 	controllerutils.AddDelayedExplicitEventHandlers(logger, cpolrInformer.Informer(), c.queue, delay, keyFunc)
-	controllerutils.AddDelayedExplicitEventHandlers(logger, admrInformer.Informer(), c.queue, delay, keyFunc)
-	controllerutils.AddDelayedExplicitEventHandlers(logger, cadmrInformer.Informer(), c.queue, delay, keyFunc)
 	controllerutils.AddDelayedExplicitEventHandlers(logger, bgscanrInformer.Informer(), c.queue, delay, keyFunc)
 	controllerutils.AddDelayedExplicitEventHandlers(logger, cbgscanrInformer.Informer(), c.queue, delay, keyFunc)
+	enqueueFromAdmr := func(obj metav1.Object) {
+		if controllerutils.HasLabel(obj, reportutils.LabelAggregatedReport) {
+			c.queue.AddAfter(keyFunc(obj), delay)
+		}
+	}
+	controllerutils.AddEventHandlersT(
+		admrInformer.Informer(),
+		func(obj metav1.Object) { enqueueFromAdmr(obj) },
+		func(_, obj metav1.Object) { enqueueFromAdmr(obj) },
+		func(obj metav1.Object) { enqueueFromAdmr(obj) },
+	)
+	controllerutils.AddEventHandlersT(
+		cadmrInformer.Informer(),
+		func(obj metav1.Object) { enqueueFromAdmr(obj) },
+		func(_, obj metav1.Object) { enqueueFromAdmr(obj) },
+		func(obj metav1.Object) { enqueueFromAdmr(obj) },
+	)
 	return &c
 }
 
@@ -114,8 +129,9 @@ func (c *controller) mergeAdmissionReports(ctx context.Context, namespace string
 		next := ""
 		for {
 			cadms, err := c.client.KyvernoV1alpha2().ClusterAdmissionReports().List(ctx, metav1.ListOptions{
-				Limit:    mergeLimit,
-				Continue: next,
+				LabelSelector: reportutils.LabelAggregatedReport,
+				Limit:         mergeLimit,
+				Continue:      next,
 			})
 			if err != nil {
 				return err
@@ -132,8 +148,9 @@ func (c *controller) mergeAdmissionReports(ctx context.Context, namespace string
 		next := ""
 		for {
 			adms, err := c.client.KyvernoV1alpha2().AdmissionReports(namespace).List(ctx, metav1.ListOptions{
-				Limit:    mergeLimit,
-				Continue: next,
+				LabelSelector: reportutils.LabelAggregatedReport,
+				Limit:         mergeLimit,
+				Continue:      next,
 			})
 			if err != nil {
 				return err

--- a/pkg/controllers/report/aggregate/controller.go
+++ b/pkg/controllers/report/aggregate/controller.go
@@ -28,7 +28,6 @@ import (
 )
 
 // TODO: resync in resource controller
-// TODO: error handling in resource controller
 // TODO: policy hash
 
 const (

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -46,6 +46,7 @@ type EventHandler func(types.UID, schema.GroupVersionKind, Resource)
 type MetadataCache interface {
 	GetResourceHash(uid types.UID) (Resource, schema.GroupVersionKind, bool)
 	AddEventHandler(EventHandler)
+	Warmup(ctx context.Context) error
 }
 
 type Controller interface {
@@ -90,6 +91,10 @@ func NewController(
 	controllerutils.AddDefaultEventHandlers(logger, polInformer.Informer(), c.queue)
 	controllerutils.AddDefaultEventHandlers(logger, cpolInformer.Informer(), c.queue)
 	return &c
+}
+
+func (c *controller) Warmup(ctx context.Context) error {
+	return c.updateDynamicWatchers(ctx)
 }
 
 func (c *controller) Run(ctx context.Context, workers int) {

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -234,7 +234,6 @@ func (c *controller) stopDynamicWatchers() {
 		watcher.watcher.Stop()
 	}
 	c.dynamicWatchers = map[schema.GroupVersionResource]*watcher{}
-
 }
 
 func (c *controller) notify(uid types.UID, gvk schema.GroupVersionKind, obj Resource) {

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -156,6 +156,7 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 	}
 	dynamicWatchers := map[schema.GroupVersionResource]*watcher{}
 	for gvk, gvr := range gvrs {
+		logger := logger.WithValues("gvr", gvr, "gvk", gvk)
 		// if we already have one, transfer it to the new map
 		if c.dynamicWatchers[gvr] != nil {
 			dynamicWatchers[gvr] = c.dynamicWatchers[gvr]
@@ -164,7 +165,7 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 			hashes := map[types.UID]Resource{}
 			objs, err := c.client.GetDynamicInterface().Resource(gvr).List(ctx, metav1.ListOptions{})
 			if err != nil {
-				logger.Error(err, "failed to list resources", "gvr", gvr)
+				logger.Error(err, "failed to list resources")
 			} else {
 				resourceVersion := objs.GetResourceVersion()
 				for _, obj := range objs.Items {
@@ -177,17 +178,18 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 					}
 					c.notify(uid, gvk, hashes[uid])
 				}
-				logger.Info("start watcher ...", "gvr", gvr, "resourceVersion", resourceVersion)
+				logger := logger.WithValues("resourceVersion", resourceVersion)
+				logger.Info("start watcher ...")
 				watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
 					watch, err := c.client.GetDynamicInterface().Resource(gvr).Watch(context.Background(), options)
 					if err != nil {
-						logger.Error(err, "failed to watch", "gvr", gvr)
+						logger.Error(err, "failed to watch")
 					}
 					return watch, err
 				}
 				watchInterface, err := watchTools.NewRetryWatcher(resourceVersion, &cache.ListWatch{WatchFunc: watchFunc})
 				if err != nil {
-					logger.Error(err, "failed to create watcher", "gvr", gvr)
+					logger.Error(err, "failed to create watcher")
 				} else {
 					w := &watcher{
 						watcher: watchInterface,

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -2,7 +2,6 @@ package resource
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -180,8 +179,8 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 				}
 				logger.Info("start watcher ...", "gvr", gvr, "resourceVersion", resourceVersion)
 				watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
-					watch, err := c.client.GetDynamicInterface().Resource(gvr).Watch(ctx, options)
-					if err != nil && !errors.Is(err, context.Canceled) {
+					watch, err := c.client.GetDynamicInterface().Resource(gvr).Watch(context.Background(), options)
+					if err != nil {
 						logger.Error(err, "failed to watch", "gvr", gvr)
 					}
 					return watch, err

--- a/pkg/utils/controller/metadata.go
+++ b/pkg/utils/controller/metadata.go
@@ -23,6 +23,15 @@ func CheckLabel(obj metav1.Object, key, value string) bool {
 	return labels[key] == value
 }
 
+func HasLabel(obj metav1.Object, key string) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+	_, exists := labels[key]
+	return exists
+}
+
 func SetAnnotation(obj metav1.Object, key, value string) {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {

--- a/pkg/utils/controller/run.go
+++ b/pkg/utils/controller/run.go
@@ -91,7 +91,7 @@ func reconcile(ctx context.Context, logger logr.Logger, obj interface{}, r recon
 		}
 	}
 	logger = logger.WithValues("key", k, "namespace", ns, "name", n)
-	logger.V(6).Info("reconciling ...")
-	defer logger.V(6).Info("done", "duration", time.Since(start).String())
+	logger.Info("reconciling ...")
+	defer logger.Info("done", "duration", time.Since(start).String())
 	return r(ctx, logger, k, ns, n)
 }

--- a/pkg/utils/report/labels.go
+++ b/pkg/utils/report/labels.go
@@ -24,6 +24,8 @@ const (
 	LabelDomainPolicy        = "pol.kyverno.io"
 	LabelPrefixClusterPolicy = LabelDomainClusterPolicy + "/"
 	LabelPrefixPolicy        = LabelDomainPolicy + "/"
+	//	aggregated admission report label
+	LabelAggregatedReport = "audit.kyverno.io/report.aggregate"
 )
 
 func IsPolicyLabel(label string) bool {

--- a/pkg/utils/report/new.go
+++ b/pkg/utils/report/new.go
@@ -12,6 +12,38 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+func EmptyAdmissionReport(uid types.UID, namespace, owner string, gvk metav1.GroupVersionKind) kyvernov1alpha2.ReportInterface {
+	var report kyvernov1alpha2.ReportInterface
+	if namespace == "" {
+		report = &kyvernov1alpha2.ClusterAdmissionReport{
+			Spec: kyvernov1alpha2.AdmissionReportSpec{
+				Owner: metav1.OwnerReference{
+					APIVersion: metav1.GroupVersion{Group: gvk.Group, Version: gvk.Version}.String(),
+					Kind:       gvk.Kind,
+					Name:       owner,
+					UID:        uid,
+				},
+			},
+		}
+	} else {
+		report = &kyvernov1alpha2.AdmissionReport{
+			Spec: kyvernov1alpha2.AdmissionReportSpec{
+				Owner: metav1.OwnerReference{
+					APIVersion: metav1.GroupVersion{Group: gvk.Group, Version: gvk.Version}.String(),
+					Kind:       gvk.Kind,
+					Name:       owner,
+					UID:        uid,
+				},
+			},
+		}
+	}
+	report.SetName(string(uid))
+	report.SetNamespace(namespace)
+	SetResourceLabels(report, uid)
+	SetManagedByKyvernoLabel(report)
+	return report
+}
+
 func NewAdmissionReport(resource unstructured.Unstructured, request *admissionv1.AdmissionRequest, gvk metav1.GroupVersionKind, responses ...*response.EngineResponse) kyvernov1alpha2.ReportInterface {
 	name := string(request.UID)
 	namespace := resource.GetNamespace()

--- a/pkg/utils/report/new.go
+++ b/pkg/utils/report/new.go
@@ -12,73 +12,30 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func EmptyAdmissionReport(uid types.UID, namespace, owner string, gvk metav1.GroupVersionKind) kyvernov1alpha2.ReportInterface {
+func NewAdmissionReport(namespace, name, owner string, uid types.UID, gvk metav1.GroupVersionKind) kyvernov1alpha2.ReportInterface {
+	ownerRef := metav1.OwnerReference{
+		APIVersion: metav1.GroupVersion{Group: gvk.Group, Version: gvk.Version}.String(),
+		Kind:       gvk.Kind,
+		Name:       owner,
+		UID:        uid,
+	}
 	var report kyvernov1alpha2.ReportInterface
 	if namespace == "" {
-		report = &kyvernov1alpha2.ClusterAdmissionReport{
-			Spec: kyvernov1alpha2.AdmissionReportSpec{
-				Owner: metav1.OwnerReference{
-					APIVersion: metav1.GroupVersion{Group: gvk.Group, Version: gvk.Version}.String(),
-					Kind:       gvk.Kind,
-					Name:       owner,
-					UID:        uid,
-				},
-			},
-		}
+		report = &kyvernov1alpha2.ClusterAdmissionReport{Spec: kyvernov1alpha2.AdmissionReportSpec{Owner: ownerRef}}
 	} else {
-		report = &kyvernov1alpha2.AdmissionReport{
-			Spec: kyvernov1alpha2.AdmissionReportSpec{
-				Owner: metav1.OwnerReference{
-					APIVersion: metav1.GroupVersion{Group: gvk.Group, Version: gvk.Version}.String(),
-					Kind:       gvk.Kind,
-					Name:       owner,
-					UID:        uid,
-				},
-			},
-		}
+		report = &kyvernov1alpha2.AdmissionReport{Spec: kyvernov1alpha2.AdmissionReportSpec{Owner: ownerRef}}
 	}
-	report.SetName(string(uid))
+	report.SetName(name)
 	report.SetNamespace(namespace)
 	SetResourceLabels(report, uid)
 	SetManagedByKyvernoLabel(report)
 	return report
 }
 
-func NewAdmissionReport(resource unstructured.Unstructured, request *admissionv1.AdmissionRequest, gvk metav1.GroupVersionKind, responses ...*response.EngineResponse) kyvernov1alpha2.ReportInterface {
-	name := string(request.UID)
-	namespace := resource.GetNamespace()
-	owner := resource.GetName()
-	uid := resource.GetUID()
-	var report kyvernov1alpha2.ReportInterface
-	if namespace == "" {
-		report = &kyvernov1alpha2.ClusterAdmissionReport{
-			Spec: kyvernov1alpha2.AdmissionReportSpec{
-				Owner: metav1.OwnerReference{
-					APIVersion: metav1.GroupVersion{Group: gvk.Group, Version: gvk.Version}.String(),
-					Kind:       gvk.Kind,
-					Name:       owner,
-					UID:        uid,
-				},
-			},
-		}
-	} else {
-		report = &kyvernov1alpha2.AdmissionReport{
-			Spec: kyvernov1alpha2.AdmissionReportSpec{
-				Owner: metav1.OwnerReference{
-					APIVersion: metav1.GroupVersion{Group: gvk.Group, Version: gvk.Version}.String(),
-					Kind:       gvk.Kind,
-					Name:       owner,
-					UID:        uid,
-				},
-			},
-		}
-	}
-	report.SetName(name)
-	report.SetNamespace(namespace)
-	SetResourceLabels(report, uid)
+func BuildAdmissionReport(resource unstructured.Unstructured, request *admissionv1.AdmissionRequest, gvk metav1.GroupVersionKind, responses ...*response.EngineResponse) kyvernov1alpha2.ReportInterface {
+	report := NewAdmissionReport(resource.GetNamespace(), string(request.UID), resource.GetName(), resource.GetUID(), gvk)
 	SetResourceVersionLabels(report, &resource)
 	SetResponses(report, responses...)
-	SetManagedByKyvernoLabel(report)
 	return report
 }
 

--- a/pkg/webhooks/resource/imageverification/handler.go
+++ b/pkg/webhooks/resource/imageverification/handler.go
@@ -147,7 +147,7 @@ func (v *imageVerificationHandler) handleAudit(
 	if !reportutils.IsGvkSupported(schema.GroupVersionKind(request.Kind)) {
 		return
 	}
-	report := reportutils.NewAdmissionReport(resource, request, request.Kind, engineResponses...)
+	report := reportutils.BuildAdmissionReport(resource, request, request.Kind, engineResponses...)
 	// if it's not a creation, the resource already exists, we can set the owner
 	if request.Operation != admissionv1.Create {
 		gv := metav1.GroupVersion{Group: request.Kind.Group, Version: request.Kind.Version}

--- a/pkg/webhooks/resource/validation/validation.go
+++ b/pkg/webhooks/resource/validation/validation.go
@@ -172,7 +172,7 @@ func (v *validationHandler) handleAudit(
 		v.log.Error(err, "failed to build audit responses")
 	}
 	responses = append(responses, engineResponses...)
-	report := reportutils.NewAdmissionReport(resource, request, request.Kind, responses...)
+	report := reportutils.BuildAdmissionReport(resource, request, request.Kind, responses...)
 	// if it's not a creation, the resource already exists, we can set the owner
 	if request.Operation != admissionv1.Create {
 		gv := metav1.GroupVersion{Group: request.Kind.Group, Version: request.Kind.Version}


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR fixes admission reports stacking up.
This is due to admission of same resource again and again, therefore the hash does not change and we never get a chance to cleanup reports.

The solution is to continuously aggregate admission reports into one and delete reports that have been aggregated.

Aggregated reports are labeled specifically so that high level reports can consider only those aggregated admission reports.