### PR TITLE
Fixes `time_now` failing

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -883,20 +883,29 @@ func jpTimeNow(arguments []interface{}) (interface{}, error) {
 		return nil, err
 	}
 
-	var t time.Time
-
-	t = time.Now()
+	var ts time.Time = time.Now()
+	var t string
 	if layout.String() != "" {
-		t, err = time.Parse(layout.String(), t.String())
+		t = ts.Format(layout.String())
 	} else {
-		t, err = time.Parse(time.RFC3339, t.String())
+		t = ts.Format(time.RFC3339)
 	}
 
+	// time.Format does not return an error
+	// so we are reverse checking to verify time format string is valid
+	if layout.String() != "" {
+		ts, err = time.Parse(layout.String(), t)
+		// if layout is invalid, golang returns 0000-01-01 00:00:00 +0000 UTC
+		// if the year is 0, then something went wrong
+		if ts.Year() == 0 {
+			return nil, fmt.Errorf("'%v' is an invalid layout format", layout.String())
+		}
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	return t.String(), nil
+	return t, nil
 }
 
 func jpPathCanonicalize(arguments []interface{}) (interface{}, error) {

--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -380,10 +380,7 @@ func GetFunctions() []*FunctionEntry {
 		},
 		{
 			Entry: &gojmespath.FunctionEntry{
-				Name: timeNow,
-				Arguments: []ArgSpec{
-					{Types: []JpType{JpString}},
-				},
+				Name:    timeNow,
 				Handler: jpTimeNow,
 			},
 			ReturnType: []JpType{JpString},
@@ -877,34 +874,8 @@ func jpTimeSince(arguments []interface{}) (interface{}, error) {
 }
 
 func jpTimeNow(arguments []interface{}) (interface{}, error) {
-	var err error
-	layout, err := validateArg("", arguments, 0, reflect.String)
-	if err != nil {
-		return nil, err
-	}
-
 	var ts time.Time = time.Now()
-	var t string
-	if layout.String() != "" {
-		t = ts.Format(layout.String())
-	} else {
-		t = ts.Format(time.RFC3339)
-	}
-
-	// time.Format does not return an error
-	// so we are reverse checking to verify time format string is valid
-	if layout.String() != "" {
-		ts, err = time.Parse(layout.String(), t)
-		// if layout is invalid, golang returns 0000-01-01 00:00:00 +0000 UTC
-		// if the year is 0, then something went wrong
-		if ts.Year() == 0 {
-			return nil, fmt.Errorf("'%v' is an invalid layout format", layout.String())
-		}
-	}
-	if err != nil {
-		return nil, err
-	}
-
+	var t string = ts.Format(time.RFC3339)
 	return t, nil
 }
 

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -1647,16 +1647,7 @@ func Test_TimeNow(t *testing.T) {
 		layout string
 	}{
 		{
-			test:   "time_now('')",
-			layout: "2006-01-02T15:04:05Z07:00",
-		},
-		{
-			test:   "time_now('Mon Jan 02 15:04:05 MST 2006')",
-			layout: "Mon Jan 02 15:04:05 MST 2006",
-		},
-		{
-			test:   "time_now('2006-01-02T15:04:05Z07:00')",
-			layout: "2006-01-02T15:04:05Z07:00",
+			test: "time_now()",
 		},
 	}
 	for i, tc := range testCases {
@@ -1670,7 +1661,7 @@ func Test_TimeNow(t *testing.T) {
 			result, ok := res.(string)
 			assert.Assert(t, ok)
 
-			assert.Equal(t, result, time.Now().Format(tc.layout))
+			assert.Equal(t, result, time.Now().Format(time.RFC3339))
 		})
 	}
 }

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
 )
@@ -1642,24 +1643,20 @@ func Test_TimeParse(t *testing.T) {
 
 func Test_TimeNow(t *testing.T) {
 	testCases := []struct {
-		test           string
-		expectedResult string
+		test   string
+		layout string
 	}{
 		{
-			test:           "time_now('')",
-			expectedResult: "",
+			test:   "time_now('')",
+			layout: "2006-01-02T15:04:05Z07:00",
 		},
 		{
-			test:           "time_now('Mon Jan 02 15:04:05 MST 2006')",
-			expectedResult: "",
+			test:   "time_now('Mon Jan 02 15:04:05 MST 2006')",
+			layout: "Mon Jan 02 15:04:05 MST 2006",
 		},
 		{
-			test:           "time_now('2006-01-02T15:04:05Z07:00')",
-			expectedResult: "",
-		},
-		{
-			test:           "time_now('qwerty')",
-			expectedResult: "",
+			test:   "time_now('2006-01-02T15:04:05Z07:00')",
+			layout: "2006-01-02T15:04:05Z07:00",
 		},
 	}
 	for i, tc := range testCases {
@@ -1673,7 +1670,7 @@ func Test_TimeNow(t *testing.T) {
 			result, ok := res.(string)
 			assert.Assert(t, ok)
 
-			assert.Equal(t, result, tc.expectedResult)
+			assert.Equal(t, result, time.Now().Format(tc.layout))
 		})
 	}
 }

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -1639,3 +1639,41 @@ func Test_TimeParse(t *testing.T) {
 		})
 	}
 }
+
+func Test_TimeNow(t *testing.T) {
+	testCases := []struct {
+		test           string
+		expectedResult string
+	}{
+		{
+			test:           "time_now('')",
+			expectedResult: "",
+		},
+		{
+			test:           "time_now('Mon Jan 02 15:04:05 MST 2006')",
+			expectedResult: "",
+		},
+		{
+			test:           "time_now('2006-01-02T15:04:05Z07:00')",
+			expectedResult: "",
+		},
+		{
+			test:           "time_now('qwerty')",
+			expectedResult: "",
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			query, err := New(tc.test)
+			assert.NilError(t, err)
+
+			res, err := query.Search("")
+			assert.NilError(t, err)
+
+			result, ok := res.(string)
+			assert.Assert(t, ok)
+
+			assert.Equal(t, result, tc.expectedResult)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Vishal Choudhary <contactvishaltech@gmail.com>

## Explanation
`time_now` function currently fails in returning correct time
```
1 generate.go:357] background "msg"="variable substitution failed for rule %s" "error"="failed to resolve time_now('') at path /generate/data/spec/schedule: JMESPath query failed: parsing time \"2023-01-07 13:20:09.0738949 +0000 UTC m=+1177.923478701\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \" 13:20:09.0738949 +0000 UTC m=+1177.923478701\" as \"T\"" ""="(MISSING)" "apiVersion"="kyverno.io/v2alpha1" "kind"="PolicyException" "name"="mynewpolex" "namespace"="foo" "policy"="automate-cleanup"
```
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue 

Fixes #5800 

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
This PR fixes the failing of tests

The result string is manually verified to be of right format as there is no way to assert equality with current time
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
