### PR TITLE
refactor: discovery client

### DIFF
--- a/pkg/clients/dclient/discovery.go
+++ b/pkg/clients/dclient/discovery.go
@@ -14,38 +14,37 @@ import (
 	"k8s.io/client-go/discovery"
 )
 
-// GroupVersionResourceSubresource contains a group/version/resource/subresource reference
-type GroupVersionResourceSubresource struct {
+// TopLevelApiDescription contains a group/version/resource/subresource reference
+type TopLevelApiDescription struct {
 	schema.GroupVersion
 	Kind        string
 	Resource    string
 	SubResource string
 }
 
-func (gvrs GroupVersionResourceSubresource) GroupVersionResource() schema.GroupVersionResource {
+func (gvrs TopLevelApiDescription) GroupVersionResource() schema.GroupVersionResource {
 	return gvrs.WithResource(gvrs.Resource)
 }
 
-func (gvrs GroupVersionResourceSubresource) GroupVersionKind() schema.GroupVersionKind {
+func (gvrs TopLevelApiDescription) GroupVersionKind() schema.GroupVersionKind {
 	return gvrs.WithKind(gvrs.Kind)
 }
 
-func (gvrs GroupVersionResourceSubresource) ResourceSubresource() string {
+func (gvrs TopLevelApiDescription) ResourceSubresource() string {
 	if gvrs.SubResource == "" {
 		return gvrs.Resource
 	}
 	return gvrs.Resource + "/" + gvrs.SubResource
 }
 
-func (gvrs GroupVersionResourceSubresource) WithSubResource(subresource string) GroupVersionResourceSubresource {
+func (gvrs TopLevelApiDescription) WithSubResource(subresource string) TopLevelApiDescription {
 	gvrs.SubResource = subresource
 	return gvrs
 }
 
 // IDiscovery provides interface to mange Kind and GVR mapping
 type IDiscovery interface {
-	FindResources(group, version, kind, subresource string) (map[GroupVersionResourceSubresource]metav1.APIResource, error)
-	FindResource(groupVersion string, kind string) (apiResource, parentAPIResource *metav1.APIResource, gvr schema.GroupVersionResource, err error)
+	FindResources(group, version, kind, subresource string) (map[TopLevelApiDescription]metav1.APIResource, error)
 	// TODO: there's no mapping from GVK to GVR, this is very error prone
 	GetGVRFromGVK(schema.GroupVersionKind) (schema.GroupVersionResource, error)
 	GetGVKFromGVR(schema.GroupVersionResource) (schema.GroupVersionKind, error)
@@ -168,7 +167,7 @@ func (c serverResources) FindResource(groupVersion string, kind string) (apiReso
 	return nil, nil, schema.GroupVersionResource{}, err
 }
 
-func (c serverResources) FindResources(group, version, kind, subresource string) (map[GroupVersionResourceSubresource]metav1.APIResource, error) {
+func (c serverResources) FindResources(group, version, kind, subresource string) (map[TopLevelApiDescription]metav1.APIResource, error) {
 	resources, err := c.findResources(group, version, kind, subresource)
 	if err != nil {
 		if !c.cachedClient.Fresh() {
@@ -179,7 +178,7 @@ func (c serverResources) FindResources(group, version, kind, subresource string)
 	return resources, err
 }
 
-func (c serverResources) findResources(group, version, kind, subresource string) (map[GroupVersionResourceSubresource]metav1.APIResource, error) {
+func (c serverResources) findResources(group, version, kind, subresource string) (map[TopLevelApiDescription]metav1.APIResource, error) {
 	_, serverGroupsAndResources, err := c.cachedClient.ServerGroupsAndResources()
 	if err != nil && !strings.Contains(err.Error(), "Got empty response for") {
 		if discovery.IsGroupDiscoveryFailedError(err) {
@@ -204,7 +203,7 @@ func (c serverResources) findResources(group, version, kind, subresource string)
 			Kind:    kind,
 		}
 	}
-	resources := map[GroupVersionResourceSubresource]metav1.APIResource{}
+	resources := map[TopLevelApiDescription]metav1.APIResource{}
 	// first match resouces
 	for _, list := range serverGroupsAndResources {
 		gv, err := schema.ParseGroupVersion(list.GroupVersion)
@@ -215,7 +214,7 @@ func (c serverResources) findResources(group, version, kind, subresource string)
 				if !strings.Contains(resource.Name, "/") {
 					gvk := getGVK(gv, resource.Group, resource.Version, resource.Kind)
 					if wildcard.Match(group, gvk.Group) && wildcard.Match(version, gvk.Version) && wildcard.Match(kind, gvk.Kind) {
-						gvrs := GroupVersionResourceSubresource{
+						gvrs := TopLevelApiDescription{
 							GroupVersion: gv,
 							Kind:         resource.Kind,
 							Resource:     resource.Name,
@@ -227,7 +226,7 @@ func (c serverResources) findResources(group, version, kind, subresource string)
 		}
 	}
 	// second match subresouces if necessary
-	subresources := map[GroupVersionResourceSubresource]metav1.APIResource{}
+	subresources := map[TopLevelApiDescription]metav1.APIResource{}
 	if subresource != "" {
 		for _, list := range serverGroupsAndResources {
 			for _, resource := range list.APIResources {

--- a/pkg/clients/dclient/fake.go
+++ b/pkg/clients/dclient/fake.go
@@ -77,11 +77,7 @@ func (c *fakeDiscoveryClient) GetGVRFromGVK(gvk schema.GroupVersionKind) (schema
 	return c.getGVR(resource)
 }
 
-func (c *fakeDiscoveryClient) FindResource(groupVersion string, kind string) (apiResource, parentAPIResource *metav1.APIResource, gvr schema.GroupVersionResource, err error) {
-	return nil, nil, schema.GroupVersionResource{}, fmt.Errorf("not implemented")
-}
-
-func (c *fakeDiscoveryClient) FindResources(group, version, kind, subresource string) (map[GroupVersionResourceSubresource]metav1.APIResource, error) {
+func (c *fakeDiscoveryClient) FindResources(group, version, kind, subresource string) (map[TopLevelApiDescription]metav1.APIResource, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/policycache/cache.go
+++ b/pkg/policycache/cache.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ResourceFinder interface {
-	FindResources(group, version, kind, subresource string) (map[dclient.GroupVersionResourceSubresource]metav1.APIResource, error)
+	FindResources(group, version, kind, subresource string) (map[dclient.TopLevelApiDescription]metav1.APIResource, error)
 }
 
 // Cache get method use for to get policy names and mostly use to test cache testcases

--- a/pkg/policycache/test.go
+++ b/pkg/policycache/test.go
@@ -32,8 +32,8 @@ var (
 	replicationcontrollersGVRS = mapGVR(replicationcontrollersGVR, "ReplicationController")
 )
 
-func mapGVR(gvr schema.GroupVersionResource, kind string) dclient.GroupVersionResourceSubresource {
-	return dclient.GroupVersionResourceSubresource{
+func mapGVR(gvr schema.GroupVersionResource, kind string) dclient.TopLevelApiDescription {
+	return dclient.TopLevelApiDescription{
 		GroupVersion: gvr.GroupVersion(),
 		Kind:         kind,
 		Resource:     gvr.Resource,
@@ -42,29 +42,29 @@ func mapGVR(gvr schema.GroupVersionResource, kind string) dclient.GroupVersionRe
 
 type TestResourceFinder struct{}
 
-func (TestResourceFinder) FindResources(group, version, kind, subresource string) (map[dclient.GroupVersionResourceSubresource]metav1.APIResource, error) {
+func (TestResourceFinder) FindResources(group, version, kind, subresource string) (map[dclient.TopLevelApiDescription]metav1.APIResource, error) {
 	var dummy metav1.APIResource
 	switch kind {
 	case "Pod":
-		return map[dclient.GroupVersionResourceSubresource]metav1.APIResource{podsGVRS: dummy}, nil
+		return map[dclient.TopLevelApiDescription]metav1.APIResource{podsGVRS: dummy}, nil
 	case "Namespace":
-		return map[dclient.GroupVersionResourceSubresource]metav1.APIResource{namespacesGVRS: dummy}, nil
+		return map[dclient.TopLevelApiDescription]metav1.APIResource{namespacesGVRS: dummy}, nil
 	case "ClusterRole":
-		return map[dclient.GroupVersionResourceSubresource]metav1.APIResource{clusterrolesGVRS: dummy}, nil
+		return map[dclient.TopLevelApiDescription]metav1.APIResource{clusterrolesGVRS: dummy}, nil
 	case "Deployment":
-		return map[dclient.GroupVersionResourceSubresource]metav1.APIResource{deploymentsGVRS: dummy}, nil
+		return map[dclient.TopLevelApiDescription]metav1.APIResource{deploymentsGVRS: dummy}, nil
 	case "StatefulSet":
-		return map[dclient.GroupVersionResourceSubresource]metav1.APIResource{statefulsetsGVRS: dummy}, nil
+		return map[dclient.TopLevelApiDescription]metav1.APIResource{statefulsetsGVRS: dummy}, nil
 	case "DaemonSet":
-		return map[dclient.GroupVersionResourceSubresource]metav1.APIResource{daemonsetsGVRS: dummy}, nil
+		return map[dclient.TopLevelApiDescription]metav1.APIResource{daemonsetsGVRS: dummy}, nil
 	case "ReplicaSet":
-		return map[dclient.GroupVersionResourceSubresource]metav1.APIResource{replicasetsGVRS: dummy}, nil
+		return map[dclient.TopLevelApiDescription]metav1.APIResource{replicasetsGVRS: dummy}, nil
 	case "Job":
-		return map[dclient.GroupVersionResourceSubresource]metav1.APIResource{jobsGVRS: dummy}, nil
+		return map[dclient.TopLevelApiDescription]metav1.APIResource{jobsGVRS: dummy}, nil
 	case "ReplicationController":
-		return map[dclient.GroupVersionResourceSubresource]metav1.APIResource{replicationcontrollersGVRS: dummy}, nil
+		return map[dclient.TopLevelApiDescription]metav1.APIResource{replicationcontrollersGVRS: dummy}, nil
 	case "CronJob":
-		return map[dclient.GroupVersionResourceSubresource]metav1.APIResource{cronjobsGVRS: dummy}, nil
+		return map[dclient.TopLevelApiDescription]metav1.APIResource{cronjobsGVRS: dummy}, nil
 	}
 	return nil, fmt.Errorf("not found: %s", kind)
 }


### PR DESCRIPTION
## Explanation

This PR refactors our discovery client:
- removes the `FindResource` method
