### PR TITLE
chore: do not run pr update workflow if token is not defined

### DIFF
--- a/.github/workflows/pr-update.yaml
+++ b/.github/workflows/pr-update.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   autoupdate:
+    if: ${{ secrets.PR_UPDATE_TOKEN }}
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Explanation

This PR skips running `pr update` workflow if token is not defined.
