### PR TITLE
Adds JMESPath filter for returning current time

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -71,6 +71,7 @@ var (
 	base64Decode           = "base64_decode"
 	base64Encode           = "base64_encode"
 	timeSince              = "time_since"
+	timeCurrent            = "time_current"
 	pathCanonicalize       = "path_canonicalize"
 	truncate               = "truncate"
 	semverCompare          = "semver_compare"
@@ -356,6 +357,16 @@ func GetFunctions() []*FunctionEntry {
 					{Types: []JpType{JpString}},
 				},
 				Handler: jpTimeSince,
+			},
+			ReturnType: []JpType{JpString},
+		},
+		{
+			Entry: &gojmespath.FunctionEntry{
+				Name: timeCurrent,
+				Arguments: []ArgSpec{
+					{Types: []JpType{JpString}},
+				},
+				Handler: jpTimeCurrent,
 			},
 			ReturnType: []JpType{JpString},
 		},
@@ -806,6 +817,29 @@ func jpTimeSince(arguments []interface{}) (interface{}, error) {
 	}
 
 	return t2.Sub(t1).String(), nil
+}
+
+func jpTimeCurrent(arguments []interface{}) (interface{}, error) {
+	var err error
+	layout, err := validateArg("", arguments, 0, reflect.String)
+	if err != nil {
+		return nil, err
+	}
+
+	var t time.Time
+
+	t = time.Now()
+	if layout.String() != "" {
+		t, err = time.Parse(layout.String(), t.String())
+	} else {
+		t, err = time.Parse(time.RFC3339, t.String())
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return t.String(), nil
 }
 
 func jpPathCanonicalize(arguments []interface{}) (interface{}, error) {

--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -71,7 +71,7 @@ var (
 	base64Decode           = "base64_decode"
 	base64Encode           = "base64_encode"
 	timeSince              = "time_since"
-	timeCurrent            = "time_current"
+	timeNow                = "time_now"
 	pathCanonicalize       = "path_canonicalize"
 	truncate               = "truncate"
 	semverCompare          = "semver_compare"
@@ -362,11 +362,11 @@ func GetFunctions() []*FunctionEntry {
 		},
 		{
 			Entry: &gojmespath.FunctionEntry{
-				Name: timeCurrent,
+				Name: timeNow,
 				Arguments: []ArgSpec{
 					{Types: []JpType{JpString}},
 				},
-				Handler: jpTimeCurrent,
+				Handler: jpTimeNow,
 			},
 			ReturnType: []JpType{JpString},
 		},
@@ -819,7 +819,7 @@ func jpTimeSince(arguments []interface{}) (interface{}, error) {
 	return t2.Sub(t1).String(), nil
 }
 
-func jpTimeCurrent(arguments []interface{}) (interface{}, error) {
+func jpTimeNow(arguments []interface{}) (interface{}, error) {
 	var err error
 	layout, err := validateArg("", arguments, 0, reflect.String)
 	if err != nil {

--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -369,6 +369,7 @@ func GetFunctions() []*FunctionEntry {
 				Handler: jpTimeNow,
 			},
 			ReturnType: []JpType{JpString},
+			Note:       "returns current time in RFC 3339 format",
 		},
 		{
 			Entry: &gojmespath.FunctionEntry{


### PR DESCRIPTION
Signed-off-by: Vishal Choudhary <contactvishaltech@gmail.com>

## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->
Adds a custom JMESPath filter which simply prints the current time in, minimally, RFC 3339 format.


## Related issue
Closes #5799 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind feature

## Proposed Changes

Add `time_now('<layout>')` JMESPath function

Policy
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: test-policy
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: test-rule
    match:
      resources:
        kinds:
          - Pod
    validate:
      message: "Denied"
      deny:
        conditions:
        - key: "{{ time_since('') }}"
          operator: Equals
          value: '2023-01-01T22:39:05-07:00'
```
Pod
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: myapp
spec:
  containers:
    - name: my-container
      image: nginx
```
Policy
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: test-policy
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: test-rule
    match:
      resources:
        kinds:
          - Pod
    validate:
      message: "Denied"
      deny:
        conditions:
        - key: "{{ time_since('2021-01-02T20:34:45Z') }}"
          operator: Equals
          value: '2023-01-01T22:29:45Z'

```
Pod
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: myapp
spec:
  containers:
    - name: my-container
      image: nginx
```
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
