### PR TITLE
fix: make flag default values configurable

### DIFF
--- a/cmd/reports-controller/main.go
+++ b/cmd/reports-controller/main.go
@@ -188,7 +188,11 @@ func main() {
 		internal.WithFlagSets(flagset),
 	)
 	// parse flags
-	internal.ParseFlags(appConfig)
+	internal.ParseFlags(
+		appConfig,
+		internal.WithDefaultQps(300),
+		internal.WithDefaultBurst(300),
+	)
 	// setup
 	ctx, setup, sdown := internal.Setup(appConfig, "kyverno-reports-controller", skipResourceFilters)
 	defer sdown()


### PR DESCRIPTION
## Explanation

This PR makes flag default values configurable (QPS / Burst in reports controller for example).
