### PR TITLE
issue-4613: Add support for cache enhancements with informers

### DIFF
--- a/pkg/engine/context/resolvers/constants.go
+++ b/pkg/engine/context/resolvers/constants.go
@@ -1,0 +1,7 @@
+package resolvers
+
+const (
+	TEST_NAMESPACE = "default"
+	TEST_CONFIGMAP = "myconfigmap"
+	LabelCacheKey  = "cache.kyverno.io/enabled"
+)

--- a/pkg/engine/context/resolvers/resolvers.go
+++ b/pkg/engine/context/resolvers/resolvers.go
@@ -1,0 +1,70 @@
+package resolvers
+
+import (
+	"context"
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+type informerBasedResolver struct {
+	lister corev1listers.ConfigMapLister
+}
+
+func NewInformerBasedResolver(lister corev1listers.ConfigMapLister) (ConfigmapResolver, error) {
+	if lister == nil {
+		return nil, errors.New("lister must not be nil")
+	}
+	return &informerBasedResolver{lister}, nil
+}
+
+func (i *informerBasedResolver) Get(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error) {
+	return i.lister.ConfigMaps(namespace).Get(name)
+}
+
+type clientBasedResolver struct {
+	kubeClient kubernetes.Interface
+}
+
+func NewClientBasedResolver(client kubernetes.Interface) (ConfigmapResolver, error) {
+	if client == nil {
+		return nil, errors.New("client must not be nil")
+	}
+	return &clientBasedResolver{client}, nil
+}
+
+func (c *clientBasedResolver) Get(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error) {
+	return c.kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+type resolverChain []ConfigmapResolver
+
+func NewResolverChain(resolvers ...ConfigmapResolver) (ConfigmapResolver, error) {
+	if len(resolvers) == 0 {
+		return nil, errors.New("no resolvers")
+	}
+	for _, resolver := range resolvers {
+		if resolver == nil {
+			return nil, errors.New("at least one resolver is nil")
+		}
+	}
+	return resolverChain(resolvers), nil
+}
+
+func (chain resolverChain) Get(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error) {
+	// if CM is not found in informer cache, error will be stored in
+	// lastErr variable and resolver chain will try to get CM using
+	// Kubernetes client
+	var lastErr error
+	for _, resolver := range chain {
+		cm, err := resolver.Get(ctx, namespace, name)
+		if err == nil {
+			return cm, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}

--- a/pkg/engine/context/resolvers/resolvers_test.go
+++ b/pkg/engine/context/resolvers/resolvers_test.go
@@ -1,0 +1,230 @@
+package resolvers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+func newEmptyFakeClient() *kubefake.Clientset {
+	return kubefake.NewSimpleClientset()
+}
+
+func createConfigMaps(ctx context.Context, client *kubefake.Clientset, addLabel bool) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TEST_CONFIGMAP,
+			Namespace: TEST_NAMESPACE,
+		},
+		Data: map[string]string{"configmapkey": "key1"},
+	}
+	if addLabel {
+		cm.ObjectMeta.Labels = map[string]string{LabelCacheKey: "true"}
+	}
+	_, err := client.CoreV1().ConfigMaps(TEST_NAMESPACE).Create(
+		ctx, cm, metav1.CreateOptions{})
+	return err
+}
+
+func initialiseInformer(client *kubefake.Clientset) kubeinformers.SharedInformerFactory {
+	selector, err := GetCacheSelector()
+	if err != nil {
+		return nil
+	}
+	labelOptions := kubeinformers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+		opts.LabelSelector = selector.String()
+	})
+	kubeResourceInformer := kubeinformers.NewSharedInformerFactoryWithOptions(client, 15*time.Minute, labelOptions)
+	return kubeResourceInformer
+}
+
+func Test_InformerCacheSuccess(t *testing.T) {
+	client := newEmptyFakeClient()
+	ctx := context.TODO()
+	err := createConfigMaps(ctx, client, true)
+	assert.NilError(t, err, "error while creating configmap")
+	informer := initialiseInformer(client)
+	informerResolver, err := NewInformerBasedResolver(informer.Core().V1().ConfigMaps().Lister())
+	assert.NilError(t, err)
+	informer.Start(make(<-chan struct{}))
+	time.Sleep(10 * time.Second)
+	_, err = informerResolver.Get(ctx, TEST_NAMESPACE, TEST_CONFIGMAP)
+	assert.NilError(t, err, "informer didn't have expected configmap")
+}
+
+func Test_InformerCacheFailure(t *testing.T) {
+	client := newEmptyFakeClient()
+	ctx := context.TODO()
+	err := createConfigMaps(ctx, client, false)
+	assert.NilError(t, err, "error while creating configmap")
+	informer := initialiseInformer(client)
+	resolver, err := NewInformerBasedResolver(informer.Core().V1().ConfigMaps().Lister())
+	assert.NilError(t, err)
+	informer.Start(make(<-chan struct{}))
+	time.Sleep(10 * time.Second)
+	_, err = resolver.Get(ctx, TEST_NAMESPACE, TEST_CONFIGMAP)
+	assert.Equal(t, err.Error(), "configmap \"myconfigmap\" not found")
+}
+
+func Test_ClientBasedResolver(t *testing.T) {
+	client := newEmptyFakeClient()
+	ctx := context.TODO()
+	err := createConfigMaps(ctx, client, false)
+	assert.NilError(t, err, "error while creating configmap")
+	resolver, err := NewClientBasedResolver(client)
+	assert.NilError(t, err)
+	_, err = resolver.Get(ctx, TEST_NAMESPACE, TEST_CONFIGMAP)
+	assert.NilError(t, err, "error while getting configmap from client")
+}
+
+func Test_ResolverChainWithExistingConfigMap(t *testing.T) {
+	client := newEmptyFakeClient()
+	informer := initialiseInformer(client)
+	lister := informer.Core().V1().ConfigMaps().Lister()
+	informerBasedResolver, err := NewInformerBasedResolver(lister)
+	assert.NilError(t, err)
+	clientBasedResolver, err := NewClientBasedResolver(client)
+	assert.NilError(t, err)
+	resolvers, err := NewResolverChain(informerBasedResolver, clientBasedResolver)
+	assert.NilError(t, err)
+	ctx := context.TODO()
+	err = createConfigMaps(ctx, client, true)
+	assert.NilError(t, err, "error while creating configmap")
+	_, err = resolvers.Get(ctx, TEST_NAMESPACE, TEST_CONFIGMAP)
+	assert.NilError(t, err, "error while getting configmap")
+}
+
+func Test_ResolverChainWithNonExistingConfigMap(t *testing.T) {
+	client := newEmptyFakeClient()
+	informer := initialiseInformer(client)
+	lister := informer.Core().V1().ConfigMaps().Lister()
+	informerBasedResolver, err := NewInformerBasedResolver(lister)
+	assert.NilError(t, err)
+	clientBasedResolver, err := NewClientBasedResolver(client)
+	assert.NilError(t, err)
+	resolvers, err := NewResolverChain(informerBasedResolver, clientBasedResolver)
+	assert.NilError(t, err)
+	ctx := context.TODO()
+	_, err = resolvers.Get(ctx, TEST_NAMESPACE, TEST_CONFIGMAP)
+	assert.Error(t, err, "configmaps \"myconfigmap\" not found")
+}
+
+func TestNewInformerBasedResolver(t *testing.T) {
+	type args struct {
+		lister corev1listers.ConfigMapLister
+	}
+	client := newEmptyFakeClient()
+	informer := initialiseInformer(client)
+	lister := informer.Core().V1().ConfigMaps().Lister()
+	tests := []struct {
+		name    string
+		args    args
+		want    ConfigmapResolver
+		wantErr bool
+	}{{
+		name:    "nil shoud return an error",
+		wantErr: true,
+	}, {
+		name: "not nil",
+		args: args{lister},
+		want: &informerBasedResolver{lister},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewInformerBasedResolver(tt.args.lister)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewInformerBasedResolver() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewInformerBasedResolver() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewClientBasedResolver(t *testing.T) {
+	type args struct {
+		client kubernetes.Interface
+	}
+	client := newEmptyFakeClient()
+	tests := []struct {
+		name    string
+		args    args
+		want    ConfigmapResolver
+		wantErr bool
+	}{{
+		name:    "nil shoud return an error",
+		wantErr: true,
+	}, {
+		name: "not nil",
+		args: args{client},
+		want: &clientBasedResolver{client},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewClientBasedResolver(tt.args.client)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewClientBasedResolver() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewClientBasedResolver() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type dummyResolver struct{}
+
+func (c dummyResolver) Get(context.Context, string, string) (*corev1.ConfigMap, error) {
+	return nil, nil
+}
+
+func TestNewResolverChain(t *testing.T) {
+	type args struct {
+		resolvers []ConfigmapResolver
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    ConfigmapResolver
+		wantErr bool
+	}{{
+		name:    "nil shoud return an error",
+		wantErr: true,
+	}, {
+		name:    "empty list shoud return an error",
+		args:    args{[]ConfigmapResolver{}},
+		wantErr: true,
+	}, {
+		name:    "one nil in the list shoud return an error",
+		args:    args{[]ConfigmapResolver{dummyResolver{}, nil}},
+		wantErr: true,
+	}, {
+		name: "no nil",
+		args: args{[]ConfigmapResolver{dummyResolver{}, dummyResolver{}, dummyResolver{}}},
+		want: resolverChain{dummyResolver{}, dummyResolver{}, dummyResolver{}},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewResolverChain(tt.args.resolvers...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewResolverChain() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewResolverChain() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/engine/context/resolvers/types.go
+++ b/pkg/engine/context/resolvers/types.go
@@ -1,0 +1,13 @@
+package resolvers
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type NamespacedResourceResolver[T any] interface {
+	Get(context.Context, string, string) (T, error)
+}
+
+type ConfigmapResolver = NamespacedResourceResolver[*corev1.ConfigMap]

--- a/pkg/engine/context/resolvers/utils.go
+++ b/pkg/engine/context/resolvers/utils.go
@@ -1,0 +1,38 @@
+package resolvers
+
+import (
+	"errors"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+)
+
+func GetCacheSelector() (labels.Selector, error) {
+	selector := labels.Everything()
+	requirement, err := labels.NewRequirement(LabelCacheKey, selection.Exists, nil)
+	if err != nil {
+		return nil, err
+	}
+	return selector.Add(*requirement), err
+}
+
+func GetCacheInformerFactory(client kubernetes.Interface, resyncPeriod time.Duration) (kubeinformers.SharedInformerFactory, error) {
+	if client == nil {
+		return nil, errors.New("client cannot be nil")
+	}
+	selector, err := GetCacheSelector()
+	if err != nil {
+		return nil, err
+	}
+	return kubeinformers.NewSharedInformerFactoryWithOptions(
+		client,
+		resyncPeriod,
+		kubeinformers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+			opts.LabelSelector = selector.String()
+		}),
+	), nil
+}

--- a/pkg/engine/context/resolvers/utils_test.go
+++ b/pkg/engine/context/resolvers/utils_test.go
@@ -1,0 +1,58 @@
+package resolvers
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+func TestGetCacheSelector(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    string
+		wantErr bool
+	}{{
+		name: "ok",
+		want: LabelCacheKey,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetCacheSelector()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetCacheSelector() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got.String(), tt.want) {
+				t.Errorf("GetCacheSelector() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetCacheInformerFactory(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    string
+		client  kubernetes.Interface
+		wantErr bool
+	}{{
+		name:    "nil client",
+		wantErr: true,
+		client:  nil,
+	}, {
+		name:    "ok",
+		wantErr: false,
+		client:  newEmptyFakeClient(),
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := GetCacheInformerFactory(tt.client, 10*time.Minute)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetCacheInformerFactor() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/pkg/engine/jsonContext.go
+++ b/pkg/engine/jsonContext.go
@@ -351,16 +351,14 @@ func fetchConfigMap(logger logr.Logger, entry kyvernov1.ContextEntry, ctx *Polic
 		namespace = "default"
 	}
 
-	obj, err := ctx.client.GetResource(context.TODO(), "v1", "ConfigMap", namespace.(string), name.(string))
+	obj, err := ctx.informerCacheResolvers.Get(context.TODO(), namespace.(string), name.(string))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get configmap %s/%s : %v", namespace, name, err)
 	}
 
-	unstructuredObj := obj.DeepCopy().Object
-
 	// extract configmap data
-	contextData["data"] = unstructuredObj["data"]
-	contextData["metadata"] = unstructuredObj["metadata"]
+	contextData["data"] = obj.Data
+	contextData["metadata"] = obj.ObjectMeta
 	data, err := json.Marshal(contextData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal configmap %s/%s: %v", namespace, name, err)

--- a/pkg/webhooks/resource/fake.go
+++ b/pkg/webhooks/resource/fake.go
@@ -7,6 +7,7 @@ import (
 	kyvernoinformers "github.com/kyverno/kyverno/pkg/client/informers/externalversions"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/config"
+	"github.com/kyverno/kyverno/pkg/engine/context/resolvers"
 	"github.com/kyverno/kyverno/pkg/event"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	"github.com/kyverno/kyverno/pkg/openapi"
@@ -14,7 +15,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/webhooks"
 	"github.com/kyverno/kyverno/pkg/webhooks/updaterequest"
 	webhookutils "github.com/kyverno/kyverno/pkg/webhooks/utils"
-	"k8s.io/client-go/informers"
+	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -22,11 +23,12 @@ func NewFakeHandlers(ctx context.Context, policyCache policycache.Cache) webhook
 	client := fake.NewSimpleClientset()
 	metricsConfig := metrics.NewFakeMetricsConfig()
 
-	informers := informers.NewSharedInformerFactory(client, 0)
+	informers := kubeinformers.NewSharedInformerFactory(client, 0)
 	informers.Start(ctx.Done())
 
 	kyvernoclient := fakekyvernov1.NewSimpleClientset()
 	kyvernoInformers := kyvernoinformers.NewSharedInformerFactory(kyvernoclient, 0)
+	configMapResolver, _ := resolvers.NewClientBasedResolver(client)
 	kyvernoInformers.Start(ctx.Done())
 
 	dclient := dclient.NewEmptyFakeClient()
@@ -47,7 +49,7 @@ func NewFakeHandlers(ctx context.Context, policyCache policycache.Cache) webhook
 		urGenerator:    updaterequest.NewFake(),
 		eventGen:       event.NewFake(),
 		openApiManager: openapi.NewFake(),
-		pcBuilder:      webhookutils.NewPolicyContextBuilder(configuration, dclient, rbLister, crbLister),
+		pcBuilder:      webhookutils.NewPolicyContextBuilder(configuration, dclient, rbLister, crbLister, configMapResolver),
 		urUpdater:      webhookutils.NewUpdateRequestUpdater(kyvernoclient, urLister),
 	}
 }

--- a/pkg/webhooks/resource/handlers.go
+++ b/pkg/webhooks/resource/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/common"
 	"github.com/kyverno/kyverno/pkg/config"
 	enginectx "github.com/kyverno/kyverno/pkg/engine/context"
+	"github.com/kyverno/kyverno/pkg/engine/context/resolvers"
 	engineutils2 "github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/kyverno/kyverno/pkg/event"
 	"github.com/kyverno/kyverno/pkg/metrics"
@@ -66,6 +67,7 @@ func NewHandlers(
 	configuration config.Configuration,
 	metricsConfig metrics.MetricsConfigManager,
 	pCache policycache.Cache,
+	informerCacheResolvers resolvers.ConfigmapResolver,
 	nsLister corev1listers.NamespaceLister,
 	rbLister rbacv1listers.RoleBindingLister,
 	crbLister rbacv1listers.ClusterRoleBindingLister,
@@ -88,7 +90,7 @@ func NewHandlers(
 		urGenerator:      urGenerator,
 		eventGen:         eventGen,
 		openApiManager:   openApiManager,
-		pcBuilder:        webhookutils.NewPolicyContextBuilder(configuration, client, rbLister, crbLister),
+		pcBuilder:        webhookutils.NewPolicyContextBuilder(configuration, client, rbLister, crbLister, informerCacheResolvers),
 		urUpdater:        webhookutils.NewUpdateRequestUpdater(kyvernoClient, urLister),
 		admissionReports: admissionReports,
 	}


### PR DESCRIPTION
Signed-off-by: Pratik Shah <pratik@infracloud.io>

## Explanation

This PR adds support for cache enhancements for ConfigMap using informers.

## Related issue

Closes #4613 

## Milestone of this PR

## What type of PR is this

/kind feature

## Proposed Changes

KDP: https://github.com/kyverno/KDP/pull/38

We create new filtered shared factory instance which filters CM with labels `"cache.kyverno.io/enabled": "true"`. In other words, any CM having these labels will be stored in informer cache.

Using these shared factory instance, we create a resolverChain which gets CM either from informer cache or by using Kubernetes client.

User needs to specify these labels at the time of CM creation. If user doesn't provide these labels, call to get CM will be made to API server which will use Kubernetes client and CM won't be cached.

### Proof Manifests

Policy:
```yaml
---
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  annotations:
    pod-policies.kyverno.io/autogen-controllers: none
  name: image-verify-polset
spec:
  background: false
  failurePolicy: Fail
  rules:
  - context:
    - configMap:
        name: myconfigmap1
        namespace: default
      name: myconfigmap1
    match:
      any:
      - resources:
          kinds:
          - Pod
    name: image-verify-pol1
    verifyImages:
    - imageReferences:
      - ghcr.io/*
      mutateDigest: false
      verifyDigest: false
      attestors:
      - entries:
        - keys:
            publicKeys: "{{myconfigmap1.data.configmapkey}}"
  validationFailureAction: Audit
  webhookTimeoutSeconds: 30
```
ConfigMaps:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: myconfigmap
data:
  configmapkey: |
    -----BEGIN PUBLIC KEY-----
    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
    5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
    -----END PUBLIC KEY-----
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: myconfigmap1
  labels:
    cache.kyverno.io/enabled: "true"
data:
  configmapkey: |
    -----BEGIN PUBLIC KEY-----
    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
    5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
    -----END PUBLIC KEY-----
```
Resource:
```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    run: test
  name: test
spec:
  containers:
  - image: ghcr.io/kyverno/test-verify-image:signed
    name: test
    resources: {}
```
Results:
```bash
$ kubectl create -f policy.yaml -f configmap.yaml 
clusterpolicy.kyverno.io/image-verify-polset created
configmap/myconfigmap created
configmap/myconfigmap1 created

$ kubectl create -f resource.yaml 
pod/test created
```

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [x] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is: 
  https://github.com/kyverno/website/issues/705