### PR TITLE
test: bgscan report with image verification rule passing

### DIFF
--- a/test/conformance/kuttl/reports/background/verify-image-fail/01-pod.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-fail/01-pod.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- pod.yaml
+assert:
+- pod-assert.yaml

--- a/test/conformance/kuttl/reports/background/verify-image-fail/02-policy.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-fail/02-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- policy.yaml
+assert:
+- policy-assert.yaml

--- a/test/conformance/kuttl/reports/background/verify-image-fail/03-bgscanr.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-fail/03-bgscanr.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+assert:
+- bgscanr-assert.yaml

--- a/test/conformance/kuttl/reports/background/verify-image-fail/README.md
+++ b/test/conformance/kuttl/reports/background/verify-image-fail/README.md
@@ -1,0 +1,10 @@
+# Title
+
+This test creates pods using an unsigned or not correctly signed image.
+It then creates an image verification policy running in the background.
+
+Note: the pods have to be created first because we don't want the policy to apply at admission time.
+
+## Expected Behavior
+
+The pods are created and background scan reports are generated with a fail result.

--- a/test/conformance/kuttl/reports/background/verify-image-fail/bgscanr-assert.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-fail/bgscanr-assert.yaml
@@ -1,0 +1,29 @@
+apiVersion: kyverno.io/v1alpha2
+kind: BackgroundScanReport
+metadata:
+  ownerReferences:
+  - apiVersion: v1
+    kind: Pod
+    name: unsigned
+spec:
+  summary:
+    error: 0
+    fail: 1
+    pass: 0
+    skip: 0
+    warn: 0
+---
+apiVersion: kyverno.io/v1alpha2
+kind: BackgroundScanReport
+metadata:
+  ownerReferences:
+  - apiVersion: v1
+    kind: Pod
+    name: signed-by-someone-else
+spec:
+  summary:
+    error: 0
+    fail: 1
+    pass: 0
+    skip: 0
+    warn: 0

--- a/test/conformance/kuttl/reports/background/verify-image-fail/pod-assert.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-fail/pod-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: unsigned
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: signed-by-someone-else

--- a/test/conformance/kuttl/reports/background/verify-image-fail/pod.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-fail/pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: unsigned
+spec:
+  containers:
+  - image: ghcr.io/kyverno/test-verify-image:unsigned
+    name: test-secret
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: signed-by-someone-else
+spec:
+  containers:
+  - image: ghcr.io/kyverno/test-verify-image:signed-by-someone-else
+    name: test-secret

--- a/test/conformance/kuttl/reports/background/verify-image-fail/policy-assert.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-fail/policy-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: keyed-basic-policy
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/kuttl/reports/background/verify-image-fail/policy.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-fail/policy.yaml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: keyed-basic-policy
+spec:
+  validationFailureAction: Audit
+  background: true
+  webhookTimeoutSeconds: 30
+  rules:
+  - name: keyed-basic-rule
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    verifyImages:
+    - imageReferences:
+      - ghcr.io/kyverno/test-verify-image:*
+      verifyDigest: false
+      required: false
+      attestors:
+      - entries:
+        - keys:
+            publicKeys: |-
+              -----BEGIN PUBLIC KEY-----
+              MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
+              5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
+              -----END PUBLIC KEY-----

--- a/test/conformance/kuttl/reports/background/verify-image-pass/01-pod.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-pass/01-pod.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- pod.yaml
+assert:
+- pod-assert.yaml

--- a/test/conformance/kuttl/reports/background/verify-image-pass/02-policy.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-pass/02-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- policy.yaml
+assert:
+- policy-assert.yaml

--- a/test/conformance/kuttl/reports/background/verify-image-pass/03-bgscanr.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-pass/03-bgscanr.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+assert:
+- bgscanr-assert.yaml

--- a/test/conformance/kuttl/reports/background/verify-image-pass/README.md
+++ b/test/conformance/kuttl/reports/background/verify-image-pass/README.md
@@ -1,0 +1,9 @@
+# Title
+
+This test create an image verification policy runing in the background.
+It then creates a pod that satisfies the policy.
+Note: the pod has to be created first because we don't want the policy to apply at admission time.
+
+## Expected Behavior
+
+The pod is created and a background scan report is generated for it with a pass result.

--- a/test/conformance/kuttl/reports/background/verify-image-pass/README.md
+++ b/test/conformance/kuttl/reports/background/verify-image-pass/README.md
@@ -1,7 +1,8 @@
 # Title
 
-This test create an image verification policy runing in the background.
-It then creates a pod that satisfies the policy.
+This test creates a pod using a valid signed image.
+It then creates an image verification policy running in the background.
+
 Note: the pod has to be created first because we don't want the policy to apply at admission time.
 
 ## Expected Behavior

--- a/test/conformance/kuttl/reports/background/verify-image-pass/bgscanr-assert.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-pass/bgscanr-assert.yaml
@@ -1,0 +1,14 @@
+apiVersion: kyverno.io/v1alpha2
+kind: BackgroundScanReport
+metadata:
+  ownerReferences:
+  - apiVersion: v1
+    kind: Pod
+    name: test-secret-pod
+spec:
+  summary:
+    error: 0
+    fail: 0
+    pass: 1
+    skip: 0
+    warn: 0

--- a/test/conformance/kuttl/reports/background/verify-image-pass/bgscanr-assert.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-pass/bgscanr-assert.yaml
@@ -4,7 +4,7 @@ metadata:
   ownerReferences:
   - apiVersion: v1
     kind: Pod
-    name: test-secret-pod
+    name: signed
 spec:
   summary:
     error: 0

--- a/test/conformance/kuttl/reports/background/verify-image-pass/pod-assert.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-pass/pod-assert.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-secret-pod

--- a/test/conformance/kuttl/reports/background/verify-image-pass/pod-assert.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-pass/pod-assert.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-secret-pod
+  name: signed

--- a/test/conformance/kuttl/reports/background/verify-image-pass/pod.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-pass/pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-secret-pod
+spec:
+  containers:
+  - image: ghcr.io/kyverno/test-verify-image:signed
+    name: test-secret

--- a/test/conformance/kuttl/reports/background/verify-image-pass/pod.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-pass/pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-secret-pod
+  name: signed
 spec:
   containers:
   - image: ghcr.io/kyverno/test-verify-image:signed

--- a/test/conformance/kuttl/reports/background/verify-image-pass/policy-assert.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-pass/policy-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: keyed-basic-policy
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/kuttl/reports/background/verify-image-pass/policy.yaml
+++ b/test/conformance/kuttl/reports/background/verify-image-pass/policy.yaml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: keyed-basic-policy
+spec:
+  validationFailureAction: Audit
+  background: true
+  webhookTimeoutSeconds: 30
+  rules:
+  - name: keyed-basic-rule
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    verifyImages:
+    - imageReferences:
+      - ghcr.io/kyverno/test-verify-image:*
+      verifyDigest: false
+      required: false
+      attestors:
+      - entries:
+        - keys:
+            publicKeys: |-
+              -----BEGIN PUBLIC KEY-----
+              MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
+              5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
+              -----END PUBLIC KEY-----


### PR DESCRIPTION
## Explanation

This PR adds a kuttl test for bgscan report with image verification rule passing.
This is to make sure the reports controller works as expected.
