### PR TITLE
fix: Configure webhook to add `ephemeralcontainers` for policies matching on Pod

### DIFF
--- a/pkg/controllers/webhook/utils.go
+++ b/pkg/controllers/webhook/utils.go
@@ -31,6 +31,11 @@ func (wh *webhook) buildRulesWithOperations(ops ...admissionregistrationv1.Opera
 	var rules []admissionregistrationv1.RuleWithOperations
 	for gvr := range wh.rules {
 		resources := sets.New(gvr.Resource)
+		ephemeralContainersGVR := schema.GroupVersionResource{Resource: "pods/ephemeralcontainers", Group: "", Version: "v1"}
+		_, rulesContainEphemeralContainers := wh.rules[ephemeralContainersGVR]
+		if resources.Has("pods") && !rulesContainEphemeralContainers {
+			resources.Insert("pods/ephemeralcontainers")
+		}
 		rules = append(rules, admissionregistrationv1.RuleWithOperations{
 			Rule: admissionregistrationv1.Rule{
 				APIGroups:   []string{gvr.Group},

--- a/pkg/engine/utils.go
+++ b/pkg/engine/utils.go
@@ -116,7 +116,8 @@ func doesResourceMatchConditionBlock(subresourceGVKToAPIResource map[string]*met
 	var errs []error
 
 	if len(conditionBlock.Kinds) > 0 {
-		if !matched.CheckKind(subresourceGVKToAPIResource, conditionBlock.Kinds, resource.GroupVersionKind(), subresourceInAdmnReview) {
+		// Matching on ephemeralcontainers even when they are not explicitly specified for backward compatibility.
+		if !matched.CheckKind(subresourceGVKToAPIResource, conditionBlock.Kinds, resource.GroupVersionKind(), subresourceInAdmnReview, true) {
 			errs = append(errs, fmt.Errorf("kind does not match %v", conditionBlock.Kinds))
 		}
 	}

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -407,7 +407,6 @@ func Validate(policy kyvernov1.PolicyInterface, client dclient.Interface, mock b
 			}
 			checkForScaleSubresource(validationJson, allKinds, &warnings)
 			checkForStatusSubresource(validationJson, allKinds, &warnings)
-			checkForEphemeralContainersSubresource(validationJson, allKinds, &warnings)
 		}
 
 		if rule.HasMutate() {
@@ -421,7 +420,6 @@ func Validate(policy kyvernov1.PolicyInterface, client dclient.Interface, mock b
 			}
 			checkForScaleSubresource(mutationJson, allKinds, &warnings)
 			checkForStatusSubresource(mutationJson, allKinds, &warnings)
-			checkForEphemeralContainersSubresource(mutationJson, allKinds, &warnings)
 		}
 	}
 	if !mock && (spec.SchemaValidation == nil || *spec.SchemaValidation) {
@@ -1335,18 +1333,6 @@ func checkForStatusSubresource(ruleTypeJson []byte, allKinds []string, warnings 
 			}
 		}
 		msg := "You are matching on status but not including the status subresource in the policy."
-		*warnings = append(*warnings, msg)
-	}
-}
-
-func checkForEphemeralContainersSubresource(ruleTypeJson []byte, allKinds []string, warnings *[]string) {
-	if strings.Contains(string(ruleTypeJson), "ephemeralcontainers") {
-		for _, kind := range allKinds {
-			if strings.Contains(strings.ToLower(kind), "ephemeralcontainers") {
-				return
-			}
-		}
-		msg := "You are matching on ephemeralcontainers but not including the ephemeralcontainers subresource in the policy."
 		*warnings = append(*warnings, msg)
 	}
 }

--- a/pkg/utils/match/match_test.go
+++ b/pkg/utils/match/match_test.go
@@ -10,27 +10,31 @@ import (
 
 func Test_CheckKind(t *testing.T) {
 	subresourceGVKToAPIResource := make(map[string]*metav1.APIResource)
-	match := CheckKind(subresourceGVKToAPIResource, []string{"*"}, schema.GroupVersionKind{Kind: "Deployment", Group: "", Version: "v1"}, "")
+	match := CheckKind(subresourceGVKToAPIResource, []string{"*"}, schema.GroupVersionKind{Kind: "Deployment", Group: "", Version: "v1"}, "", false)
 	assert.Equal(t, match, true)
 
-	match = CheckKind(subresourceGVKToAPIResource, []string{"Pod"}, schema.GroupVersionKind{Kind: "Pod", Group: "", Version: "v1"}, "")
+	match = CheckKind(subresourceGVKToAPIResource, []string{"Pod"}, schema.GroupVersionKind{Kind: "Pod", Group: "", Version: "v1"}, "", false)
 	assert.Equal(t, match, true)
 
-	match = CheckKind(subresourceGVKToAPIResource, []string{"v1/Pod"}, schema.GroupVersionKind{Kind: "Pod", Group: "", Version: "v1"}, "")
+	match = CheckKind(subresourceGVKToAPIResource, []string{"v1/Pod"}, schema.GroupVersionKind{Kind: "Pod", Group: "", Version: "v1"}, "", false)
 	assert.Equal(t, match, true)
 
-	match = CheckKind(subresourceGVKToAPIResource, []string{"tekton.dev/v1beta1/TaskRun"}, schema.GroupVersionKind{Kind: "TaskRun", Group: "tekton.dev", Version: "v1beta1"}, "")
+	match = CheckKind(subresourceGVKToAPIResource, []string{"tekton.dev/v1beta1/TaskRun"}, schema.GroupVersionKind{Kind: "TaskRun", Group: "tekton.dev", Version: "v1beta1"}, "", false)
 	assert.Equal(t, match, true)
 
-	match = CheckKind(subresourceGVKToAPIResource, []string{"tekton.dev/*/TaskRun"}, schema.GroupVersionKind{Kind: "TaskRun", Group: "tekton.dev", Version: "v1alpha1"}, "")
+	match = CheckKind(subresourceGVKToAPIResource, []string{"tekton.dev/*/TaskRun"}, schema.GroupVersionKind{Kind: "TaskRun", Group: "tekton.dev", Version: "v1alpha1"}, "", false)
 	assert.Equal(t, match, true)
 
 	// Though both 'pods', 'pods/status' have same kind i.e. 'Pod' but they are different resources, 'subresourceInAdmnReview' is used in determining that.
-	match = CheckKind(subresourceGVKToAPIResource, []string{"v1/Pod"}, schema.GroupVersionKind{Kind: "Pod", Group: "", Version: "v1"}, "status")
+	match = CheckKind(subresourceGVKToAPIResource, []string{"v1/Pod"}, schema.GroupVersionKind{Kind: "Pod", Group: "", Version: "v1"}, "status", false)
 	assert.Equal(t, match, false)
 
-	// Though both 'pods', 'pods/status' have same kind i.e. 'Pod' but they are different resources, 'subresourceInAdmnReview' is used in determining that.
-	match = CheckKind(subresourceGVKToAPIResource, []string{"v1/Pod"}, schema.GroupVersionKind{Kind: "Pod", Group: "", Version: "v1"}, "ephemeralcontainers")
+	// Though both 'pods', 'pods/ephemeralcontainers' have same kind i.e. 'Pod' but they are different resources, allowEphemeralContainers governs how to match this case.
+	match = CheckKind(subresourceGVKToAPIResource, []string{"v1/Pod"}, schema.GroupVersionKind{Kind: "Pod", Group: "", Version: "v1"}, "ephemeralcontainers", true)
+	assert.Equal(t, match, true)
+
+	// Though both 'pods', 'pods/ephemeralcontainers' have same kind i.e. 'Pod' but they are different resources, allowEphemeralContainers governs how to match this case.
+	match = CheckKind(subresourceGVKToAPIResource, []string{"v1/Pod"}, schema.GroupVersionKind{Kind: "Pod", Group: "", Version: "v1"}, "ephemeralcontainers", false)
 	assert.Equal(t, match, false)
 
 	subresourceGVKToAPIResource["networking.k8s.io/v1/NetworkPolicy/status"] = &metav1.APIResource{
@@ -60,15 +64,15 @@ func Test_CheckKind(t *testing.T) {
 		Version:      "v1",
 	}
 
-	match = CheckKind(subresourceGVKToAPIResource, []string{"networking.k8s.io/v1/NetworkPolicy/status"}, schema.GroupVersionKind{Kind: "NetworkPolicy", Group: "networking.k8s.io", Version: "v1"}, "status")
+	match = CheckKind(subresourceGVKToAPIResource, []string{"networking.k8s.io/v1/NetworkPolicy/status"}, schema.GroupVersionKind{Kind: "NetworkPolicy", Group: "networking.k8s.io", Version: "v1"}, "status", false)
 	assert.Equal(t, match, true)
 
-	match = CheckKind(subresourceGVKToAPIResource, []string{"v1/Pod.status"}, schema.GroupVersionKind{Kind: "Pod", Group: "", Version: "v1"}, "status")
+	match = CheckKind(subresourceGVKToAPIResource, []string{"v1/Pod.status"}, schema.GroupVersionKind{Kind: "Pod", Group: "", Version: "v1"}, "status", false)
 	assert.Equal(t, match, true)
 
-	match = CheckKind(subresourceGVKToAPIResource, []string{"*/Pod.eviction"}, schema.GroupVersionKind{Kind: "Eviction", Group: "policy", Version: "v1"}, "eviction")
+	match = CheckKind(subresourceGVKToAPIResource, []string{"*/Pod.eviction"}, schema.GroupVersionKind{Kind: "Eviction", Group: "policy", Version: "v1"}, "eviction", false)
 	assert.Equal(t, match, true)
 
-	match = CheckKind(subresourceGVKToAPIResource, []string{"v1alpha1/Pod.eviction"}, schema.GroupVersionKind{Kind: "Eviction", Group: "policy", Version: "v1"}, "eviction")
+	match = CheckKind(subresourceGVKToAPIResource, []string{"v1alpha1/Pod.eviction"}, schema.GroupVersionKind{Kind: "Eviction", Group: "policy", Version: "v1"}, "eviction", false)
 	assert.Equal(t, match, false)
 }


### PR DESCRIPTION
Signed-off-by: Vyom-Yadav <jackhammervyom@gmail.com>

## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

https://github.com/kyverno/kyverno/pull/4916 added support for subresources and removed hardcoded subresources from webhooks (`pods/ephemeralcontainers` and `services/status`). Removal of `pods/ephemeralcontainers` resulted in losing backward compatibility for existing [PSS policies](https://kyverno.io/policies/pod-security/) as all those policies did not explicitly match on `pods/ephemeralcontainers`.

If policies were updated with the kind `Pod/ephemeralcontainers`, it resulted in breaking the auto-gen feature. Finally, it was decided to keep the hardcoded value of `pods/ephemeralcontainers` in the webhook.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
1.9.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/kind bug
<!--
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
```bash
$ kustomize build https://github.com/kyverno/policies/pod-security | kubectl apply -f -
Warning: Validation failure actions enforce/audit are deprecated, use Enforce/Audit instead.
clusterpolicy.kyverno.io/disallow-capabilities created
clusterpolicy.kyverno.io/disallow-capabilities-strict created
clusterpolicy.kyverno.io/disallow-host-namespaces created
clusterpolicy.kyverno.io/disallow-host-path created
clusterpolicy.kyverno.io/disallow-host-ports created
clusterpolicy.kyverno.io/disallow-host-process created
clusterpolicy.kyverno.io/disallow-privilege-escalation created
clusterpolicy.kyverno.io/disallow-privileged-containers created
clusterpolicy.kyverno.io/disallow-proc-mount created
clusterpolicy.kyverno.io/disallow-selinux created
clusterpolicy.kyverno.io/require-run-as-non-root-user created
clusterpolicy.kyverno.io/require-run-as-nonroot created
clusterpolicy.kyverno.io/restrict-apparmor-profiles created
clusterpolicy.kyverno.io/restrict-seccomp created
clusterpolicy.kyverno.io/restrict-seccomp-strict created
clusterpolicy.kyverno.io/restrict-sysctls created
clusterpolicy.kyverno.io/restrict-volume-types created
```

```bash
$ kubectl get ValidatingWebhookConfiguration kyverno-resource-validating-webhook-cfg -o yaml
```
```yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  creationTimestamp: "2023-01-06T06:03:16Z"
  generation: 2
  labels:
    webhook.kyverno.io/managed-by: kyverno
  name: kyverno-resource-validating-webhook-cfg
  resourceVersion: "1865"
  uid: 17c7b00a-2710-425a-97c6-2614013d8e14
webhooks:
- admissionReviewVersions:
  - v1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM3VENDQWRXZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFZTVJZd0ZBWURWUVFEREEwcUxtdDUKZG1WeWJtOHVjM1pqTUI0WERUSXpNREV3TmpBMU1ETXhOVm9YRFRJME1ERXdOakEyTURNeE5Wb3dHREVXTUJRRwpBMVVFQXd3TktpNXJlWFpsY201dkxuTjJZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBTkpVUGJmc2I3Z1VjT1BrNHgwL3Z2VDNaMEtIdDd3RStYTFBvdG5pSjA0QXJQL0w2d0syTHhrNkQ3a1MKVWdoNE1LR3BvSC9qUkl6ZmROUFVlbWRFdm1LTWNMT3Q3MmdNdTVaWUg1VkVNdDQweXJiVGVJTy9TYk5FUTRQRworWnVTd1poZDJBQUNuZml2SVdnd0x5YzVIWGZnUVFJTUwvU2RQd3g1dmlOWTF0bS9mc0JBOEl4K3libzNNOW82CjJsaExjc3NxMlZHT0FlOXM3Q0RxU0xLd3UrOEpzV2tCeTVlcktrTUFuTGQ5K0NjWEYrSlFoQ3BkZVV5N2VaQk8KdnRrNkZMNDZlam1PWUtJQ2QxT1ZjMGNwNUN1c08xVUJyWEJvUmEyWmxCMlRlMnhjbDRYMllNOVdzb1UzeHZmLwpYMDNjS0x4Ymd3UXJuVnc4Z3NIK1hRQXVScE1DQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHCkExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkErMG53ZDhHTnhCdnEwcjdTaDZlbXYrWU1UME1BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJVeXM0YkZLM25iZjBKMTRwN3RDeUI0b1VFSzNGU0VIK0dWamJSQ3NPcgpaTHRicElRTXFoQ0xXLzE2MjFSZlBNejAzNUFoTWloTDNpdW41cFY0S2IvT1ZIN2Fudi8yU0w0bHFtdzJJQmh0CjNxQkZxb2ljRVl0am9YU2lKK1JJN0djRStFK0dhejEzcldEUHZiT3kzTE1MTkxWYTFKYmQ4bExiY0xJeGdkaHkKU28zQXJRYU9VQjZQeHhsN1JCTGdLQ1o1SURNYnRGWVFHdFBTMmwwQ0JrMW55YlR4MXNIQkI3bHJ5NzRuMTFHKwpDL1B6dDd6MklGOUhvNVhFUGlVeXFTRmRwZDIrTERpeWt5VjNmYnZIeUU2NnhFWjhEZDlsNjR0Z0xkd1QvUWQwCndDbkZhQWNzOHdMWmkrcHc4eGJ6UUlzcERFaStiemxYTVZLU1NIU285Ym1DCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    service:
      name: kyverno-svc
      namespace: kyverno
      path: /validate/fail
      port: 443
  failurePolicy: Fail
  matchPolicy: Equivalent
  name: validate.kyverno.svc-fail
  namespaceSelector:
    matchExpressions:
    - key: kubernetes.io/metadata.name
      operator: NotIn
      values:
      - kyverno
  objectSelector: {}
  rules:
  - apiGroups:
    - ""
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - replicationcontrollers
    scope: '*'
  - apiGroups:
    - ""
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - pods
    - pods/ephemeralcontainers
    scope: '*'
  - apiGroups:
    - apps
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - daemonsets
    scope: '*'
  - apiGroups:
    - apps
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - deployments
    scope: '*'
  - apiGroups:
    - apps
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - replicasets
    scope: '*'
  - apiGroups:
    - apps
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - statefulsets
    scope: '*'
  - apiGroups:
    - batch
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - cronjobs
    scope: '*'
  - apiGroups:
    - batch
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - jobs
    scope: '*'
  sideEffects: NoneOnDryRun
  timeoutSeconds: 10
```

Duplicate Check:

```bash
$ kubectl apply -f - <<EOF                                                                                                                  1 ⨯
heredoc> apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: simple-policy
spec:
  background: false
  rules:
    - name: rule
      match:
        resources:
          kinds:
            - Pod/ephemeralcontainers
      validate:
        message: ""
        pattern:
          metadata:
            name: nginx
EOF
clusterpolicy.kyverno.io/simple-policy created
```
```bash
$ kubectl get ValidatingWebhookConfiguration kyverno-resource-validating-webhook-cfg -o yaml
```
```yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  creationTimestamp: "2023-01-06T06:54:33Z"
  generation: 5
  labels:
    webhook.kyverno.io/managed-by: kyverno
  name: kyverno-resource-validating-webhook-cfg
  resourceVersion: "2388"
  uid: c411aa49-994a-4ed3-a3d6-fc64545cac86
webhooks:
- admissionReviewVersions:
  - v1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM3VENDQWRXZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFZTVJZd0ZBWURWUVFEREEwcUxtdDUKZG1WeWJtOHVjM1pqTUI0WERUSXpNREV3TmpBMU5UUXpNbG9YRFRJME1ERXdOakEyTlRRek1sb3dHREVXTUJRRwpBMVVFQXd3TktpNXJlWFpsY201dkxuTjJZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBTUZJNUZVYTZVSjYxYTFYN2RHeUc1OUU5VjBVbEhCclJkL3BCa0YwQWRSSTVpWEpReGlxdEZWSnpqakUKb3FkZ1djTU5RRHFtU28xQ2VVNTFnWGdheEZ3TTBic0xRbG1ORzlNbGN2V0xGeDlMbTc0SFl6clJLVW1VY09HSwpMSE5PRktiRnhtZTRuMm9Wc3lWNDdCOEYzTy9VVzZoY1dwL1FBY1lXSlpzcTZaVVRzdEFuU1dkTGh4Y3dndVlHClJpREVxbkZZdHNNWlluVXdhc0J2U0ZRQ0pkbU5vdVBKVzFiMnJFTWNJOUR0WUlZbklnVzVmN2VDRzgxMjV1N1IKbUtwaUl3d2FMbHcvdmlSeTRwYy9NamlJMi9idnRuRUZoVHkyVGRyL2FzRmtvK1hSd2ZnRCt1OXhucE44ZzBPdgptTlJ2OGJXSWVsYU5VRHEzdVE1VkNFQlNCbU1DQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHCkExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRk1wU2wraUFpWDVNclhkU3JuWGd6Z2NRdjN2aU1BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUFQUTdNYUJUR1graW16UXpqTU40V25DazJaVzg1N2lJdFNiaDlBeW5wdgpsWlY2UE9sZm0wYjdiRDZnVTZQRm85VkJNb3lQTW9iV21kYWYzNkYrOURkczcwRTZ0TW5tYmFxWVlRMkxTV3BrClBtNmd4bE9MZXF6V2JsVThwV0JNZExiMmIvbWNGVEFVblRMUWZQbm1sd0IrOTFBa3ZBcmptM1F4N0U2WldLKzAKVUJoOUFtQzV4MmV4V09VMmpVdlpVcmdDZ0JkODZabTZIZkhGWngwWThzR1M1ZmNzN1RLQVU5ZDY2VlVaRC9ZNAorNGRmckU3MlJYL3BhVnZIaG82QU9Mb1p2T2hVL0tzYzcvemQ0U1ZuYlZqTnJpYjdvYnlVMHFIMDh5WmZRQnZTClFwWEh6OWpvSWY0MWpLbm4vWWJCbGtwUzgzb0c4M0FOSytPQWhsQjRhM2NkCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    service:
      name: kyverno-svc
      namespace: kyverno
      path: /validate/fail
      port: 443
  failurePolicy: Fail
  matchPolicy: Equivalent
  name: validate.kyverno.svc-fail
  namespaceSelector:
    matchExpressions:
    - key: kubernetes.io/metadata.name
      operator: NotIn
      values:
      - kyverno
  objectSelector: {}
  rules:
  - apiGroups:
    - ""
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - pods
    scope: '*'
  - apiGroups:
    - ""
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - pods/ephemeralcontainers
    scope: '*'
  - apiGroups:
    - ""
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - replicationcontrollers
    scope: '*'
  - apiGroups:
    - apps
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - daemonsets
    scope: '*'
  - apiGroups:
    - apps
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - deployments
    scope: '*'
  - apiGroups:
    - apps
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - replicasets
    scope: '*'
  - apiGroups:
    - apps
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - statefulsets
    scope: '*'
  - apiGroups:
    - batch
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - cronjobs
    scope: '*'
  - apiGroups:
    - batch
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    - CONNECT
    resources:
    - jobs
    scope: '*'
  sideEffects: NoneOnDryRun
  timeoutSeconds: 10
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```



-->

Duplicate entry for `ephemeralcontainers` is not created.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

cc @realshuting @chipzoller 
