### PR TITLE
fix: generate namespace policy rule clone and sync behaviour 

### DIFF
--- a/pkg/background/common/util.go
+++ b/pkg/background/common/util.go
@@ -23,6 +23,7 @@ func Update(client versioned.Interface, urLister kyvernov1beta1listers.UpdateReq
 		}
 		ur = ur.DeepCopy()
 		mutator(ur)
+		ur.SetResourceVersion(ur.GetResourceVersion())
 		_, err = client.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace()).Update(context.TODO(), ur, metav1.UpdateOptions{})
 		if err != nil {
 			logging.Error(err, "[ATTEMPT] failed to update update request", "name", name)

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/01-policy.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/01-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- policy.yaml
+assert:
+- policy-ready.yaml
+- required-resources-ready.yaml

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/02-trigger.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/02-trigger.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+  - configmap.yaml
+assert:
+  - resource-assert.yaml

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/03-update-generated-resource.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/03-update-generated-resource.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+  - update-generated-resource.yaml
+assert:
+  - synchronized-generated-resource.yaml

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/README.md
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/README.md
@@ -1,0 +1,12 @@
+## Description
+
+This test verifies the synchronized behavior of generated resource. If the generated resource is updated, then the generated resource should revert to the source resource.
+
+## Expected Behavior
+
+This test ensures that any update in generated resource(Secret: myclonedsecret) should result in reverting the generated resource to the source resource, otherwise the test fails.
+The source resource is identified through the policy which created the generated resource. 
+
+## Reference Issue(s)
+
+#5100

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/configmap.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  test: test
+kind: ConfigMap
+metadata:
+  name: cm-2
+  namespace: poltest

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/policy-ready.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/policy-ready.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: pol-sync-clone
+  namespace: poltest
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/policy.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/policy.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: poltest
+---
+apiVersion: v1
+data:
+  foo: YmFy
+kind: Secret
+metadata:
+  name: regcred
+  namespace: poltest
+type: Opaque
+---
+apiVersion: kyverno.io/v2beta1
+kind: Policy
+metadata:
+  name: pol-sync-clone
+  namespace: poltest
+spec:
+  rules:
+  - name: gen-zk
+    match:
+      any:
+      - resources:
+          kinds:
+          - ConfigMap
+    generate:
+      apiVersion: v1
+      kind: Secret
+      name: myclonedsecret
+      namespace: poltest
+      synchronize: true
+      clone:
+        namespace: poltest
+        name: regcred

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/required-resources-ready.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/required-resources-ready.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: regcred
+  namespace: poltest
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: poltest
+status:
+  phase: Active

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/resource-assert.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/resource-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm-2
+  namespace: poltest
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: myclonedsecret
+  namespace: poltest

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/synchronized-generated-resource.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/synchronized-generated-resource.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+data:
+  foo: YmFy
+metadata:
+  name: myclonedsecret
+  namespace: poltest

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/update-generated-resource.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-update/update-generated-resource.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  foo: dGVzdDIk
+kind: Secret
+metadata:
+  name: myclonedsecret
+  namespace: poltest
+type: Opaque


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@nirmata.com>

## Explanation

 Fix the generate namespace policy clone and sync behaviour when the target resource gets updated to keep the downstream resource in sync.

## Related issue

Fixes #5100 
