### PR TITLE
fix: cleanup controller - restrict cronjobs by PSS restricted checks

### DIFF
--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -156,8 +156,8 @@ func (c *controller) buildCronJob(cronJob *batchv1.CronJob, pol kyvernov2alpha1.
 	}
 	var successfulJobsHistoryLimit int32 = 0
 	var failedJobsHistoryLimit int32 = 1
-	var boolFalse = false
-	var boolTrue = true
+	var boolFalse bool = false
+	var boolTrue bool = true
 	var int1000 int64 = 1000
 	// set spec
 	cronJob.Spec = batchv1.CronJobSpec{

--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -156,6 +156,8 @@ func (c *controller) buildCronJob(cronJob *batchv1.CronJob, pol kyvernov2alpha1.
 	}
 	var successfulJobsHistoryLimit int32 = 0
 	var failedJobsHistoryLimit int32 = 1
+	var boolFalse = false
+	var boolTrue = true
 	// set spec
 	cronJob.Spec = batchv1.CronJobSpec{
 		Schedule:                   pol.GetSpec().Schedule,
@@ -177,6 +179,16 @@ func (c *controller) buildCronJob(cronJob *batchv1.CronJob, pol kyvernov2alpha1.
 									// "--cacert",
 									// "/tmp/ca.crt",
 									fmt.Sprintf("%s%s?policy=%s", c.cleanupService, CleanupServicePath, policyName),
+								},
+								SecurityContext: &corev1.SecurityContext{
+									AllowPrivilegeEscalation: &boolFalse,
+									RunAsNonRoot:             &boolTrue,
+									SeccompProfile: &corev1.SeccompProfile{
+										Type: corev1.SeccompProfileTypeRuntimeDefault,
+									},
+									Capabilities: &corev1.Capabilities{
+										Drop: []corev1.Capability{"ALL"},
+									},
 								},
 							},
 						},

--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -158,6 +158,7 @@ func (c *controller) buildCronJob(cronJob *batchv1.CronJob, pol kyvernov2alpha1.
 	var failedJobsHistoryLimit int32 = 1
 	var boolFalse = false
 	var boolTrue = true
+	var int1000 int64 = 1000
 	// set spec
 	cronJob.Spec = batchv1.CronJobSpec{
 		Schedule:                   pol.GetSpec().Schedule,
@@ -183,8 +184,12 @@ func (c *controller) buildCronJob(cronJob *batchv1.CronJob, pol kyvernov2alpha1.
 								SecurityContext: &corev1.SecurityContext{
 									AllowPrivilegeEscalation: &boolFalse,
 									RunAsNonRoot:             &boolTrue,
+									RunAsUser:                &int1000,
 									SeccompProfile: &corev1.SeccompProfile{
 										Type: corev1.SeccompProfileTypeRuntimeDefault,
+									},
+									Capabilities: &corev1.Capabilities{
+										Drop: []corev1.Capability{"ALL"},
 									},
 								},
 							},

--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -186,9 +186,6 @@ func (c *controller) buildCronJob(cronJob *batchv1.CronJob, pol kyvernov2alpha1.
 									SeccompProfile: &corev1.SeccompProfile{
 										Type: corev1.SeccompProfileTypeRuntimeDefault,
 									},
-									Capabilities: &corev1.Capabilities{
-										Drop: []corev1.Capability{"ALL"},
-									},
 								},
 							},
 						},


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Explanation

Cronjobs created by the Kyverno cleanup controller should be locked down to PSS restricted checks.
