### PR TITLE
chore: make check actions pinned by hash a standalone ci job

### DIFF
--- a/.github/workflows/check-actions.yaml
+++ b/.github/workflows/check-actions.yaml
@@ -1,0 +1,25 @@
+name: Check actions
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release*'
+  pull_request:
+    branches:
+      - 'main'
+      - 'release*'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Ensure SHA pinned actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@fe7afd3f619254d126dcb69aabacc269f8ef8fd7 # v2.0.3
+        with:
+          # slsa-github-generator requires using a semver tag for reusable workflows. 
+          # See: https://github.com/slsa-framework/slsa-github-generator#referencing-slsa-builders-and-generators
+          allowlist: |
+            slsa-framework/slsa-github-generator

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,5 @@
 name: tests
+
 on:
   push:
     branches:
@@ -22,16 +23,6 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-
-      # see https://michaelheap.com/ensure-github-actions-pinned-sha/
-      - name: Ensure SHA pinned actions
-        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@fe7afd3f619254d126dcb69aabacc269f8ef8fd7 # pin@v2.0.3
-        with:
-          # slsa-github-generator requires using a semver tag for reusable workflows. 
-          # See: https://github.com/slsa-framework/slsa-github-generator#referencing-slsa-builders-and-generators
-          allowlist: |
-            slsa-framework/slsa-github-generator
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # pin@v3
         with:


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR makes check actions pinned by hash a standalone ci job.
