### PR TITLE
refactor: context loading and engine methods

### DIFF
--- a/cmd/background-controller/main.go
+++ b/cmd/background-controller/main.go
@@ -214,7 +214,8 @@ func main() {
 	engine := engine.NewEngine(
 		configuration,
 		dClient,
-		engine.LegacyContextLoaderFactory(dClient, rclient, configMapResolver),
+		rclient,
+		engine.LegacyContextLoaderFactory(configMapResolver),
 		// TODO: do we need exceptions here ?
 		nil,
 	)

--- a/cmd/cli/kubectl-kyverno/utils/common/common.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common.go
@@ -477,7 +477,8 @@ OuterLoop:
 	eng := engine.NewEngine(
 		cfg,
 		c.Client,
-		engine.LegacyContextLoaderFactory(c.Client, registryclient.NewOrDie(), nil),
+		registryclient.NewOrDie(),
+		engine.LegacyContextLoaderFactory(nil),
 		nil,
 	)
 	policyContext := engine.NewPolicyContextWithJsonContext(ctx).
@@ -525,11 +526,7 @@ OuterLoop:
 		engineResponses = append(engineResponses, validateResponse)
 	}
 
-	verifyImageResponse, _ := eng.VerifyAndPatchImages(
-		context.Background(),
-		registryclient.NewOrDie(),
-		policyContext,
-	)
+	verifyImageResponse, _ := eng.VerifyAndPatchImages(context.TODO(), policyContext)
 	if verifyImageResponse != nil && !verifyImageResponse.IsEmpty() {
 		engineResponses = append(engineResponses, verifyImageResponse)
 		info = ProcessValidateEngineResponse(c.Policy, verifyImageResponse, resPath, c.Rc, c.PolicyReport, c.AuditWarn)
@@ -543,9 +540,7 @@ OuterLoop:
 	}
 
 	if policyHasGenerate {
-		generateResponse := eng.ApplyBackgroundChecks(
-			policyContext,
-		)
+		generateResponse := eng.ApplyBackgroundChecks(context.TODO(), policyContext)
 		if generateResponse != nil && !generateResponse.IsEmpty() {
 			newRuleResponse, err := handleGeneratePolicy(generateResponse, *policyContext, c.RuleToCloneSourceResource)
 			if err != nil {
@@ -1081,7 +1076,8 @@ func initializeMockController(objects []runtime.Object) (*generate.GenerateContr
 	c := generate.NewGenerateControllerWithOnlyClient(client, engine.NewEngine(
 		config.NewDefaultConfiguration(),
 		client,
-		engine.LegacyContextLoaderFactory(client, nil, nil),
+		nil,
+		engine.LegacyContextLoaderFactory(nil),
 		nil,
 	))
 	return c, nil

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -367,7 +367,8 @@ func main() {
 	eng := engine.NewEngine(
 		configuration,
 		dClient,
-		engine.LegacyContextLoaderFactory(dClient, rclient, configMapResolver),
+		rclient,
+		engine.LegacyContextLoaderFactory(configMapResolver),
 		exceptionsLister,
 	)
 	// create non leader controllers

--- a/cmd/reports-controller/main.go
+++ b/cmd/reports-controller/main.go
@@ -129,7 +129,6 @@ func createReportControllers(
 				backgroundscancontroller.NewController(
 					client,
 					kyvernoClient,
-					rclient,
 					eng,
 					metadataFactory,
 					kyvernoV1.Policies(),
@@ -315,7 +314,8 @@ func main() {
 	eng := engine.NewEngine(
 		configuration,
 		dClient,
-		engine.LegacyContextLoaderFactory(dClient, rclient, configMapResolver),
+		rclient,
+		engine.LegacyContextLoaderFactory(configMapResolver),
 		exceptionsLister,
 	)
 	// setup leader election

--- a/pkg/background/generate/generate.go
+++ b/pkg/background/generate/generate.go
@@ -197,7 +197,7 @@ func (c *GenerateController) applyGenerate(resource unstructured.Unstructured, u
 	}
 
 	// check if the policy still applies to the resource
-	engineResponse := c.engine.GenerateResponse(policyContext, ur)
+	engineResponse := c.engine.GenerateResponse(context.Background(), policyContext, ur)
 	if len(engineResponse.PolicyResponse.Rules) == 0 {
 		logger.V(4).Info(doesNotApply)
 		return nil, false, errors.New(doesNotApply)
@@ -343,7 +343,7 @@ func (c *GenerateController) ApplyGeneratePolicy(log logr.Logger, policyContext 
 		}
 
 		// add configmap json data to context
-		if err := c.engine.ContextLoader(policyContext, rule.Name).Load(context.TODO(), rule.Context, policyContext.JSONContext()); err != nil {
+		if err := c.engine.ContextLoader(policyContext.Policy(), rule)(context.TODO(), rule.Context, policyContext.JSONContext()); err != nil {
 			log.Error(err, "cannot add configmaps to context")
 			return nil, processExisting, err
 		}

--- a/pkg/controllers/report/background/controller.go
+++ b/pkg/controllers/report/background/controller.go
@@ -19,7 +19,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/controllers/report/utils"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/event"
-	"github.com/kyverno/kyverno/pkg/registryclient"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -47,7 +46,6 @@ type controller struct {
 	// clients
 	client        dclient.Interface
 	kyvernoClient versioned.Interface
-	rclient       registryclient.Client
 	engine        engineapi.Engine
 
 	// listers
@@ -73,7 +71,6 @@ type controller struct {
 func NewController(
 	client dclient.Interface,
 	kyvernoClient versioned.Interface,
-	rclient registryclient.Client,
 	engine engineapi.Engine,
 	metadataFactory metadatainformers.SharedInformerFactory,
 	polInformer kyvernov1informers.PolicyInformer,
@@ -91,7 +88,6 @@ func NewController(
 	c := controller{
 		client:                 client,
 		kyvernoClient:          kyvernoClient,
-		rclient:                rclient,
 		engine:                 engine,
 		polLister:              polInformer.Lister(),
 		cpolLister:             cpolInformer.Lister(),
@@ -308,7 +304,7 @@ func (c *controller) reconcileReport(
 	// calculate necessary results
 	for _, policy := range backgroundPolicies {
 		if full || actual[reportutils.PolicyLabel(policy)] != policy.GetResourceVersion() {
-			scanner := utils.NewScanner(logger, c.engine, c.client, c.rclient, c.config)
+			scanner := utils.NewScanner(logger, c.engine, c.config)
 			for _, result := range scanner.ScanResource(ctx, *target, nsLabels, policy) {
 				if result.Error != nil {
 					return result.Error

--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -5,22 +5,18 @@ import (
 
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
-	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/engine"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
-	"github.com/kyverno/kyverno/pkg/registryclient"
 	"go.uber.org/multierr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type scanner struct {
-	logger  logr.Logger
-	engine  engineapi.Engine
-	client  dclient.Interface
-	rclient registryclient.Client
-	config  config.Configuration
+	logger logr.Logger
+	engine engineapi.Engine
+	config config.Configuration
 }
 
 type ScanResult struct {
@@ -35,16 +31,12 @@ type Scanner interface {
 func NewScanner(
 	logger logr.Logger,
 	engine engineapi.Engine,
-	client dclient.Interface,
-	rclient registryclient.Client,
 	config config.Configuration,
 ) Scanner {
 	return &scanner{
-		logger:  logger,
-		engine:  engine,
-		client:  client,
-		rclient: rclient,
-		config:  config,
+		logger: logger,
+		engine: engine,
+		config: config,
 	}
 }
 
@@ -114,7 +106,7 @@ func (s *scanner) validateImages(ctx context.Context, resource unstructured.Unst
 		WithNewResource(resource).
 		WithPolicy(policy).
 		WithNamespaceLabels(nsLabels)
-	response, _ := s.engine.VerifyAndPatchImages(ctx, s.rclient, policyCtx)
+	response, _ := s.engine.VerifyAndPatchImages(ctx, policyCtx)
 	if len(response.PolicyResponse.Rules) > 0 {
 		s.logger.Info("validateImages", "policy", policy, "response", response)
 	}

--- a/pkg/engine/api/contextloader.go
+++ b/pkg/engine/api/contextloader.go
@@ -4,13 +4,22 @@ import (
 	"context"
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
+	"github.com/kyverno/kyverno/pkg/registryclient"
 )
 
 // ContextLoaderFactory provides a ContextLoader given a policy context and rule name
-type ContextLoaderFactory = func(pContext PolicyContext, ruleName string) ContextLoader
+type ContextLoaderFactory = func(policy kyvernov1.PolicyInterface, rule kyvernov1.Rule) ContextLoader
 
 // ContextLoader abstracts the mechanics to load context entries in the underlying json context
 type ContextLoader interface {
-	Load(ctx context.Context, contextEntries []kyvernov1.ContextEntry, jsonContext enginecontext.Interface) error
+	Load(
+		ctx context.Context,
+		client dclient.Interface,
+		rclient registryclient.Client,
+		exceptionSelector PolicyExceptionSelector,
+		contextEntries []kyvernov1.ContextEntry,
+		jsonContext enginecontext.Interface,
+	) error
 }

--- a/pkg/engine/api/engine.go
+++ b/pkg/engine/api/engine.go
@@ -3,9 +3,12 @@ package api
 import (
 	"context"
 
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
-	"github.com/kyverno/kyverno/pkg/registryclient"
+	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
 )
+
+type EngineContextLoader = func(ctx context.Context, contextEntries []kyvernov1.ContextEntry, jsonContext enginecontext.Interface) error
 
 // Engine is the main interface to run policies against resources
 type Engine interface {
@@ -24,7 +27,6 @@ type Engine interface {
 	// VerifyAndPatchImages ...
 	VerifyAndPatchImages(
 		ctx context.Context,
-		rclient registryclient.Client,
 		policyContext PolicyContext,
 	) (*EngineResponse, *ImageVerificationMetadata)
 
@@ -34,17 +36,19 @@ type Engine interface {
 	//
 	// 2. returns the list of rules that are applicable on this policy and resource, if 1 succeed
 	ApplyBackgroundChecks(
+		ctx context.Context,
 		policyContext PolicyContext,
 	) *EngineResponse
 
 	// GenerateResponse checks for validity of generate rule on the resource
 	GenerateResponse(
+		ctx context.Context,
 		policyContext PolicyContext,
 		gr kyvernov1beta1.UpdateRequest,
 	) *EngineResponse
 
 	ContextLoader(
-		policyContext PolicyContext,
-		ruleName string,
-	) ContextLoader
+		policy kyvernov1.PolicyInterface,
+		rule kyvernov1.Rule,
+	) EngineContextLoader
 }

--- a/pkg/engine/background.go
+++ b/pkg/engine/background.go
@@ -132,7 +132,7 @@ func (e *engine) filterRule(
 	policyContext.JSONContext().Checkpoint()
 	defer policyContext.JSONContext().Restore()
 
-	if err := internal.LoadContext(context.TODO(), e.contextLoader, rule.Context, policyContext, rule.Name); err != nil {
+	if err := internal.LoadContext(context.TODO(), e, policyContext, rule); err != nil {
 		logger.V(4).Info("cannot add external data to the context", "reason", err.Error())
 		return nil
 	}

--- a/pkg/engine/background.go
+++ b/pkg/engine/background.go
@@ -19,6 +19,7 @@ import (
 //
 // 2. returns the list of rules that are applicable on this policy and resource, if 1 succeed
 func (e *engine) applyBackgroundChecks(
+	ctx context.Context,
 	policyContext engineapi.PolicyContext,
 ) (resp *engineapi.EngineResponse) {
 	policyStartTime := time.Now()

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/registryclient"
 )
 
@@ -75,6 +76,15 @@ func (e *engine) ContextLoader(
 	policy kyvernov1.PolicyInterface,
 	rule kyvernov1.Rule,
 ) engineapi.EngineContextLoader {
-	return nil
-	// return e.contextLoader(policy, rule)
+	loader := e.contextLoader(policy, rule)
+	return func(ctx context.Context, contextEntries []kyvernov1.ContextEntry, jsonContext enginecontext.Interface) error {
+		return loader.Load(
+			ctx,
+			e.client,
+			e.rclient,
+			e.exceptionSelector,
+			contextEntries,
+			jsonContext,
+		)
+	}
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/config"
@@ -13,6 +14,7 @@ import (
 type engine struct {
 	configuration     config.Configuration
 	client            dclient.Interface
+	rclient           registryclient.Client
 	contextLoader     engineapi.ContextLoaderFactory
 	exceptionSelector engineapi.PolicyExceptionSelector
 }
@@ -20,12 +22,14 @@ type engine struct {
 func NewEngine(
 	configuration config.Configuration,
 	client dclient.Interface,
+	rclient registryclient.Client,
 	contextLoader engineapi.ContextLoaderFactory,
 	exceptionSelector engineapi.PolicyExceptionSelector,
 ) engineapi.Engine {
 	return &engine{
 		configuration:     configuration,
 		client:            client,
+		rclient:           rclient,
 		contextLoader:     contextLoader,
 		exceptionSelector: exceptionSelector,
 	}
@@ -47,19 +51,20 @@ func (e *engine) Mutate(
 
 func (e *engine) VerifyAndPatchImages(
 	ctx context.Context,
-	rclient registryclient.Client,
 	policyContext engineapi.PolicyContext,
 ) (*engineapi.EngineResponse, *engineapi.ImageVerificationMetadata) {
-	return e.verifyAndPatchImages(ctx, rclient, policyContext)
+	return e.verifyAndPatchImages(ctx, policyContext)
 }
 
 func (e *engine) ApplyBackgroundChecks(
+	ctx context.Context,
 	policyContext engineapi.PolicyContext,
 ) *engineapi.EngineResponse {
 	return e.applyBackgroundChecks(policyContext)
 }
 
 func (e *engine) GenerateResponse(
+	ctx context.Context,
 	policyContext engineapi.PolicyContext,
 	gr kyvernov1beta1.UpdateRequest,
 ) *engineapi.EngineResponse {
@@ -67,8 +72,9 @@ func (e *engine) GenerateResponse(
 }
 
 func (e *engine) ContextLoader(
-	policyContext engineapi.PolicyContext,
-	ruleName string,
-) engineapi.ContextLoader {
-	return e.contextLoader(policyContext, ruleName)
+	policy kyvernov1.PolicyInterface,
+	rule kyvernov1.Rule,
+) engineapi.EngineContextLoader {
+	return nil
+	// return e.contextLoader(policy, rule)
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -61,7 +61,7 @@ func (e *engine) ApplyBackgroundChecks(
 	ctx context.Context,
 	policyContext engineapi.PolicyContext,
 ) *engineapi.EngineResponse {
-	return e.applyBackgroundChecks(policyContext)
+	return e.applyBackgroundChecks(ctx, policyContext)
 }
 
 func (e *engine) GenerateResponse(
@@ -69,7 +69,7 @@ func (e *engine) GenerateResponse(
 	policyContext engineapi.PolicyContext,
 	gr kyvernov1beta1.UpdateRequest,
 ) *engineapi.EngineResponse {
-	return e.generateResponse(policyContext, gr)
+	return e.generateResponse(ctx, policyContext, gr)
 }
 
 func (e *engine) ContextLoader(

--- a/pkg/engine/generation.go
+++ b/pkg/engine/generation.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"time"
 
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
@@ -12,6 +13,7 @@ import (
 
 // GenerateResponse checks for validity of generate rule on the resource
 func (e *engine) generateResponse(
+	ctx context.Context,
 	policyContext engineapi.PolicyContext,
 	gr kyvernov1beta1.UpdateRequest,
 ) (resp *engineapi.EngineResponse) {

--- a/pkg/engine/imageVerify.go
+++ b/pkg/engine/imageVerify.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine/internal"
 	"github.com/kyverno/kyverno/pkg/engine/variables"
 	"github.com/kyverno/kyverno/pkg/logging"
-	"github.com/kyverno/kyverno/pkg/registryclient"
 	"github.com/kyverno/kyverno/pkg/tracing"
 	apiutils "github.com/kyverno/kyverno/pkg/utils/api"
 	"github.com/kyverno/kyverno/pkg/utils/wildcard"
@@ -23,7 +22,6 @@ import (
 
 func (e *engine) verifyAndPatchImages(
 	ctx context.Context,
-	rclient registryclient.Client,
 	policyContext engineapi.PolicyContext,
 ) (*engineapi.EngineResponse, *engineapi.ImageVerificationMetadata) {
 	resp := &engineapi.EngineResponse{}
@@ -98,7 +96,7 @@ func (e *engine) verifyAndPatchImages(
 					return
 				}
 				policyContext.JSONContext().Restore()
-				if err := internal.LoadContext(ctx, e.contextLoader, rule.Context, policyContext, rule.Name); err != nil {
+				if err := internal.LoadContext(ctx, e, policyContext, *rule); err != nil {
 					internal.AddRuleResponse(
 						&resp.PolicyResponse,
 						internal.RuleError(rule, engineapi.ImageVerify, "failed to load context", err),
@@ -117,7 +115,7 @@ func (e *engine) verifyAndPatchImages(
 				}
 				iv := internal.NewImageVerifier(
 					logger,
-					rclient,
+					e.rclient,
 					policyContext,
 					ruleCopy,
 					ivm,

--- a/pkg/engine/imageVerifyValidate.go
+++ b/pkg/engine/imageVerifyValidate.go
@@ -32,7 +32,7 @@ func (e *engine) processImageValidationRule(
 	if len(matchingImages) == 0 {
 		return internal.RuleSkip(rule, engineapi.Validation, "image verified")
 	}
-	if err := internal.LoadContext(ctx, e.contextLoader, rule.Context, enginectx, rule.Name); err != nil {
+	if err := internal.LoadContext(ctx, e, enginectx, *rule); err != nil {
 		if _, ok := err.(gojmespath.NotFoundError); ok {
 			log.V(3).Info("failed to load context", "reason", err.Error())
 		} else {

--- a/pkg/engine/imageVerify_test.go
+++ b/pkg/engine/imageVerify_test.go
@@ -171,12 +171,12 @@ func testVerifyAndPatchImages(
 	e := NewEngine(
 		cfg,
 		nil,
-		LegacyContextLoaderFactory(nil, rclient, cmResolver),
+		rclient,
+		LegacyContextLoaderFactory(cmResolver),
 		nil,
 	)
 	return e.VerifyAndPatchImages(
 		ctx,
-		rclient,
 		pContext,
 	)
 }

--- a/pkg/engine/internal/context.go
+++ b/pkg/engine/internal/context.go
@@ -7,6 +7,12 @@ import (
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 )
 
-func LoadContext(ctx context.Context, factory engineapi.ContextLoaderFactory, contextEntries []kyvernov1.ContextEntry, pContext engineapi.PolicyContext, ruleName string) error {
-	return factory(pContext, ruleName).Load(ctx, contextEntries, pContext.JSONContext())
+func LoadContext(
+	ctx context.Context,
+	engine engineapi.Engine,
+	pContext engineapi.PolicyContext,
+	rule kyvernov1.Rule,
+) error {
+	loader := engine.ContextLoader(pContext.Policy(), rule)
+	return loader(ctx, rule.Context, pContext.JSONContext())
 }

--- a/pkg/engine/jsonContext.go
+++ b/pkg/engine/jsonContext.go
@@ -19,56 +19,52 @@ import (
 )
 
 func LegacyContextLoaderFactory(
-	client dclient.Interface,
-	rclient registryclient.Client,
 	cmResolver engineapi.ConfigmapResolver,
 ) engineapi.ContextLoaderFactory {
-	if store.IsMock() {
-		return func(pContext engineapi.PolicyContext, ruleName string) engineapi.ContextLoader {
-			policy := pContext.Policy()
+	return func(policy kyvernov1.PolicyInterface, rule kyvernov1.Rule) engineapi.ContextLoader {
+		if store.IsMock() {
 			return &mockContextLoader{
 				logger:     logging.WithName("MockContextLoaderFactory"),
 				policyName: policy.GetName(),
-				ruleName:   ruleName,
-				client:     client,
-				rclient:    rclient,
+				ruleName:   rule.Name,
+			}
+		} else {
+			return &contextLoader{
+				logger:     logging.WithName("LegacyContextLoaderFactory"),
 				cmResolver: cmResolver,
 			}
-		}
-	}
-	return func(pContext engineapi.PolicyContext, ruleName string) engineapi.ContextLoader {
-		return &contextLoader{
-			logger:     logging.WithName("LegacyContextLoaderFactory"),
-			client:     client,
-			rclient:    rclient,
-			cmResolver: cmResolver,
 		}
 	}
 }
 
 type contextLoader struct {
 	logger     logr.Logger
-	rclient    registryclient.Client
-	client     dclient.Interface
 	cmResolver engineapi.ConfigmapResolver
 }
 
-func (l *contextLoader) Load(ctx context.Context, contextEntries []kyvernov1.ContextEntry, enginectx enginecontext.Interface) error {
+func (l *contextLoader) Load(
+	ctx context.Context,
+	client dclient.Interface,
+	rclient registryclient.Client,
+	exceptionSelector engineapi.PolicyExceptionSelector,
+	contextEntries []kyvernov1.ContextEntry,
+	jsonContext enginecontext.Interface,
+) error {
 	for _, entry := range contextEntries {
 		if entry.ConfigMap != nil {
-			if err := loadConfigMap(ctx, l.logger, entry, enginectx, l.cmResolver); err != nil {
+			if err := loadConfigMap(ctx, l.logger, entry, jsonContext, l.cmResolver); err != nil {
 				return err
 			}
 		} else if entry.APICall != nil {
-			if err := loadAPIData(ctx, l.logger, entry, enginectx, l.client); err != nil {
+			if err := loadAPIData(ctx, l.logger, entry, jsonContext, client); err != nil {
 				return err
 			}
 		} else if entry.ImageRegistry != nil {
-			if err := loadImageData(ctx, l.rclient, l.logger, entry, enginectx); err != nil {
+			if err := loadImageData(ctx, rclient, l.logger, entry, jsonContext); err != nil {
 				return err
 			}
 		} else if entry.Variable != nil {
-			if err := loadVariable(l.logger, entry, enginectx); err != nil {
+			if err := loadVariable(l.logger, entry, jsonContext); err != nil {
 				return err
 			}
 		}
@@ -80,17 +76,21 @@ type mockContextLoader struct {
 	logger     logr.Logger
 	policyName string
 	ruleName   string
-	rclient    registryclient.Client
-	client     dclient.Interface
-	cmResolver engineapi.ConfigmapResolver
 }
 
-func (l *mockContextLoader) Load(ctx context.Context, contextEntries []kyvernov1.ContextEntry, enginectx enginecontext.Interface) error {
+func (l *mockContextLoader) Load(
+	ctx context.Context,
+	client dclient.Interface,
+	_ registryclient.Client,
+	_ engineapi.PolicyExceptionSelector,
+	contextEntries []kyvernov1.ContextEntry,
+	jsonContext enginecontext.Interface,
+) error {
 	rule := store.GetPolicyRule(l.policyName, l.ruleName)
 	if rule != nil && len(rule.Values) > 0 {
 		variables := rule.Values
 		for key, value := range variables {
-			if err := enginectx.AddVariable(key, value); err != nil {
+			if err := jsonContext.AddVariable(key, value); err != nil {
 				return err
 			}
 		}
@@ -100,22 +100,22 @@ func (l *mockContextLoader) Load(ctx context.Context, contextEntries []kyvernov1
 	for _, entry := range contextEntries {
 		if entry.ImageRegistry != nil && hasRegistryAccess {
 			rclient := store.GetRegistryClient()
-			if err := loadImageData(ctx, rclient, l.logger, entry, enginectx); err != nil {
+			if err := loadImageData(ctx, rclient, l.logger, entry, jsonContext); err != nil {
 				return err
 			}
 		} else if entry.Variable != nil {
-			if err := loadVariable(l.logger, entry, enginectx); err != nil {
+			if err := loadVariable(l.logger, entry, jsonContext); err != nil {
 				return err
 			}
 		} else if entry.APICall != nil && store.IsApiCallAllowed() {
-			if err := loadAPIData(ctx, l.logger, entry, enginectx, l.client); err != nil {
+			if err := loadAPIData(ctx, l.logger, entry, jsonContext, client); err != nil {
 				return err
 			}
 		}
 	}
 	if rule != nil && len(rule.ForEachValues) > 0 {
 		for key, value := range rule.ForEachValues {
-			if err := enginectx.AddVariable(key, value[store.GetForeachElement()]); err != nil {
+			if err := jsonContext.AddVariable(key, value[store.GetForeachElement()]); err != nil {
 				return err
 			}
 		}

--- a/pkg/engine/mutation_test.go
+++ b/pkg/engine/mutation_test.go
@@ -30,7 +30,8 @@ func testMutate(
 	e := NewEngine(
 		cfg,
 		client,
-		LegacyContextLoaderFactory(client, rclient, nil),
+		rclient,
+		LegacyContextLoaderFactory(nil),
 		nil,
 	)
 	return e.Mutate(

--- a/pkg/engine/validation_test.go
+++ b/pkg/engine/validation_test.go
@@ -23,7 +23,8 @@ func testValidate(ctx context.Context, rclient registryclient.Client, pContext *
 	e := NewEngine(
 		cfg,
 		nil,
-		LegacyContextLoaderFactory(nil, rclient, nil),
+		rclient,
+		LegacyContextLoaderFactory(nil),
 		nil,
 	)
 	return e.Validate(

--- a/pkg/policy/policy_controller.go
+++ b/pkg/policy/policy_controller.go
@@ -513,7 +513,7 @@ func (pc *PolicyController) handleUpdateRequest(ur *kyvernov1beta1.UpdateRequest
 		return false, fmt.Errorf("failed to build policy context for rule %s: %w", rule.Name, err)
 	}
 
-	engineResponse := pc.engine.ApplyBackgroundChecks(policyContext)
+	engineResponse := pc.engine.ApplyBackgroundChecks(context.TODO(), policyContext)
 	if len(engineResponse.PolicyResponse.Rules) == 0 {
 		return true, nil
 	}

--- a/pkg/testrunner/scenario.go
+++ b/pkg/testrunner/scenario.go
@@ -149,7 +149,8 @@ func runTestCase(t *testing.T, tc TestCase) bool {
 	eng := engine.NewEngine(
 		config.NewDefaultConfiguration(),
 		nil,
-		engine.LegacyContextLoaderFactory(nil, registryclient.NewOrDie(), nil),
+		registryclient.NewOrDie(),
+		engine.LegacyContextLoaderFactory(nil),
 		nil,
 	)
 	er := eng.Mutate(
@@ -184,11 +185,7 @@ func runTestCase(t *testing.T, tc TestCase) bool {
 		if err := createNamespace(client, resource); err != nil {
 			t.Error(err)
 		} else {
-			// policyContext := policyContext.WithClient(client)
-
-			er = eng.ApplyBackgroundChecks(
-				policyContext,
-			)
+			er = eng.ApplyBackgroundChecks(context.TODO(), policyContext)
 			t.Log(("---Generation---"))
 			validateResponse(t, er.PolicyResponse, tc.Expected.Generation.PolicyResponse)
 			// Expected generate resource will be in same namespaces as resource

--- a/pkg/webhooks/resource/fake.go
+++ b/pkg/webhooks/resource/fake.go
@@ -59,7 +59,8 @@ func NewFakeHandlers(ctx context.Context, policyCache policycache.Cache) webhook
 		engine: engine.NewEngine(
 			configuration,
 			dclient,
-			engine.LegacyContextLoaderFactory(dclient, rclient, configMapResolver),
+			rclient,
+			engine.LegacyContextLoaderFactory(configMapResolver),
 			peLister,
 		),
 	}

--- a/pkg/webhooks/resource/generation/generation.go
+++ b/pkg/webhooks/resource/generation/generation.go
@@ -92,7 +92,7 @@ func (h *generationHandler) Handle(
 			if request.Kind.Kind != "Namespace" && request.Namespace != "" {
 				policyContext = policyContext.WithNamespaceLabels(engineutils.GetNamespaceSelectorsFromNamespaceLister(request.Kind.Kind, request.Namespace, h.nsLister, h.log))
 			}
-			engineResponse := h.engine.ApplyBackgroundChecks(policyContext)
+			engineResponse := h.engine.ApplyBackgroundChecks(ctx, policyContext)
 			for _, rule := range engineResponse.PolicyResponse.Rules {
 				if rule.Status != engineapi.RuleStatusPass {
 					h.deleteGR(ctx, engineResponse)

--- a/pkg/webhooks/resource/handlers.go
+++ b/pkg/webhooks/resource/handlers.go
@@ -182,7 +182,7 @@ func (h *handlers) Mutate(ctx context.Context, logger logr.Logger, request *admi
 		logger.Error(err, "failed to build policy context")
 		return admissionutils.Response(request.UID, err)
 	}
-	ivh := imageverification.NewImageVerificationHandler(logger, h.kyvernoClient, h.engine, h.rclient, h.eventGen, h.admissionReports, h.configuration)
+	ivh := imageverification.NewImageVerificationHandler(logger, h.kyvernoClient, h.engine, h.eventGen, h.admissionReports, h.configuration)
 	imagePatches, imageVerifyWarnings, err := ivh.Handle(ctx, newRequest, verifyImagesPolicies, policyContext)
 	if err != nil {
 		logger.Error(err, "image verification failed")

--- a/pkg/webhooks/resource/imageverification/handler.go
+++ b/pkg/webhooks/resource/imageverification/handler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/event"
-	"github.com/kyverno/kyverno/pkg/registryclient"
 	"github.com/kyverno/kyverno/pkg/tracing"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
 	jsonutils "github.com/kyverno/kyverno/pkg/utils/json"
@@ -33,7 +32,6 @@ type ImageVerificationHandler interface {
 type imageVerificationHandler struct {
 	kyvernoClient    versioned.Interface
 	engine           engineapi.Engine
-	rclient          registryclient.Client
 	log              logr.Logger
 	eventGen         event.Interface
 	admissionReports bool

--- a/pkg/webhooks/resource/imageverification/handler.go
+++ b/pkg/webhooks/resource/imageverification/handler.go
@@ -44,7 +44,6 @@ func NewImageVerificationHandler(
 	log logr.Logger,
 	kyvernoClient versioned.Interface,
 	engine engineapi.Engine,
-	rclient registryclient.Client,
 	eventGen event.Interface,
 	admissionReports bool,
 	cfg config.Configuration,
@@ -52,7 +51,6 @@ func NewImageVerificationHandler(
 	return &imageVerificationHandler{
 		kyvernoClient:    kyvernoClient,
 		engine:           engine,
-		rclient:          rclient,
 		log:              log,
 		eventGen:         eventGen,
 		admissionReports: admissionReports,
@@ -94,7 +92,7 @@ func (h *imageVerificationHandler) handleVerifyImages(
 			fmt.Sprintf("POLICY %s/%s", policy.GetNamespace(), policy.GetName()),
 			func(ctx context.Context, span trace.Span) {
 				policyContext := policyContext.WithPolicy(policy)
-				resp, ivm := h.engine.VerifyAndPatchImages(ctx, h.rclient, policyContext)
+				resp, ivm := h.engine.VerifyAndPatchImages(ctx, policyContext)
 
 				engineResponses = append(engineResponses, resp)
 				patches = append(patches, resp.GetPatches()...)

--- a/pkg/webhooks/resource/updaterequest.go
+++ b/pkg/webhooks/resource/updaterequest.go
@@ -43,7 +43,7 @@ func (h *handlers) handleMutateExisting(ctx context.Context, logger logr.Logger,
 
 		var rules []engineapi.RuleResponse
 		policyContext := policyContext.WithPolicy(policy)
-		engineResponse := h.engine.ApplyBackgroundChecks(policyContext)
+		engineResponse := h.engine.ApplyBackgroundChecks(ctx, policyContext)
 
 		for _, rule := range engineResponse.PolicyResponse.Rules {
 			if rule.Status == engineapi.RuleStatusPass {

--- a/pkg/webhooks/resource/validation_test.go
+++ b/pkg/webhooks/resource/validation_test.go
@@ -1052,7 +1052,8 @@ func TestValidate_failure_action_overrides(t *testing.T) {
 	eng := engine.NewEngine(
 		config.NewDefaultConfiguration(),
 		nil,
-		engine.LegacyContextLoaderFactory(nil, registryclient.NewOrDie(), nil),
+		registryclient.NewOrDie(),
+		engine.LegacyContextLoaderFactory(nil),
 		nil,
 	)
 	for i, tc := range testcases {
@@ -1130,7 +1131,8 @@ func Test_RuleSelector(t *testing.T) {
 	eng := engine.NewEngine(
 		config.NewDefaultConfiguration(),
 		nil,
-		engine.LegacyContextLoaderFactory(nil, registryclient.NewOrDie(), nil),
+		registryclient.NewOrDie(),
+		engine.LegacyContextLoaderFactory(nil),
 		nil,
 	)
 	resp := eng.Validate(


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

## Explanation

This PR refactors context loading and engine methods:
- add `context.Context` where missing
- manage registry client in engine
