### PR TITLE
fix: compile regex globally

### DIFF
--- a/pkg/utils/kube/kind.go
+++ b/pkg/utils/kube/kind.go
@@ -10,7 +10,7 @@ import (
 var versionRegex = regexp.MustCompile(`^v\d((alpha|beta)\d)?|\*$`)
 
 // GetKindFromGVK - get kind and APIVersion from GVK
-func GetKindFromGVK(str string) (groupVersion string, kind string) {
+func GetKindFromGVK(str string) (string, string) {
 	parts := strings.Split(str, "/")
 	switch len(parts) {
 	case 1:

--- a/pkg/utils/kube/kind.go
+++ b/pkg/utils/kube/kind.go
@@ -7,11 +7,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+var versionRegex = regexp.MustCompile(`v\d((alpha|beta)\d)?`)
+
 // GetKindFromGVK - get kind and APIVersion from GVK
 func GetKindFromGVK(str string) (groupVersion string, kind string) {
 	parts := strings.Split(str, "/")
 	count := len(parts)
-	versionRegex := regexp.MustCompile(`v\d((alpha|beta)\d)?`)
 
 	if count == 2 {
 		if versionRegex.MatchString(parts[0]) || parts[0] == "*" {

--- a/pkg/utils/kube/kind_test.go
+++ b/pkg/utils/kube/kind_test.go
@@ -12,6 +12,14 @@ func Test_GetKindFromGVK(t *testing.T) {
 	assert.Equal(t, "", apiVersion)
 	assert.Equal(t, "*", kind)
 
+	apiVersion, kind = GetKindFromGVK("*.*")
+	assert.Equal(t, "", apiVersion)
+	assert.Equal(t, "*/*", kind)
+
+	apiVersion, kind = GetKindFromGVK("*/*")
+	assert.Equal(t, "", apiVersion)
+	assert.Equal(t, "*/*", kind)
+
 	apiVersion, kind = GetKindFromGVK("Pod")
 	assert.Equal(t, "", apiVersion)
 	assert.Equal(t, "Pod", kind)


### PR DESCRIPTION
## Explanation

This PR compiles a regex globally instead on every call.
It also supports parsing `*/*`.
