### PR TITLE
fix: add annotations support for all SA in helm chart

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -293,6 +293,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | cleanupController.enabled | bool | `true` | Enable cleanup controller. |
 | cleanupController.rbac.create | bool | `true` | Create RBAC resources |
 | cleanupController.rbac.serviceAccount.name | string | `nil` | Service account name |
+| cleanupController.rbac.serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
 | cleanupController.rbac.clusterRole.extraResources | list | `[]` | Extra resource permissions to add in the cluster role |
 | cleanupController.createSelfSignedCert | bool | `false` | Create self-signed certificates at deployment time. The certificates won't be automatically renewed if this is set to `true`. |
 | cleanupController.image.registry | string | `"ghcr.io"` | Image registry |
@@ -351,6 +352,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | reportsController.enabled | bool | `true` | Enable reports controller. |
 | reportsController.rbac.create | bool | `true` | Create RBAC resources |
 | reportsController.rbac.serviceAccount.name | string | `nil` | Service account name |
+| reportsController.rbac.serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
 | reportsController.rbac.clusterRole.extraResources | list | `[]` | Extra resource permissions to add in the cluster role |
 | reportsController.image.registry | string | `"ghcr.io"` | Image registry |
 | reportsController.image.repository | string | `"kyverno/reports-controller"` | Image repository |
@@ -401,6 +403,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | backgroundController.enabled | bool | `true` | Enable background controller. |
 | backgroundController.rbac.create | bool | `true` | Create RBAC resources |
 | backgroundController.rbac.serviceAccount.name | string | `nil` | Service account name |
+| backgroundController.rbac.serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
 | backgroundController.rbac.clusterRole.extraResources | list | `[]` | Extra resource permissions to add in the cluster role |
 | backgroundController.image.registry | string | `nil` | Image registry |
 | backgroundController.image.repository | string | `"ghcr.io/kyverno/background-controller"` | Image repository |

--- a/charts/kyverno/templates/background-controller/serviceaccount.yaml
+++ b/charts/kyverno/templates/background-controller/serviceaccount.yaml
@@ -4,8 +4,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kyverno.background-controller.serviceAccountName" . }}
+  namespace: {{ template "kyverno.namespace" . }}
   labels:
     {{- include "kyverno.background-controller.labels" . | nindent 4 }}
-  namespace: {{ template "kyverno.namespace" . }}
+  {{- with .Values.backgroundController.rbac.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/cleanup-controller/serviceaccount.yaml
+++ b/charts/kyverno/templates/cleanup-controller/serviceaccount.yaml
@@ -7,5 +7,9 @@ metadata:
   namespace: {{ template "kyverno.namespace" . }}
   labels:
     {{- include "kyverno.cleanup-controller.labels" . | nindent 4 }}
+  {{- with .Values.cleanupController.rbac.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/kyverno/templates/reports-controller/serviceaccount.yaml
+++ b/charts/kyverno/templates/reports-controller/serviceaccount.yaml
@@ -4,8 +4,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kyverno.reports-controller.serviceAccountName" . }}
+  namespace: {{ template "kyverno.namespace" . }}
   labels:
     {{- include "kyverno.reports-controller.labels" . | nindent 4 }}
-  namespace: {{ template "kyverno.namespace" . }}
+  {{- with .Values.reportsController.rbac.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -553,6 +553,10 @@ cleanupController:
       # -- Service account name
       name:
 
+      # -- Annotations for the ServiceAccount
+      annotations: {}
+        # example.com/annotation: value
+
     clusterRole:
       # -- Extra resource permissions to add in the cluster role
       extraResources: []
@@ -797,6 +801,10 @@ reportsController:
       # -- Service account name
       name:
 
+      # -- Annotations for the ServiceAccount
+      annotations: {}
+        # example.com/annotation: value
+
     clusterRole:
       # -- Extra resource permissions to add in the cluster role
       extraResources: []
@@ -1028,6 +1036,10 @@ backgroundController:
     serviceAccount:
       # -- Service account name
       name:
+
+      # -- Annotations for the ServiceAccount
+      annotations: {}
+        # example.com/annotation: value
 
     clusterRole:
       # -- Extra resource permissions to add in the cluster role


### PR DESCRIPTION
## Explanation

This PR adds annotations support for all service accounts in helm chart.
