### PR TITLE
fix: remove `exceptionNamespace` from init-container

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -186,7 +186,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | initImage.repository | string | `"kyverno/kyvernopre"` | Image repository |
 | initImage.tag | string | `nil` | Image tag If initImage.tag is missing, defaults to image.tag |
 | initImage.pullPolicy | string | `nil` | Image pull policy If initImage.pullPolicy is missing, defaults to image.pullPolicy |
-| initContainer.extraArgs | list | `["--loggingFormat=text","--exceptionNamespace={{ include \"kyverno.namespace\" . }}"]` | Extra arguments to give to the kyvernopre binary. |
+| initContainer.extraArgs | list | `["--loggingFormat=text"]` | Extra arguments to give to the kyvernopre binary. |
 | replicaCount | int | `nil` | Desired number of pods |
 | podLabels | object | `{}` | Additional labels to add to each pod |
 | podAnnotations | object | `{}` | Additional annotations to add to each pod |

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -233,7 +233,6 @@ initContainer:
   # -- Extra arguments to give to the kyvernopre binary.
   extraArgs:
     - --loggingFormat=text
-    - --exceptionNamespace={{ include "kyverno.namespace" . }}
 
 # -- (int) Desired number of pods
 replicaCount: ~

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -32313,7 +32313,6 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --loggingFormat=text
-            - --exceptionNamespace=kyverno
           resources: 
             limits:
               cpu: 100m


### PR DESCRIPTION
Signed-off-by: ShutingZhao <shuting@nirmata.com>

## Explanation

`exceptionNamespace` is not an init-container flag, this PR fixes the issue.
