### PR TITLE
fix: use labels.Everything in userinfo clusterroles matching

### DIFF
--- a/pkg/userinfo/roleRef.go
+++ b/pkg/userinfo/roleRef.go
@@ -34,7 +34,7 @@ func GetRoleRef(rbLister rbacv1listers.RoleBindingLister, crbLister rbacv1lister
 	}
 	rs, crs := getRoleRefByRoleBindings(roleBindings, request.UserInfo)
 	// clusterrolebindings
-	clusterroleBindings, err := crbLister.List(labels.NewSelector())
+	clusterroleBindings, err := crbLister.List(labels.Everything())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to list clusterrolebindings: %v", err)
 	}


### PR DESCRIPTION
## Explanation

This PR uses `labels.Everything()` in userinfo clusterroles matching (instead of `labels.NewSelector()`).
