### PR TITLE
fix: no skip result when no image match the rule

### DIFF
--- a/pkg/engine/imageVerify.go
+++ b/pkg/engine/imageVerify.go
@@ -88,7 +88,7 @@ func (e *engine) doVerifyAndPatch(
 
 	logger.V(3).Info("processing image verification rule")
 
-	ruleImages, imageRefs, err := engineutils.ExtractMatchingImages(
+	ruleImages, _, err := engineutils.ExtractMatchingImages(
 		policyContext.NewResource(),
 		policyContext.JSONContext(),
 		rule,
@@ -103,15 +103,6 @@ func (e *engine) doVerifyAndPatch(
 		return
 	}
 	if len(ruleImages) == 0 {
-		internal.AddRuleResponse(
-			&resp.PolicyResponse,
-			internal.RuleSkip(
-				rule,
-				engineapi.ImageVerify,
-				fmt.Sprintf("skip run verification as image in resource not found in imageRefs '%s'", imageRefs),
-			),
-			startTime,
-		)
 		return
 	}
 	policyContext.JSONContext().Restore()


### PR DESCRIPTION
## Explanation

This PR removes `skip` results when no image match the rule.
