### PR TITLE
Revert "chore(deps): bump ossf/scorecard-action from 2.1.0 to 2.1.1 (#5724)

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@15c10fcf1cf912bd22260bfec67569a359ab87da # tag=v2.1.1
+        uses: ossf/scorecard-action@937ffa90d79c7d720498178154ad4c7ba1e4ad8c # tag=v2.1.0
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
This reverts commit 2d231d60c4324558c2cbd3e1be0bd2a33c895268 in #5724.

