### PR TITLE
chore: bump flux action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,7 +125,7 @@ jobs:
           go-version: ~1.18.6
 
       - name: Setup Flux CLI
-        uses: fluxcd/flux2/action@1fa48bf916fa5ce5800190f8a0c9fdf7ae86559b # v0.35.0
+        uses: fluxcd/flux2/action@8674f31874b23ec1d03fc51efde27d1280d116db # v0.37.0
         with:
           version: 0.35.0
 


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR bumps flux action and sets correct release version.
