### PR TITLE
chore: use builtin slices.Clone

### DIFF
--- a/pkg/engine/jsonutils/traverse.go
+++ b/pkg/engine/jsonutils/traverse.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kyverno/kyverno/pkg/utils"
+	"golang.org/x/exp/slices"
 )
 
 // ActionData represents data available for action on current element
@@ -73,7 +74,7 @@ func (t *Traversal) traverseJSON(element interface{}, path string) (interface{},
 		return t.traverseObject(utils.CopyMap(typed), path)
 
 	case []interface{}:
-		return t.traverseList(utils.CopySlice(typed), path)
+		return t.traverseList(slices.Clone(typed), path)
 
 	case []map[string]interface{}:
 		return t.traverseList(utils.CopySliceOfMaps(typed), path)

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -34,14 +34,6 @@ func CopyMap(m map[string]interface{}) map[string]interface{} {
 	return mapCopy
 }
 
-// CopySlice creates a full copy of the target slice
-func CopySlice(s []interface{}) []interface{} {
-	sliceCopy := make([]interface{}, len(s))
-	copy(sliceCopy, s)
-
-	return sliceCopy
-}
-
 // CopySliceOfMaps creates a full copy of the target slice
 func CopySliceOfMaps(s []map[string]interface{}) []interface{} {
 	sliceCopy := make([]interface{}, len(s))

--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -21,21 +21,6 @@ func Test_OriginalMapMustNotBeChanged(t *testing.T) {
 	assert.Equal(t, originalMap["r"], 2138)
 }
 
-func Test_OriginalSliceMustNotBeChanged(t *testing.T) {
-	// no variables
-	originalSlice := []interface{}{
-		3711,
-		2138,
-		1908,
-		912,
-	}
-
-	sliceCopy := CopySlice(originalSlice)
-	sliceCopy[0] = 1
-
-	assert.Equal(t, originalSlice[0], 3711)
-}
-
 func Test_containsNs(t *testing.T) {
 	var patterns []string
 	var res bool


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR makes use of builtin `slices.Clone` instead of our own implementation.
