### PR TITLE
feat: add flag to skip resource filters in reports controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Refactored `kyverno` chart, migration instructions are available in chart `README.md`.
 - Image references in the json context are not mutated to canonical form anymore, do not assume a registry domain is always present.
 - Added support for configuring webhook annotations in the config map through `webhookAnnotations` stanza.
+- Added new flag `skipResourceFilters` to reports controller to enable/disable considering resource filters in the background (default value is `true`)
 
 ## v1.9.0-rc.1
 

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -384,7 +384,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | reportsController.priorityClassName | string | `""` | Optional priority class |
 | reportsController.hostNetwork | bool | `false` | Change `hostNetwork` to `true` when you want the pod to share its host's network namespace. Useful for situations like when you end up dealing with a custom CNI over Amazon EKS. Update the `dnsPolicy` accordingly as well to suit the host network mode. |
 | reportsController.dnsPolicy | string | `"ClusterFirst"` | `dnsPolicy` determines the manner in which DNS resolution happens in the cluster. In case of `hostNetwork: true`, usually, the `dnsPolicy` is suitable to be `ClusterFirstWithHostNet`. For further reference: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy. |
-| reportsController.extraArgs | object | `{"clientRateLimitBurst":300,"clientRateLimitQPS":300}` | Extra arguments passed to the container on the command line |
+| reportsController.extraArgs | object | `{"clientRateLimitBurst":300,"clientRateLimitQPS":300,"skipResourceFilters":true}` | Extra arguments passed to the container on the command line |
 | reportsController.resources.limits | object | `{"memory":"128Mi"}` | Pod resource limits |
 | reportsController.resources.requests | object | `{"cpu":"100m","memory":"64Mi"}` | Pod resource requests |
 | reportsController.nodeSelector | object | `{}` | Node labels for pod assignment |

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -937,6 +937,7 @@ reportsController:
   extraArgs:
     clientRateLimitQPS: 300
     clientRateLimitBurst: 300
+    skipResourceFilters: true
 
   resources:
     # -- Pod resource limits

--- a/cmd/background-controller/main.go
+++ b/cmd/background-controller/main.go
@@ -207,7 +207,7 @@ func main() {
 		logger.Error(err, "failed to create config map resolver")
 		os.Exit(1)
 	}
-	configuration, err := config.NewConfiguration(kubeClient)
+	configuration, err := config.NewConfiguration(kubeClient, false)
 	if err != nil {
 		logger.Error(err, "failed to initialize configuration")
 		os.Exit(1)

--- a/cmd/cleanup-controller/main.go
+++ b/cmd/cleanup-controller/main.go
@@ -225,7 +225,7 @@ func main() {
 			DumpPayload: dumpPayload,
 		},
 		probes{},
-		config.NewDefaultConfiguration(),
+		config.NewDefaultConfiguration(false),
 	)
 	// start server
 	server.Run(ctx.Done())

--- a/cmd/cli/kubectl-kyverno/utils/common/common.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common.go
@@ -451,7 +451,7 @@ OuterLoop:
 		}
 	}
 
-	cfg := config.NewDefaultConfiguration()
+	cfg := config.NewDefaultConfiguration(false)
 	if err := ctx.AddImageInfos(c.Resource, cfg); err != nil {
 		log.Log.Error(err, "failed to add image variables to context")
 	}
@@ -1072,7 +1072,7 @@ func initializeMockController(objects []runtime.Object) (*generate.GenerateContr
 
 	client.SetDiscovery(dclient.NewFakeDiscoveryClient(nil))
 	c := generate.NewGenerateControllerWithOnlyClient(client, engine.NewEngine(
-		config.NewDefaultConfiguration(),
+		config.NewDefaultConfiguration(false),
 		client,
 		nil,
 		store.ContextLoaderFactory(nil),

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -322,7 +322,7 @@ func main() {
 		logger.Error(err, "failed to create config map resolver")
 		os.Exit(1)
 	}
-	configuration, err := config.NewConfiguration(kubeClient)
+	configuration, err := config.NewConfiguration(kubeClient, false)
 	if err != nil {
 		logger.Error(err, "failed to initialize configuration")
 		os.Exit(1)

--- a/cmd/reports-controller/main.go
+++ b/cmd/reports-controller/main.go
@@ -220,6 +220,7 @@ func main() {
 		maxQueuedEvents           int
 		enablePolicyException     bool
 		exceptionNamespace        string
+		skipResourceFilters       bool
 	)
 	flagset := flag.NewFlagSet("reports-controller", flag.ExitOnError)
 	flagset.DurationVar(&leaderElectionRetryPeriod, "leaderElectionRetryPeriod", leaderelection.DefaultRetryPeriod, "Configure leader election retry period.")
@@ -234,6 +235,7 @@ func main() {
 	flagset.IntVar(&maxQueuedEvents, "maxQueuedEvents", 1000, "Maximum events to be queued.")
 	flagset.StringVar(&exceptionNamespace, "exceptionNamespace", "", "Configure the namespace to accept PolicyExceptions.")
 	flagset.BoolVar(&enablePolicyException, "enablePolicyException", false, "Enable PolicyException feature.")
+	flagset.BoolVar(&skipResourceFilters, "skipResourceFilters", true, "If true, resource filters wont be considered.")
 	// config
 	appConfig := internal.NewConfiguration(
 		internal.WithProfiling(),
@@ -298,7 +300,7 @@ func main() {
 		logger.Error(err, "failed to create config map resolver")
 		os.Exit(1)
 	}
-	configuration, err := config.NewConfiguration(kubeClient)
+	configuration, err := config.NewConfiguration(kubeClient, skipResourceFilters)
 	if err != nil {
 		logger.Error(err, "failed to initialize configuration")
 		os.Exit(1)

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -34969,6 +34969,7 @@ spec:
             - --metricsPort=8000
             - --clientRateLimitBurst=300
             - --clientRateLimitQPS=300
+            - --skipResourceFilters=true
           env:
           - name: METRICS_CONFIG
             value: kyverno-metrics

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -157,6 +157,7 @@ type Configuration interface {
 
 // configuration stores the configuration
 type configuration struct {
+	skipResourceFilters           bool
 	defaultRegistry               string
 	enableDefaultRegistryMutation bool
 	excludedGroups                []string
@@ -170,8 +171,9 @@ type configuration struct {
 }
 
 // NewDefaultConfiguration ...
-func NewDefaultConfiguration() *configuration {
+func NewDefaultConfiguration(skipResourceFilters bool) *configuration {
 	return &configuration{
+		skipResourceFilters:           skipResourceFilters,
 		defaultRegistry:               "docker.io",
 		enableDefaultRegistryMutation: true,
 		excludedGroups:                defaultExcludedGroups,
@@ -180,8 +182,8 @@ func NewDefaultConfiguration() *configuration {
 }
 
 // NewConfiguration ...
-func NewConfiguration(client kubernetes.Interface) (Configuration, error) {
-	cd := NewDefaultConfiguration()
+func NewConfiguration(client kubernetes.Interface, skipResourceFilters bool) (Configuration, error) {
+	cd := NewDefaultConfiguration(skipResourceFilters)
 	if cm, err := client.CoreV1().ConfigMaps(kyvernoNamespace).Get(context.TODO(), kyvernoConfigMapName, metav1.GetOptions{}); err != nil {
 		if !errors.IsNotFound(err) {
 			return nil, err
@@ -195,14 +197,16 @@ func NewConfiguration(client kubernetes.Interface) (Configuration, error) {
 func (cd *configuration) ToFilter(kind, namespace, name string) bool {
 	cd.mux.RLock()
 	defer cd.mux.RUnlock()
-	for _, f := range cd.filters {
-		if wildcard.Match(f.Kind, kind) && wildcard.Match(f.Namespace, namespace) && wildcard.Match(f.Name, name) {
-			return true
-		}
-		if kind == "Namespace" {
-			// [Namespace,kube-system,*] || [*,kube-system,*]
-			if (f.Kind == "Namespace" || f.Kind == "*") && wildcard.Match(f.Namespace, name) {
+	if !cd.skipResourceFilters {
+		for _, f := range cd.filters {
+			if wildcard.Match(f.Kind, kind) && wildcard.Match(f.Namespace, namespace) && wildcard.Match(f.Name, name) {
 				return true
+			}
+			if kind == "Namespace" {
+				// [Namespace,kube-system,*] || [*,kube-system,*]
+				if (f.Kind == "Namespace" || f.Kind == "*") && wildcard.Match(f.Namespace, name) {
+					return true
+				}
 			}
 		}
 	}

--- a/pkg/controllers/generic/webhook/controller.go
+++ b/pkg/controllers/generic/webhook/controller.go
@@ -140,7 +140,7 @@ func (c *controller) enqueue() {
 }
 
 func (c *controller) loadConfig() config.Configuration {
-	cfg := config.NewDefaultConfiguration()
+	cfg := config.NewDefaultConfiguration(false)
 	cm, err := c.configMapLister.ConfigMaps(config.KyvernoNamespace()).Get(config.KyvernoConfigMapName())
 	if err == nil {
 		cfg.Load(cm)

--- a/pkg/controllers/webhook/controller.go
+++ b/pkg/controllers/webhook/controller.go
@@ -294,7 +294,7 @@ func (c *controller) enqueueVerifyWebhook() {
 }
 
 func (c *controller) loadConfig() config.Configuration {
-	cfg := config.NewDefaultConfiguration()
+	cfg := config.NewDefaultConfiguration(false)
 	cm, err := c.configMapLister.ConfigMaps(config.KyvernoNamespace()).Get(config.KyvernoConfigMapName())
 	if err == nil {
 		cfg.Load(cm)

--- a/pkg/engine/handlers/validation/validate_manifest_test.go
+++ b/pkg/engine/handlers/validation/validate_manifest_test.go
@@ -619,7 +619,7 @@ FdGxexVrR4YqO1pRViKxmD9oMu4I7K/4sM51nbH65ycB2uRiDfIdRoV/+A==
 
 var (
 	h   = validateManifestHandler{}
-	cfg = config.NewDefaultConfiguration()
+	cfg = config.NewDefaultConfiguration(false)
 )
 
 func Test_VerifyManifest_SignedYAML(t *testing.T) {

--- a/pkg/engine/image_verify_test.go
+++ b/pkg/engine/image_verify_test.go
@@ -161,7 +161,7 @@ var signaturePayloads = [][]byte{
 	[]byte(`{"critical":{"identity":{"docker-reference":"ghcr.io/kyverno/test-verify-image"},"image":{"docker-manifest-digest":"sha256:b31bfb4d0213f254d361e0079deaaebefa4f82ba7aa76ef82e90b4935ad5b105"},"type":"cosign container image signature"},"optional":null}`),
 }
 
-var cfg = config.NewDefaultConfiguration()
+var cfg = config.NewDefaultConfiguration(false)
 
 func testVerifyAndPatchImages(
 	ctx context.Context,

--- a/pkg/utils/api/image_test.go
+++ b/pkg/utils/api/image_test.go
@@ -10,7 +10,7 @@ import (
 	"gotest.tools/assert"
 )
 
-var cfg = config.NewDefaultConfiguration()
+var cfg = config.NewDefaultConfiguration(false)
 
 func Test_extractImageInfo(t *testing.T) {
 	tests := []struct {

--- a/pkg/utils/image/infos_test.go
+++ b/pkg/utils/image/infos_test.go
@@ -21,7 +21,7 @@ func initializeMockConfig(defaultRegistry string, enableDefaultRegistryMutation 
 		Data:       configMapData,
 	}
 	cs := fake.NewSimpleClientset(&cm)
-	dynamicConfig, err := config.NewConfiguration(cs)
+	dynamicConfig, err := config.NewConfiguration(cs, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/webhooks/resource/fake.go
+++ b/pkg/webhooks/resource/fake.go
@@ -35,7 +35,7 @@ func NewFakeHandlers(ctx context.Context, policyCache policycache.Cache) webhook
 	kyvernoInformers.Start(ctx.Done())
 
 	dclient := dclient.NewEmptyFakeClient()
-	configuration := config.NewDefaultConfiguration()
+	configuration := config.NewDefaultConfiguration(false)
 	rbLister := informers.Rbac().V1().RoleBindings().Lister()
 	crbLister := informers.Rbac().V1().ClusterRoleBindings().Lister()
 	urLister := kyvernoInformers.Kyverno().V1beta1().UpdateRequests().Lister().UpdateRequests(config.KyvernoNamespace())

--- a/pkg/webhooks/resource/validation_test.go
+++ b/pkg/webhooks/resource/validation_test.go
@@ -1050,7 +1050,7 @@ func TestValidate_failure_action_overrides(t *testing.T) {
 	}
 
 	eng := engine.NewEngine(
-		config.NewDefaultConfiguration(),
+		config.NewDefaultConfiguration(false),
 		nil,
 		registryclient.NewOrDie(),
 		engineapi.DefaultContextLoaderFactory(nil),
@@ -1129,7 +1129,7 @@ func Test_RuleSelector(t *testing.T) {
 	ctx := engine.NewPolicyContext(kyvernov1.Create).WithPolicy(&policy).WithNewResource(*resourceUnstructured)
 
 	eng := engine.NewEngine(
-		config.NewDefaultConfiguration(),
+		config.NewDefaultConfiguration(false),
 		nil,
 		registryclient.NewOrDie(),
 		engineapi.DefaultContextLoaderFactory(nil),


### PR DESCRIPTION
## Explanation

This PR adds a flag to skip resource filters in reports controller.
By default the reports controller will scan all resources, whatever is configured in resource filters in the config map.

Setting the flag to false will enable resource filters in the reports controller.

Fixes https://github.com/kyverno/kyverno/issues/5028
