### PR TITLE
chore: move ConvertToUnstructured from engine utils to kube utils (cherry-pick #5847)

### DIFF
--- a/cmd/cli/kubectl-kyverno/apply/report.go
+++ b/cmd/cli/kubectl-kyverno/apply/report.go
@@ -10,7 +10,7 @@ import (
 	policyreportv1alpha2 "github.com/kyverno/kyverno/api/policyreport/v1alpha2"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/utils/common"
 	"github.com/kyverno/kyverno/pkg/engine/response"
-	engineutils "github.com/kyverno/kyverno/pkg/engine/utils"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -60,7 +60,7 @@ func buildPolicyReports(pvInfos []common.Info) (res []*unstructured.Unstructured
 			}
 		}
 
-		reportUnstructured, err := engineutils.ConvertToUnstructured(raw)
+		reportUnstructured, err := kubeutils.BytesToUnstructured(raw)
 		if err != nil {
 			log.Log.V(3).Info("failed to convert policy report", "scope", scope, "error", err)
 			continue

--- a/cmd/cli/kubectl-kyverno/utils/common/common.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common.go
@@ -24,7 +24,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine"
 	engineContext "github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/engine/response"
-	ut "github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/kyverno/kyverno/pkg/engine/variables"
 	"github.com/kyverno/kyverno/pkg/registryclient"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
@@ -429,7 +428,7 @@ OuterLoop:
 		log.Log.Error(err, "failed to marshal resource")
 	}
 
-	updatedResource, err := ut.ConvertToUnstructured(resourceRaw)
+	updatedResource, err := kubeutils.BytesToUnstructured(resourceRaw)
 	if err != nil {
 		log.Log.Error(err, "unable to convert raw resource to unstructured")
 	}

--- a/cmd/cli/kubectl-kyverno/utils/common/fetch.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/fetch.go
@@ -14,7 +14,6 @@ import (
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/autogen"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
-	engineutils "github.com/kyverno/kyverno/pkg/engine/utils"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	yamlutils "github.com/kyverno/kyverno/pkg/utils/yaml"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -299,7 +298,7 @@ func convertResourceToUnstructured(resourceYaml []byte) (*unstructured.Unstructu
 		return nil, err
 	}
 
-	resource, err := engineutils.ConvertToUnstructured(resourceJSON)
+	resource, err := kubeutils.BytesToUnstructured(resourceJSON)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/background/generate/generate.go
+++ b/pkg/background/generate/generate.go
@@ -24,7 +24,6 @@ import (
 	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/engine/context/resolvers"
 	"github.com/kyverno/kyverno/pkg/engine/response"
-	"github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/kyverno/kyverno/pkg/engine/variables"
 	"github.com/kyverno/kyverno/pkg/event"
 	"github.com/kyverno/kyverno/pkg/registryclient"
@@ -813,7 +812,7 @@ func GetUnstrRule(rule *kyvernov1.Generation) (*unstructured.Unstructured, error
 	if err != nil {
 		return nil, err
 	}
-	return utils.ConvertToUnstructured(ruleData)
+	return kubeutils.BytesToUnstructured(ruleData)
 }
 
 func (c *GenerateController) ApplyResource(resource *unstructured.Unstructured) error {

--- a/pkg/clients/dclient/client.go
+++ b/pkg/clients/dclient/client.go
@@ -175,7 +175,7 @@ func (c *client) CreateResource(ctx context.Context, apiVersion string, kind str
 		options = metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}
 	}
 	// convert typed to unstructured obj
-	if unstructuredObj, err := kubeutils.ConvertToUnstructured(obj); err == nil && unstructuredObj != nil {
+	if unstructuredObj, err := kubeutils.ObjToUnstructured(obj); err == nil && unstructuredObj != nil {
 		return c.getResourceInterface(apiVersion, kind, namespace).Create(ctx, unstructuredObj, options)
 	}
 	return nil, fmt.Errorf("unable to create resource ")
@@ -188,7 +188,7 @@ func (c *client) UpdateResource(ctx context.Context, apiVersion string, kind str
 		options = metav1.UpdateOptions{DryRun: []string{metav1.DryRunAll}}
 	}
 	// convert typed to unstructured obj
-	if unstructuredObj, err := kubeutils.ConvertToUnstructured(obj); err == nil && unstructuredObj != nil {
+	if unstructuredObj, err := kubeutils.ObjToUnstructured(obj); err == nil && unstructuredObj != nil {
 		return c.getResourceInterface(apiVersion, kind, namespace).Update(ctx, unstructuredObj, options, subresources...)
 	}
 	return nil, fmt.Errorf("unable to update resource ")
@@ -201,7 +201,7 @@ func (c *client) UpdateStatusResource(ctx context.Context, apiVersion string, ki
 		options = metav1.UpdateOptions{DryRun: []string{metav1.DryRunAll}}
 	}
 	// convert typed to unstructured obj
-	if unstructuredObj, err := kubeutils.ConvertToUnstructured(obj); err == nil && unstructuredObj != nil {
+	if unstructuredObj, err := kubeutils.ObjToUnstructured(obj); err == nil && unstructuredObj != nil {
 		return c.getResourceInterface(apiVersion, kind, namespace).UpdateStatus(ctx, unstructuredObj, options)
 	}
 	return nil, fmt.Errorf("unable to update resource ")

--- a/pkg/engine/forceMutate_test.go
+++ b/pkg/engine/forceMutate_test.go
@@ -6,7 +6,7 @@ import (
 
 	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/engine/context"
-	"github.com/kyverno/kyverno/pkg/engine/utils"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -97,7 +97,7 @@ func Test_ForceMutateSubstituteVars(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	ctx := context.NewContext()
 	err = context.AddResource(ctx, rawResource)
@@ -202,7 +202,7 @@ func Test_ForceMutateSubstituteVarsWithPatchesJson6902(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	ctx := context.NewContext()
 	err = context.AddResource(ctx, rawResource)
@@ -288,7 +288,7 @@ func Test_ForceMutateSubstituteVarsWithPatchStrategicMerge(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	ctx := context.NewContext()
 	err = context.AddResource(ctx, rawResource)

--- a/pkg/engine/imageVerify_test.go
+++ b/pkg/engine/imageVerify_test.go
@@ -7,18 +7,18 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kyverno/kyverno/pkg/logging"
-	"github.com/kyverno/kyverno/pkg/registryclient"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	kubefake "k8s.io/client-go/kubernetes/fake"
-
 	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/cosign"
 	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/engine/context/resolvers"
 	"github.com/kyverno/kyverno/pkg/engine/response"
 	"github.com/kyverno/kyverno/pkg/engine/utils"
+	"github.com/kyverno/kyverno/pkg/logging"
+	"github.com/kyverno/kyverno/pkg/registryclient"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
 var testPolicyGood = `{
@@ -186,7 +186,7 @@ func buildContext(t *testing.T, policy, resource string, oldResource string) *Po
 	err := json.Unmarshal([]byte(policy), &cpol)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured([]byte(resource))
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(resource))
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -200,7 +200,7 @@ func buildContext(t *testing.T, policy, resource string, oldResource string) *Po
 	}
 
 	if oldResource != "" {
-		oldResourceUnstructured, err := utils.ConvertToUnstructured([]byte(oldResource))
+		oldResourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(oldResource))
 		assert.NilError(t, err)
 
 		err = enginecontext.AddOldResource(ctx, []byte(oldResource))

--- a/pkg/engine/mutate/mutation_test.go
+++ b/pkg/engine/mutate/mutation_test.go
@@ -4,17 +4,14 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/kyverno/kyverno/pkg/engine/context"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-
 	types "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/engine/response"
-
 	"github.com/kyverno/kyverno/pkg/logging"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"gotest.tools/assert"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/kyverno/kyverno/pkg/engine/utils"
 )
 
 // jsonPatch is used to build test patches
@@ -69,7 +66,7 @@ func applyPatches(rule *types.Rule, resource unstructured.Unstructured) (*respon
 
 func TestProcessPatches_EmptyPatches(t *testing.T) {
 	emptyRule := &types.Rule{Name: "emptyRule"}
-	resourceUnstructured, err := utils.ConvertToUnstructured([]byte(endpointsDocument))
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
 	if err != nil {
 		t.Error(err)
 	}
@@ -124,7 +121,7 @@ func TestProcessPatches_AddPathDoesntExist(t *testing.T) {
 	patch := makeAddIsMutatedLabelPatch()
 	patch.Path = "/metadata/additional/is-mutated"
 	rule := makeRuleWithPatch(t, patch)
-	resourceUnstructured, err := utils.ConvertToUnstructured([]byte(endpointsDocument))
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
 	if err != nil {
 		t.Error(err)
 	}
@@ -136,7 +133,7 @@ func TestProcessPatches_AddPathDoesntExist(t *testing.T) {
 func TestProcessPatches_RemovePathDoesntExist(t *testing.T) {
 	patch := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
 	rule := makeRuleWithPatch(t, patch)
-	resourceUnstructured, err := utils.ConvertToUnstructured([]byte(endpointsDocument))
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
 	if err != nil {
 		t.Error(err)
 	}
@@ -149,7 +146,7 @@ func TestProcessPatches_AddAndRemovePathsDontExist_EmptyResult(t *testing.T) {
 	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
 	patch2 := jsonPatch{Path: "/spec/labels/label3", Operation: "add", Value: "label3Value"}
 	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2})
-	resourceUnstructured, err := utils.ConvertToUnstructured([]byte(endpointsDocument))
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
 	if err != nil {
 		t.Error(err)
 	}
@@ -163,7 +160,7 @@ func TestProcessPatches_AddAndRemovePathsDontExist_ContinueOnError_NotEmptyResul
 	patch2 := jsonPatch{Path: "/spec/labels/label2", Operation: "remove", Value: "label2Value"}
 	patch3 := jsonPatch{Path: "/metadata/labels/label3", Operation: "add", Value: "label3Value"}
 	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2, patch3})
-	resourceUnstructured, err := utils.ConvertToUnstructured([]byte(endpointsDocument))
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
 	if err != nil {
 		t.Error(err)
 	}
@@ -177,7 +174,7 @@ func TestProcessPatches_AddAndRemovePathsDontExist_ContinueOnError_NotEmptyResul
 func TestProcessPatches_RemovePathDoesntExist_EmptyResult(t *testing.T) {
 	patch := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
 	rule := makeRuleWithPatch(t, patch)
-	resourceUnstructured, err := utils.ConvertToUnstructured([]byte(endpointsDocument))
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
 	if err != nil {
 		t.Error(err)
 	}
@@ -190,7 +187,7 @@ func TestProcessPatches_RemovePathDoesntExist_NotEmptyResult(t *testing.T) {
 	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
 	patch2 := jsonPatch{Path: "/metadata/labels/label2", Operation: "add", Value: "label2Value"}
 	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2})
-	resourceUnstructured, err := utils.ConvertToUnstructured([]byte(endpointsDocument))
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/engine/mutation_test.go
+++ b/pkg/engine/mutation_test.go
@@ -12,8 +12,8 @@ import (
 	client "github.com/kyverno/kyverno/pkg/clients/dclient"
 	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/engine/response"
-	"github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/kyverno/kyverno/pkg/registryclient"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -77,7 +77,7 @@ func Test_VariableSubstitutionPatchStrategicMerge(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 	ctx := enginecontext.NewContext()
 	err = enginecontext.AddResource(ctx, resourceRaw)
@@ -157,7 +157,7 @@ func Test_variableSubstitutionPathNotExist(t *testing.T) {
 	var policy kyverno.ClusterPolicy
 	err := json.Unmarshal(policyRaw, &policy)
 	assert.NilError(t, err)
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -253,7 +253,7 @@ func Test_variableSubstitutionCLI(t *testing.T) {
 	var policy kyverno.ClusterPolicy
 	err := json.Unmarshal(policyRaw, &policy)
 	assert.NilError(t, err)
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -356,7 +356,7 @@ func Test_chained_rules(t *testing.T) {
 	err := json.Unmarshal(policyRaw, &policy)
 	assert.NilError(t, err)
 
-	resource, err := utils.ConvertToUnstructured(resourceRaw)
+	resource, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -450,7 +450,7 @@ func Test_precondition(t *testing.T) {
 	var policy kyverno.ClusterPolicy
 	err := json.Unmarshal(policyRaw, &policy)
 	assert.NilError(t, err)
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -547,7 +547,7 @@ func Test_nonZeroIndexNumberPatchesJson6902(t *testing.T) {
 	var policy kyverno.ClusterPolicy
 	err := json.Unmarshal(policyraw, &policy)
 	assert.NilError(t, err)
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -635,7 +635,7 @@ func Test_foreach(t *testing.T) {
 	err := json.Unmarshal(policyRaw, &policy)
 	assert.NilError(t, err)
 
-	resource, err := utils.ConvertToUnstructured(resourceRaw)
+	resource, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -742,7 +742,7 @@ func Test_foreach_element_mutation(t *testing.T) {
 	err := json.Unmarshal(policyRaw, &policy)
 	assert.NilError(t, err)
 
-	resource, err := utils.ConvertToUnstructured(resourceRaw)
+	resource, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -868,7 +868,7 @@ func Test_Container_InitContainer_foreach(t *testing.T) {
 	err := json.Unmarshal(policyRaw, &policy)
 	assert.NilError(t, err)
 
-	resource, err := utils.ConvertToUnstructured(resourceRaw)
+	resource, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -1018,7 +1018,7 @@ func testApplyPolicyToResource(t *testing.T, policyRaw, resourceRaw []byte) *res
 	err := json.Unmarshal(policyRaw, &policy)
 	assert.NilError(t, err)
 
-	resource, err := utils.ConvertToUnstructured(resourceRaw)
+	resource, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -1557,11 +1557,11 @@ func Test_mutate_existing_resources(t *testing.T) {
 		err := json.Unmarshal(test.policy, &policy)
 		assert.NilError(t, err)
 
-		trigger, err := utils.ConvertToUnstructured(test.trigger)
+		trigger, err := kubeutils.BytesToUnstructured(test.trigger)
 		assert.NilError(t, err)
 
 		for _, target := range test.targets {
-			target, err := utils.ConvertToUnstructured(target)
+			target, err := kubeutils.BytesToUnstructured(target)
 			assert.NilError(t, err)
 
 			ctx := enginecontext.NewContext()
@@ -1679,7 +1679,7 @@ func Test_RuleSelectorMutate(t *testing.T) {
 		t.Error(err)
 	}
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 	ctx := enginecontext.NewContext()
 	err = enginecontext.AddResource(ctx, resourceRaw)
@@ -2058,7 +2058,7 @@ func Test_SpecialCharacters(t *testing.T) {
 			}
 
 			// Parse resource document.
-			resource, err := utils.ConvertToUnstructured(tt.documentRaw)
+			resource, err := kubeutils.BytesToUnstructured(tt.documentRaw)
 			if err != nil {
 				t.Fatalf("ConvertToUnstructured() error = %v", err)
 			}

--- a/pkg/engine/utils/utils.go
+++ b/pkg/engine/utils/utils.go
@@ -5,7 +5,6 @@ import (
 	commonAnchor "github.com/kyverno/kyverno/pkg/engine/anchor"
 	"github.com/kyverno/kyverno/pkg/logging"
 	jsonutils "github.com/kyverno/kyverno/pkg/utils/json"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // ApplyPatches patches given resource with given patches and returns patched document
@@ -44,16 +43,6 @@ func ApplyPatchNew(resource, patch []byte) ([]byte, error) {
 	}
 
 	return patchedResource, err
-}
-
-// ConvertToUnstructured converts the resource to unstructured format
-func ConvertToUnstructured(data []byte) (*unstructured.Unstructured, error) {
-	resource := &unstructured.Unstructured{}
-	err := resource.UnmarshalJSON(data)
-	if err != nil {
-		return nil, err
-	}
-	return resource, nil
 }
 
 // GetAnchorsFromMap gets the conditional anchor map

--- a/pkg/engine/utils_test.go
+++ b/pkg/engine/utils_test.go
@@ -9,7 +9,7 @@ import (
 	v1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/autogen"
-	"github.com/kyverno/kyverno/pkg/engine/utils"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"gotest.tools/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -902,7 +902,7 @@ func TestMatchesResourceDescription(t *testing.T) {
 		if err != nil {
 			t.Errorf("Testcase %d invalid policy raw", i+1)
 		}
-		resource, _ := utils.ConvertToUnstructured(tc.Resource)
+		resource, _ := kubeutils.BytesToUnstructured(tc.Resource)
 
 		for _, rule := range autogen.ComputeRules(&policy) {
 			err := MatchesResourceDescription(make(map[string]*metav1.APIResource), *resource, rule, tc.AdmissionInfo, []string{}, nil, "", "")
@@ -1807,7 +1807,7 @@ func TestMatchesResourceDescription_GenerateName(t *testing.T) {
 		if err != nil {
 			t.Errorf("Testcase %d invalid policy raw", i+1)
 		}
-		resource, _ := utils.ConvertToUnstructured(tc.Resource)
+		resource, _ := kubeutils.BytesToUnstructured(tc.Resource)
 
 		for _, rule := range autogen.ComputeRules(&policy) {
 			err := MatchesResourceDescription(make(map[string]*metav1.APIResource), *resource, rule, tc.AdmissionInfo, []string{}, nil, "", "")
@@ -1864,7 +1864,7 @@ func TestResourceDescriptionMatch_MultipleKind(t *testing.T) {
 		   }
 		}
 	 }`)
-	resource, err := utils.ConvertToUnstructured(rawResource)
+	resource, err := kubeutils.BytesToUnstructured(rawResource)
 	if err != nil {
 		t.Errorf("unable to convert raw resource to unstructured: %v", err)
 	}
@@ -1922,7 +1922,7 @@ func TestResourceDescriptionMatch_Name(t *testing.T) {
 		   }
 		}
 	 }`)
-	resource, err := utils.ConvertToUnstructured(rawResource)
+	resource, err := kubeutils.BytesToUnstructured(rawResource)
 	if err != nil {
 		t.Errorf("unable to convert raw resource to unstructured: %v", err)
 	}
@@ -1980,7 +1980,7 @@ func TestResourceDescriptionMatch_GenerateName(t *testing.T) {
 		   }
 		}
 	 }`)
-	resource, err := utils.ConvertToUnstructured(rawResource)
+	resource, err := kubeutils.BytesToUnstructured(rawResource)
 	if err != nil {
 		t.Errorf("unable to convert raw resource to unstructured: %v", err)
 	}
@@ -2039,7 +2039,7 @@ func TestResourceDescriptionMatch_Name_Regex(t *testing.T) {
 		   }
 		}
 	 }`)
-	resource, err := utils.ConvertToUnstructured(rawResource)
+	resource, err := kubeutils.BytesToUnstructured(rawResource)
 	if err != nil {
 		t.Errorf("unable to convert raw resource to unstructured: %v", err)
 	}
@@ -2097,7 +2097,7 @@ func TestResourceDescriptionMatch_GenerateName_Regex(t *testing.T) {
 		   }
 		}
 	 }`)
-	resource, err := utils.ConvertToUnstructured(rawResource)
+	resource, err := kubeutils.BytesToUnstructured(rawResource)
 	if err != nil {
 		t.Errorf("unable to convert raw resource to unstructured: %v", err)
 	}
@@ -2156,7 +2156,7 @@ func TestResourceDescriptionMatch_Label_Expression_NotMatch(t *testing.T) {
 		   }
 		}
 	 }`)
-	resource, err := utils.ConvertToUnstructured(rawResource)
+	resource, err := kubeutils.BytesToUnstructured(rawResource)
 	if err != nil {
 		t.Errorf("unable to convert raw resource to unstructured: %v", err)
 	}
@@ -2223,7 +2223,7 @@ func TestResourceDescriptionMatch_Label_Expression_Match(t *testing.T) {
 		   }
 		}
 	 }`)
-	resource, err := utils.ConvertToUnstructured(rawResource)
+	resource, err := kubeutils.BytesToUnstructured(rawResource)
 	if err != nil {
 		t.Errorf("unable to convert raw resource to unstructured: %v", err)
 	}
@@ -2292,7 +2292,7 @@ func TestResourceDescriptionExclude_Label_Expression_Match(t *testing.T) {
 		   }
 		}
 	 }`)
-	resource, err := utils.ConvertToUnstructured(rawResource)
+	resource, err := kubeutils.BytesToUnstructured(rawResource)
 	if err != nil {
 		t.Errorf("unable to convert raw resource to unstructured: %v", err)
 	}
@@ -2464,7 +2464,7 @@ func TestManagedPodResource(t *testing.T) {
 		err := json.Unmarshal(tc.policy, &policy)
 		assert.Assert(t, err == nil, "Test %d/%s invalid policy raw: %v", i+1, tc.name, err)
 
-		resource, _ := utils.ConvertToUnstructured(tc.resource)
+		resource, _ := kubeutils.BytesToUnstructured(tc.resource)
 		res := ManagedPodResource(&policy, *resource)
 		assert.Equal(t, res, tc.expectedResult, "test %d/%s failed, expect %v, got %v", i+1, tc.name, tc.expectedResult, res)
 	}

--- a/pkg/engine/validation_test.go
+++ b/pkg/engine/validation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/kyverno/kyverno/pkg/registryclient"
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"gotest.tools/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 )
@@ -126,7 +127,7 @@ func TestValidate_image_tag_fail(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	msgs := []string{
 		"validation rule 'validate-tag' passed.",
@@ -227,7 +228,7 @@ func TestValidate_image_tag_pass(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	msgs := []string{
 		"validation rule 'validate-tag' passed.",
@@ -305,7 +306,7 @@ func TestValidate_Fail_anyPattern(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	assert.Assert(t, !er.IsSuccessful())
@@ -388,7 +389,7 @@ func TestValidate_host_network_port(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	msgs := []string{"validation error: Host network and port are not allowed. rule validate-host-network-port failed at path /spec/containers/0/ports/0/hostPort/"}
@@ -478,7 +479,7 @@ func TestValidate_anchor_arraymap_pass(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	msgs := []string{"validation rule 'validate-host-path' passed."}
@@ -566,7 +567,7 @@ func TestValidate_anchor_arraymap_fail(t *testing.T) {
 	var policy kyverno.ClusterPolicy
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	msgs := []string{"validation error: Host path '/var/lib/' is not allowed. rule validate-host-path failed at path /spec/volumes/0/hostPath/path/"}
@@ -636,7 +637,7 @@ func TestValidate_anchor_map_notfound(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	msgs := []string{"validation rule 'pod rule 2' passed."}
@@ -709,7 +710,7 @@ func TestValidate_anchor_map_found_valid(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	msgs := []string{"validation rule 'pod rule 2' passed."}
@@ -783,7 +784,7 @@ func TestValidate_inequality_List_Processing(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	msgs := []string{"validation rule 'pod rule 2' passed."}
@@ -863,7 +864,7 @@ func TestValidate_inequality_List_ProcessingBrackets(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	msgs := []string{"validation rule 'pod rule 2' passed."}
@@ -937,7 +938,7 @@ func TestValidate_anchor_map_found_invalid(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	msgs := []string{"validation error: pod: validate run as non root user. rule pod rule 2 failed at path /spec/securityContext/runAsNonRoot/"}
@@ -1012,7 +1013,7 @@ func TestValidate_AnchorList_pass(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	msgs := []string{"validation rule 'pod image rule' passed."}
@@ -1087,7 +1088,7 @@ func TestValidate_AnchorList_fail(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	assert.Assert(t, !er.IsSuccessful())
@@ -1157,7 +1158,7 @@ func TestValidate_existenceAnchor_fail(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	assert.Assert(t, !er.IsSuccessful())
@@ -1227,7 +1228,7 @@ func TestValidate_existenceAnchor_pass(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	msgs := []string{"validation rule 'pod image rule' passed."}
@@ -1315,7 +1316,7 @@ func TestValidate_negationAnchor_deny(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	msgs := []string{"validation error: Host path is not allowed. rule validate-host-path failed at path /spec/volumes/0/hostPath/"}
@@ -1402,7 +1403,7 @@ func TestValidate_negationAnchor_pass(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})
 	msgs := []string{"validation rule 'validate-host-path' passed."}
@@ -1469,7 +1470,7 @@ func Test_VariableSubstitutionPathNotExistInPattern(t *testing.T) {
 	var policy kyverno.ClusterPolicy
 	err := json.Unmarshal(policyraw, &policy)
 	assert.NilError(t, err)
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -1563,7 +1564,7 @@ func Test_VariableSubstitutionPathNotExistInAnyPattern_OnePatternStatisfiesButSu
 
 	var policy kyverno.ClusterPolicy
 	assert.NilError(t, json.Unmarshal(policyraw, &policy))
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -1625,7 +1626,7 @@ func Test_VariableSubstitution_NotOperatorWithStringVariable(t *testing.T) {
 
 	var policy kyverno.ClusterPolicy
 	assert.NilError(t, json.Unmarshal(policyraw, &policy))
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -1717,7 +1718,7 @@ func Test_VariableSubstitutionPathNotExistInAnyPattern_AllPathNotPresent(t *test
 
 	var policy kyverno.ClusterPolicy
 	assert.NilError(t, json.Unmarshal(policyraw, &policy))
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -1811,7 +1812,7 @@ func Test_VariableSubstitutionPathNotExistInAnyPattern_AllPathPresent_NonePatter
 
 	var policy kyverno.ClusterPolicy
 	assert.NilError(t, json.Unmarshal(policyraw, &policy))
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -1917,7 +1918,7 @@ func Test_VariableSubstitutionValidate_VariablesInMessageAreResolved(t *testing.
 
 	var policy kyverno.ClusterPolicy
 	assert.NilError(t, json.Unmarshal(policyraw, &policy))
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -1971,7 +1972,7 @@ func Test_Flux_Kustomization_PathNotPresent(t *testing.T) {
 	for _, test := range tests {
 		var policy kyverno.ClusterPolicy
 		assert.NilError(t, json.Unmarshal(test.policyRaw, &policy))
-		resourceUnstructured, err := utils.ConvertToUnstructured(test.resourceRaw)
+		resourceUnstructured, err := kubeutils.BytesToUnstructured(test.resourceRaw)
 		assert.NilError(t, err)
 
 		ctx := enginecontext.NewContext()
@@ -2243,7 +2244,7 @@ func TestValidate_context_variable_substitution_CLI(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	msgs := []string{
 		"restrict pod counts to be no more than 10 on node minikube",
@@ -2334,7 +2335,7 @@ func Test_EmptyStringInDenyCondition(t *testing.T) {
 	err = enginecontext.AddResource(ctx, resourceRaw)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: ctx})
@@ -2423,7 +2424,7 @@ func Test_StringInDenyCondition(t *testing.T) {
 	err = enginecontext.AddResource(ctx, resourceRaw)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: ctx})
@@ -3093,7 +3094,7 @@ func Test_foreach_validate_nested(t *testing.T) {
 func testForEach(t *testing.T, policyraw []byte, resourceRaw []byte, msg string, status response.RuleStatus) {
 	var policy kyverno.ClusterPolicy
 	assert.NilError(t, json.Unmarshal(policyraw, &policy))
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -3157,7 +3158,7 @@ func Test_delete_ignore_pattern(t *testing.T) {
 
 	var policy kyverno.ClusterPolicy
 	assert.NilError(t, json.Unmarshal(policyRaw, &policy))
-	resourceUnstructured, err := utils.ConvertToUnstructured(resourceRaw)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
 	ctx := enginecontext.NewContext()
@@ -3234,7 +3235,7 @@ func Test_ValidatePattern_anyPattern(t *testing.T) {
 			err := json.Unmarshal(tc.rawPolicy, &policy)
 			assert.NilError(t, err)
 
-			resourceUnstructured, err := utils.ConvertToUnstructured(tc.rawResource)
+			resourceUnstructured, err := kubeutils.BytesToUnstructured(tc.rawResource)
 			assert.NilError(t, err)
 
 			er := Validate(context.TODO(), registryclient.NewOrDie(), &PolicyContext{policy: &policy, newResource: *resourceUnstructured, jsonContext: enginecontext.NewContext()})

--- a/pkg/utils/admission/resource.go
+++ b/pkg/utils/admission/resource.go
@@ -3,7 +3,7 @@ package admission
 import (
 	"fmt"
 
-	engineutils "github.com/kyverno/kyverno/pkg/engine/utils"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -50,7 +50,7 @@ func ExtractResources(newRaw []byte, request *admissionv1.AdmissionRequest) (uns
 
 // ConvertResource converts raw bytes to an unstructured object
 func ConvertResource(raw []byte, group, version, kind, namespace string) (unstructured.Unstructured, error) {
-	obj, err := engineutils.ConvertToUnstructured(raw)
+	obj, err := kubeutils.BytesToUnstructured(raw)
 	if err != nil {
 		return unstructured.Unstructured{}, fmt.Errorf("failed to convert raw to unstructured: %v", err)
 	}

--- a/pkg/utils/api/image_test.go
+++ b/pkg/utils/api/image_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
-	"github.com/kyverno/kyverno/pkg/engine/utils"
 	imageutils "github.com/kyverno/kyverno/pkg/utils/image"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"gotest.tools/assert"
 )
 
@@ -217,7 +217,7 @@ func Test_extractImageInfo(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		resource, err := utils.ConvertToUnstructured(test.raw)
+		resource, err := kubeutils.BytesToUnstructured(test.raw)
 		assert.NilError(t, err)
 		images, err := ExtractImagesFromResource(*resource, test.extractionConfig)
 		assert.NilError(t, err)

--- a/pkg/utils/kube/unstructured.go
+++ b/pkg/utils/kube/unstructured.go
@@ -6,7 +6,17 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func ConvertToUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
+// BytesToUnstructured converts the resource to unstructured format
+func BytesToUnstructured(data []byte) (*unstructured.Unstructured, error) {
+	resource := &unstructured.Unstructured{}
+	err := resource.UnmarshalJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	return resource, nil
+}
+
+func ObjToUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
 	raw, err := json.Marshal(obj)
 	if err != nil {
 		return nil, err

--- a/pkg/utils/kube/unstructured_test.go
+++ b/pkg/utils/kube/unstructured_test.go
@@ -53,10 +53,9 @@ func TestConvertToUnstructured(t *testing.T) {
 			err:  fmt.Errorf("json: cannot unmarshal number into Go value of type map[string]interface {}"),
 		},
 	}
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := ConvertToUnstructured(tc.obj)
+			got, err := ObjToUnstructured(tc.obj)
 			if (err != nil) != (tc.err != nil) {
 				t.Errorf("expected error %v but got %v", tc.err, err)
 			}

--- a/pkg/webhooks/handlers/dump.go
+++ b/pkg/webhooks/handlers/dump.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	engineutils "github.com/kyverno/kyverno/pkg/engine/utils"
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -66,7 +65,7 @@ func newAdmissionRequestPayload(request *admissionv1.AdmissionRequest) (*admissi
 	}
 	options := new(unstructured.Unstructured)
 	if request.Options.Raw != nil {
-		options, err = engineutils.ConvertToUnstructured(request.Options.Raw)
+		options, err = kubeutils.BytesToUnstructured(request.Options.Raw)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/webhooks/resource/generation/generation.go
+++ b/pkg/webhooks/resource/generation/generation.go
@@ -17,11 +17,11 @@ import (
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/engine"
 	"github.com/kyverno/kyverno/pkg/engine/response"
-	enginutils "github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/kyverno/kyverno/pkg/event"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	"github.com/kyverno/kyverno/pkg/registryclient"
 	engineutils "github.com/kyverno/kyverno/pkg/utils/engine"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	webhookgenerate "github.com/kyverno/kyverno/pkg/webhooks/updaterequest"
 	webhookutils "github.com/kyverno/kyverno/pkg/webhooks/utils"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -136,7 +136,7 @@ func (h *generationHandler) HandleUpdatesForGenerateRules(ctx context.Context, r
 		return
 	}
 
-	resource, err := enginutils.ConvertToUnstructured(request.OldObject.Raw)
+	resource, err := kubeutils.BytesToUnstructured(request.OldObject.Raw)
 	if err != nil {
 		h.log.Error(err, "failed to convert object resource to unstructured format")
 	}
@@ -184,7 +184,7 @@ func (h *generationHandler) handleUpdateGenerateSourceResource(ctx context.Conte
 // handleUpdateGenerateTargetResource - handles update of target resource for generate policy
 func (h *generationHandler) handleUpdateGenerateTargetResource(ctx context.Context, request *admissionv1.AdmissionRequest, policies []kyvernov1.PolicyInterface, resLabels map[string]string) {
 	enqueueBool := false
-	newRes, err := enginutils.ConvertToUnstructured(request.Object.Raw)
+	newRes, err := kubeutils.BytesToUnstructured(request.Object.Raw)
 	if err != nil {
 		h.log.Error(err, "failed to convert object resource to unstructured format")
 	}

--- a/pkg/webhooks/resource/handlers.go
+++ b/pkg/webhooks/resource/handlers.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/config"
 	enginectx "github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/engine/context/resolvers"
-	engineutils2 "github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/kyverno/kyverno/pkg/event"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	"github.com/kyverno/kyverno/pkg/openapi"
@@ -24,6 +23,7 @@ import (
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	engineutils "github.com/kyverno/kyverno/pkg/utils/engine"
 	jsonutils "github.com/kyverno/kyverno/pkg/utils/json"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"github.com/kyverno/kyverno/pkg/webhooks"
 	"github.com/kyverno/kyverno/pkg/webhooks/resource/generation"
 	"github.com/kyverno/kyverno/pkg/webhooks/resource/imageverification"
@@ -199,7 +199,7 @@ func (h *handlers) Mutate(ctx context.Context, logger logr.Logger, request *admi
 
 func (h *handlers) handleDelete(logger logr.Logger, request *admissionv1.AdmissionRequest) {
 	if request.Operation == admissionv1.Delete {
-		resource, err := engineutils2.ConvertToUnstructured(request.OldObject.Raw)
+		resource, err := kubeutils.BytesToUnstructured(request.OldObject.Raw)
 		if err != nil {
 			logger.Error(err, "failed to convert object resource to unstructured format")
 		}

--- a/pkg/webhooks/resource/validation_test.go
+++ b/pkg/webhooks/resource/validation_test.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"testing"
 
-	log "github.com/kyverno/kyverno/pkg/logging"
-	"github.com/kyverno/kyverno/pkg/registryclient"
-
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/engine"
 	"github.com/kyverno/kyverno/pkg/engine/response"
-	"github.com/kyverno/kyverno/pkg/engine/utils"
+	log "github.com/kyverno/kyverno/pkg/logging"
+	"github.com/kyverno/kyverno/pkg/registryclient"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	webhookutils "github.com/kyverno/kyverno/pkg/webhooks/utils"
 	"gotest.tools/assert"
 )
@@ -528,7 +527,7 @@ func TestValidate_failure_action_overrides(t *testing.T) {
 			var policy kyvernov1.ClusterPolicy
 			err := json.Unmarshal(tc.rawPolicy, &policy)
 			assert.NilError(t, err)
-			resourceUnstructured, err := utils.ConvertToUnstructured(tc.rawResource)
+			resourceUnstructured, err := kubeutils.BytesToUnstructured(tc.rawResource)
 			assert.NilError(t, err)
 
 			er := engine.Validate(
@@ -589,7 +588,7 @@ func Test_RuleSelector(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.NilError(t, err)
 
-	resourceUnstructured, err := utils.ConvertToUnstructured(rawResource)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
 	assert.Assert(t, resourceUnstructured != nil)
 


### PR DESCRIPTION
chore: move ConvertToUnstructured from engine utils to kube utils (cherry-pick #5847)