### PR TITLE
fix: dump admission response

### DIFF
--- a/pkg/webhooks/handlers/dump.go
+++ b/pkg/webhooks/handlers/dump.go
@@ -54,7 +54,10 @@ func dumpPayload(
 	if err != nil {
 		logger.Error(err, "Failed to extract resources")
 	} else {
-		logger.Info("Logging admission request and response payload ", "AdmissionRequest", reqPayload, "AdmissionResponse", response)
+		if response != nil {
+			logger = logger.WithValues("AdmissionResponse", *response)
+		}
+		logger.Info("Logging admission request and response payload ", "AdmissionRequest", reqPayload)
 	}
 }
 


### PR DESCRIPTION
## Explanation

This PR fixes dumping admission response.

### Proof Manifests

Before:

```
    "AdmissionResponse": "&AdmissionResponse{UID:62135ba8-b346-47e5-a036-5e1f01ed7df2,Allowed:true,Result:nil,Patch:nil,PatchType:nil,AuditAnnotations:map[string]string{},Warnings:[],}"
```

After:

```
    "AdmissionResponse": {
        "uid": "67950be9-3385-4ed9-845f-8f359f5aabaf",
        "allowed": true
    },
```