### PR TITLE
Server-Side Apply in Kyverno [WIP]

### DIFF
--- a/pkg/background/generate/generate.go
+++ b/pkg/background/generate/generate.go
@@ -478,7 +478,7 @@ func applyRule(log logr.Logger, client dclient.Interface, rule kyvernov1.Rule, r
 			newResource.SetLabels(label)
 
 			// Create the resource
-			_, err = client.CreateResource(context.TODO(), rdata.GenAPIVersion, rdata.GenKind, rdata.GenNamespace, newResource, false)
+			_, err = client.ApplyResource(context.TODO(), rdata.GenAPIVersion, rdata.GenKind, rdata.GenNamespace, rdata.GenName, newResource)
 			if err != nil {
 				if !apierrors.IsAlreadyExists(err) {
 					newGenResources = append(newGenResources, noGenResource)
@@ -492,7 +492,7 @@ func applyRule(log logr.Logger, client dclient.Interface, rule kyvernov1.Rule, r
 			if err != nil {
 				logger.Error(err, fmt.Sprintf("generated resource not found  name:%v namespace:%v kind:%v", genName, genNamespace, genKind))
 				logger.V(2).Info(fmt.Sprintf("creating generate resource name:name:%v namespace:%v kind:%v", genName, genNamespace, genKind))
-				_, err = client.CreateResource(context.TODO(), rdata.GenAPIVersion, rdata.GenKind, rdata.GenNamespace, newResource, false)
+				_, err = client.ApplyResource(context.TODO(), rdata.GenAPIVersion, rdata.GenKind, rdata.GenNamespace, rdata.GenName, newResource)
 				if err != nil {
 					newGenResources = append(newGenResources, noGenResource)
 					return newGenResources, err
@@ -514,7 +514,7 @@ func applyRule(log logr.Logger, client dclient.Interface, rule kyvernov1.Rule, r
 					}
 
 					if _, err := ValidateResourceWithPattern(logger, generatedObj.Object, newResource.Object); err != nil {
-						_, err = client.UpdateResource(context.TODO(), rdata.GenAPIVersion, rdata.GenKind, rdata.GenNamespace, newResource, false)
+						_, err = client.ApplyResource(context.TODO(), rdata.GenAPIVersion, rdata.GenKind, rdata.GenNamespace, rdata.GenName, newResource)
 						if err != nil {
 							logger.Error(err, "failed to update resource")
 							newGenResources = append(newGenResources, noGenResource)
@@ -532,7 +532,7 @@ func applyRule(log logr.Logger, client dclient.Interface, rule kyvernov1.Rule, r
 						currentGeneratedResourcelabel[LabelSynchronize] = "disable"
 						generatedObj.SetLabels(currentGeneratedResourcelabel)
 
-						_, err = client.UpdateResource(context.TODO(), rdata.GenAPIVersion, rdata.GenKind, rdata.GenNamespace, generatedObj, false)
+						_, err = client.ApplyResource(context.TODO(), rdata.GenAPIVersion, rdata.GenKind, rdata.GenNamespace, rdata.GenName, generatedObj)
 						if err != nil {
 							logger.Error(err, "failed to update label in existing resource")
 							newGenResources = append(newGenResources, noGenResource)

--- a/pkg/background/mutate/mutate.go
+++ b/pkg/background/mutate/mutate.go
@@ -144,7 +144,9 @@ func (c *MutateExistingController) ProcessUR(ur *kyvernov1beta1.UpdateRequest) e
 						}
 						_, updateErr = c.client.UpdateResource(context.TODO(), parentResourceGV.String(), parentResourceGVK.Kind, patchedNew.GetNamespace(), patchedNew.Object, false, patchedTargetSubresourceName)
 					} else {
-						_, updateErr = c.client.UpdateResource(context.TODO(), patchedNew.GetAPIVersion(), patchedNew.GetKind(), patchedNew.GetNamespace(), patchedNew.Object, false)
+						// _, updateErr = c.client.UpdateResource(context.TODO(), patchedNew.GetAPIVersion(), patchedNew.GetKind(), patchedNew.GetNamespace(), patchedNew.Object, false)
+						ptch, _ := patchedNew.MarshalJSON()
+						_, updateErr = c.client.ApplyResource(context.TODO(), patchedNew.GetAPIVersion(), patchedNew.GetKind(), patchedNew.GetNamespace(), patchedNew.GetName(), ptch)
 					}
 					if updateErr != nil {
 						errs = append(errs, updateErr)

--- a/pkg/clients/dclient/client.go
+++ b/pkg/clients/dclient/client.go
@@ -213,7 +213,7 @@ func (c *client) UpdateStatusResource(ctx context.Context, apiVersion string, ki
 
 // ApplyResource updates object for the specified resource/namespace using server-side apply
 func (c *client) ApplyResource(ctx context.Context, apiVersion string, kind string, namespace string, name string, obj interface{}, subresources ...string) (*unstructured.Unstructured, error) {
-	options := metav1.ApplyOptions{FieldManager: "kyverno-update-controller", Force: true}
+	options := metav1.ApplyOptions{FieldManager: "kyverno", Force: true}
 	if unstructuredObj, err := kubeutils.ObjToUnstructured(obj); err == nil && unstructuredObj != nil {
 		return c.getResourceInterface(apiVersion, kind, namespace).Apply(ctx, name, unstructuredObj, options, subresources...)
 	}
@@ -222,7 +222,7 @@ func (c *client) ApplyResource(ctx context.Context, apiVersion string, kind stri
 
 // ApplyStatusResource updates the resource "status" subresource using server-side apply
 func (c *client) ApplyStatusResource(ctx context.Context, apiVersion string, kind string, namespace string, name string, obj interface{}) (*unstructured.Unstructured, error) {
-	options := metav1.ApplyOptions{FieldManager: "kyverno-update-controller", Force: true}
+	options := metav1.ApplyOptions{FieldManager: "kyverno", Force: true}
 	if unstructuredObj, err := kubeutils.ObjToUnstructured(obj); err == nil && unstructuredObj != nil {
 		return c.getResourceInterface(apiVersion, kind, namespace).ApplyStatus(ctx, name, unstructuredObj, options)
 	}

--- a/pkg/webhooks/resource/mutation/mutation.go
+++ b/pkg/webhooks/resource/mutation/mutation.go
@@ -2,6 +2,7 @@ package mutation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -146,6 +147,14 @@ func (v *mutationHandler) applyMutations(
 	}
 
 	logMutationResponse(patches, engineResponses, v.log)
+
+	p := jsonutils.NewPatchOperation("/metadata/managedFields/0/manager", "replace", "kyverno")
+	fieldManagerPatch, err := p.Marshal()
+	if err != nil {
+		v.log.Info("failed to add fieldmanager patch to list of patches")
+		return nil, nil, errors.New("failed to marshal fieldmanager patch")
+	}
+	patches = append(patches, fieldManagerPatch)
 
 	// patches holds all the successful patches, if no patch is created, it returns nil
 	return jsonutils.JoinPatches(patches...), engineResponses, nil


### PR DESCRIPTION
Signed-off-by: damilola olayinka <holayinkajr@gmail.com>

## Explanation
This PR adds support for managedFields when mutating/generating a resource with Kyverno. Kyverno uses Server-Side Apply, letting other controllers know the fields it owns. Resources below show the addition of kyverno as a field manager for the fields managed by it.

#### Mutate
```yaml
apiVersion: v1
items:
- apiVersion: v1
  data:
    newKey1: newValue1
    player_initial_lives: "3"
    player2: kskkk
  kind: ConfigMap
  metadata:
    annotations:
      policies.kyverno.io/last-applied-patches: |
        mutant.mutant.kyverno.io: added /data/newKey1
    creationTimestamp: "2023-02-12T21:29:37Z"
    managedFields:
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        f:data:
          f:player_initial_lives: {}
          f:player2: {}
      manager: kyverno
      operation: Apply
      time: "2023-02-12T21:29:37Z"
    name: cmtwo
    namespace: default
    resourceVersion: "1754"
    uid: f91cc980-3765-438d-862b-75e0a461e53a
kind: List
metadata:
  resourceVersion: ""
```
#### Mutate Existing
```yaml
apiVersion: v1
items:
- apiVersion: v1
  data:
    a: bbb
  kind: ConfigMap
  metadata:
    creationTimestamp: "2023-02-11T19:22:45Z"
    managedFields:
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        f:data:
          f:a: {}
      manager: kubectl
      operation: Apply
      time: "2023-02-11T19:22:45Z"
    name: cmone
    namespace: default
    resourceVersion: "3578"
    uid: 1c2f6b65-60c0-44c8-9f2a-59b463beee10
- apiVersion: v1
  data:
    player_initial_lives: "3"
    player2: kskkk
  kind: ConfigMap
  metadata:
    annotations:
      policies.kyverno.io/last-applied-patches: |
        mutant.mutant.kyverno.io: added /metadata/labels
    creationTimestamp: "2023-02-11T19:22:28Z"
    labels:
      foo: bar
    managedFields:
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        f:data:
          f:player_initial_lives: {}
          f:player2: {}
      manager: kubectl
      operation: Apply
      time: "2023-02-11T19:22:28Z"
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        f:data:
          f:player_initial_lives: {}
          f:player2: {}
        f:metadata:
          f:annotations:
            f:policies.kyverno.io/last-applied-patches: {}
          f:labels:
            f:foo: {}
      manager: kyverno
      operation: Apply
      time: "2023-02-11T19:22:47Z"
    name: cmtwo
    namespace: default
    resourceVersion: "3585"
    uid: b5c0e9e4-6524-4485-8ddf-2ceba2e06e54

kind: List
metadata:
  resourceVersion: ""
```

#### Generate
```yaml
apiVersion: v1
items:
- apiVersion: v1
  data:
    KAFKA_ADDRESS: 192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092
    ZK_ADDRESS: 192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181
  kind: ConfigMap
  metadata:
    creationTimestamp: "2023-02-12T19:48:00Z"
    labels:
      app.kubernetes.io/managed-by: kyverno
      kyverno.io/background-gen-rule: k-kafka-address
      kyverno.io/generated-by-kind: Namespace
      kyverno.io/generated-by-name: default
      kyverno.io/generated-by-namespace: ""
      policy.kyverno.io/policy-name: zk-kafka-address
      policy.kyverno.io/synchronize: enable
      policy.kyverno.io/ur-name: ur-xfgct
      somekey: somevalue
    managedFields:
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        f:data:
          f:KAFKA_ADDRESS: {}
          f:ZK_ADDRESS: {}
        f:metadata:
          f:labels:
            f:app.kubernetes.io/managed-by: {}
            f:kyverno.io/background-gen-rule: {}
            f:kyverno.io/generated-by-kind: {}
            f:kyverno.io/generated-by-name: {}
            f:kyverno.io/generated-by-namespace: {}
            f:policy.kyverno.io/policy-name: {}
            f:policy.kyverno.io/synchronize: {}
            f:policy.kyverno.io/ur-name: {}
            f:somekey: {}
      manager: kyverno
      operation: Apply
      time: "2023-02-12T19:48:00Z"
    name: zk-kafka-address
    namespace: default
    resourceVersion: "1585"
    uid: e6c5b309-0760-495c-be95-b816b5721586
kind: List
metadata:
  resourceVersion: ""
  ```
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
https://github.com/kyverno/kyverno/issues/3800
https://github.com/kyverno/kyverno/issues/5077

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
#### Resource for Mutate
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: cmtwo
data:
  player_initial_lives: "3"
  player2: "kskkk"
```
#### Policy for Mutate
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: mutant
spec:
  mutateExistingOnPolicyUpdate: false
  rules:
    - name: mutant
      match:
        any:
        - resources:
            kinds:
            - ConfigMap
      mutate:
        patchesJson6902: |-
          - path: "/data/newKey1"
            op: add
            value: newValue1
```
#### Policy for MutateExisting
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: mutant
spec:
  mutateExistingOnPolicyUpdate: false
  rules:
    - name: mutant
      match:
        any:
        - resources:
            kinds:
            - ConfigMap
            names:
            - cmone
      mutate:
        targets:
        - apiVersion: v1
          kind: ConfigMap
          name: cmtwo
        patchStrategicMerge:
          metadata:
            labels:
              foo: bar
```
#### Resources for MutateExisting
- Trigger
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: cmone
data:
  a: "bbb"
```
- Target
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: cmtwo
data:
  player_initial_lives: "3"
  player2: "kskkk"
```

#### Policy for Generate
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: zk-kafka-address
spec:
  generateExistingOnPolicyUpdate: true
  rules:
  - name: k-kafka-address
    match:
      any:
      - resources:
          kinds:
          - Namespace
    generate:
      synchronize: true
      apiVersion: v1
      kind: ConfigMap
      name: zk-kafka-address
      # generate the resource in the new namespace
      namespace: "{{request.object.metadata.name}}"
      data:
        kind: ConfigMap
        metadata:
          labels:
            somekey: somevalue
        data:
          ZK_ADDRESS: "192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181"
          KAFKA_ADDRESS: "192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092"
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
