### PR TITLE
fix: missing user info matching

### DIFF
--- a/cmd/cleanup-controller/handlers/cleanup/handlers.go
+++ b/cmd/cleanup-controller/handlers/cleanup/handlers.go
@@ -101,7 +101,8 @@ func (h *handlers) executePolicy(ctx context.Context, logger logr.Logger, policy
 						nsLabels,
 						nil,
 						"",
-						// TODO(eddycharly): we don't have user info here
+						// TODO(eddycharly): we don't have user info here, we should check that
+						// we don't have user conditions in the policy rule
 						kyvernov1beta1.RequestInfo{},
 						nil,
 					)
@@ -116,7 +117,8 @@ func (h *handlers) executePolicy(ctx context.Context, logger logr.Logger, policy
 							nsLabels,
 							nil,
 							"",
-							// TODO(eddycharly): we don't have user info here
+							// TODO(eddycharly): we don't have user info here, we should check that
+							// we don't have user conditions in the policy rule
 							kyvernov1beta1.RequestInfo{},
 							nil,
 						)

--- a/cmd/cleanup-controller/handlers/cleanup/handlers.go
+++ b/cmd/cleanup-controller/handlers/cleanup/handlers.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	kyvernov2alpha1 "github.com/kyverno/kyverno/api/kyverno/v2alpha1"
 	kyvernov2alpha1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v2alpha1"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
@@ -94,13 +95,30 @@ func (h *handlers) executePolicy(ctx context.Context, logger logr.Logger, policy
 						debug.Info("resource namespace didn't match policy namespace", "result", err)
 					}
 					// match resource with match/exclude clause
-					matched := match.CheckMatchesResources(resource, spec.MatchResources, nsLabels, nil, "")
+					matched := match.CheckMatchesResources(
+						resource,
+						spec.MatchResources,
+						nsLabels,
+						nil,
+						"",
+						kyvernov1beta1.RequestInfo{},
+						nil,
+					)
 					if matched != nil {
 						debug.Info("resource/match didn't match", "result", matched)
 						continue
 					}
 					if spec.ExcludeResources != nil {
-						excluded := match.CheckMatchesResources(resource, *spec.ExcludeResources, nsLabels, nil, "")
+						excluded := match.CheckMatchesResources(
+							resource,
+							*spec.ExcludeResources,
+							nsLabels,
+							nil,
+							"",
+							// TODO(eddycharly): we don't have user info here
+							kyvernov1beta1.RequestInfo{},
+							nil,
+						)
 						if excluded == nil {
 							debug.Info("resource/exclude matched")
 							continue

--- a/cmd/cleanup-controller/handlers/cleanup/handlers.go
+++ b/cmd/cleanup-controller/handlers/cleanup/handlers.go
@@ -101,6 +101,7 @@ func (h *handlers) executePolicy(ctx context.Context, logger logr.Logger, policy
 						nsLabels,
 						nil,
 						"",
+						// TODO(eddycharly): we don't have user info here
 						kyvernov1beta1.RequestInfo{},
 						nil,
 					)

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -775,13 +775,25 @@ func (v *validator) substituteDeny() error {
 }
 
 // matchesException checks if an exception applies to the resource being admitted
-func matchesException(policyContext *PolicyContext, rule *kyvernov1.Rule, subresourceGVKToAPIResource map[string]*metav1.APIResource) (*kyvernov2alpha1.PolicyException, error) {
+func matchesException(
+	policyContext *PolicyContext,
+	rule *kyvernov1.Rule,
+	subresourceGVKToAPIResource map[string]*metav1.APIResource,
+) (*kyvernov2alpha1.PolicyException, error) {
 	candidates, err := policyContext.FindExceptions(rule.Name)
 	if err != nil {
 		return nil, err
 	}
 	for _, candidate := range candidates {
-		err := matched.CheckMatchesResources(policyContext.newResource, candidate.Spec.Match, policyContext.namespaceLabels, subresourceGVKToAPIResource, policyContext.subresource)
+		err := matched.CheckMatchesResources(
+			policyContext.newResource,
+			candidate.Spec.Match,
+			policyContext.namespaceLabels,
+			subresourceGVKToAPIResource,
+			policyContext.subresource,
+			policyContext.admissionInfo,
+			policyContext.excludeGroupRole,
+		)
 		// if there's no error it means a match
 		if err == nil {
 			return candidate, nil


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR adds missing user info matching in util funcs (used by policy exceptions and cleanup policies).

Fixes https://github.com/kyverno/kyverno/issues/5930