### PR TITLE
fix: do not pass dynamicConfig to matchesResourceDescriptionMatchHelper (#6231)

### DIFF
--- a/pkg/engine/utils.go
+++ b/pkg/engine/utils.go
@@ -180,6 +180,7 @@ func MatchesResourceDescription(subresourceGVKToAPIResource map[string]*metav1.A
 	rule := ruleRef.DeepCopy()
 	resource := *resourceRef.DeepCopy()
 	admissionInfo := *admissionInfoRef.DeepCopy()
+	empty := []string{}
 
 	var reasonsForFailure []error
 	if policyNamespace != "" && policyNamespace != resourceRef.GetNamespace() {
@@ -192,7 +193,7 @@ func MatchesResourceDescription(subresourceGVKToAPIResource map[string]*metav1.A
 		oneMatched := false
 		for _, rmr := range rule.MatchResources.Any {
 			// if there are no errors it means it was a match
-			if len(matchesResourceDescriptionMatchHelper(subresourceGVKToAPIResource, rmr, admissionInfo, resource, dynamicConfig, namespaceLabels, subresourceInAdmnReview)) == 0 {
+			if len(matchesResourceDescriptionMatchHelper(subresourceGVKToAPIResource, rmr, admissionInfo, resource, empty, namespaceLabels, subresourceInAdmnReview)) == 0 {
 				oneMatched = true
 				break
 			}
@@ -203,11 +204,11 @@ func MatchesResourceDescription(subresourceGVKToAPIResource map[string]*metav1.A
 	} else if len(rule.MatchResources.All) > 0 {
 		// include object if ALL of the criteria match
 		for _, rmr := range rule.MatchResources.All {
-			reasonsForFailure = append(reasonsForFailure, matchesResourceDescriptionMatchHelper(subresourceGVKToAPIResource, rmr, admissionInfo, resource, dynamicConfig, namespaceLabels, subresourceInAdmnReview)...)
+			reasonsForFailure = append(reasonsForFailure, matchesResourceDescriptionMatchHelper(subresourceGVKToAPIResource, rmr, admissionInfo, resource, empty, namespaceLabels, subresourceInAdmnReview)...)
 		}
 	} else {
 		rmr := kyvernov1.ResourceFilter{UserInfo: rule.MatchResources.UserInfo, ResourceDescription: rule.MatchResources.ResourceDescription}
-		reasonsForFailure = append(reasonsForFailure, matchesResourceDescriptionMatchHelper(subresourceGVKToAPIResource, rmr, admissionInfo, resource, dynamicConfig, namespaceLabels, subresourceInAdmnReview)...)
+		reasonsForFailure = append(reasonsForFailure, matchesResourceDescriptionMatchHelper(subresourceGVKToAPIResource, rmr, admissionInfo, resource, empty, namespaceLabels, subresourceInAdmnReview)...)
 	}
 
 	if len(rule.ExcludeResources.Any) > 0 {

--- a/pkg/engine/utils_test.go
+++ b/pkg/engine/utils_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+
 	v1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/autogen"
@@ -1877,6 +1880,152 @@ func TestResourceDescriptionMatch_MultipleKind(t *testing.T) {
 
 	if err := MatchesResourceDescription(make(map[string]*metav1.APIResource), *resource, rule, v1beta1.RequestInfo{}, []string{}, nil, "", ""); err != nil {
 		t.Errorf("Testcase has failed due to the following:%v", err)
+	}
+}
+
+func TestResourceDescriptionMatch_ExcludeDefaultGroups(t *testing.T) {
+
+	// slightly simplified ingress controller pod that lives in the ingress-nginx namespace
+	rawResource := []byte(`{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "ingress-nginx-controller-57bc6474bb-mcpt2",
+			"namespace": "ingress-nginx"
+		},
+		"spec": {
+			"containers": [
+				{
+					"args": ["/nginx-ingress-controller"],
+					"env": [],
+					"image": "registry.k8s.io/ingress-nginx/controller:v1.5.1",
+					"imagePullPolicy": "IfNotPresent",
+					"name": "controller",
+					"securityContext": {
+						"allowPrivilegeEscalation": true,
+						"capabilities": {
+							"add": [
+								"NET_BIND_SERVICE"
+							],
+							"drop": [
+								"ALL"
+							]
+						},
+						"runAsUser": 101
+					},
+					"volumeMounts": [
+						{
+							"mountPath": "/usr/local/certificates/",
+							"name": "webhook-cert",
+							"readOnly": true
+						},
+						{
+							"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+							"name": "kube-api-access-vc2qz",
+							"readOnly": true
+						}
+					]
+				}
+			],
+			"securityContext": {},
+			"serviceAccount": "ingress-nginx",
+			"serviceAccountName": "ingress-nginx"
+		}
+	}`)
+	resource, err := kubeutils.BytesToUnstructured(rawResource)
+	if err != nil {
+		t.Errorf("unable to convert raw resource to unstructured: %v", err)
+	}
+
+	// this rule should match only pods in the user1-restricted namespace, and also pods of User:user1.
+	rule := v1.Rule{
+		MatchResources: v1.MatchResources{Any: v1.ResourceFilters{
+			// pods in user1-restricted namespace
+			v1.ResourceFilter{
+				ResourceDescription: v1.ResourceDescription{
+					Kinds: []string{"Pod"},
+					Namespaces: []string{
+						"user1-restricted",
+					},
+				},
+			},
+			// pods for User user1 account
+			v1.ResourceFilter{
+				ResourceDescription: v1.ResourceDescription{
+					Kinds: []string{"Pod"},
+				},
+				UserInfo: v1.UserInfo{
+					Subjects: []rbacv1.Subject{
+						{
+							Kind: "User",
+							Name: "user1",
+						},
+					},
+				},
+			},
+		}},
+		ExcludeResources: v1.MatchResources{},
+	}
+
+	// the following groups are added by default to ensure that these groups or users are always excluded
+	// these should not affect the rule in our case, we expect our rule to NOT match with the nginx pod.
+
+	dynamicConfig := []string{
+		"system:serviceaccounts:kube-system",
+		"system:nodes",
+		"system:kube-scheduler",
+	}
+
+	// this is the request info that was also passed with the mocked pod
+	requestInfo := v1beta1.RequestInfo{
+		AdmissionUserInfo: authenticationv1.UserInfo{
+			Username: "system:serviceaccount:kube-system:replicaset-controller",
+			UID:      "8f36cad4-eb68-4931-bea8-8a42dd1fee4c",
+			Groups: []string{
+				"system:serviceaccounts",
+				"system:serviceaccounts:kube-system",
+				"system:authenticated",
+			},
+		},
+	}
+
+	// First test: confirm that this above rule produces errors (and raise an error if err == nil)
+	if err := MatchesResourceDescription(make(map[string]*metav1.APIResource), *resource, rule, requestInfo, dynamicConfig, nil, "", ""); err == nil {
+		t.Error("Testcase was expected to fail, but err was nil")
+	}
+
+	// This next rule *should* match, because we explicitly match the ingress-nginx namespace this time.
+	rule2 := v1.Rule{
+		MatchResources: v1.MatchResources{Any: v1.ResourceFilters{
+			v1.ResourceFilter{
+				ResourceDescription: v1.ResourceDescription{
+					Kinds: []string{"Pod"},
+					Namespaces: []string{
+						"ingress-nginx",
+					},
+				},
+			},
+		}},
+		ExcludeResources: v1.MatchResources{Any: v1.ResourceFilters{}},
+	}
+
+	// Second test: confirm that matching this rule does not create any errors (and raise if err != nil)
+	if err := MatchesResourceDescription(make(map[string]*metav1.APIResource), *resource, rule2, requestInfo, dynamicConfig, nil, "", ""); err != nil {
+		t.Errorf("Testcase was expected to not fail, but err was %s", err)
+	}
+
+	// Now we extend the previous rule to have an Exclude part. Making it 'not-empty' should make the exclude-code run.
+	rule2.ExcludeResources = v1.MatchResources{Any: v1.ResourceFilters{
+		v1.ResourceFilter{
+			ResourceDescription: v1.ResourceDescription{
+				Kinds: []string{"Pod"},
+			},
+		},
+	}}
+
+	// Third test: confirm that now the custom exclude-snippet should run in CheckSubjects() and that should result in this rule failing (raise if err == nil for that reason)
+	if err := MatchesResourceDescription(make(map[string]*metav1.APIResource), *resource, rule2, requestInfo, dynamicConfig, nil, "", ""); err == nil {
+		t.Error("Testcase was expected to fail, but err was nil #1!")
 	}
 }
 


### PR DESCRIPTION
## Explanation

We filed a bug earlier today -- https://github.com/kyverno/kyverno/issues/6231 -- where we found a problem with some of our Mutating Policies. These policies of ours were basically tied to specific users and namespaces only:

```
  - exclude:
      resources: {}
    generate:
      clone: {}
    match:
      any:
      - resources:
          kinds:
          - Pod
          namespaces:
          - user1-restricted
      - resources:
          kinds:
          - Pod
        subjects:
        - kind: User
          name: user1
      resources: {}
```
(In case it's helpful, I also added the full exported yaml for this particular rule in `user1.yaml` as an attachment
[user1.yaml.txt](https://github.com/kyverno/kyverno/files/10669023/user1.yaml.txt))

However, we saw them being applied to completely unrelated Pods (and other kinds of Resources), such as an Ingress Controller. I think this is because the three calls to `matchesResourceDescriptionMatchHelper` that I changed in this Pull Request are being passed `dynamicConfig`, which appears to contain, at least in the one case I'm talking about the following items (it's a `[]string`):

* `system:serviceaccounts:kube-system`
* `system:nodes`
* `system:kube-scheduler`

I spot a few calls intended for the `Any` or `All` rule, and then calls for the "Exclude" part of the rule. My guess is the dynamicConfig was actually only intended for those exclude calls.

If you follow where this `dynamicConfig` goes to, via:

* `matchesResourceDescriptionMatchHelper` ..., they forward this config to a nested call to:
* `doesResourceMatchConditionBlock` ..., which forwards it to:
* `matchSubjects` ..., which forwards it to (for the non-mock case):
* `(matchutils).CheckSubjects`

And in that last function, `CheckSubjects`, the parameter is called "excludeGroupRole", which leads me to believe my proposed change could be correct. But I have to admit I'm not fully at home with the Kyverno codebase.

Note that I almost overlooked that the path for Exclude is using a different function: `matchesResourceDescriptionExcludeHelper`, the different name didn't catch my attention at first, but I suspect the `dynamicConfig` is only valid to be passed to this function?

## Related issue

* https://github.com/kyverno/kyverno/issues/6231
* https://github.com/kyverno/kyverno/issues/5150

## Milestone of this PR

Sorry don't know what to put here..

## What type of PR is this

Sorry don't know what to put here..

## Proposed Changes

I hope I already did a decent job in my Explanation part of this PR text.

### Proof Manifests

The easiest way to reproduce it is to follow instructions from the linked Bug.

I had quite some trouble trying to make a smaller test example.
Maybe I could in theory do a better job now, but I don't know if this is really necessary. I hope someone with more understanding of the code can see if this proposed change is a correct fix or not.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
