### PR TITLE
fix: use client instead of discovery for sanity checks (cherry-pick #6296)

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -56,6 +56,7 @@ import (
 	webhookgenerate "github.com/kyverno/kyverno/pkg/webhooks/updaterequest"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiserver "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -100,8 +101,8 @@ func showWarnings(logger logr.Logger) {
 	}
 }
 
-func sanityChecks(dynamicClient dclient.Interface) error {
-	if !kubeutils.CRDsInstalled(dynamicClient.Discovery()) {
+func sanityChecks(apiserverClient apiserver.Interface) error {
+	if !kubeutils.CRDsInstalled(apiserverClient) {
 		return fmt.Errorf("CRDs not installed")
 	}
 	return nil
@@ -457,11 +458,16 @@ func main() {
 		logger.Error(err, "failed to create dynamic client")
 		os.Exit(1)
 	}
+	apiserverClient, err := apiserver.NewForConfig(internal.CreateClientConfig(logger))
+	if err != nil {
+		logger.Error(err, "failed to create apiserver client")
+		os.Exit(1)
+	}
 	// THIS IS AN UGLY FIX
 	// ELSE KYAML IS NOT THREAD SAFE
 	kyamlopenapi.Schema()
 	// check we can run
-	if err := sanityChecks(dClient); err != nil {
+	if err := sanityChecks(apiserverClient); err != nil {
 		logger.Error(err, "sanity checks failed")
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/IGLOU-EU/go-wildcard v1.0.3
 	github.com/aquilax/truncate v1.0.0
-	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20221221165957-55f4180e6214
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
@@ -57,7 +56,6 @@ require (
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.4.0
 	golang.org/x/exp v0.0.0-20221230185412-738e83a70c30
-	golang.org/x/text v0.5.0
 	google.golang.org/grpc v1.51.0
 	gopkg.in/inf.v0 v0.9.1
 	gopkg.in/yaml.v2 v2.4.0
@@ -115,6 +113,7 @@ require (
 	github.com/aliyun/credentials-go v1.2.4 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go-v2 v1.17.3 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.18.7 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.7 // indirect
@@ -316,6 +315,7 @@ require (
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/term v0.3.0 // indirect
+	golang.org/x/text v0.5.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.4.0 // indirect
 	google.golang.org/api v0.105.0 // indirect


### PR DESCRIPTION
fix: use client instead of discovery for sanity checks (cherry-pick #6296)