### PR TITLE
fix: add custom labels support back in helm chart

### DIFF
--- a/charts/kyverno/templates/_helpers/_image.tpl
+++ b/charts/kyverno/templates/_helpers/_image.tpl
@@ -3,7 +3,7 @@
 {{- define "kyverno.image" -}}
 {{- $tag := default .defaultTag .image.tag -}}
 {{- if not (typeIs "string" $tag) -}}
-    {{ fail "Image tags must be strings." }}
+  {{ fail "Image tags must be strings." }}
 {{- end -}}
 {{- if .image.registry -}}
   {{- print .image.registry "/" (required "An image repository is required" .image.repository) ":" $tag -}}

--- a/charts/kyverno/templates/_helpers/_labels.tpl
+++ b/charts/kyverno/templates/_helpers/_labels.tpl
@@ -3,10 +3,10 @@
 {{- define "kyverno.labels.merge" -}}
 {{- $labels := dict -}}
 {{- range . -}}
-    {{- $labels = merge $labels (fromYaml .) -}}
+  {{- $labels = merge $labels (fromYaml .) -}}
 {{- end -}}
 {{- with $labels -}}
-    {{- toYaml $labels -}}
+  {{- toYaml $labels -}}
 {{- end -}}
 {{- end -}}
 
@@ -22,7 +22,11 @@ app.kubernetes.io/version: {{ template "kyverno.chartVersion" . }}
 {{- end -}}
 
 {{- define "kyverno.labels.common" -}}
-{{- template "kyverno.labels.merge" (list (include "kyverno.labels.helm" .) (include "kyverno.labels.version" .)) -}}
+{{- template "kyverno.labels.merge" (list
+  (include "kyverno.labels.helm" .)
+  (include "kyverno.labels.version" .)
+  (toYaml .Values.customLabels)
+) -}}
 {{- end -}}
 
 {{- define "kyverno.matchLabels.common" -}}

--- a/charts/kyverno/templates/_helpers/_pdb.tpl
+++ b/charts/kyverno/templates/_helpers/_pdb.tpl
@@ -10,7 +10,7 @@ policy/v1beta1
 
 {{- define "kyverno.pdb.spec" -}}
 {{- if and .minAvailable .maxUnavailable -}}
-    {{- fail "Cannot set both .minAvailable and .maxUnavailable" -}}
+  {{- fail "Cannot set both .minAvailable and .maxUnavailable" -}}
 {{- end -}}
 {{- if not .maxUnavailable }}
 minAvailable: {{ default 1 .minAvailable }}


### PR DESCRIPTION
## Explanation

This PR adds custom labels support back in helm chart.
