### PR TITLE
fix: admission review variables for DELETE operations

### DIFF
--- a/pkg/background/common/resource.go
+++ b/pkg/background/common/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	retryutils "github.com/kyverno/kyverno/pkg/utils/retry"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -51,6 +52,16 @@ func GetResource(client dclient.Interface, urSpec kyvernov1beta1.UpdateRequestSp
 		return nil, err
 	}
 
-	log.V(2).Info("fetched trigger resource", "resourceSpec", resourceSpec)
+	if resource == nil && urSpec.Context.AdmissionRequestInfo.AdmissionRequest != nil {
+		request := urSpec.Context.AdmissionRequestInfo.AdmissionRequest
+		raw := request.Object.Raw
+		if request.Operation == admissionv1.Delete {
+			raw = request.OldObject.Raw
+		}
+
+		resource, err = kubeutils.BytesToUnstructured(raw)
+	}
+
+	log.V(3).Info("fetched trigger resource", "resourceSpec", resourceSpec)
 	return resource, err
 }

--- a/pkg/webhooks/resource/utils.go
+++ b/pkg/webhooks/resource/utils.go
@@ -49,7 +49,7 @@ func applyUpdateRequest(
 	ctx context.Context,
 	request *admissionv1.AdmissionRequest,
 	ruleType kyvernov1beta1.RequestType,
-	grGenerator updaterequest.Generator,
+	urGenerator updaterequest.Generator,
 	userRequestInfo kyvernov1beta1.RequestInfo,
 	action admissionv1.Operation,
 	engineResponses ...*engineapi.EngineResponse,
@@ -61,7 +61,7 @@ func applyUpdateRequest(
 
 	for _, er := range engineResponses {
 		ur := transform(admissionRequestInfo, userRequestInfo, er, ruleType)
-		if err := grGenerator.Apply(ctx, ur, action); err != nil {
+		if err := urGenerator.Apply(ctx, ur, action); err != nil {
 			failedUpdateRequest = append(failedUpdateRequest, updateRequestResponse{ur: ur, err: err})
 		}
 	}

--- a/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/basic-delete/01-assert.yaml
+++ b/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/basic-delete/01-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: test-post-mutation-delete-trigger
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/basic-delete/01-manifests.yaml
+++ b/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/basic-delete/01-manifests.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: staging-2
+  labels:
+    app-type: corp
+  annotations:
+    cloud.platformzero.com/serviceClass: "xl2"
+---
+apiVersion: v1
+data:
+  foo: bar
+kind: ConfigMap
+metadata:
+  name: dictionary-2
+  namespace: staging-2
+---
+apiVersion: v1
+data:
+  foo: YmFy
+kind: Secret
+metadata:
+  name: test-secret-2
+  namespace: staging-2
+type: Opaque
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: test-post-mutation-delete-trigger
+spec:
+  mutateExistingOnPolicyUpdate: false
+  rules:
+    - name: mutate-secret-on-configmap-delete
+      match:
+        any:
+        - resources:
+            kinds:
+            - ConfigMap
+            names:
+            - dictionary-2
+            namespaces:
+            - staging-2
+      preconditions:
+        any:
+        - key: "{{ request.operation }}"
+          operator: Equals
+          value: DELETE
+      mutate:
+        targets:
+        - apiVersion: v1
+          kind: Secret
+          name: test-secret-2
+          namespace: "{{ request.object.metadata.namespace }}"
+        patchStrategicMerge:
+          metadata:
+            labels:
+              foo: "{{ request.object.metadata.name }}"

--- a/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/basic-delete/02-delete-cm.yaml
+++ b/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/basic-delete/02-delete-cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: v1
+  kind: ConfigMap
+  name: dictionary-2
+  namespace: staging-2

--- a/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/basic-delete/03-assert.yaml
+++ b/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/basic-delete/03-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret-2
+  namespace: staging-2
+  labels:
+    foo: dictionary-2

--- a/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/basic-delete/README.md
+++ b/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/basic-delete/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This is a basic test for the mutate existing capability which ensures that specifically deleting a triggering resource, via a precondition, results in the correct mutation of a different resource.
+
+## Expected Behavior
+
+When the `dictionary-2` ConfigMap is deleted, this should result in the mutation of the Secret named `test-secret-2` within the same Namespace to add the label `foo` with value set to the name or `dictionary-2` in this case. If the Secret is mutated so that the label `foo: dictionary-2` is present, the test passes. If not, the test fails.
+
+## Reference Issue(s)
+
+N/A

--- a/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/basic-delete/cleanup.yaml
+++ b/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/basic-delete/cleanup.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete -f 01-manifests.yaml --force --wait=true --ignore-not-found=true

--- a/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/temp/basic-delete/01-assert.yaml
+++ b/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/temp/basic-delete/01-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: test-post-mutation-delete-trigger
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/temp/basic-delete/01-assert.yaml
+++ b/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/temp/basic-delete/01-assert.yaml
@@ -1,9 +1,0 @@
-apiVersion: kyverno.io/v1
-kind: ClusterPolicy
-metadata:
-  name: test-post-mutation-delete-trigger
-status:
-  conditions:
-  - reason: Succeeded
-    status: "True"
-    type: Ready


### PR DESCRIPTION
## Explanation

>When a background (generate/mutateExisting) policy defines variables referring to admission request data on DELETE operation, these variables may not be available anymore if the resource is removed from the cluster.

This PR supports admission review variables in DELETE requests for background policies.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes https://github.com/kyverno/kyverno/issues/6189.
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.10
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
