### PR TITLE
fix: pods logs in ci debug step

### DIFF
--- a/.github/actions/kyverno-logs/action.yaml
+++ b/.github/actions/kyverno-logs/action.yaml
@@ -15,11 +15,11 @@ runs:
         kubectl -n kyverno describe pod | grep -i events -A10
     - shell: bash
       run: |
-        kubectl -n kyverno logs deploy/kyverno --all-containers -p || true
+        kubectl -n kyverno logs deploy/kyverno-admission-controller --all-containers -p || true
         kubectl -n kyverno logs deploy/kyverno-cleanup-controller --all-containers -p || true
         kubectl -n kyverno logs deploy/kyverno-background-controller --all-containers -p || true
     - shell: bash
       run: |
-        kubectl -n kyverno logs deploy/kyverno --all-containers
+        kubectl -n kyverno logs deploy/kyverno-admission-controller --all-containers
         kubectl -n kyverno logs deploy/kyverno-cleanup-controller --all-containers
         kubectl -n kyverno logs deploy/kyverno-background-controller --all-containers


### PR DESCRIPTION
## Explanation

This PR fixes pods logs in ci debug step.
This is needed because we changed the admission controller deployment name.
