### PR TITLE
feat: use lister in registry client

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -53,6 +53,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	metadatainformers "k8s.io/client-go/metadata/metadatainformer"
 	kyamlopenapi "sigs.k8s.io/kustomize/kyaml/openapi"
 )
@@ -61,7 +62,7 @@ const (
 	resyncPeriod = 15 * time.Minute
 )
 
-func setupRegistryClient(logger logr.Logger, kubeClient kubernetes.Interface, imagePullSecrets string, allowInsecureRegistry bool) (registryclient.Client, error) {
+func setupRegistryClient(logger logr.Logger, lister corev1listers.SecretNamespaceLister, imagePullSecrets string, allowInsecureRegistry bool) (registryclient.Client, error) {
 	logger = logger.WithName("registry-client")
 	logger.Info("setup registry client...", "secrets", imagePullSecrets, "insecure", allowInsecureRegistry)
 	var registryOptions []registryclient.Option
@@ -69,9 +70,7 @@ func setupRegistryClient(logger logr.Logger, kubeClient kubernetes.Interface, im
 	if imagePullSecrets != "" && len(secrets) > 0 {
 		registryOptions = append(registryOptions, registryclient.WithKeychainPullSecrets(
 			context.TODO(),
-			kubeClient,
-			config.KyvernoNamespace(),
-			"",
+			lister,
 			secrets...,
 		))
 	}
@@ -397,14 +396,6 @@ func main() {
 		logger.Error(err, "failed to create dynamic client")
 		os.Exit(1)
 	}
-	// setup registry client
-	rclient, err := setupRegistryClient(logger, kubeClient, imagePullSecrets, allowInsecureRegistry)
-	if err != nil {
-		logger.Error(err, "failed to setup registry client")
-		os.Exit(1)
-	}
-	// setup cosign
-	setupCosign(logger, imageSignatureRepository)
 	// THIS IS AN UGLY FIX
 	// ELSE KYAML IS NOT THREAD SAFE
 	kyamlopenapi.Schema()
@@ -423,6 +414,14 @@ func main() {
 		os.Exit(1)
 	}
 	secretLister := kubeKyvernoInformer.Core().V1().Secrets().Lister().Secrets(config.KyvernoNamespace())
+	// setup registry client
+	rclient, err := setupRegistryClient(logger, secretLister, imagePullSecrets, allowInsecureRegistry)
+	if err != nil {
+		logger.Error(err, "failed to setup registry client")
+		os.Exit(1)
+	}
+	// setup cosign
+	setupCosign(logger, imageSignatureRepository)
 	informerBasedResolver, err := resolvers.NewInformerBasedResolver(cacheInformer.Core().V1().ConfigMaps().Lister())
 	if err != nil {
 		logger.Error(err, "failed to create informer based resolver")

--- a/pkg/engine/imageVerify.go
+++ b/pkg/engine/imageVerify.go
@@ -82,11 +82,6 @@ func VerifyAndPatchImages(rclient registryclient.Client, policyContext *PolicyCo
 	policyContext.jsonContext.Checkpoint()
 	defer policyContext.jsonContext.Restore()
 
-	// update image registry secrets
-	if err := rclient.RefreshKeychainPullSecrets(context.TODO()); err != nil {
-		logger.Error(err, "failed to update image pull secrets")
-	}
-
 	ivm := &ImageVerificationMetadata{}
 	rules := autogen.ComputeRules(policyContext.policy)
 	applyRules := policy.GetSpec().GetApplyRules()

--- a/pkg/engine/jsonContext.go
+++ b/pkg/engine/jsonContext.go
@@ -142,9 +142,6 @@ func loadVariable(logger logr.Logger, entry kyvernov1.ContextEntry, ctx *PolicyC
 }
 
 func loadImageData(rclient registryclient.Client, logger logr.Logger, entry kyvernov1.ContextEntry, ctx *PolicyContext) error {
-	if err := rclient.RefreshKeychainPullSecrets(context.TODO()); err != nil {
-		return fmt.Errorf("unable to load image registry credentials, %w", err)
-	}
 	imageData, err := fetchImageData(rclient, logger, entry, ctx)
 	if err != nil {
 		return err

--- a/pkg/registryclient/utils.go
+++ b/pkg/registryclient/utils.go
@@ -5,20 +5,21 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	kauth "github.com/google/go-containerregistry/pkg/authn/kubernetes"
-	"github.com/pkg/errors"
-	"k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 // generateKeychainForPullSecrets generates keychain by fetching secrets data from imagePullSecrets.
-func generateKeychainForPullSecrets(ctx context.Context, client kubernetes.Interface, namespace, serviceAccount string, imagePullSecrets ...string) (authn.Keychain, error) {
-	kcOpts := kauth.Options{
-		Namespace:          namespace,
-		ServiceAccountName: serviceAccount,
-		ImagePullSecrets:   imagePullSecrets,
+func generateKeychainForPullSecrets(ctx context.Context, lister corev1listers.SecretNamespaceLister, imagePullSecrets ...string) (authn.Keychain, error) {
+	var secrets []corev1.Secret
+	for _, imagePullSecret := range imagePullSecrets {
+		secret, err := lister.Get(imagePullSecret)
+		if err == nil {
+			secrets = append(secrets, *secret)
+		} else if !k8serrors.IsNotFound(err) {
+			return nil, err
+		}
 	}
-	kc, err := kauth.New(ctx, client, kcOpts) // uses k8s client to fetch secrets data
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to initialize registry keychain")
-	}
-	return kc, err
+	return kauth.NewFromPullSecrets(ctx, secrets)
 }


### PR DESCRIPTION
## Explanation

This PR uses a lister in registry client to fetch image pull secrets instead of making api calls.
