### PR TITLE
fix: missing metrics for policies in audit mode (cherry-pick #6363)

### DIFF
--- a/pkg/webhooks/resource/validation/validation.go
+++ b/pkg/webhooks/resource/validation/validation.go
@@ -162,7 +162,10 @@ func (v *validationHandler) buildAuditResponses(
 			fmt.Sprintf("POLICY %s/%s", policy.GetNamespace(), policy.GetName()),
 			func(ctx context.Context, span trace.Span) {
 				policyContext := policyContext.WithPolicy(policy).WithNamespaceLabels(namespaceLabels)
-				responses = append(responses, engine.Validate(ctx, v.rclient, policyContext))
+				response := engine.Validate(ctx, v.rclient, policyContext)
+				responses = append(responses, response)
+				go webhookutils.RegisterPolicyResultsMetricValidation(ctx, v.log, v.metrics, string(request.Operation), policyContext.Policy(), *response)
+				go webhookutils.RegisterPolicyExecutionDurationMetricValidate(ctx, v.log, v.metrics, string(request.Operation), policyContext.Policy(), *response)
 			},
 		)
 	}


### PR DESCRIPTION
## Explanation

Cherry-pick of https://github.com/kyverno/kyverno/pull/6363 on to `release-1.9`, because the automated cherry-pick in that PR failed.

## Related issue

- https://github.com/kyverno/kyverno/pull/6363
- https://github.com/kyverno/kyverno/issues/6315

