### PR TITLE
chore: do not run scorecard workflow if token is not defined

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -22,9 +22,16 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           persist-credentials: false
+      - name: Check secret
+        id: checksecret
+        uses: ./.github/actions/is-defined
+        with:
+          value: ${{ secrets.SCORECARD_READ_TOKEN }}
       - name: Setup build env
+        if: steps.checksecret.outputs.result == 'true'
         uses: ./.github/actions/setup-build-env
       - name: Run analysis
+        if: steps.checksecret.outputs.result == 'true'
         uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
         with:
           results_file: results.sarif
@@ -32,12 +39,14 @@ jobs:
           repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
           publish_results: true
       - name: Upload artifact
+        if: steps.checksecret.outputs.result == 'true'
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
       - name: Upload to code-scanning
+        if: steps.checksecret.outputs.result == 'true'
         uses: github/codeql-action/upload-sarif@959cbb7472c4d4ad70cdfe6f4976053fe48ab394 # v2.1.37
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR skips scorecard workflow if token is not defined.
