### PR TITLE
cleanup: bring back action on `validation failed` logging (cherry-pick #5416)

### DIFF
--- a/pkg/webhooks/resource/validation/validation.go
+++ b/pkg/webhooks/resource/validation/validation.go
@@ -106,7 +106,7 @@ func (v *validationHandler) HandleValidation(
 
 		engineResponses = append(engineResponses, engineResponse)
 		if !engineResponse.IsSuccessful() {
-			logger.V(2).Info("validation failed", "policy", policy.GetName(), "failed rules", engineResponse.GetFailedRules())
+			logger.V(2).Info("validation failed", "action", policy.GetSpec().ValidationFailureAction, "policy", policy.GetName(), "failed rules", engineResponse.GetFailedRules())
 			continue
 		}
 


### PR DESCRIPTION
cleanup: bring back action on validation failed logging (cherry-pick #5416)