### PR TITLE
refactor: engine responses

### DIFF
--- a/pkg/engine/api/policyresponse.go
+++ b/pkg/engine/api/policyresponse.go
@@ -7,3 +7,16 @@ type PolicyResponse struct {
 	// Rules contains policy rules responses
 	Rules []RuleResponse
 }
+
+func (pr *PolicyResponse) Add(rr RuleResponse) {
+	pr.Rules = append(pr.Rules, rr)
+	if rr.Status == RuleStatusPass || rr.Status == RuleStatusFail {
+		pr.Stats.RulesAppliedCount++
+	} else if rr.Status == RuleStatusError {
+		pr.Stats.RulesErrorCount++
+	}
+}
+
+func NewPolicyResponse() PolicyResponse {
+	return PolicyResponse{}
+}

--- a/pkg/engine/api/stats.go
+++ b/pkg/engine/api/stats.go
@@ -24,8 +24,6 @@ func (s *ExecutionStats) Done(timestamp time.Time) {
 
 // PolicyStats stores statistics for the single policy application
 type PolicyStats struct {
-	// ExecutionStats policy execution stats
-	// ExecutionStats
 	// RulesAppliedCount is the count of rules that were applied successfully
 	RulesAppliedCount int
 	// RulesErrorCount is the count of rules that with execution errors

--- a/pkg/engine/api/stats.go
+++ b/pkg/engine/api/stats.go
@@ -12,10 +12,20 @@ type ExecutionStats struct {
 	Timestamp int64
 }
 
+func NewExecutionStats(timestamp time.Time) ExecutionStats {
+	return ExecutionStats{
+		Timestamp: timestamp.Unix(),
+	}
+}
+
+func (s *ExecutionStats) Done(timestamp time.Time) {
+	s.ProcessingTime = timestamp.Sub(time.Unix(s.Timestamp, 0))
+}
+
 // PolicyStats stores statistics for the single policy application
 type PolicyStats struct {
 	// ExecutionStats policy execution stats
-	ExecutionStats
+	// ExecutionStats
 	// RulesAppliedCount is the count of rules that were applied successfully
 	RulesAppliedCount int
 	// RulesErrorCount is the count of rules that with execution errors

--- a/pkg/engine/background.go
+++ b/pkg/engine/background.go
@@ -23,7 +23,7 @@ func (e *engine) applyBackgroundChecks(
 	ctx context.Context,
 	logger logr.Logger,
 	policyContext engineapi.PolicyContext,
-) engineapi.EngineResponse {
+) engineapi.PolicyResponse {
 	return e.filterRules(policyContext, logger, time.Now())
 }
 
@@ -31,15 +31,14 @@ func (e *engine) filterRules(
 	policyContext engineapi.PolicyContext,
 	logger logr.Logger,
 	startTime time.Time,
-) engineapi.EngineResponse {
+) engineapi.PolicyResponse {
 	policy := policyContext.Policy()
-	resp := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
-	resp.PolicyResponse = engineapi.PolicyResponse{}
+	resp := engineapi.NewPolicyResponse()
 	applyRules := policy.GetSpec().GetApplyRules()
 	for _, rule := range autogen.ComputeRules(policy) {
 		logger := internal.LoggerWithRule(logger, rule)
 		if ruleResp := e.filterRule(rule, logger, policyContext); ruleResp != nil {
-			resp.PolicyResponse.Rules = append(resp.PolicyResponse.Rules, *ruleResp)
+			resp.Rules = append(resp.Rules, *ruleResp)
 			if applyRules == kyvernov1.ApplyOne && ruleResp.Status != engineapi.RuleStatusSkip {
 				break
 			}

--- a/pkg/engine/background.go
+++ b/pkg/engine/background.go
@@ -33,14 +33,8 @@ func (e *engine) filterRules(
 	startTime time.Time,
 ) engineapi.EngineResponse {
 	policy := policyContext.Policy()
-	resp := engineapi.NewEngineResponseFromPolicyContext(policyContext, nil)
-	resp.PolicyResponse = engineapi.PolicyResponse{
-		Stats: engineapi.PolicyStats{
-			ExecutionStats: engineapi.ExecutionStats{
-				Timestamp: startTime.Unix(),
-			},
-		},
-	}
+	resp := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
+	resp.PolicyResponse = engineapi.PolicyResponse{}
 	applyRules := policy.GetSpec().GetApplyRules()
 	for _, rule := range autogen.ComputeRules(policy) {
 		logger := internal.LoggerWithRule(logger, rule)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -80,7 +80,8 @@ func (e *engine) Validate(
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.validate"), policyContext)
 	if internal.MatchPolicyContext(logger, policyContext, e.configuration) {
-		response = response.WithPolicyResponse(e.validate(ctx, logger, policyContext))
+		policyResponse := e.validate(ctx, logger, policyContext)
+		response = response.WithPolicyResponse(policyResponse)
 	}
 	return response.Done(time.Now())
 }
@@ -93,8 +94,9 @@ func (e *engine) Mutate(
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.mutate"), policyContext)
 	if internal.MatchPolicyContext(logger, policyContext, e.configuration) {
 		policyResponse, patchedResource := e.mutate(ctx, logger, policyContext)
-		response = response.WithPolicyResponse(policyResponse)
-		response = response.WithPatchedResource(patchedResource)
+		response = response.
+			WithPolicyResponse(policyResponse).
+			WithPatchedResource(patchedResource)
 	}
 	return response.Done(time.Now())
 }
@@ -108,8 +110,7 @@ func (e *engine) VerifyAndPatchImages(
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.verify"), policyContext)
 	if internal.MatchPolicyContext(logger, policyContext, e.configuration) {
 		policyResponse, innerIvm := e.verifyAndPatchImages(ctx, logger, policyContext)
-		response = response.WithPolicyResponse(policyResponse)
-		ivm = innerIvm
+		response, ivm = response.WithPolicyResponse(policyResponse), innerIvm
 	}
 	return response.Done(time.Now()), ivm
 }
@@ -121,7 +122,8 @@ func (e *engine) ApplyBackgroundChecks(
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.background"), policyContext)
 	if internal.MatchPolicyContext(logger, policyContext, e.configuration) {
-		response = e.applyBackgroundChecks(ctx, logger, policyContext)
+		policyResponse := e.applyBackgroundChecks(ctx, logger, policyContext)
+		response = response.WithPolicyResponse(policyResponse)
 	}
 	return response.Done(time.Now())
 }
@@ -134,7 +136,8 @@ func (e *engine) GenerateResponse(
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.generate"), policyContext)
 	if internal.MatchPolicyContext(logger, policyContext, e.configuration) {
-		response = e.generateResponse(ctx, logger, policyContext, gr)
+		policyResponse := e.generateResponse(ctx, logger, policyContext, gr)
+		response = response.WithPolicyResponse(policyResponse)
 	}
 	return response.Done(time.Now())
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	gojmespath "github.com/jmespath/go-jmespath"
@@ -74,44 +75,51 @@ func (e *engine) Validate(
 	ctx context.Context,
 	policyContext engineapi.PolicyContext,
 ) engineapi.EngineResponse {
+	response := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.validate"), policyContext)
-	if !internal.MatchPolicyContext(logger, policyContext, e.configuration) {
-		return engineapi.NewEngineResponseFromPolicyContext(policyContext, nil)
+	if internal.MatchPolicyContext(logger, policyContext, e.configuration) {
+		response = response.WithPolicyResponse(e.validate(ctx, logger, policyContext))
 	}
-	return e.validate(ctx, logger, policyContext)
+	return response.Done(time.Now())
 }
 
 func (e *engine) Mutate(
 	ctx context.Context,
 	policyContext engineapi.PolicyContext,
 ) engineapi.EngineResponse {
+	response := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.mutate"), policyContext)
-	if !internal.MatchPolicyContext(logger, policyContext, e.configuration) {
-		return engineapi.NewEngineResponseFromPolicyContext(policyContext, nil)
+	if internal.MatchPolicyContext(logger, policyContext, e.configuration) {
+		policyResponse, patchedResource := e.mutate(ctx, logger, policyContext)
+		response = response.WithPolicyResponse(policyResponse)
+		response = response.WithPatchedResource(patchedResource)
 	}
-	return e.mutate(ctx, logger, policyContext)
+	return response.Done(time.Now())
 }
 
 func (e *engine) VerifyAndPatchImages(
 	ctx context.Context,
 	policyContext engineapi.PolicyContext,
 ) (engineapi.EngineResponse, engineapi.ImageVerificationMetadata) {
+	response := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
+	ivm := engineapi.ImageVerificationMetadata{}
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.verify"), policyContext)
-	if !internal.MatchPolicyContext(logger, policyContext, e.configuration) {
-		return engineapi.NewEngineResponseFromPolicyContext(policyContext, nil), engineapi.ImageVerificationMetadata{}
+	if internal.MatchPolicyContext(logger, policyContext, e.configuration) {
+		response, ivm = e.verifyAndPatchImages(ctx, logger, policyContext)
 	}
-	return e.verifyAndPatchImages(ctx, logger, policyContext)
+	return response.Done(time.Now()), ivm
 }
 
 func (e *engine) ApplyBackgroundChecks(
 	ctx context.Context,
 	policyContext engineapi.PolicyContext,
 ) engineapi.EngineResponse {
+	response := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.background"), policyContext)
-	if !internal.MatchPolicyContext(logger, policyContext, e.configuration) {
-		return engineapi.NewEngineResponseFromPolicyContext(policyContext, nil)
+	if internal.MatchPolicyContext(logger, policyContext, e.configuration) {
+		response = e.applyBackgroundChecks(ctx, logger, policyContext)
 	}
-	return e.applyBackgroundChecks(ctx, logger, policyContext)
+	return response.Done(time.Now())
 }
 
 func (e *engine) GenerateResponse(
@@ -119,11 +127,12 @@ func (e *engine) GenerateResponse(
 	policyContext engineapi.PolicyContext,
 	gr kyvernov1beta1.UpdateRequest,
 ) engineapi.EngineResponse {
+	response := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.generate"), policyContext)
-	if !internal.MatchPolicyContext(logger, policyContext, e.configuration) {
-		return engineapi.NewEngineResponseFromPolicyContext(policyContext, nil)
+	if internal.MatchPolicyContext(logger, policyContext, e.configuration) {
+		response = e.generateResponse(ctx, logger, policyContext, gr)
 	}
-	return e.generateResponse(ctx, logger, policyContext, gr)
+	return response.Done(time.Now())
 }
 
 func (e *engine) ContextLoader(

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -107,7 +107,9 @@ func (e *engine) VerifyAndPatchImages(
 	ivm := engineapi.ImageVerificationMetadata{}
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.verify"), policyContext)
 	if internal.MatchPolicyContext(logger, policyContext, e.configuration) {
-		response, ivm = e.verifyAndPatchImages(ctx, logger, policyContext)
+		policyResponse, innerIvm := e.verifyAndPatchImages(ctx, logger, policyContext)
+		response = response.WithPolicyResponse(policyResponse)
+		ivm = innerIvm
 	}
 	return response.Done(time.Now()), ivm
 }

--- a/pkg/engine/generation.go
+++ b/pkg/engine/generation.go
@@ -17,7 +17,7 @@ func (e *engine) generateResponse(
 	logger logr.Logger,
 	policyContext engineapi.PolicyContext,
 	gr kyvernov1beta1.UpdateRequest,
-) engineapi.EngineResponse {
+) engineapi.PolicyResponse {
 	return e.filterGenerateRules(policyContext, logger, gr.Spec.Policy, time.Now())
 }
 
@@ -26,13 +26,12 @@ func (e *engine) filterGenerateRules(
 	logger logr.Logger,
 	policyNameKey string,
 	startTime time.Time,
-) engineapi.EngineResponse {
-	resp := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
-	resp.PolicyResponse = engineapi.PolicyResponse{}
+) engineapi.PolicyResponse {
+	resp := engineapi.NewPolicyResponse()
 	for _, rule := range autogen.ComputeRules(policyContext.Policy()) {
 		logger := internal.LoggerWithRule(logger, rule)
 		if ruleResp := e.filterRule(rule, logger, policyContext); ruleResp != nil {
-			resp.PolicyResponse.Rules = append(resp.PolicyResponse.Rules, *ruleResp)
+			resp.Rules = append(resp.Rules, *ruleResp)
 		}
 	}
 	return resp

--- a/pkg/engine/generation.go
+++ b/pkg/engine/generation.go
@@ -27,14 +27,8 @@ func (e *engine) filterGenerateRules(
 	policyNameKey string,
 	startTime time.Time,
 ) engineapi.EngineResponse {
-	resp := engineapi.NewEngineResponseFromPolicyContext(policyContext, nil)
-	resp.PolicyResponse = engineapi.PolicyResponse{
-		Stats: engineapi.PolicyStats{
-			ExecutionStats: engineapi.ExecutionStats{
-				Timestamp: startTime.Unix(),
-			},
-		},
-	}
+	resp := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
+	resp.PolicyResponse = engineapi.PolicyResponse{}
 	for _, rule := range autogen.ComputeRules(policyContext.Policy()) {
 		logger := internal.LoggerWithRule(logger, rule)
 		if ruleResp := e.filterRule(rule, logger, policyContext); ruleResp != nil {

--- a/pkg/engine/imageVerify.go
+++ b/pkg/engine/imageVerify.go
@@ -23,14 +23,14 @@ func (e *engine) verifyAndPatchImages(
 	policyContext engineapi.PolicyContext,
 ) (engineapi.EngineResponse, engineapi.ImageVerificationMetadata) {
 	policy := policyContext.Policy()
-	resp := engineapi.NewEngineResponseFromPolicyContext(policyContext, nil)
+	resp := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
 
 	startTime := time.Now()
 
 	defer func() {
 		internal.BuildResponse(policyContext, &resp, startTime)
 		logger.V(4).Info("processed image verification rules",
-			"time", resp.PolicyResponse.Stats.ProcessingTime.String(),
+			"time", resp.Stats.ProcessingTime.String(),
 			"applied", resp.PolicyResponse.Stats.RulesAppliedCount,
 			"successful", resp.IsSuccessful(),
 		)

--- a/pkg/engine/imageVerify.go
+++ b/pkg/engine/imageVerify.go
@@ -21,20 +21,9 @@ func (e *engine) verifyAndPatchImages(
 	ctx context.Context,
 	logger logr.Logger,
 	policyContext engineapi.PolicyContext,
-) (engineapi.EngineResponse, engineapi.ImageVerificationMetadata) {
+) (engineapi.PolicyResponse, engineapi.ImageVerificationMetadata) {
 	policy := policyContext.Policy()
-	resp := engineapi.NewEngineResponseFromPolicyContext(policyContext, time.Now())
-
-	startTime := time.Now()
-
-	defer func() {
-		internal.BuildResponse(policyContext, &resp, startTime)
-		logger.V(4).Info("processed image verification rules",
-			"time", resp.Stats.ProcessingTime.String(),
-			"applied", resp.PolicyResponse.Stats.RulesAppliedCount,
-			"successful", resp.IsSuccessful(),
-		)
-	}()
+	resp := engineapi.NewPolicyResponse()
 
 	policyContext.JSONContext().Checkpoint()
 	defer policyContext.JSONContext().Restore()
@@ -52,11 +41,11 @@ func (e *engine) verifyAndPatchImages(
 			},
 		)
 
-		if applyRules == kyvernov1.ApplyOne && resp.PolicyResponse.Stats.RulesAppliedCount > 0 {
+		if applyRules == kyvernov1.ApplyOne && resp.Stats.RulesAppliedCount > 0 {
 			break
 		}
 	}
-	internal.BuildResponse(policyContext, &resp, startTime)
+	// TODO: i doesn't make sense to not return the patched resource here
 	return resp, ivm
 }
 
@@ -65,7 +54,7 @@ func (e *engine) doVerifyAndPatch(
 	logger logr.Logger,
 	policyContext engineapi.PolicyContext,
 	rule kyvernov1.Rule,
-	resp *engineapi.EngineResponse,
+	resp *engineapi.PolicyResponse,
 	ivm *engineapi.ImageVerificationMetadata,
 ) {
 	if len(rule.VerifyImages) == 0 {
@@ -82,7 +71,7 @@ func (e *engine) doVerifyAndPatch(
 	// check if there is a corresponding policy exception
 	ruleResp := e.hasPolicyExceptions(logger, engineapi.ImageVerify, policyContext, rule)
 	if ruleResp != nil {
-		resp.PolicyResponse.Rules = append(resp.PolicyResponse.Rules, *ruleResp)
+		resp.Rules = append(resp.Rules, *ruleResp)
 		return
 	}
 
@@ -96,7 +85,7 @@ func (e *engine) doVerifyAndPatch(
 	)
 	if err != nil {
 		internal.AddRuleResponse(
-			&resp.PolicyResponse,
+			resp,
 			internal.RuleError(rule, engineapi.ImageVerify, "failed to extract images", err),
 			startTime,
 		)
@@ -104,7 +93,7 @@ func (e *engine) doVerifyAndPatch(
 	}
 	if len(ruleImages) == 0 {
 		internal.AddRuleResponse(
-			&resp.PolicyResponse,
+			resp,
 			internal.RuleSkip(
 				rule,
 				engineapi.ImageVerify,
@@ -117,7 +106,7 @@ func (e *engine) doVerifyAndPatch(
 	policyContext.JSONContext().Restore()
 	if err := internal.LoadContext(ctx, e, policyContext, rule); err != nil {
 		internal.AddRuleResponse(
-			&resp.PolicyResponse,
+			resp,
 			internal.RuleError(rule, engineapi.ImageVerify, "failed to load context", err),
 			startTime,
 		)
@@ -126,7 +115,7 @@ func (e *engine) doVerifyAndPatch(
 	ruleCopy, err := substituteVariables(&rule, policyContext.JSONContext(), logger)
 	if err != nil {
 		internal.AddRuleResponse(
-			&resp.PolicyResponse,
+			resp,
 			internal.RuleError(rule, engineapi.ImageVerify, "failed to substitute variables", err),
 			startTime,
 		)
@@ -141,7 +130,7 @@ func (e *engine) doVerifyAndPatch(
 	)
 	for _, imageVerify := range ruleCopy.VerifyImages {
 		for _, r := range iv.Verify(ctx, imageVerify, ruleImages, e.configuration) {
-			internal.AddRuleResponse(&resp.PolicyResponse, r, startTime)
+			internal.AddRuleResponse(resp, r, startTime)
 		}
 	}
 }

--- a/pkg/engine/internal/response.go
+++ b/pkg/engine/internal/response.go
@@ -50,7 +50,7 @@ func BuildResponse(ctx engineapi.PolicyContext, resp *engineapi.EngineResponse, 
 		}
 		resp.PatchedResource = resource
 	}
-	resp.PolicyResponse.Stats.ProcessingTime = time.Since(startTime)
-	resp.PolicyResponse.Stats.Timestamp = startTime.Unix()
+	resp.Stats.ProcessingTime = time.Since(startTime)
+	resp.Stats.Timestamp = startTime.Unix()
 	return resp
 }

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -16,21 +16,7 @@ func (e *engine) validate(
 	ctx context.Context,
 	logger logr.Logger,
 	policyContext engineapi.PolicyContext,
-) engineapi.EngineResponse {
-	startTime := time.Now()
-	logger.V(4).Info("start validate policy processing", "startTime", startTime)
-	policyResponse := e.validateResource(ctx, logger, policyContext)
-	defer logger.V(4).Info("finished policy processing", "processingTime", policyResponse.Stats.ProcessingTime.String(), "validationRulesApplied", policyResponse.Stats.RulesAppliedCount)
-	engineResponse := engineapi.NewEngineResponseFromPolicyContext(policyContext, nil)
-	engineResponse.PolicyResponse = *policyResponse
-	return *internal.BuildResponse(policyContext, &engineResponse, startTime)
-}
-
-func (e *engine) validateResource(
-	ctx context.Context,
-	logger logr.Logger,
-	policyContext engineapi.PolicyContext,
-) *engineapi.PolicyResponse {
+) engineapi.PolicyResponse {
 	resp := &engineapi.PolicyResponse{}
 
 	policyContext.JSONContext().Checkpoint()
@@ -67,5 +53,5 @@ func (e *engine) validateResource(
 			break
 		}
 	}
-	return resp
+	return *resp
 }

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
@@ -35,7 +36,7 @@ func newEngineResponse(policy, rule string, patchesStr []string, status engineap
 		},
 	}
 	policyResponse := newPolicyResponse(rule, patchesStr, status)
-	response := engineapi.NewEngineResponse(unstructured.Unstructured{}, p, nil, &policyResponse)
+	response := engineapi.NewEngineResponse(unstructured.Unstructured{}, p, nil, &policyResponse, time.Now())
 	response.PatchedResource = unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{

--- a/pkg/webhooks/utils/block_test.go
+++ b/pkg/webhooks/utils/block_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
@@ -92,7 +93,7 @@ func TestBlockRequest(t *testing.T) {
 							Message: "message fail",
 						},
 					},
-				}),
+				}, time.Now()),
 			},
 			failurePolicy: kyvernov1.Fail,
 			log:           logr.Discard(),
@@ -110,7 +111,7 @@ func TestBlockRequest(t *testing.T) {
 							Message: "message fail",
 						},
 					},
-				}),
+				}, time.Now()),
 			},
 			failurePolicy: kyvernov1.Fail,
 			log:           logr.Discard(),
@@ -128,7 +129,7 @@ func TestBlockRequest(t *testing.T) {
 							Message: "message error",
 						},
 					},
-				}),
+				}, time.Now()),
 			},
 			failurePolicy: kyvernov1.Fail,
 			log:           logr.Discard(),
@@ -146,7 +147,7 @@ func TestBlockRequest(t *testing.T) {
 							Message: "message error",
 						},
 					},
-				}),
+				}, time.Now()),
 			},
 			failurePolicy: kyvernov1.Ignore,
 			log:           logr.Discard(),
@@ -164,7 +165,7 @@ func TestBlockRequest(t *testing.T) {
 							Message: "message warning",
 						},
 					},
-				}),
+				}, time.Now()),
 			},
 			failurePolicy: kyvernov1.Ignore,
 			log:           logr.Discard(),
@@ -182,7 +183,7 @@ func TestBlockRequest(t *testing.T) {
 							Message: "message warning",
 						},
 					},
-				}),
+				}, time.Now()),
 			},
 			failurePolicy: kyvernov1.Fail,
 			log:           logr.Discard(),
@@ -234,7 +235,7 @@ func TestGetBlockedMessages(t *testing.T) {
 							Message: "message fail",
 						},
 					},
-				}),
+				}, time.Now()),
 			},
 		},
 		want: "\n\npolicy foo/bar/baz for resource violation: \n\ntest:\n  rule-fail: message fail\n",
@@ -250,7 +251,7 @@ func TestGetBlockedMessages(t *testing.T) {
 							Message: "message error",
 						},
 					},
-				}),
+				}, time.Now()),
 			},
 		},
 		want: "\n\npolicy foo/bar/baz for resource error: \n\ntest:\n  rule-error: message error\n",
@@ -271,7 +272,7 @@ func TestGetBlockedMessages(t *testing.T) {
 							Message: "message error",
 						},
 					},
-				}),
+				}, time.Now()),
 			},
 		},
 		want: "\n\npolicy foo/bar/baz for resource violation: \n\ntest:\n  rule-error: message error\n  rule-fail: message fail\n",


### PR DESCRIPTION
## Explanation

This PR refactors engine responses:
- moves execution stats from policy response to engine response
- adds a `Done()` method to update the processing time
- adds `WithPolicyResponse()` and `WithPatchedResource()` making engine response immutable
- changes private handlers to return a policy response instead of an engine response
