### PR TITLE
fix: cleanup-controller version

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -13,3 +13,8 @@ builds:
   main: ./cmd/cli
   ldflags:
   - '{{ if index .Env "LD_FLAGS" }}{{ .Env.LD_FLAGS }}{{ end }}'
+
+- id: cleanup-controller
+  main: ./cmd/cleanup-controller
+  ldflags:
+  - '{{ if index .Env "LD_FLAGS" }}{{ .Env.LD_FLAGS }}{{ end }}'


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR fixes cleanup-controller version not being embedded in the binary.
