### PR TITLE
fix: use GVR in reports resource controller

### DIFF
--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -221,27 +221,31 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 		return err
 	}
 	kinds := utils.BuildKindSet(logger, utils.RemoveNonValidationPolicies(append(clusterPolicies, policies...)...)...)
-	gvrs := map[schema.GroupVersionKind]schema.GroupVersionResource{}
-	for _, kind := range sets.List(kinds) {
-		apiVersion, kind := kubeutils.GetKindFromGVK(kind)
-		apiResource, _, gvr, err := c.client.Discovery().FindResource(apiVersion, kind)
+	gvkToGvr := map[schema.GroupVersionKind]schema.GroupVersionResource{}
+	for _, policyKind := range sets.List(kinds) {
+		group, version, kind, subresource := kubeutils.ParseKindSelector(policyKind)
+		gvrss, err := c.client.Discovery().FindResources(group, version, kind, subresource)
 		if err != nil {
 			logger.Error(err, "failed to get gvr from kind", "kind", kind)
 		} else {
-			gvk := schema.GroupVersionKind{Group: apiResource.Group, Version: apiResource.Version, Kind: apiResource.Kind}
-			if !reportutils.IsGvkSupported(gvk) {
-				logger.Info("kind is not supported", "gvk", gvk)
-			} else {
-				if slices.Contains(apiResource.Verbs, "list") && slices.Contains(apiResource.Verbs, "watch") {
-					gvrs[gvk] = gvr
-				} else {
-					logger.Info("list/watch not supported for kind", "kind", kind)
+			for gvrs, api := range gvrss {
+				if gvrs.SubResource == "" {
+					gvk := schema.GroupVersionKind{Group: gvrs.Group, Version: gvrs.Version, Kind: policyKind}
+					if !reportutils.IsGvkSupported(gvk) {
+						logger.Info("kind is not supported", "gvk", gvk)
+					} else {
+						if slices.Contains(api.Verbs, "list") && slices.Contains(api.Verbs, "watch") {
+							gvkToGvr[gvk] = gvrs.GroupVersionResource
+						} else {
+							logger.Info("list/watch not supported for kind", "kind", kind)
+						}
+					}
 				}
 			}
 		}
 	}
 	dynamicWatchers := map[schema.GroupVersionResource]*watcher{}
-	for gvk, gvr := range gvrs {
+	for gvk, gvr := range gvkToGvr {
 		logger := logger.WithValues("gvr", gvr, "gvk", gvk)
 		// if we already have one, transfer it to the new map
 		if c.dynamicWatchers[gvr] != nil {


### PR DESCRIPTION
## Explanation

This PR uses GVR in reports resource controller.
This is needed when a policy targets multiple resources.
