### PR TITLE
fix: logger key value in wrong order

### DIFF
--- a/pkg/utils/image/infos.go
+++ b/pkg/utils/image/infos.go
@@ -53,7 +53,7 @@ func (i *ImageInfo) ReferenceWithTag() string {
 func GetImageInfo(image string, cfg config.Configuration) (*ImageInfo, error) {
 	logger.V(2).Info(
 		"Getting the image info",
-		image, "image",
+		"image", image,
 		"defaultRegistry", config.Configuration.GetDefaultRegistry(cfg),
 		"enableDefaultRegistryMutation", config.Configuration.GetEnableDefaultRegistryMutation(cfg),
 	)


### PR DESCRIPTION
## Explanation

This PR fixes a logger call where key/value are in the wrong order.
