### PR TITLE
fix: imageRef mismatch

### DIFF
--- a/pkg/engine/imageVerify.go
+++ b/pkg/engine/imageVerify.go
@@ -339,11 +339,8 @@ func (iv *imageVerifier) verifyImage(
 	}
 
 	if len(imageVerify.Attestors) > 0 {
-		for _, image := range imageVerify.ImageReferences {
-			if !wildcard.Match(image, imageInfo.String()) {
-				iv.logger.V(5).Info("images mismatch, skipping", "expected", image, "received", imageInfo.String())
-				return nil, ""
-			}
+		if !matchImageReferences(imageVerify.ImageReferences, imageInfo.String()) {
+			return nil, ""
 		}
 
 		ruleResp, cosignResp := iv.verifyAttestors(ctx, imageVerify.Attestors, imageVerify, imageInfo, "")
@@ -728,4 +725,13 @@ func evaluateConditions(
 
 	pass := variables.EvaluateAnyAllConditions(log, ctx, c)
 	return pass, nil
+}
+
+func matchImageReferences(imageReferences []string, image string) bool {
+	for _, imageRef := range imageReferences {
+		if wildcard.Match(imageRef, image) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/engine/imageVerify.go
+++ b/pkg/engine/imageVerify.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/registryclient"
 	"github.com/kyverno/kyverno/pkg/tracing"
 	apiutils "github.com/kyverno/kyverno/pkg/utils/api"
+	datautils "github.com/kyverno/kyverno/pkg/utils/data"
 	"github.com/kyverno/kyverno/pkg/utils/jsonpointer"
 	"github.com/kyverno/kyverno/pkg/utils/wildcard"
 	"github.com/pkg/errors"
@@ -339,6 +340,11 @@ func (iv *imageVerifier) verifyImage(
 	}
 
 	if len(imageVerify.Attestors) > 0 {
+		if !datautils.SliceContains(imageVerify.ImageReferences, imageInfo.String()) {
+			iv.logger.V(5).Info("images mismatch, skipping", "expected", imageVerify.ImageReferences, "received", imageInfo.String())
+			return nil, ""
+		}
+
 		ruleResp, cosignResp := iv.verifyAttestors(ctx, imageVerify.Attestors, imageVerify, imageInfo, "")
 		if ruleResp.Status != response.RuleStatusPass {
 			return ruleResp, ""

--- a/pkg/engine/imageVerify.go
+++ b/pkg/engine/imageVerify.go
@@ -340,7 +340,8 @@ func (iv *imageVerifier) verifyImage(
 	}
 
 	if len(imageVerify.Attestors) > 0 {
-		if !datautils.SliceContains(imageVerify.ImageReferences, imageInfo.String()) {
+		if !datautils.SliceContains(imageVerify.ImageReferences, "*") &&
+			!datautils.SliceContains(imageVerify.ImageReferences, imageInfo.String()) {
 			iv.logger.V(5).Info("images mismatch, skipping", "expected", imageVerify.ImageReferences, "received", imageInfo.String())
 			return nil, ""
 		}

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/01-assert.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/01-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-signatures
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/01-policy.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/01-policy.yaml
@@ -1,0 +1,53 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-signatures
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+spec:
+  validationFailureAction: enforce
+  webhookTimeoutSeconds: 30
+  background: false
+  rules:
+    - name: check-1
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      verifyImages:
+      - attestors:
+        - count: 1
+          entries:
+          - keys:
+              publicKeys: |-
+                -----BEGIN PUBLIC KEY-----
+                MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
+                5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
+                -----END PUBLIC KEY-----
+        imageReferences:
+        - ghcr.io/kyverno/test-verify-image:*
+        mutateDigest: true
+        required: true
+        verifyDigest: true
+    - name: check-2
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      verifyImages:
+      - attestors:
+        - count: 1
+          entries:
+          - keys:
+              publicKeys: |-
+                -----BEGIN PUBLIC KEY-----
+                MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOUD2uzRHLnx1oH6XAnF+8haL73BF
+                zh9pMI1x1/c4Nj/w+rsrgMCDyV/S8hmsXEbizhYD3QndVtV1piBDfDIb8w==
+                -----END PUBLIC KEY-----
+        imageReferences:
+        - my.local.repo/*
+        mutateDigest: false
+        required: true
+        verifyDigest: false

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/02-assert.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/02-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: signed
+  namespace: default
+spec:
+  containers:
+  - image: ghcr.io/kyverno/test-verify-image:signed
+    imagePullPolicy: IfNotPresent
+    name: signed

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/02-assert.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/02-assert.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: default
 spec:
   containers:
-  - image: ghcr.io/kyverno/test-verify-image:signed
-    imagePullPolicy: IfNotPresent
-    name: signed
+  - name: signed

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/02-pod.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/02-pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: signed
+  namespace: default
+spec:
+  containers:
+  - image: ghcr.io/kyverno/test-verify-image:signed
+    imagePullPolicy: IfNotPresent
+    name: signed

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/02-pod.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/02-pod.yaml
@@ -5,4 +5,6 @@ metadata:
   namespace: default
 spec:
   containers:
-  - name: signed
+  - image: ghcr.io/kyverno/test-verify-image:signed
+    imagePullPolicy: IfNotPresent
+    name: signed

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/02-pod.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/02-pod.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: default
 spec:
   containers:
-  - image: ghcr.io/kyverno/test-verify-image:signed
-    imagePullPolicy: IfNotPresent
-    name: signed
+  - name: signed

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/99-cleanup.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/99-cleanup.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete -f 01-policy.yaml,02-pod.yaml --force --wait=true --ignore-not-found=true

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/README.md
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/README.md
@@ -1,0 +1,11 @@
+## Description
+
+A `VerifyImages` rule specifying multiple attestors should allow pod creation with valid images.
+
+## Expected Behavior
+
+The pod `signed` should be created successfully.
+
+## Reference Issue(s)
+
+Slack discussion - https://kubernetes.slack.com/archives/CLGR9BJU9/p1673303296239259.


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Explanation
This PR fixes the images mismatch issue when a verifyImages rule has multiple attestors defined.
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Reported in Slack: https://kubernetes.slack.com/archives/CLGR9BJU9/p1673303296239259

Related PR: https://github.com/kyverno/kyverno/pull/5272
cc @shahpratikr 

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.9.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
See the kuttl test.
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
