### PR TITLE
fix: cleanup policies with user infos in match/exclude should be rejected

### DIFF
--- a/api/kyverno/v1/user_info_types.go
+++ b/api/kyverno/v1/user_info_types.go
@@ -57,6 +57,22 @@ func (u *UserInfo) ValidateRoles(path *field.Path) (errs field.ErrorList) {
 	return errs
 }
 
+// ValidateNoUserInfo verifies that no user info is used
+func (u *UserInfo) ValidateNoUserInfo(path *field.Path) (errs field.ErrorList) {
+	if u != nil {
+		if len(u.Roles) != 0 {
+			errs = append(errs, field.Forbidden(path.Child("roles"), "Usage of user info is forbidden"))
+		}
+		if len(u.ClusterRoles) != 0 {
+			errs = append(errs, field.Forbidden(path.Child("clusterRoles"), "Usage of user info is forbidden"))
+		}
+		if len(u.Subjects) != 0 {
+			errs = append(errs, field.Forbidden(path.Child("subjects"), "Usage of user info is forbidden"))
+		}
+	}
+	return errs
+}
+
 // Validate implements programmatic validation
 func (u *UserInfo) Validate(path *field.Path) (errs field.ErrorList) {
 	errs = append(errs, u.ValidateSubjects(path.Child("subjects"))...)

--- a/api/kyverno/v2beta1/match_resources_types.go
+++ b/api/kyverno/v2beta1/match_resources_types.go
@@ -30,6 +30,19 @@ func (m *MatchResources) GetKinds() []string {
 	return kinds
 }
 
+// ValidateNoUserInfo verifies that no user info is used
+func (m *MatchResources) ValidateNoUserInfo(path *field.Path) (errs field.ErrorList) {
+	anyPath := path.Child("any")
+	for i, filter := range m.Any {
+		errs = append(errs, filter.UserInfo.ValidateNoUserInfo(anyPath.Index(i))...)
+	}
+	allPath := path.Child("all")
+	for i, filter := range m.All {
+		errs = append(errs, filter.UserInfo.ValidateNoUserInfo(allPath.Index(i))...)
+	}
+	return errs
+}
+
 // Validate implements programmatic validation
 func (m *MatchResources) Validate(path *field.Path, namespaced bool, clusterResources sets.Set[string]) (errs field.ErrorList) {
 	if len(m.Any) > 0 && len(m.All) > 0 {
@@ -42,7 +55,7 @@ func (m *MatchResources) Validate(path *field.Path, namespaced bool, clusterReso
 	}
 	allPath := path.Child("all")
 	for i, filter := range m.All {
-		errs = append(errs, filter.UserInfo.Validate(anyPath.Index(i))...)
+		errs = append(errs, filter.UserInfo.Validate(allPath.Index(i))...)
 		errs = append(errs, filter.ResourceDescription.Validate(allPath.Index(i), namespaced, clusterResources)...)
 	}
 	return errs

--- a/test/conformance/kuttl/cleanup/validation/no-user-info-in-match/01-cleanuppolicy.yaml
+++ b/test/conformance/kuttl/cleanup/validation/no-user-info-in-match/01-cleanuppolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+  - file: cleanuppolicy-with-subjects.yaml
+    shouldFail: true
+  - file: cleanuppolicy-with-roles.yaml
+    shouldFail: true
+  - file: cleanuppolicy-with-clusterroles.yaml
+    shouldFail: true

--- a/test/conformance/kuttl/cleanup/validation/no-user-info-in-match/README.md
+++ b/test/conformance/kuttl/cleanup/validation/no-user-info-in-match/README.md
@@ -1,0 +1,8 @@
+## Description
+
+This test creates a cleanup policy containing user infos in `match` statement.
+The creation should fail as cleanup policies with user infos are not allowed.
+
+## Steps
+
+1.  - Try create a couple of cleanup policies, expecting the creation to fail because they contain user infos

--- a/test/conformance/kuttl/cleanup/validation/no-user-info-in-match/cleanuppolicy-with-clusterroles.yaml
+++ b/test/conformance/kuttl/cleanup/validation/no-user-info-in-match/cleanuppolicy-with-clusterroles.yaml
@@ -1,0 +1,13 @@
+apiVersion: kyverno.io/v2alpha1
+kind: ClusterCleanupPolicy
+metadata:
+  name: cleanuppolicy
+spec:
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+        clusterRoles:
+          - clusteradmin
+  schedule: '* * * * *'

--- a/test/conformance/kuttl/cleanup/validation/no-user-info-in-match/cleanuppolicy-with-roles.yaml
+++ b/test/conformance/kuttl/cleanup/validation/no-user-info-in-match/cleanuppolicy-with-roles.yaml
@@ -1,0 +1,13 @@
+apiVersion: kyverno.io/v2alpha1
+kind: ClusterCleanupPolicy
+metadata:
+  name: cleanuppolicy
+spec:
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+        roles:
+          - admin
+  schedule: '* * * * *'

--- a/test/conformance/kuttl/cleanup/validation/no-user-info-in-match/cleanuppolicy-with-subjects.yaml
+++ b/test/conformance/kuttl/cleanup/validation/no-user-info-in-match/cleanuppolicy-with-subjects.yaml
@@ -1,0 +1,14 @@
+apiVersion: kyverno.io/v2alpha1
+kind: ClusterCleanupPolicy
+metadata:
+  name: cleanuppolicy
+spec:
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+        subjects:
+          - kind: User
+            name: chip
+  schedule: '* * * * *'


### PR DESCRIPTION
## Explanation

This PR adds cleanup policies validation to reject policies with user infos in match/exclude.
As they are exclusively processed in the background we don't have user infos when executing those policies.