### PR TITLE
feat: add support for ready message

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "program": "${workspaceFolder}/cmd/kyverno",
             "args": [
                 "--kubeconfig=${userHome}/.kube/config",
-                "--serverIP=<SERVER-IP>:9443",
+                "--serverIP=192.168.1.6:9443",
                 "-v=2",
             ],
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "program": "${workspaceFolder}/cmd/kyverno",
             "args": [
                 "--kubeconfig=${userHome}/.kube/config",
-                "--serverIP=192.168.1.6:9443",
+                "--serverIP=<SERVER-IP>:9443",
                 "-v=2",
             ],
         },

--- a/api/kyverno/v1/clusterpolicy_types.go
+++ b/api/kyverno/v1/clusterpolicy_types.go
@@ -23,6 +23,7 @@ import (
 // +kubebuilder:printcolumn:name="Mutate",type=integer,JSONPath=`.status.rulecount.mutate`,priority=1
 // +kubebuilder:printcolumn:name="Generate",type=integer,JSONPath=`.status.rulecount.generate`,priority=1
 // +kubebuilder:printcolumn:name="Verifyimages",type=integer,JSONPath=`.status.rulecount.verifyimages`,priority=1
+// +kubebuilder:printcolumn:name="MESSAGE",type=string,JSONPath=`.status.conditions[?(@.type == "Ready")].message`
 // +kubebuilder:storageversion
 
 // ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.

--- a/api/kyverno/v1/policy_status.go
+++ b/api/kyverno/v1/policy_status.go
@@ -48,9 +48,10 @@ type RuleCountStatus struct {
 	VerifyImages int `json:"verifyimages" yaml:"verifyimages"`
 }
 
-func (status *PolicyStatus) SetReady(ready bool) {
+func (status *PolicyStatus) SetReady(ready bool, message string) {
 	condition := metav1.Condition{
-		Type: PolicyConditionReady,
+		Type:    PolicyConditionReady,
+		Message: message,
 	}
 	if ready {
 		condition.Status = metav1.ConditionTrue

--- a/api/kyverno/v1/policy_types.go
+++ b/api/kyverno/v1/policy_types.go
@@ -22,6 +22,7 @@ import (
 // +kubebuilder:printcolumn:name="Generate",type=integer,JSONPath=`.status.rulecount.generate`,priority=1
 // +kubebuilder:printcolumn:name="Verifyimages",type=integer,JSONPath=`.status.rulecount.verifyimages`,priority=1
 // +kubebuilder:resource:shortName=pol,categories=kyverno
+// +kubebuilder:printcolumn:name="MESSAGE",type=string,JSONPath=`.status.conditions[?(@.type == "Ready")].message`
 // +kubebuilder:storageversion
 
 // Policy declares validation, mutation, and generation behaviors for matching resources.

--- a/api/kyverno/v2beta1/clusterpolicy_types.go
+++ b/api/kyverno/v2beta1/clusterpolicy_types.go
@@ -24,6 +24,7 @@ import (
 // +kubebuilder:printcolumn:name="Mutate",type=integer,JSONPath=`.status.rulecount.mutate`,priority=1
 // +kubebuilder:printcolumn:name="Generate",type=integer,JSONPath=`.status.rulecount.generate`,priority=1
 // +kubebuilder:printcolumn:name="Verifyimages",type=integer,JSONPath=`.status.rulecount.verifyimages`,priority=1
+// +kubebuilder:printcolumn:name="MESSAGE",type=string,JSONPath=`.status.conditions[?(@.type == "Ready")].message`
 
 // ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.
 type ClusterPolicy struct {

--- a/api/kyverno/v2beta1/policy_types.go
+++ b/api/kyverno/v2beta1/policy_types.go
@@ -22,6 +22,7 @@ import (
 // +kubebuilder:printcolumn:name="Mutate",type=integer,JSONPath=`.status.rulecount.mutate`,priority=1
 // +kubebuilder:printcolumn:name="Generate",type=integer,JSONPath=`.status.rulecount.generate`,priority=1
 // +kubebuilder:printcolumn:name="Verifyimages",type=integer,JSONPath=`.status.rulecount.verifyimages`,priority=1
+// +kubebuilder:printcolumn:name="MESSAGE",type=string,JSONPath=`.status.conditions[?(@.type == "Ready")].message`
 // +kubebuilder:resource:shortName=pol,categories=kyverno
 
 // Policy declares validation, mutation, and generation behaviors for matching resources.

--- a/charts/kyverno/templates/crds/crds.yaml
+++ b/charts/kyverno/templates/crds/crds.yaml
@@ -3438,6 +3438,9 @@ spec:
       name: Verifyimages
       priority: 1
       type: integer
+    - jsonPath: .status.conditions[?(@.type == "Ready")].message
+      name: MESSAGE
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -10152,6 +10155,9 @@ spec:
       name: Verifyimages
       priority: 1
       type: integer
+    - jsonPath: .status.conditions[?(@.type == "Ready")].message
+      name: MESSAGE
+      type: string
     name: v2beta1
     schema:
       openAPIV3Schema:
@@ -16622,6 +16628,9 @@ spec:
       name: Verifyimages
       priority: 1
       type: integer
+    - jsonPath: .status.conditions[?(@.type == "Ready")].message
+      name: MESSAGE
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -23338,6 +23347,9 @@ spec:
       name: Verifyimages
       priority: 1
       type: integer
+    - jsonPath: .status.conditions[?(@.type == "Ready")].message
+      name: MESSAGE
+      type: string
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno.io_clusterpolicies.yaml
+++ b/config/crds/kyverno.io_clusterpolicies.yaml
@@ -52,6 +52,9 @@ spec:
       name: Verifyimages
       priority: 1
       type: integer
+    - jsonPath: .status.conditions[?(@.type == "Ready")].message
+      name: MESSAGE
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -6766,6 +6769,9 @@ spec:
       name: Verifyimages
       priority: 1
       type: integer
+    - jsonPath: .status.conditions[?(@.type == "Ready")].message
+      name: MESSAGE
+      type: string
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno.io_policies.yaml
+++ b/config/crds/kyverno.io_policies.yaml
@@ -52,6 +52,9 @@ spec:
       name: Verifyimages
       priority: 1
       type: integer
+    - jsonPath: .status.conditions[?(@.type == "Ready")].message
+      name: MESSAGE
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -6768,6 +6771,9 @@ spec:
       name: Verifyimages
       priority: 1
       type: integer
+    - jsonPath: .status.conditions[?(@.type == "Ready")].message
+      name: MESSAGE
+      type: string
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -3521,6 +3521,9 @@ spec:
       name: Verifyimages
       priority: 1
       type: integer
+    - jsonPath: .status.conditions[?(@.type == "Ready")].message
+      name: MESSAGE
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -10235,6 +10238,9 @@ spec:
       name: Verifyimages
       priority: 1
       type: integer
+    - jsonPath: .status.conditions[?(@.type == "Ready")].message
+      name: MESSAGE
+      type: string
     name: v2beta1
     schema:
       openAPIV3Schema:
@@ -16705,6 +16711,9 @@ spec:
       name: Verifyimages
       priority: 1
       type: integer
+    - jsonPath: .status.conditions[?(@.type == "Ready")].message
+      name: MESSAGE
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -23421,6 +23430,9 @@ spec:
       name: Verifyimages
       priority: 1
       type: integer
+    - jsonPath: .status.conditions[?(@.type == "Ready")].message
+      name: MESSAGE
+      type: string
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/pkg/controllers/webhook/controller.go
+++ b/pkg/controllers/webhook/controller.go
@@ -437,17 +437,17 @@ func (c *controller) updatePolicyStatuses(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		ready := true
+		ready, message := true, "Ready"
 		if c.autoUpdateWebhooks {
 			for _, set := range c.policyState {
 				if !set.Has(policyKey) {
-					ready = false
+					ready, message = false, "Not ready yet"
 					break
 				}
 			}
 		}
 		status := policy.GetStatus()
-		status.SetReady(ready)
+		status.SetReady(ready, message)
 		status.Autogen.Rules = nil
 		rules := autogen.ComputeRules(policy)
 		setRuleCount(rules, status)

--- a/pkg/webhooks/handlers/trace.go
+++ b/pkg/webhooks/handlers/trace.go
@@ -25,7 +25,7 @@ func (inner HttpHandler) WithTrace(name string) HttpHandler {
 			},
 			trace.WithAttributes(
 				semconv.HTTPRequestContentLengthKey.Int64(request.ContentLength),
-				// semconv.HTTPHostKey.String(tracing.StringValue(request.Host)),
+				semconv.NetSockPeerAddrKey.String(tracing.StringValue(request.Host)),
 				semconv.HTTPMethodKey.String(tracing.StringValue(request.Method)),
 				semconv.HTTPURLKey.String(tracing.StringValue(request.RequestURI)),
 			),


### PR DESCRIPTION
## Explanation

This PR adds support for ready message.

### Proof Manifests

```console
$ kubectl get cpol
NAME           BACKGROUND   VALIDATE ACTION   READY   AGE   MESSAGE
verify-image   false        enforce           True    32m   Ready
```