### PR TITLE
fix: adding verbosity to the ./pkg/autogen unit tests

### DIFF
--- a/pkg/autogen/autogen_test.go
+++ b/pkg/autogen/autogen_test.go
@@ -28,8 +28,10 @@ func Test_getAutogenRuleName(t *testing.T) {
 		{"truncated-cronjob", "too-long-this-rule-name-will-be-truncated-to-63-characters", "autogen-cronjob", "autogen-cronjob-too-long-this-rule-name-will-be-truncated-to-63"},
 	}
 	for _, test := range testCases {
-		res := getAutogenRuleName(test.prefix, test.ruleName)
-		assert.Equal(t, test.expected, res)
+		t.Run(test.name, func(t *testing.T) {
+			res := getAutogenRuleName(test.prefix, test.ruleName)
+			assert.Equal(t, test.expected, res)
+		})
 	}
 }
 
@@ -46,8 +48,10 @@ func Test_isAutogenRule(t *testing.T) {
 		{"truncated-cronjob", "autogen-cronjob-too-long-this-rule-name-will-be-truncated-to-63", true},
 	}
 	for _, test := range testCases {
-		res := isAutogenRuleName(test.ruleName)
-		assert.Equal(t, test.expected, res)
+		t.Run(test.name, func(t *testing.T) {
+			res := isAutogenRuleName(test.ruleName)
+			assert.Equal(t, test.expected, res)
+		})
 	}
 }
 
@@ -140,15 +144,17 @@ func Test_CanAutoGen(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		var policy kyverno.ClusterPolicy
-		err := json.Unmarshal(test.policy, &policy)
-		assert.NilError(t, err)
+		t.Run(test.name, func(t *testing.T) {
+			var policy kyverno.ClusterPolicy
+			err := json.Unmarshal(test.policy, &policy)
+			assert.NilError(t, err)
 
-		applyAutoGen, controllers := CanAutoGen(&policy.Spec)
-		if !applyAutoGen {
-			controllers = "none"
-		}
-		assert.Equal(t, test.expectedControllers, controllers, fmt.Sprintf("test %s failed", test.name))
+			applyAutoGen, controllers := CanAutoGen(&policy.Spec)
+			if !applyAutoGen {
+				controllers = "none"
+			}
+			assert.Equal(t, test.expectedControllers, controllers, fmt.Sprintf("test %s failed", test.name))
+		})
 	}
 }
 
@@ -241,18 +247,20 @@ func Test_GetSupportedControllers(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		var policy kyverno.ClusterPolicy
-		err := json.Unmarshal(test.policy, &policy)
-		assert.NilError(t, err)
+		t.Run(test.name, func(t *testing.T) {
+			var policy kyverno.ClusterPolicy
+			err := json.Unmarshal(test.policy, &policy)
+			assert.NilError(t, err)
 
-		controllers := GetSupportedControllers(&policy.Spec)
+			controllers := GetSupportedControllers(&policy.Spec)
 
-		var expectedControllers []string
-		if test.expectedControllers != "none" {
-			expectedControllers = strings.Split(test.expectedControllers, ",")
-		}
+			var expectedControllers []string
+			if test.expectedControllers != "none" {
+				expectedControllers = strings.Split(test.expectedControllers, ",")
+			}
 
-		assert.DeepEqual(t, expectedControllers, controllers)
+			assert.DeepEqual(t, expectedControllers, controllers)
+		})
 	}
 }
 
@@ -295,8 +303,10 @@ func Test_GetRequestedControllers(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		controllers := GetRequestedControllers(&test.meta)
-		assert.DeepEqual(t, test.expectedControllers, controllers)
+		t.Run(test.name, func(t *testing.T) {
+			controllers := GetRequestedControllers(&test.meta)
+			assert.DeepEqual(t, test.expectedControllers, controllers)
+		})
 	}
 }
 
@@ -830,11 +840,13 @@ kA==
 	}
 
 	for _, test := range testCases {
-		policies, err := yamlutils.GetPolicy([]byte(test.policy))
-		assert.NilError(t, err)
-		assert.Equal(t, 1, len(policies))
-		rules := computeRules(policies[0])
-		assert.DeepEqual(t, test.expectedRules, rules)
+		t.Run(test.name, func(t *testing.T) {
+			policies, err := yamlutils.GetPolicy([]byte(test.policy))
+			assert.NilError(t, err)
+			assert.Equal(t, 1, len(policies))
+			rules := computeRules(policies[0])
+			assert.DeepEqual(t, test.expectedRules, rules)
+		})
 	}
 }
 


### PR DESCRIPTION
## Explanation

This PR adds verbosity to the `pkg/autogen` unit tests.