### PR TITLE
fix: bump log level for autogen debug logs

### DIFF
--- a/pkg/autogen/autogen.go
+++ b/pkg/autogen/autogen.go
@@ -75,30 +75,30 @@ func CanAutoGen(spec *kyvernov1.Spec) (applyAutoGen bool, controllers string) {
 		}
 		match, exclude := rule.MatchResources, rule.ExcludeResources
 		if !checkAutogenSupport(&needed, match.ResourceDescription, exclude.ResourceDescription) {
-			logger.V(3).Info("skip generating rule on pod controllers: Name / Selector in resource description may not be applicable.", "rule", rule.Name)
+			debug.Info("skip generating rule on pod controllers: Name / Selector in resource description may not be applicable.", "rule", rule.Name)
 			return false, ""
 		}
 		for _, value := range match.Any {
 			if !checkAutogenSupport(&needed, value.ResourceDescription) {
-				logger.V(3).Info("skip generating rule on pod controllers: Name / Selector in match any block is not applicable.", "rule", rule.Name)
+				debug.Info("skip generating rule on pod controllers: Name / Selector in match any block is not applicable.", "rule", rule.Name)
 				return false, ""
 			}
 		}
 		for _, value := range match.All {
 			if !checkAutogenSupport(&needed, value.ResourceDescription) {
-				logger.V(3).Info("skip generating rule on pod controllers: Name / Selector in match all block is not applicable.", "rule", rule.Name)
+				debug.Info("skip generating rule on pod controllers: Name / Selector in match all block is not applicable.", "rule", rule.Name)
 				return false, ""
 			}
 		}
 		for _, value := range exclude.Any {
 			if !checkAutogenSupport(&needed, value.ResourceDescription) {
-				logger.V(3).Info("skip generating rule on pod controllers: Name / Selector in exclude any block is not applicable.", "rule", rule.Name)
+				debug.Info("skip generating rule on pod controllers: Name / Selector in exclude any block is not applicable.", "rule", rule.Name)
 				return false, ""
 			}
 		}
 		for _, value := range exclude.All {
 			if !checkAutogenSupport(&needed, value.ResourceDescription) {
-				logger.V(3).Info("skip generating rule on pod controllers: Name / Selector in exclud all block is not applicable.", "rule", rule.Name)
+				debug.Info("skip generating rule on pod controllers: Name / Selector in exclud all block is not applicable.", "rule", rule.Name)
 				return false, ""
 			}
 		}

--- a/pkg/autogen/log.go
+++ b/pkg/autogen/log.go
@@ -2,4 +2,7 @@ package autogen
 
 import "github.com/kyverno/kyverno/pkg/logging"
 
-var logger = logging.WithName("autogen")
+var (
+	logger = logging.WithName("autogen")
+	debug  = logger.V(5)
+)

--- a/pkg/autogen/rule.go
+++ b/pkg/autogen/rule.go
@@ -227,10 +227,10 @@ func getAnyAllAutogenRule(v kyvernov1.ResourceFilters, match string, kinds []str
 
 func generateRuleForControllers(rule *kyvernov1.Rule, controllers string) *kyvernov1.Rule {
 	if isAutogenRuleName(rule.Name) || controllers == "" {
-		logger.V(5).Info("skip generateRuleForControllers")
+		debug.Info("skip generateRuleForControllers")
 		return nil
 	}
-	logger.V(3).Info("processing rule", "rulename", rule.Name)
+	debug.Info("processing rule", "rulename", rule.Name)
 	match, exclude := rule.MatchResources, rule.ExcludeResources
 	matchKinds, excludeKinds := match.GetKinds(), exclude.GetKinds()
 	if !kubeutils.ContainsKind(matchKinds, "Pod") || (len(excludeKinds) != 0 && !kubeutils.ContainsKind(excludeKinds, "Pod")) {
@@ -283,7 +283,7 @@ func generateCronJobRule(rule *kyvernov1.Rule, controllers string) *kyvernov1.Ru
 	if !hasCronJob {
 		return nil
 	}
-	logger.V(3).Info("generating rule for cronJob")
+	debug.Info("generating rule for cronJob")
 	return generateRule(
 		getAutogenRuleName("autogen-cronjob", rule.Name),
 		generateRuleForControllers(rule, controllers),


### PR DESCRIPTION
## Explanation

This PR bumps log level for `autogen` debug logs.
Level 3 is too low, they are polluting logs too much.
