### PR TITLE
refactor: make funcs part of engine struct to reduce parameter passing

### DIFF
--- a/pkg/engine/background.go
+++ b/pkg/engine/background.go
@@ -6,7 +6,6 @@ import (
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/autogen"
-	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/engine/utils"
 	"github.com/kyverno/kyverno/pkg/engine/variables"
@@ -18,22 +17,16 @@ import (
 //   - the caller has to check the ruleResponse to determine whether the path exist
 //
 // 2. returns the list of rules that are applicable on this policy and resource, if 1 succeed
-func doApplyBackgroundChecks(
-	contextLoader engineapi.ContextLoaderFactory,
-	selector engineapi.PolicyExceptionSelector,
+func (e *engine) applyBackgroundChecks(
 	policyContext engineapi.PolicyContext,
-	cfg config.Configuration,
 ) (resp *engineapi.EngineResponse) {
 	policyStartTime := time.Now()
-	return filterRules(contextLoader, selector, policyContext, policyStartTime, cfg)
+	return e.filterRules(policyContext, policyStartTime)
 }
 
-func filterRules(
-	contextLoader engineapi.ContextLoaderFactory,
-	selector engineapi.PolicyExceptionSelector,
+func (e *engine) filterRules(
 	policyContext engineapi.PolicyContext,
 	startTime time.Time,
-	cfg config.Configuration,
 ) *engineapi.EngineResponse {
 	newResource := policyContext.NewResource()
 	policy := policyContext.Policy()
@@ -61,14 +54,14 @@ func filterRules(
 		},
 	}
 
-	if cfg.ToFilter(kind, namespace, name) {
+	if e.configuration.ToFilter(kind, namespace, name) {
 		logging.WithName("ApplyBackgroundChecks").Info("resource excluded", "kind", kind, "namespace", namespace, "name", name)
 		return resp
 	}
 
 	applyRules := policy.GetSpec().GetApplyRules()
 	for _, rule := range autogen.ComputeRules(policy) {
-		if ruleResp := filterRule(contextLoader, selector, rule, policyContext, cfg); ruleResp != nil {
+		if ruleResp := e.filterRule(rule, policyContext); ruleResp != nil {
 			resp.PolicyResponse.Rules = append(resp.PolicyResponse.Rules, *ruleResp)
 			if applyRules == kyvernov1.ApplyOne && ruleResp.Status != engineapi.RuleStatusSkip {
 				break
@@ -79,12 +72,9 @@ func filterRules(
 	return resp
 }
 
-func filterRule(
-	contextLoader engineapi.ContextLoaderFactory,
-	selector engineapi.PolicyExceptionSelector,
+func (e *engine) filterRule(
 	rule kyvernov1.Rule,
 	policyContext engineapi.PolicyContext,
-	cfg config.Configuration,
 ) *engineapi.RuleResponse {
 	if !rule.HasGenerate() && !rule.IsMutateExisting() {
 		return nil
@@ -96,7 +86,7 @@ func filterRule(
 	subresourceGVKToAPIResource := GetSubresourceGVKToAPIResourceMap(kindsInPolicy, policyContext)
 
 	// check if there is a corresponding policy exception
-	ruleResp := hasPolicyExceptions(logger, selector, policyContext, &rule, subresourceGVKToAPIResource, cfg)
+	ruleResp := hasPolicyExceptions(logger, e.exceptionSelector, policyContext, &rule, subresourceGVKToAPIResource, e.configuration)
 	if ruleResp != nil {
 		return ruleResp
 	}
@@ -113,7 +103,7 @@ func filterRule(
 	oldResource := policyContext.OldResource()
 	admissionInfo := policyContext.AdmissionInfo()
 	ctx := policyContext.JSONContext()
-	excludeGroupRole := cfg.GetExcludeGroupRole()
+	excludeGroupRole := e.configuration.GetExcludeGroupRole()
 	namespaceLabels := policyContext.NamespaceLabels()
 
 	logger = logging.WithName(string(ruleType)).WithValues("policy", policy.GetName(),
@@ -141,7 +131,7 @@ func filterRule(
 	policyContext.JSONContext().Checkpoint()
 	defer policyContext.JSONContext().Restore()
 
-	if err := LoadContext(context.TODO(), contextLoader, rule.Context, policyContext, rule.Name); err != nil {
+	if err := LoadContext(context.TODO(), e.contextLoader, rule.Context, policyContext, rule.Name); err != nil {
 		logger.V(4).Info("cannot add external data to the context", "reason", err.Error())
 		return nil
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -52,14 +52,14 @@ func (e *engine) VerifyAndPatchImages(
 func (e *engine) ApplyBackgroundChecks(
 	policyContext engineapi.PolicyContext,
 ) *engineapi.EngineResponse {
-	return doApplyBackgroundChecks(e.contextLoader, e.exceptionSelector, policyContext, e.configuration)
+	return e.applyBackgroundChecks(policyContext)
 }
 
 func (e *engine) GenerateResponse(
 	policyContext engineapi.PolicyContext,
 	gr kyvernov1beta1.UpdateRequest,
 ) *engineapi.EngineResponse {
-	return doGenerateResponse(e.contextLoader, e.exceptionSelector, policyContext, gr, e.configuration)
+	return e.generateResponse(policyContext, gr)
 }
 
 func (e *engine) ContextLoader(

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -31,14 +31,14 @@ func (e *engine) Validate(
 	ctx context.Context,
 	policyContext engineapi.PolicyContext,
 ) *engineapi.EngineResponse {
-	return doValidate(ctx, e.contextLoader, e.exceptionSelector, policyContext, e.configuration)
+	return e.validate(ctx, policyContext)
 }
 
 func (e *engine) Mutate(
 	ctx context.Context,
 	policyContext engineapi.PolicyContext,
 ) *engineapi.EngineResponse {
-	return doMutate(ctx, e.contextLoader, e.exceptionSelector, policyContext, e.configuration)
+	return e.mutate(ctx, policyContext)
 }
 
 func (e *engine) VerifyAndPatchImages(
@@ -46,7 +46,7 @@ func (e *engine) VerifyAndPatchImages(
 	rclient registryclient.Client,
 	policyContext engineapi.PolicyContext,
 ) (*engineapi.EngineResponse, *engineapi.ImageVerificationMetadata) {
-	return doVerifyAndPatchImages(ctx, e.contextLoader, e.exceptionSelector, rclient, policyContext, e.configuration)
+	return e.verifyAndPatchImages(ctx, rclient, policyContext)
 }
 
 func (e *engine) ApplyBackgroundChecks(

--- a/pkg/engine/generation.go
+++ b/pkg/engine/generation.go
@@ -5,31 +5,24 @@ import (
 
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/autogen"
-	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/logging"
 	"k8s.io/client-go/tools/cache"
 )
 
 // GenerateResponse checks for validity of generate rule on the resource
-func doGenerateResponse(
-	contextLoader engineapi.ContextLoaderFactory,
-	selector engineapi.PolicyExceptionSelector,
+func (e *engine) generateResponse(
 	policyContext engineapi.PolicyContext,
 	gr kyvernov1beta1.UpdateRequest,
-	cfg config.Configuration,
 ) (resp *engineapi.EngineResponse) {
 	policyStartTime := time.Now()
-	return filterGenerateRules(contextLoader, selector, policyContext, gr.Spec.Policy, policyStartTime, cfg)
+	return e.filterGenerateRules(policyContext, gr.Spec.Policy, policyStartTime)
 }
 
-func filterGenerateRules(
-	contextLoader engineapi.ContextLoaderFactory,
-	selector engineapi.PolicyExceptionSelector,
+func (e *engine) filterGenerateRules(
 	policyContext engineapi.PolicyContext,
 	policyNameKey string,
 	startTime time.Time,
-	cfg config.Configuration,
 ) *engineapi.EngineResponse {
 	newResource := policyContext.NewResource()
 	kind := newResource.GetKind()
@@ -59,13 +52,13 @@ func filterGenerateRules(
 			},
 		},
 	}
-	if cfg.ToFilter(kind, namespace, name) {
+	if e.configuration.ToFilter(kind, namespace, name) {
 		logging.WithName("Generate").Info("resource excluded", "kind", kind, "namespace", namespace, "name", name)
 		return resp
 	}
 
 	for _, rule := range autogen.ComputeRules(policyContext.Policy()) {
-		if ruleResp := filterRule(contextLoader, selector, rule, policyContext, cfg); ruleResp != nil {
+		if ruleResp := e.filterRule(rule, policyContext); ruleResp != nil {
 			resp.PolicyResponse.Rules = append(resp.PolicyResponse.Rules, *ruleResp)
 		}
 	}

--- a/pkg/engine/imageVerify_test.go
+++ b/pkg/engine/imageVerify_test.go
@@ -167,13 +167,15 @@ func testVerifyAndPatchImages(
 	pContext engineapi.PolicyContext,
 	cfg config.Configuration,
 ) (*engineapi.EngineResponse, *engineapi.ImageVerificationMetadata) {
-	return doVerifyAndPatchImages(
-		ctx,
+	e := NewEngine(
+		cfg,
 		LegacyContextLoaderFactory(rclient, cmResolver),
 		nil,
+	)
+	return e.VerifyAndPatchImages(
+		ctx,
 		rclient,
 		pContext,
-		cfg,
 	)
 }
 

--- a/pkg/engine/mutation_test.go
+++ b/pkg/engine/mutation_test.go
@@ -10,7 +10,6 @@ import (
 	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/utils/store"
 	client "github.com/kyverno/kyverno/pkg/clients/dclient"
-	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/registryclient"
@@ -26,12 +25,14 @@ func testMutate(
 	rclient registryclient.Client,
 	pContext *PolicyContext,
 ) *engineapi.EngineResponse {
-	return doMutate(
-		ctx,
+	e := NewEngine(
+		cfg,
 		LegacyContextLoaderFactory(rclient, nil),
 		nil,
+	)
+	return e.Mutate(
+		ctx,
 		pContext,
-		config.NewDefaultConfiguration(),
 	)
 }
 

--- a/pkg/engine/validation_test.go
+++ b/pkg/engine/validation_test.go
@@ -20,12 +20,14 @@ import (
 )
 
 func testValidate(ctx context.Context, rclient registryclient.Client, pContext *PolicyContext, cfg config.Configuration) *engineapi.EngineResponse {
-	return doValidate(
-		ctx,
+	e := NewEngine(
+		cfg,
 		LegacyContextLoaderFactory(rclient, nil),
 		nil,
+	)
+	return e.Validate(
+		ctx,
 		pContext,
-		cfg,
 	)
 }
 


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR moves engine funcs to methods to stop passing all parameters to every func.
