### PR TITLE
chore: use Audit instead of audit in kuttl tests

### DIFF
--- a/test/conformance/kuttl/autogen/deployment-statefulset-job/policy-assert.yaml
+++ b/test/conformance/kuttl/autogen/deployment-statefulset-job/policy-assert.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: disallow-latest-tag
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - match:
       resources:

--- a/test/conformance/kuttl/autogen/deployment-statefulset-job/policy.yaml
+++ b/test/conformance/kuttl/autogen/deployment-statefulset-job/policy.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     pod-policies.kyverno.io/autogen-controllers: Deployment,StatefulSet,Job
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - match:
       resources:

--- a/test/conformance/kuttl/autogen/none/policy-assert.yaml
+++ b/test/conformance/kuttl/autogen/none/policy-assert.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: disallow-latest-tag
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - match:
       resources:

--- a/test/conformance/kuttl/autogen/none/policy.yaml
+++ b/test/conformance/kuttl/autogen/none/policy.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - match:
       resources:

--- a/test/conformance/kuttl/autogen/only-cronjob/policy-assert.yaml
+++ b/test/conformance/kuttl/autogen/only-cronjob/policy-assert.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: disallow-latest-tag
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - match:
       resources:

--- a/test/conformance/kuttl/autogen/only-cronjob/policy.yaml
+++ b/test/conformance/kuttl/autogen/only-cronjob/policy.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     pod-policies.kyverno.io/autogen-controllers: CronJob
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - match:
       resources:

--- a/test/conformance/kuttl/autogen/only-deployment/policy-assert.yaml
+++ b/test/conformance/kuttl/autogen/only-deployment/policy-assert.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: disallow-latest-tag
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - match:
       resources:

--- a/test/conformance/kuttl/autogen/only-deployment/policy.yaml
+++ b/test/conformance/kuttl/autogen/only-deployment/policy.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     pod-policies.kyverno.io/autogen-controllers: Deployment
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - match:
       resources:

--- a/test/conformance/kuttl/autogen/should-autogen/policy-assert.yaml
+++ b/test/conformance/kuttl/autogen/should-autogen/policy-assert.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: disallow-latest-tag
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - match:
       resources:

--- a/test/conformance/kuttl/autogen/should-autogen/policy.yaml
+++ b/test/conformance/kuttl/autogen/should-autogen/policy.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: disallow-latest-tag
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - match:
       resources:

--- a/test/conformance/kuttl/autogen/should-not-autogen/policy-assert.yaml
+++ b/test/conformance/kuttl/autogen/should-not-autogen/policy-assert.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: disallow-latest-tag
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - match:
       resources:

--- a/test/conformance/kuttl/autogen/should-not-autogen/policy.yaml
+++ b/test/conformance/kuttl/autogen/should-not-autogen/policy.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: disallow-latest-tag
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - match:
       resources:

--- a/test/conformance/kuttl/reports/admission/test-report-admission-mode/01-manifests.yaml
+++ b/test/conformance/kuttl/reports/admission/test-report-admission-mode/01-manifests.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: require-owner
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: check-owner

--- a/test/conformance/kuttl/reports/background/background-scan-report-deletion/policy.yaml
+++ b/test/conformance/kuttl/reports/background/background-scan-report-deletion/policy.yaml
@@ -15,4 +15,4 @@ spec:
       podSecurity:
         level: restricted
         version: latest
-  validationFailureAction: audit
+  validationFailureAction: Audit

--- a/test/conformance/kuttl/reports/background/test-report-background-mode/policy-assert.yaml
+++ b/test/conformance/kuttl/reports/background/test-report-background-mode/policy-assert.yaml
@@ -15,7 +15,7 @@ spec:
       podSecurity:
         level: restricted
         version: latest
-  validationFailureAction: audit
+  validationFailureAction: Audit
 status:
   conditions:
   - reason: Succeeded

--- a/test/conformance/kuttl/reports/background/test-report-background-mode/policy.yaml
+++ b/test/conformance/kuttl/reports/background/test-report-background-mode/policy.yaml
@@ -18,7 +18,7 @@ metadata:
       restricted profile through the latest version of the Pod Security Standards cluster wide.
 spec:
   background: true
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: restricted
     match:

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-match-clusterRoles/02-errors.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-match-clusterRoles/02-errors.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: background-match-clusterroles
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: ns-clusterroles

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-match-clusterRoles/manifests.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-match-clusterRoles/manifests.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: background-match-clusterroles
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: ns-clusterroles

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-match-roles/02-errors.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-match-roles/02-errors.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: background-match-roles
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: ns-roles

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-match-roles/manifests.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-match-roles/manifests.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: background-match-roles
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: ns-roles

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-vars-roles/02-errors.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-vars-roles/02-errors.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: background-vars-roles
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: ns-vars-roles

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-vars-roles/manifests.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-vars-roles/manifests.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: background-vars-roles
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: ns-vars-roles

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-vars-serviceAccountName/02-errors.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-vars-serviceAccountName/02-errors.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: background-vars-serviceaccountname
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: ns-vars-serviceaccountname

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-vars-serviceAccountName/manifests.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-vars-serviceAccountName/manifests.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: background-vars-serviceaccountname
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: ns-vars-serviceaccountname

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-vars-userInfo/02-errors.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-vars-userInfo/02-errors.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: background-vars-userinfo
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: ns-vars-userinfo

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-vars-userInfo/manifests.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/audit/background-vars-userInfo/manifests.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: background-vars-userinfo
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: ns-vars-userinfo

--- a/test/conformance/kuttl/validate/clusterpolicy/standard/audit/configmap-context-lookup/01-manifests.yaml
+++ b/test/conformance/kuttl/validate/clusterpolicy/standard/audit/configmap-context-lookup/01-manifests.yaml
@@ -16,7 +16,7 @@ kind: ClusterPolicy
 metadata:
   name: validate-labels
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: validate-labels


### PR DESCRIPTION
## Explanation

This PR uses `Audit` instead of `audit` in kuttl tests.
