### PR TITLE
fix: Panic on nil error

### DIFF
--- a/pkg/background/mutate/mutate.go
+++ b/pkg/background/mutate/mutate.go
@@ -158,7 +158,7 @@ func (c *MutateExistingController) report(err error, policy, rule string, target
 	var events []event.Info
 
 	if target == nil {
-		c.log.WithName("mutateExisting").Info("cannot generate events for empty target resource", "policy", policy, "rule", rule, "err", err.Error())
+		c.log.WithName("mutateExisting").Info("cannot generate events for empty target resource", "policy", policy, "rule", rule)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Explanation
This PR fixes the panic issue for background mutating, reported from [Slack](https://kubernetes.slack.com/archives/CLGR9BJU9/p1670469596364199) against Kyverno v1.7.X:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1ebbe0b]
goroutine 1126 [running]:
[k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0](http://k8s.io/apimachinery/pkg/util/runtime.HandleCrash(%7B0x0), 0x0, 0xfffffffe?})
	/go/pkg/mod/k8s.io/apimachinery@v0.23.5/pkg/util/runtime/runtime.go:55 +0xd8
panic({0x228d360, 0x4294410})
	/usr/local/go/src/runtime/panic.go:838 +0x207
[github.com/kyverno/kyverno/pkg/background/mutate.(*MutateExistingController).report(0xc001909848](http://github.com/kyverno/kyverno/pkg/background/mutate.(*MutateExistingController).report(0xc001909848), {0x0, 0x0}, {0xc001a40630, 0xf}, {0xc00474fb00, 0x1b}, 0x0)
	/src/pkg/background/mutate/mutate.go:173 +0xeb
[github.com/kyverno/kyverno/pkg/background/mutate.(*MutateExistingController).ProcessUR(0xc001909848](http://github.com/kyverno/kyverno/pkg/background/mutate.(*MutateExistingController).ProcessUR(0xc001909848), 0xc000662cc8)
	/src/pkg/background/mutate/mutate.go:122 +0xbf0
[github.com/kyverno/kyverno/pkg/background.(*controller).processUR(0x2faaf78](http://github.com/kyverno/kyverno/pkg/background.(*controller).processUR(0x2faaf78)?, 0xc000662cc8)
	/src/pkg/background/update_request_controller.go:322 +0x2a7
[github.com/kyverno/kyverno/pkg/background.(*controller).syncUpdateRequest(0xc0005fa600](http://github.com/kyverno/kyverno/pkg/background.(*controller).syncUpdateRequest(0xc0005fa600), {0xc001a40820, 0x10})
	/src/pkg/background/update_request_controller.go:232 +0x51c
[github.com/kyverno/kyverno/pkg/background.(*controller).processNextWorkItem(0xc0005fa600)](http://github.com/kyverno/kyverno/pkg/background.(*controller).processNextWorkItem(0xc0005fa600))
	/src/pkg/background/update_request_controller.go:142 +0xd6
[github.com/kyverno/kyverno/pkg/background.(*controller).worker(0xc00018c6a0?)](http://github.com/kyverno/kyverno/pkg/background.(*controller).worker(0xc00018c6a0?))
	/src/pkg/background/update_request_controller.go:131 +0x25
[k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x0?)](http://k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x0?))
	/go/pkg/mod/k8s.io/apimachinery@v0.23.5/pkg/util/wait/wait.go:155 +0x3e
[k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x21256e0](http://k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x21256e0)?, {0x2f84a80, 0xc000a562d0}, 0x1, 0xc0000a21e0)
	/go/pkg/mod/k8s.io/apimachinery@v0.23.5/pkg/util/wait/wait.go:156 +0xb6
[k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0](http://k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0)?, 0x3b9aca00, 0x0, 0x0?, 0x442025?)
	/go/pkg/mod/k8s.io/apimachinery@v0.23.5/pkg/util/wait/wait.go:133 +0x89
[k8s.io/apimachinery/pkg/util/wait.Until(0x0](http://k8s.io/apimachinery/pkg/util/wait.Until(0x0)?, 0xc0000a21e0?, 0x0?)
	/go/pkg/mod/k8s.io/apimachinery@v0.23.5/pkg/util/wait/wait.go:90 +0x25
```