### PR TITLE
fix: don't filter on group when service based apiservice discovery fails

### DIFF
--- a/pkg/clients/dclient/discovery.go
+++ b/pkg/clients/dclient/discovery.go
@@ -133,7 +133,7 @@ func (c serverResources) findResourceFromResourceName(gvr schema.GroupVersionRes
 	if err != nil && !strings.Contains(err.Error(), "Got empty response for") {
 		if discovery.IsGroupDiscoveryFailedError(err) {
 			logDiscoveryErrors(err)
-		} else if isMetricsServerUnavailable(gvr.GroupVersion(), err) {
+		} else if isServerCurrentlyUnableToHandleRequest(err) {
 			logger.V(3).Info("failed to find preferred resource version", "error", err.Error())
 		} else {
 			logger.Error(err, "failed to find preferred resource version")
@@ -257,14 +257,14 @@ func (c serverResources) findResource(groupVersion string, kind string) (apiReso
 	serverPreferredResources, _ := c.cachedClient.ServerPreferredResources()
 	_, serverGroupsAndResources, err := c.cachedClient.ServerGroupsAndResources()
 	if err != nil && !strings.Contains(err.Error(), "Got empty response for") {
-		gv, err := schema.ParseGroupVersion(groupVersion)
+		_, err := schema.ParseGroupVersion(groupVersion)
 		if err != nil {
 			logger.Error(err, "failed to parse group/version", "groupVersion", groupVersion)
 			return nil, nil, schema.GroupVersionResource{}, err
 		}
 		if discovery.IsGroupDiscoveryFailedError(err) {
 			logDiscoveryErrors(err)
-		} else if isMetricsServerUnavailable(gv, err) {
+		} else if isServerCurrentlyUnableToHandleRequest(err) {
 			logger.V(3).Info("failed to find preferred resource version", "error", err.Error())
 		} else {
 			logger.Error(err, "failed to find preferred resource version")

--- a/pkg/clients/dclient/utils.go
+++ b/pkg/clients/dclient/utils.go
@@ -3,7 +3,6 @@ package dclient
 import (
 	"strings"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 )
 
@@ -25,11 +24,4 @@ func logDiscoveryErrors(err error) {
 // the underlying service, this is typically due to kyverno blocking `TokenReview` admission requests.
 func isServerCurrentlyUnableToHandleRequest(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "the server is currently unable to handle the request")
-}
-
-func isMetricsServerUnavailable(gv schema.GroupVersion, err error) bool {
-	// error message is defined at:
-	// https://github.com/kubernetes/apimachinery/blob/2456ebdaba229616fab2161a615148884b46644b/pkg/api/errors/errors.go#L432
-	return (gv.Group == "metrics.k8s.io" || gv.Group == "custom.metrics.k8s.io" || gv.Group == "external.metrics.k8s.io") &&
-		isServerCurrentlyUnableToHandleRequest(err)
 }

--- a/pkg/clients/dclient/utils_test.go
+++ b/pkg/clients/dclient/utils_test.go
@@ -3,8 +3,6 @@ package dclient
 import (
 	"errors"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func Test_isServerCurrentlyUnableToHandleRequest(t *testing.T) {
@@ -50,55 +48,6 @@ func Test_isServerCurrentlyUnableToHandleRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isServerCurrentlyUnableToHandleRequest(tt.args.err); got != tt.want {
 				t.Errorf("isServerCurrentlyUnableToHandleRequest() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_isMetricsServerUnavailable(t *testing.T) {
-	type args struct {
-		gv  schema.GroupVersion
-		err error
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{{
-		args: args{
-			gv:  schema.GroupVersion{Group: "core", Version: "v1"},
-			err: nil,
-		},
-		want: false,
-	}, {
-		args: args{
-			gv:  schema.GroupVersion{Group: "core", Version: "v1"},
-			err: errors.New("the server is currently unable to handle the request"),
-		},
-		want: false,
-	}, {
-		args: args{
-			gv:  schema.GroupVersion{Group: "metrics.k8s.io", Version: "v1"},
-			err: errors.New("the server is currently unable to handle the request"),
-		},
-		want: true,
-	}, {
-		args: args{
-			gv:  schema.GroupVersion{Group: "custom.metrics.k8s.io", Version: "v1"},
-			err: errors.New("the server is currently unable to handle the request"),
-		},
-		want: true,
-	}, {
-		args: args{
-			gv:  schema.GroupVersion{Group: "external.metrics.k8s.io", Version: "v1"},
-			err: errors.New("the server is currently unable to handle the request"),
-		},
-		want: true,
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isMetricsServerUnavailable(tt.args.gv, tt.args.err); got != tt.want {
-				t.Errorf("isMetricsServerUnavailable() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Explanation

This PR stops filtering on group when service based apiservice discovery fails.
When kyverno is installed with a wildcard policy and something goes wrong, the `TokenRequest` will not work for service based apiservice and the cluster won't recover.
I don't think it makes sense to apply the group filtering, the exception should apply in all cases.

## Related issue

Fixes https://github.com/kyverno/kyverno/issues/6558
