### PR TITLE
refactor: policy response handling

### DIFF
--- a/pkg/engine/api/engineresponse.go
+++ b/pkg/engine/api/engineresponse.go
@@ -54,6 +54,7 @@ func NewEngineResponse(
 		Resource:        resource,
 		Policy:          policy,
 		NamespaceLabels: namespaceLabels,
+		PatchedResource: resource,
 	}
 	if policyResponse != nil {
 		response.SetPolicyResponse(*policyResponse)

--- a/pkg/engine/api/engineresponse.go
+++ b/pkg/engine/api/engineresponse.go
@@ -56,9 +56,13 @@ func NewEngineResponse(
 		NamespaceLabels: namespaceLabels,
 	}
 	if policyResponse != nil {
-		response.PolicyResponse = *policyResponse
+		response.SetPolicyResponse(*policyResponse)
 	}
 	return response
+}
+
+func (er *EngineResponse) SetPolicyResponse(pr PolicyResponse) {
+	er.PolicyResponse = pr
 }
 
 // IsOneOf checks if any rule has status in a given list

--- a/pkg/engine/api/policyresponse.go
+++ b/pkg/engine/api/policyresponse.go
@@ -24,3 +24,7 @@ func (pr *PolicyResponse) Add(rr RuleResponse) {
 		pr.Stats.RulesErrorCount++
 	}
 }
+
+func (pr *PolicyResponse) UpdateStats(timestamp time.Time) {
+	pr.Stats.Update(timestamp)
+}

--- a/pkg/engine/api/policyresponse.go
+++ b/pkg/engine/api/policyresponse.go
@@ -1,9 +1,26 @@
 package api
 
+import "time"
+
 // PolicyResponse policy application response
 type PolicyResponse struct {
 	// Stats contains policy statistics
 	Stats PolicyStats
 	// Rules contains policy rules responses
 	Rules []RuleResponse
+}
+
+func NewPolicyResponse(timestamp time.Time) PolicyResponse {
+	return PolicyResponse{
+		Stats: NewPolicyStats(timestamp),
+	}
+}
+
+func (pr *PolicyResponse) Add(rr RuleResponse) {
+	pr.Rules = append(pr.Rules, rr)
+	if rr.Status == RuleStatusPass || rr.Status == RuleStatusFail {
+		pr.Stats.RulesAppliedCount++
+	} else if rr.Status == RuleStatusError {
+		pr.Stats.RulesErrorCount++
+	}
 }

--- a/pkg/engine/api/stats.go
+++ b/pkg/engine/api/stats.go
@@ -12,6 +12,16 @@ type ExecutionStats struct {
 	Timestamp int64
 }
 
+func NewExecutionStats(timestamp time.Time) ExecutionStats {
+	return ExecutionStats{
+		Timestamp: timestamp.Unix(),
+	}
+}
+
+func (s *ExecutionStats) Update(timestamp time.Time) {
+	s.ProcessingTime = timestamp.Sub(time.Unix(s.Timestamp, 0))
+}
+
 // PolicyStats stores statistics for the single policy application
 type PolicyStats struct {
 	// ExecutionStats policy execution stats
@@ -20,4 +30,10 @@ type PolicyStats struct {
 	RulesAppliedCount int
 	// RulesErrorCount is the count of rules that with execution errors
 	RulesErrorCount int
+}
+
+func NewPolicyStats(timestamp time.Time) PolicyStats {
+	return PolicyStats{
+		ExecutionStats: NewExecutionStats(timestamp),
+	}
 }

--- a/pkg/engine/k8smanifest_test.go
+++ b/pkg/engine/k8smanifest_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -628,7 +629,7 @@ func Test_VerifyManifest_SignedYAML(t *testing.T) {
 		},
 	})
 	logger := logr.Discard()
-	verified, _, err := verifyManifest(nil, policyContext, verifyRule, logger)
+	verified, _, err := verifyManifest(context.TODO(), logger, nil, policyContext, verifyRule)
 	assert.NilError(t, err)
 	assert.Equal(t, verified, true)
 }
@@ -650,7 +651,7 @@ func Test_VerifyManifest_UnsignedYAML(t *testing.T) {
 		},
 	})
 	logger := logr.Discard()
-	verified, _, err := verifyManifest(nil, policyContext, verifyRule, logger)
+	verified, _, err := verifyManifest(context.TODO(), logger, nil, policyContext, verifyRule)
 	assert.NilError(t, err)
 	assert.Equal(t, verified, false)
 }
@@ -672,7 +673,7 @@ func Test_VerifyManifest_InvalidYAML(t *testing.T) {
 		},
 	})
 	logger := logr.Discard()
-	verified, _, err := verifyManifest(nil, policyContext, verifyRule, logger)
+	verified, _, err := verifyManifest(context.TODO(), logger, nil, policyContext, verifyRule)
 	assert.NilError(t, err)
 	assert.Equal(t, verified, false)
 }
@@ -699,7 +700,7 @@ func Test_VerifyManifest_MustAll_InvalidYAML(t *testing.T) {
 		},
 	})
 	logger := logr.Discard()
-	verified, _, err := verifyManifest(nil, policyContext, verifyRule, logger)
+	verified, _, err := verifyManifest(context.TODO(), logger, nil, policyContext, verifyRule)
 	errMsg := `.attestors[0].entries[1].keys: failed to verify signature: verification failed for 1 signature. all trials: ["[publickey 1/1] [signature 1/1] error: cosign.VerifyBlobCmd() returned an error: invalid signature when validating ASN.1 encoded signature"]`
 	assert.Error(t, err, errMsg)
 	assert.Equal(t, verified, false)
@@ -732,7 +733,7 @@ func Test_VerifyManifest_MustAll_ValidYAML(t *testing.T) {
 		},
 	})
 	logger := logr.Discard()
-	verified, _, err := verifyManifest(nil, policyContext, verifyRule, logger)
+	verified, _, err := verifyManifest(context.TODO(), logger, nil, policyContext, verifyRule)
 	assert.NilError(t, err)
 	assert.Equal(t, verified, true)
 }
@@ -761,7 +762,7 @@ func Test_VerifyManifest_AtLeastOne(t *testing.T) {
 		},
 	})
 	logger := logr.Discard()
-	verified, _, err := verifyManifest(nil, policyContext, verifyRule, logger)
+	verified, _, err := verifyManifest(context.TODO(), logger, nil, policyContext, verifyRule)
 	assert.NilError(t, err)
 	assert.Equal(t, verified, true)
 }

--- a/pkg/engine/utils.go
+++ b/pkg/engine/utils.go
@@ -7,6 +7,7 @@ import (
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/engine/context"
 	datautils "github.com/kyverno/kyverno/pkg/utils/data"
 	matchutils "github.com/kyverno/kyverno/pkg/utils/match"
@@ -17,6 +18,22 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+func isDeleteRequest(ctx engineapi.PolicyContext) bool {
+	newResource := ctx.NewResource()
+	// if the OldResource is not empty, and the NewResource is empty, the request is a DELETE
+	return isEmptyUnstructured(&newResource)
+}
+
+func isEmptyUnstructured(u *unstructured.Unstructured) bool {
+	if u == nil {
+		return true
+	}
+	if u.Object == nil {
+		return true
+	}
+	return false
+}
 
 func checkNameSpace(namespaces []string, resource unstructured.Unstructured) bool {
 	resourceNameSpace := resource.GetNamespace()

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -34,13 +34,17 @@ func (e *engine) validate(
 	logger logr.Logger,
 	policyContext engineapi.PolicyContext,
 ) engineapi.EngineResponse {
-	startTime := time.Now()
-	logger.V(4).Info("start validate policy processing", "startTime", startTime)
-	policyResponse := e.validateResource(ctx, logger, policyContext)
-	defer logger.V(4).Info("finished policy processing", "processingTime", policyResponse.Stats.ProcessingTime.String(), "validationRulesApplied", policyResponse.Stats.RulesAppliedCount)
 	engineResponse := engineapi.NewEngineResponseFromPolicyContext(policyContext, nil)
-	engineResponse.PolicyResponse = policyResponse
-	return *internal.BuildResponse(policyContext, &engineResponse, startTime)
+	logger.V(4).Info("start validate policy processing")
+	defer func() {
+		logger.V(4).Info(
+			"finished policy processing",
+			"processingTime", engineResponse.PolicyResponse.Stats.ProcessingTime.String(),
+			"validationRulesApplied", engineResponse.PolicyResponse.Stats.RulesAppliedCount,
+		)
+	}()
+	engineResponse.SetPolicyResponse(e.validateResource(ctx, logger, policyContext))
+	return engineResponse
 }
 
 func (e *engine) validateResource(

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -83,9 +83,9 @@ func (e *engine) validateResource(
 				}
 				policyContext.JSONContext().Reset()
 				if hasValidate && !hasYAMLSignatureVerify {
-					return e.processValidationRule(ctx, logger, policyContext, rule)
+					return e.processValidationRule(ctx, logger, policyContext, rules[i])
 				} else if hasValidateImage {
-					return e.processImageValidationRule(ctx, logger, policyContext, rule)
+					return e.processImageValidationRule(ctx, logger, policyContext, rules[i])
 				} else if hasYAMLSignatureVerify {
 					return processYAMLValidationRule(ctx, logger, e.client, policyContext, rules[i])
 				}
@@ -100,6 +100,7 @@ func (e *engine) validateResource(
 			break
 		}
 	}
+	resp.UpdateStats(time.Now())
 	return resp
 }
 
@@ -107,9 +108,9 @@ func (e *engine) processValidationRule(
 	ctx context.Context,
 	logger logr.Logger,
 	policyContext engineapi.PolicyContext,
-	rule *kyvernov1.Rule,
+	rule kyvernov1.Rule,
 ) *engineapi.RuleResponse {
-	v := newValidator(logger, e.ContextLoader(policyContext.Policy(), *rule), policyContext, rule)
+	v := newValidator(logger, e.ContextLoader(policyContext.Policy(), rule), policyContext, rule)
 	return v.validate(ctx)
 }
 
@@ -128,7 +129,7 @@ type validator struct {
 	nesting          int
 }
 
-func newValidator(log logr.Logger, contextLoader engineapi.EngineContextLoader, ctx engineapi.PolicyContext, rule *kyvernov1.Rule) *validator {
+func newValidator(log logr.Logger, contextLoader engineapi.EngineContextLoader, ctx engineapi.PolicyContext, rule kyvernov1.Rule) *validator {
 	ruleCopy := rule.DeepCopy()
 	return &validator{
 		log:              log,

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -34,8 +34,8 @@ func (e *engine) validate(
 	logger logr.Logger,
 	policyContext engineapi.PolicyContext,
 ) engineapi.EngineResponse {
-	engineResponse := engineapi.NewEngineResponseFromPolicyContext(policyContext, nil)
 	logger.V(4).Info("start validate policy processing")
+	engineResponse := engineapi.NewEngineResponseFromPolicyContext(policyContext, nil)
 	defer func() {
 		logger.V(4).Info(
 			"finished policy processing",


### PR DESCRIPTION
## Explanation

This PR refactors the way we handle policy responses.
It adds constructors to various response objects and methods to construct responses as policy/rules are being processed.
It also removes pointers when not necessary.