### PR TITLE
fix: allow image to be not present

### DIFF
--- a/pkg/utils/api/image.go
+++ b/pkg/utils/api/image.go
@@ -73,12 +73,10 @@ func extract(obj interface{}, path []string, keyPath, valuePath string, fields [
 		}
 		return nil
 	}
-
 	output, ok := obj.(map[string]interface{})
 	if !ok {
 		return fmt.Errorf("invalid image config")
 	}
-
 	if len(fields) == 0 {
 		pointer := fmt.Sprintf("/%s/%s", strings.Join(path, "/"), valuePath)
 		key := pointer
@@ -90,28 +88,24 @@ func extract(obj interface{}, path []string, keyPath, valuePath string, fields [
 		}
 		value, ok := output[valuePath].(string)
 		if !ok {
-			return fmt.Errorf("invalid value")
+			// the image may not be present
+			return nil
 		}
-
 		if jmesPath != "" {
 			jp, err := jmespath.New(jmesPath)
 			if err != nil {
 				return fmt.Errorf("invalid jmespath %s: %v", jmesPath, err)
 			}
-
 			result, err := jp.Search(value)
 			if err != nil {
 				return fmt.Errorf("failed to apply jmespath %s: %v", jmesPath, err)
 			}
-
 			resultStr, ok := result.(string)
 			if !ok {
 				return fmt.Errorf("jmespath %s must produce a string, but produced %v", jmesPath, result)
 			}
-
 			value = resultStr
 		}
-
 		if imageInfo, err := imageutils.GetImageInfo(value, cfg); err != nil {
 			return fmt.Errorf("invalid image %s", value)
 		} else {
@@ -119,7 +113,6 @@ func extract(obj interface{}, path []string, keyPath, valuePath string, fields [
 		}
 		return nil
 	}
-
 	currentPath := fields[0]
 	return extract(output[currentPath], append(path, currentPath), keyPath, valuePath, fields[1:], jmesPath, imageInfos, cfg)
 }

--- a/pkg/utils/api/image.go
+++ b/pkg/utils/api/image.go
@@ -8,6 +8,7 @@ import (
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/engine/jmespath"
+	"github.com/kyverno/kyverno/pkg/logging"
 	imageutils "github.com/kyverno/kyverno/pkg/utils/image"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -89,6 +90,7 @@ func extract(obj interface{}, path []string, keyPath, valuePath string, fields [
 		value, ok := output[valuePath].(string)
 		if !ok {
 			// the image may not be present
+			logging.V(4).Info("image information is not present", "pointer", pointer)
 			return nil
 		}
 		if jmesPath != "" {


### PR DESCRIPTION
## Explanation

This PR allows an image to be not present when parsing a resource manifest.

Fixes #6128

