### PR TITLE
test: add the kuttl test pol-clone-sync-modify-source

### DIFF
--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/01-assert.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v2beta1
+kind: Policy
+metadata:
+  name: pol-sync-clone
+  namespace: poltest
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/01-manifests.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/01-manifests.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: poltest
+---
+apiVersion: v1
+data:
+  foo: YmFy
+kind: Secret
+metadata:
+  name: regcred
+  namespace: poltest
+type: Opaque
+---
+apiVersion: kyverno.io/v2beta1
+kind: Policy
+metadata:
+  name: pol-sync-clone
+  namespace: poltest
+spec:
+  rules:
+  - name: gen-zk
+    match:
+      any:
+      - resources:
+          kinds:
+          - ConfigMap
+    generate:
+      apiVersion: v1
+      kind: Secret
+      name: myclonedsecret
+      namespace: poltest
+      synchronize: true
+      clone:
+        namespace: poltest
+        name: regcred

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/02-trigger.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/02-trigger.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  sj: js
+kind: ConfigMap
+metadata:
+  name: cm-2
+  namespace: poltest

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/03-assert.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/03-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  foo: YmFy
+kind: Secret
+metadata:
+  name: myclonedsecret
+  namespace: poltest
+type: Opaque

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/04-modifysource.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/04-modifysource.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  foo: aGVyZWlzY2hhbmdlZGRhdGE=
+kind: Secret
+metadata:
+  name: regcred
+  namespace: poltest
+type: Opaque

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/05-assert.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/05-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  foo: YmFy
+kind: Secret
+metadata:
+  name: myclonedsecret
+  namespace: poltest
+type: Opaque

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/05-assert.yaml
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/05-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  foo: YmFy
+  foo: aGVyZWlzY2hhbmdlZGRhdGE=
 kind: Secret
 metadata:
   name: myclonedsecret

--- a/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/README.md
+++ b/test/conformance/kuttl/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This test ensures that modification of the source (upstream) resource used by a Policy `generate` rule with sync enabled using a clone declaration causes those changes to be synced/propagated downstream.
+
+## Expected Behavior
+
+After the source is modified, the downstream resources should be synced to reflect those modifications. If the downstream resource reflects the changes made to the source, the test passes. If the downstream resource remains unsynced, the test fails.
+
+## Reference Issue(s)
+
+https://github.com/kyverno/kyverno/issues/5277


### PR DESCRIPTION
## Explanation

This PR adds a kuttl test for https://github.com/kyverno/kyverno/issues/5277. Changes to the source should be synced to the downstream for a generate Policy (Namespaced), with sync, clone.
