### PR TITLE
fix: replace + symbol with _ symbol on the Chart.Version field

### DIFF
--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -35,7 +35,7 @@ helm.sh/chart: {{ template "kyverno.chart" . }}
 app.kubernetes.io/component: kyverno
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ template "kyverno.name" . }}
-app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" }}"
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels }}
 {{- end }}
@@ -48,7 +48,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ template "kyverno.name" . }}-test
 app.kubernetes.io/part-of: {{ template "kyverno.name" . }}
-app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
+app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" }}"
 helm.sh/chart: {{ template "kyverno.chart" . }}
 {{- end -}}
 

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -35,7 +35,7 @@ helm.sh/chart: {{ template "kyverno.chart" . }}
 app.kubernetes.io/component: kyverno
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ template "kyverno.name" . }}
-app.kubernetes.io/version: "{{ .Chart.Version }}"
+app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels }}
 {{- end }}
@@ -48,7 +48,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ template "kyverno.name" . }}-test
 app.kubernetes.io/part-of: {{ template "kyverno.name" . }}
-app.kubernetes.io/version: "{{ .Chart.Version }}"
+app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
 helm.sh/chart: {{ template "kyverno.chart" . }}
 {{- end -}}
 


### PR DESCRIPTION
Signed-off-by: Jacob Lorenzen <jacob@lorenzen.me>

## Explanation

When using Flux the Chart version number can contain the plus symbol (+). 

This is not an allowed label field value.

The PR will replace plus symbol with underscore.

## What type of PR is this

/kind bug