### PR TITLE
chore: do not run sonar workflow if token is not defined

### DIFF
--- a/.github/workflows/pr-update.yaml
+++ b/.github/workflows/pr-update.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   autoupdate:
+    if: ${{ secrets.PR_UPDATE_TOKEN }}
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -2,9 +2,9 @@ name: Sonarcloud workflow
 
 on:
   push:
-    branches:
-      - 'main'
-      - 'release*'
+    # branches:
+    #   - 'main'
+    #   - 'release*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,14 +15,20 @@ permissions:
 
 jobs:
   sonarcloud:
-    if: ${{ secrets.SONAR_TOKEN }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Check secret
+        id: checksecret
+        uses: ./.github/actions/is-defined
+        with:
+          value: ${{ secrets.SONAR_TOKEN }}
       - name: Setup build env
+        if: steps.checksecret.outputs.result == 'true'
         uses: ./.github/actions/setup-build-env
       - name: SonarCloud Scan
+        if: steps.checksecret.outputs.result == 'true'
         uses: sonarsource/sonarcloud-github-action@cb201f3b2d7a38231a8c042dfea4539c8bea180b # v1.8
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -1,11 +1,10 @@
 name: Sonarcloud workflow
 
 on:
-  pull_request:
   push:
-    # branches:
-    #   - 'main'
-    #   - 'release*'
+    branches:
+      - 'main'
+      - 'release*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -1,6 +1,7 @@
 name: Sonarcloud workflow
 
 on:
+  pull_request:
   push:
     # branches:
     #   - 'main'

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   sonarcloud:
+    if: ${{ secrets.SONAR_TOKEN }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Explanation

This PR does not run sonar workflow if token is not defined.
Useful for forks that do not have access to the secret.