### PR TITLE
fix: error handling in last scan time parsing

### DIFF
--- a/pkg/controllers/report/background/controller.go
+++ b/pkg/controllers/report/background/controller.go
@@ -230,7 +230,8 @@ func (c *controller) updateReport(ctx context.Context, meta metav1.Object, gvk s
 		force = true
 	} else {
 		annTime, err := time.Parse(time.RFC3339, metaAnnotations[annotationLastScanTime])
-		if err == nil {
+		if err != nil {
+			logger.Error(err, "failed to parse last scan time", "namespace", resource.Namespace, "name", resource.Name)
 			force = true
 		} else {
 			force = time.Now().After(annTime.Add(c.forceDelay))


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR fixes error handling in last scan time parsing.
The condition check was actually wrong and checked error was nil instead of checking it was NOT nil.