### PR TITLE
fix: remove all category from all our CRDs

### DIFF
--- a/api/kyverno/v1/policy_types.go
+++ b/api/kyverno/v1/policy_types.go
@@ -21,7 +21,7 @@ import (
 // +kubebuilder:printcolumn:name="Mutate",type=integer,JSONPath=`.status.rulecount.mutate`,priority=1
 // +kubebuilder:printcolumn:name="Generate",type=integer,JSONPath=`.status.rulecount.generate`,priority=1
 // +kubebuilder:printcolumn:name="Verifyimages",type=integer,JSONPath=`.status.rulecount.verifyimages`,priority=1
-// +kubebuilder:resource:shortName=pol,categories=kyverno;all
+// +kubebuilder:resource:shortName=pol,categories=kyverno
 // +kubebuilder:storageversion
 
 // Policy declares validation, mutation, and generation behaviors for matching resources.

--- a/api/kyverno/v2beta1/policy_types.go
+++ b/api/kyverno/v2beta1/policy_types.go
@@ -22,7 +22,7 @@ import (
 // +kubebuilder:printcolumn:name="Mutate",type=integer,JSONPath=`.status.rulecount.mutate`,priority=1
 // +kubebuilder:printcolumn:name="Generate",type=integer,JSONPath=`.status.rulecount.generate`,priority=1
 // +kubebuilder:printcolumn:name="Verifyimages",type=integer,JSONPath=`.status.rulecount.verifyimages`,priority=1
-// +kubebuilder:resource:shortName=pol,categories=kyverno;all
+// +kubebuilder:resource:shortName=pol,categories=kyverno
 
 // Policy declares validation, mutation, and generation behaviors for matching resources.
 // See: https://kyverno.io/docs/writing-policies/ for more information.

--- a/charts/kyverno/templates/crds.yaml
+++ b/charts/kyverno/templates/crds.yaml
@@ -15991,7 +15991,6 @@ spec:
   names:
     categories:
     - kyverno
-    - all
     kind: Policy
     listKind: PolicyList
     plural: policies

--- a/config/crds/kyverno.io_policies.yaml
+++ b/config/crds/kyverno.io_policies.yaml
@@ -11,7 +11,6 @@ spec:
   names:
     categories:
     - kyverno
-    - all
     kind: Policy
     listKind: PolicyList
     plural: policies

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -16064,7 +16064,6 @@ spec:
   names:
     categories:
     - kyverno
-    - all
     kind: Policy
     listKind: PolicyList
     plural: policies


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR removes `all` category from all our CRDs.
