### PR TITLE
refactor: improve background scan reconciliation

### DIFF
--- a/pkg/controllers/report/background/controller.go
+++ b/pkg/controllers/report/background/controller.go
@@ -159,26 +159,29 @@ func (c *controller) deletePolicy(obj kyvernov1.PolicyInterface) {
 }
 
 func (c *controller) enqueue(selector labels.Selector) error {
-	bgscans, err := c.bgscanrLister.List(selector)
-	if err != nil {
-		return err
+	for _, key := range c.metadataCache.GetAllResourceKeys() {
+		c.queue.Add(key)
 	}
-	for _, bgscan := range bgscans {
-		err = c.bgscanEnqueue(bgscan)
-		if err != nil {
-			logger.Error(err, "failed to enqueue")
-		}
-	}
-	cbgscans, err := c.cbgscanrLister.List(selector)
-	if err != nil {
-		return err
-	}
-	for _, cbgscan := range cbgscans {
-		err = c.cbgscanEnqueue(cbgscan)
-		if err != nil {
-			logger.Error(err, "failed to enqueue")
-		}
-	}
+	// bgscans, err := c.bgscanrLister.List(selector)
+	// if err != nil {
+	// 	return err
+	// }
+	// for _, bgscan := range bgscans {
+	// 	err = c.bgscanEnqueue(bgscan)
+	// 	if err != nil {
+	// 		logger.Error(err, "failed to enqueue")
+	// 	}
+	// }
+	// cbgscans, err := c.cbgscanrLister.List(selector)
+	// if err != nil {
+	// 	return err
+	// }
+	// for _, cbgscan := range cbgscans {
+	// 	err = c.cbgscanEnqueue(cbgscan)
+	// 	if err != nil {
+	// 		logger.Error(err, "failed to enqueue")
+	// 	}
+	// }
 	return nil
 }
 

--- a/pkg/controllers/report/background/controller.go
+++ b/pkg/controllers/report/background/controller.go
@@ -425,5 +425,12 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, _, names
 		}
 		return err
 	}
+	defer func() {
+		if report.GetNamespace() == "" {
+			c.queue.AddAfter(report.GetName(), enqueueDelay)
+		} else {
+			c.queue.AddAfter(report.GetNamespace()+"/"+report.GetName(), enqueueDelay)
+		}
+	}()
 	return c.updateReport(ctx, report, gvk, resource)
 }

--- a/pkg/utils/controller/metadata.go
+++ b/pkg/utils/controller/metadata.go
@@ -50,6 +50,15 @@ func SetAnnotation(obj metav1.Object, key, value string) {
 	obj.SetAnnotations(annotations)
 }
 
+func HasAnnotation(obj metav1.Object, key string) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, exists := annotations[key]
+	return exists
+}
+
 func SetOwner(obj metav1.Object, apiVersion, kind, name string, uid types.UID) {
 	obj.SetOwnerReferences([]metav1.OwnerReference{{
 		APIVersion: apiVersion,


### PR DESCRIPTION
## Explanation

This PR improves background scan reconciliation:
- does not create empty reports
- unifies the full/partial report rebuild paths
- simplifies the reconciliation logic (needs reconcile/reconcile)
