### PR TITLE
fix: remove filtering for policy admission handlers

### DIFF
--- a/pkg/webhooks/handlers/filter.go
+++ b/pkg/webhooks/handlers/filter.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/kyverno/kyverno/pkg/config"
+	webhookutils "github.com/kyverno/kyverno/pkg/webhooks/utils"
 	admissionv1 "k8s.io/api/admission/v1"
 )
 
@@ -16,6 +17,9 @@ func (inner AdmissionHandler) WithFilter(configuration config.Configuration) Adm
 func (inner AdmissionHandler) withFilter(c config.Configuration) AdmissionHandler {
 	return func(ctx context.Context, logger logr.Logger, request *admissionv1.AdmissionRequest, startTime time.Time) *admissionv1.AdmissionResponse {
 		if c.ToFilter(request.Kind.Kind, request.Namespace, request.Name) {
+			return nil
+		}
+		if webhookutils.ExcludeKyvernoResources(request.Kind.Kind) {
 			return nil
 		}
 		return inner(ctx, logger, request, startTime)

--- a/pkg/webhooks/policy/handlers.go
+++ b/pkg/webhooks/policy/handlers.go
@@ -43,6 +43,6 @@ func (h *handlers) Validate(ctx context.Context, logger logr.Logger, request *ad
 	return admissionutils.Response(err, warnings...)
 }
 
-func (h *handlers) Mutate(ctx context.Context, logger logr.Logger, request *admissionv1.AdmissionRequest, _ time.Time) *admissionv1.AdmissionResponse {
+func (h *handlers) Mutate(_ context.Context, _ logr.Logger, _ *admissionv1.AdmissionRequest, _ time.Time) *admissionv1.AdmissionResponse {
 	return admissionutils.ResponseSuccess()
 }

--- a/pkg/webhooks/resource/handlers.go
+++ b/pkg/webhooks/resource/handlers.go
@@ -95,9 +95,6 @@ func NewHandlers(
 }
 
 func (h *handlers) Validate(ctx context.Context, logger logr.Logger, request *admissionv1.AdmissionRequest, failurePolicy string, startTime time.Time) *admissionv1.AdmissionResponse {
-	if webhookutils.ExcludeKyvernoResources(request.Kind.Kind) {
-		return admissionutils.ResponseSuccess()
-	}
 	kind := request.Kind.Kind
 	logger = logger.WithValues("kind", kind)
 	logger.V(4).Info("received an admission request in validating webhook")
@@ -145,9 +142,6 @@ func (h *handlers) Validate(ctx context.Context, logger logr.Logger, request *ad
 }
 
 func (h *handlers) Mutate(ctx context.Context, logger logr.Logger, request *admissionv1.AdmissionRequest, failurePolicy string, startTime time.Time) *admissionv1.AdmissionResponse {
-	if webhookutils.ExcludeKyvernoResources(request.Kind.Kind) {
-		return admissionutils.ResponseSuccess()
-	}
 	if request.Operation == admissionv1.Delete {
 		return admissionutils.ResponseSuccess()
 	}

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -103,7 +103,6 @@ func NewServer(
 		"POST",
 		config.PolicyMutatingWebhookServicePath,
 		handlers.FromAdmissionFunc("MUTATE", policyHandlers.Mutate).
-			WithFilter(configuration).
 			WithDump(debugModeOpts.DumpPayload).
 			WithMetrics(metricsConfig).
 			WithAdmission(policyLogger.WithName("mutate")).
@@ -113,7 +112,6 @@ func NewServer(
 		"POST",
 		config.PolicyValidatingWebhookServicePath,
 		handlers.FromAdmissionFunc("VALIDATE", policyHandlers.Validate).
-			WithFilter(configuration).
 			WithDump(debugModeOpts.DumpPayload).
 			WithMetrics(metricsConfig).
 			WithAdmission(policyLogger.WithName("validate")).


### PR DESCRIPTION
## Explanation

This PR removes filtering from policy admission handlers.
Filtering only applies to resource admission.
