### PR TITLE
chore: use Enforce instead of enforce in kuttl tests

### DIFF
--- a/test/conformance/kuttl/exceptions/events-creation/policy.yaml
+++ b/test/conformance/kuttl/exceptions/events-creation/policy.yaml
@@ -13,7 +13,7 @@ metadata:
       a specific version of an application Pod. This policy validates that the image
       specifies a tag and that it is not called `latest`.      
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
   - name: validate-image-tag

--- a/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/namespaceselector/policy.yaml
+++ b/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/namespaceselector/policy.yaml
@@ -6,7 +6,7 @@ metadata:
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
   mutateExistingOnPolicyUpdate: false
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
   - name: propagate org label from namespace
     match:

--- a/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/onpolicyupdate/namespaceselector/policy.yaml
+++ b/test/conformance/kuttl/mutate/clusterpolicy/standard/existing/onpolicyupdate/namespaceselector/policy.yaml
@@ -6,7 +6,7 @@ metadata:
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
   mutateExistingOnPolicyUpdate: true
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
   - name: propagate org label from namespace
     match:

--- a/test/conformance/kuttl/validate/clusterpolicy/cornercases/external-metrics/cluster-policy.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/cornercases/external-metrics/cluster-policy.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
     name: external-metrics-policy
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: external-metrics-rule

--- a/test/conformance/kuttl/validate/clusterpolicy/cornercases/external-metrics/policy.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/cornercases/external-metrics/policy.yaml
@@ -4,7 +4,7 @@ metadata:
     name: external-metrics-policy-default
     namespace: default
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: external-metrics-rule-default

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/enforce/operator-allnotin-01/01-manifests.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/enforce/operator-allnotin-01/01-manifests.yaml
@@ -24,4 +24,4 @@ spec:
           metadata:
             labels:
               app.kubernetes.io/name: "?*"
-  validationFailureAction: enforce
+  validationFailureAction: Enforce

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/enforce/resource-apply-block/01-manifests.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/enforce/resource-apply-block/01-manifests.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: require-owner
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: check-owner

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/gvk/policy.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/gvk/policy.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: rds-enforce-final-snapshot
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
     - name: rds-enforce-final-snapshot
       match:

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/wildcard/block-verifyimage/policy.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/wildcard/block-verifyimage/policy.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: verify-image     
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
     - name: verify-image

--- a/test/conformance/kuttl/validate/e2e/global-anchor/policy.yaml
+++ b/test/conformance/kuttl/validate/e2e/global-anchor/policy.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: sample
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
   - name: check-container-image
     match:

--- a/test/conformance/kuttl/validate/e2e/trusted-images/policy.yaml
+++ b/test/conformance/kuttl/validate/e2e/trusted-images/policy.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: check-trustable-images
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
   - name: only-allow-trusted-images
     match:

--- a/test/conformance/kuttl/validate/e2e/x509-decode/policy.yaml
+++ b/test/conformance/kuttl/validate/e2e/x509-decode/policy.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: test-x509-decode
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
   - name: test-x509-decode
     match:

--- a/test/conformance/kuttl/validate/e2e/yaml-signing/policy.yaml
+++ b/test/conformance/kuttl/validate/e2e/yaml-signing/policy.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: validate-resources
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   webhookTimeoutSeconds: 30
   failurePolicy: Fail  

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/01-policy.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/cornercases/multiple-attestors/01-policy.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   background: false
   rules:

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/configmap-context-lookup/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/configmap-context-lookup/01-manifests.yaml
@@ -35,7 +35,7 @@ metadata:
       key in a ConfigMap called `key` in the `default` Namespace
       and also a Namespace key in the same ConfigMap.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: check-image-with-two-keys

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/imageExtractors-complex-keyless/policy.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/imageExtractors-complex-keyless/policy.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: tasks-keyless
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   rules:
   - name: verify-images

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/imageExtractors-complex/policy.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/imageExtractors-complex/policy.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: tasks-complex
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
   - name: verify-images
     match:

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/imageExtractors-none/policy.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/imageExtractors-none/policy.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: tasks-no-extractor
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
   - name: verify-images
     match:

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/imageExtractors-simple/policy.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/imageExtractors-simple/policy.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: tasks-simple
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
   - name: verify-images
     match:

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyed-basic/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyed-basic/01-manifests.yaml
@@ -8,7 +8,7 @@ kind: ClusterPolicy
 metadata:
   name: keyed-basic-policy
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   webhookTimeoutSeconds: 30
   failurePolicy: Fail

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyed-secret/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyed-secret/01-manifests.yaml
@@ -8,7 +8,7 @@ kind: ClusterPolicy
 metadata:
   name: secret-in-keys
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   webhookTimeoutSeconds: 30
   failurePolicy: Fail

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-1/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-1/01-manifests.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   background: false
   rules:

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-2/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-2/01-manifests.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   background: false
   rules:

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-3/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-3/01-manifests.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   background: false
   rules:

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-4/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-4/01-manifests.yaml
@@ -24,4 +24,4 @@ spec:
         predicateType: https://slsa.dev/provenance/v0.2
       imageReferences:
       - ghcr.io/chipzoller/zulu*
-  validationFailureAction: enforce
+  validationFailureAction: Enforce

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-counts-1/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-counts-1/01-manifests.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   background: false
   rules:

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-counts-2/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-counts-2/01-manifests.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   background: false
   rules:

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-counts-3/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-attestations-multiple-subjects-counts-3/01-manifests.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   background: false
   rules:

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-mutatedigest-verifydigest-required/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-mutatedigest-verifydigest-required/01-manifests.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: keyless-mutatedigest-verifydigest-required
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   rules:
     - name: check-builder-id-keyless

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-nomutatedigest-noverifydigest-norequired/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-nomutatedigest-noverifydigest-norequired/01-manifests.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: keyless-nomutatedigest-noverifydigest-norequired
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   rules:
     - name: check-builder-id-keyless

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-nomutatedigest-noverifydigest-required/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/keyless-nomutatedigest-noverifydigest-required/01-manifests.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: keyless-nomutatedigest-noverifydigest-required
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   rules:
     - name: check-builder-id-keyless

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/mutateDigest-noverifyDigest-norequired/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/mutateDigest-noverifyDigest-norequired/01-manifests.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: mutatedigest-policy
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   rules:
     - name: mutatedigest-rule

--- a/test/conformance/kuttl/verifyImages/clusterpolicy/standard/nomutateDigest-verifyDigest-norequired/01-manifests.yaml
+++ b/test/conformance/kuttl/verifyImages/clusterpolicy/standard/nomutateDigest-verifyDigest-norequired/01-manifests.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: mutatedigest-policy
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   rules:
     - name: mutatedigest-rule


### PR DESCRIPTION
## Explanation

This PR uses `Enforce` instead of `enforce` in kuttl tests.
