### PR TITLE
refactor: engine patchers

### DIFF
--- a/pkg/engine/handlers/mutation/common.go
+++ b/pkg/engine/handlers/mutation/common.go
@@ -147,7 +147,7 @@ func buildRuleResponse(rule *kyvernov1.Rule, mutateResp *mutate.Response, info r
 		mutateResp.Status,
 	)
 	if mutateResp.Status == engineapi.RuleStatusPass {
-		resp = resp.WithPatches(mutate.ConvertPatches(mutateResp.Patches...)...)
+		resp = resp.WithPatches(patch.ConvertPatches(mutateResp.Patches...)...)
 		if len(rule.Mutation.Targets) != 0 {
 			resp = resp.WithPatchedTarget(&mutateResp.PatchedResource, info.parentResourceGVR, info.subresource)
 		}

--- a/pkg/engine/handlers/mutation/common.go
+++ b/pkg/engine/handlers/mutation/common.go
@@ -147,22 +147,12 @@ func buildRuleResponse(rule *kyvernov1.Rule, mutateResp *mutate.Response, info r
 		mutateResp.Status,
 	)
 	if mutateResp.Status == engineapi.RuleStatusPass {
-		resp = resp.WithPatches(convertPatches(mutateResp.Patches...)...)
+		resp = resp.WithPatches(mutate.ConvertPatches(mutateResp.Patches...)...)
 		if len(rule.Mutation.Targets) != 0 {
 			resp = resp.WithPatchedTarget(&mutateResp.PatchedResource, info.parentResourceGVR, info.subresource)
 		}
 	}
 	return resp
-}
-
-func convertPatches(in ...jsonpatch.JsonPatchOperation) [][]byte {
-	var out [][]byte
-	for _, patch := range in {
-		if patch, err := patch.MarshalJSON(); err == nil {
-			out = append(out, patch)
-		}
-	}
-	return out
 }
 
 func buildSuccessMessage(r unstructured.Unstructured) string {

--- a/pkg/engine/handlers/mutation/common.go
+++ b/pkg/engine/handlers/mutation/common.go
@@ -2,7 +2,6 @@ package mutation
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -29,7 +28,7 @@ type forEachMutator struct {
 
 func (f *forEachMutator) mutateForEach(ctx context.Context) *mutate.Response {
 	var applyCount int
-	allPatches := make([][]byte, 0)
+	var allPatches []jsonpatch.JsonPatchOperation
 
 	for _, foreach := range f.foreach {
 		elements, err := engineutils.EvaluateList(foreach.List, f.policyContext.JSONContext())
@@ -69,7 +68,7 @@ func (f *forEachMutator) mutateElements(ctx context.Context, foreach kyvernov1.F
 	defer f.policyContext.JSONContext().Restore()
 
 	patchedResource := f.resource
-	var allPatches [][]byte
+	var allPatches []jsonpatch.JsonPatchOperation
 	if foreach.RawPatchStrategicMerge != nil {
 		engineutils.InvertedElement(elements)
 	}
@@ -132,24 +131,8 @@ func (f *forEachMutator) mutateElements(ctx context.Context, foreach kyvernov1.F
 			allPatches = append(allPatches, mutateResp.Patches...)
 		}
 	}
-	var sortedPatches []jsonpatch.JsonPatchOperation
-	for _, p := range allPatches {
-		var jp jsonpatch.JsonPatchOperation
-		if err := json.Unmarshal(p, &jp); err != nil {
-			return mutate.NewErrorResponse("failed to convert patch", err)
-		}
-		sortedPatches = append(sortedPatches, jp)
-	}
-	sortedPatches = patch.FilterAndSortPatches(sortedPatches)
-	var finalPatches [][]byte
-	for _, p := range sortedPatches {
-		if data, err := p.MarshalJSON(); err != nil {
-			return mutate.NewErrorResponse("failed to marshal patch", err)
-		} else {
-			finalPatches = append(finalPatches, data)
-		}
-	}
-	return mutate.NewResponse(engineapi.RuleStatusPass, patchedResource.unstructured, finalPatches, "")
+	sortedPatches := patch.FilterAndSortPatches(allPatches)
+	return mutate.NewResponse(engineapi.RuleStatusPass, patchedResource.unstructured, sortedPatches, "")
 }
 
 func buildRuleResponse(rule *kyvernov1.Rule, mutateResp *mutate.Response, info resourceInfo) *engineapi.RuleResponse {
@@ -164,12 +147,22 @@ func buildRuleResponse(rule *kyvernov1.Rule, mutateResp *mutate.Response, info r
 		mutateResp.Status,
 	)
 	if mutateResp.Status == engineapi.RuleStatusPass {
-		resp = resp.WithPatches(mutateResp.Patches...)
+		resp = resp.WithPatches(convertPatches(mutateResp.Patches...)...)
 		if len(rule.Mutation.Targets) != 0 {
 			resp = resp.WithPatchedTarget(&mutateResp.PatchedResource, info.parentResourceGVR, info.subresource)
 		}
 	}
 	return resp
+}
+
+func convertPatches(in ...jsonpatch.JsonPatchOperation) [][]byte {
+	var out [][]byte
+	for _, patch := range in {
+		if patch, err := patch.MarshalJSON(); err == nil {
+			out = append(out, patch)
+		}
+	}
+	return out
 }
 
 func buildSuccessMessage(r unstructured.Unstructured) string {

--- a/pkg/engine/mutate/mutation.go
+++ b/pkg/engine/mutate/mutation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine/mutate/patch"
 	"github.com/kyverno/kyverno/pkg/engine/variables"
 	datautils "github.com/kyverno/kyverno/pkg/utils/data"
+	"github.com/mattbaird/jsonpatch"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -18,7 +19,7 @@ import (
 type Response struct {
 	Status          engineapi.RuleStatus
 	PatchedResource unstructured.Unstructured
-	Patches         [][]byte
+	Patches         []jsonpatch.JsonPatchOperation
 	Message         string
 }
 
@@ -26,7 +27,7 @@ func NewErrorResponse(msg string, err error) *Response {
 	return NewResponse(engineapi.RuleStatusError, unstructured.Unstructured{}, nil, fmt.Sprintf("%s: %v", msg, err))
 }
 
-func NewResponse(status engineapi.RuleStatus, resource unstructured.Unstructured, patches [][]byte, msg string) *Response {
+func NewResponse(status engineapi.RuleStatus, resource unstructured.Unstructured, patches []jsonpatch.JsonPatchOperation, msg string) *Response {
 	return &Response{
 		Status:          status,
 		PatchedResource: resource,
@@ -40,33 +41,35 @@ func Mutate(rule *kyvernov1.Rule, ctx context.Interface, resource unstructured.U
 	if err != nil {
 		return NewErrorResponse("variable substitution failed", err)
 	}
-
 	m := updatedRule.Mutation
-	patcher := NewPatcher(updatedRule.Name, m.GetPatchStrategicMerge(), m.PatchesJSON6902, resource, logger)
+	patcher := NewPatcher(m.GetPatchStrategicMerge(), m.PatchesJSON6902)
 	if patcher == nil {
 		return NewResponse(engineapi.RuleStatusError, resource, nil, "empty mutate rule")
 	}
-
-	resp, patchedResource := patcher.Patch()
-	if resp.Status() != engineapi.RuleStatusPass {
-		return NewResponse(resp.Status(), resource, nil, resp.Message())
+	resourceBytes, err := resource.MarshalJSON()
+	if err != nil {
+		return NewErrorResponse("failed to marshal resource", err)
 	}
-
-	if resp.Patches() == nil {
-		return NewResponse(engineapi.RuleStatusSkip, resource, nil, "no patches applied")
+	resourceBytes, patches, err := patcher.Patch(logger, resourceBytes)
+	if err != nil {
+		return NewErrorResponse("failed to patch resource", err)
 	}
-
+	if patches == nil {
+		return NewResponse(engineapi.RuleStatusSkip, unstructured.Unstructured{}, nil, "no patches applied")
+	}
+	if err := resource.UnmarshalJSON(resourceBytes); err != nil {
+		return NewErrorResponse("failed to unmarshal patched resource", err)
+	}
 	if rule.IsMutateExisting() {
-		if err := ctx.AddTargetResource(patchedResource.Object); err != nil {
+		if err := ctx.AddTargetResource(resource.Object); err != nil {
 			return NewErrorResponse("failed to update patched resource in the JSON context", err)
 		}
 	} else {
-		if err := ctx.AddResource(patchedResource.Object); err != nil {
+		if err := ctx.AddResource(resource.Object); err != nil {
 			return NewErrorResponse("failed to update patched resource in the JSON context", err)
 		}
 	}
-
-	return NewResponse(engineapi.RuleStatusPass, patchedResource, resp.Patches(), resp.Message())
+	return NewResponse(engineapi.RuleStatusPass, resource, patches, "resource patched")
 }
 
 func ForEach(name string, foreach kyvernov1.ForEachMutation, policyContext engineapi.PolicyContext, resource unstructured.Unstructured, element interface{}, logger logr.Logger) *Response {
@@ -75,26 +78,28 @@ func ForEach(name string, foreach kyvernov1.ForEachMutation, policyContext engin
 	if err != nil {
 		return NewErrorResponse("variable substitution failed", err)
 	}
-
-	patcher := NewPatcher(name, fe.GetPatchStrategicMerge(), fe.PatchesJSON6902, resource, logger)
+	patcher := NewPatcher(fe.GetPatchStrategicMerge(), fe.PatchesJSON6902)
 	if patcher == nil {
 		return NewResponse(engineapi.RuleStatusError, unstructured.Unstructured{}, nil, "no patches found")
 	}
-
-	resp, patchedResource := patcher.Patch()
-	if resp.Status() != engineapi.RuleStatusPass {
-		return NewResponse(resp.Status(), unstructured.Unstructured{}, nil, resp.Message())
+	resourceBytes, err := resource.MarshalJSON()
+	if err != nil {
+		return NewErrorResponse("failed to marshal resource", err)
 	}
-
-	if resp.Patches() == nil {
+	resourceBytes, patches, err := patcher.Patch(logger, resourceBytes)
+	if err != nil {
+		return NewErrorResponse("failed to patch resource", err)
+	}
+	if patches == nil {
 		return NewResponse(engineapi.RuleStatusSkip, unstructured.Unstructured{}, nil, "no patches applied")
 	}
-
-	if err := ctx.AddResource(patchedResource.Object); err != nil {
+	if err := resource.UnmarshalJSON(resourceBytes); err != nil {
+		return NewErrorResponse("failed to unmarshal patched resource", err)
+	} else if err := ctx.AddResource(resource.Object); err != nil {
 		return NewErrorResponse("failed to update patched resource in the JSON context", err)
+	} else {
+		return NewResponse(engineapi.RuleStatusPass, resource, patches, "resource patched")
 	}
-
-	return NewResponse(engineapi.RuleStatusPass, patchedResource, resp.Patches(), resp.Message())
 }
 
 func substituteAllInForEach(fe kyvernov1.ForEachMutation, ctx context.Interface, logger logr.Logger) (*kyvernov1.ForEachMutation, error) {
@@ -121,14 +126,12 @@ func substituteAllInForEach(fe kyvernov1.ForEachMutation, ctx context.Interface,
 	return &updatedForEach, nil
 }
 
-func NewPatcher(name string, strategicMergePatch apiextensions.JSON, jsonPatch string, r unstructured.Unstructured, logger logr.Logger) patch.Patcher {
+func NewPatcher(strategicMergePatch apiextensions.JSON, jsonPatch string) patch.Patcher {
 	if strategicMergePatch != nil {
-		return patch.NewPatchStrategicMerge(name, strategicMergePatch, r, logger)
+		return patch.NewPatchStrategicMerge(strategicMergePatch)
 	}
-
 	if len(jsonPatch) > 0 {
-		return patch.NewPatchesJSON6902(name, jsonPatch, r, logger)
+		return patch.NewPatchesJSON6902(jsonPatch)
 	}
-
 	return nil
 }

--- a/pkg/engine/mutate/mutation.go
+++ b/pkg/engine/mutate/mutation.go
@@ -54,7 +54,7 @@ func Mutate(rule *kyvernov1.Rule, ctx context.Interface, resource unstructured.U
 	if err != nil {
 		return NewErrorResponse("failed to patch resource", err)
 	}
-	if patches == nil {
+	if len(patches) == 0 {
 		return NewResponse(engineapi.RuleStatusSkip, unstructured.Unstructured{}, nil, "no patches applied")
 	}
 	if err := resource.UnmarshalJSON(resourceBytes); err != nil {
@@ -90,7 +90,7 @@ func ForEach(name string, foreach kyvernov1.ForEachMutation, policyContext engin
 	if err != nil {
 		return NewErrorResponse("failed to patch resource", err)
 	}
-	if patches == nil {
+	if len(patches) == 0 {
 		return NewResponse(engineapi.RuleStatusSkip, unstructured.Unstructured{}, nil, "no patches applied")
 	}
 	if err := resource.UnmarshalJSON(resourceBytes); err != nil {
@@ -134,4 +134,14 @@ func NewPatcher(strategicMergePatch apiextensions.JSON, jsonPatch string) patch.
 		return patch.NewPatchesJSON6902(jsonPatch)
 	}
 	return nil
+}
+
+func ConvertPatches(in ...jsonpatch.JsonPatchOperation) [][]byte {
+	var out [][]byte
+	for _, patch := range in {
+		if patch, err := patch.MarshalJSON(); err == nil {
+			out = append(out, patch)
+		}
+	}
+	return out
 }

--- a/pkg/engine/mutate/mutation.go
+++ b/pkg/engine/mutate/mutation.go
@@ -135,13 +135,3 @@ func NewPatcher(strategicMergePatch apiextensions.JSON, jsonPatch string) patch.
 	}
 	return nil
 }
-
-func ConvertPatches(in ...jsonpatch.JsonPatchOperation) [][]byte {
-	var out [][]byte
-	for _, patch := range in {
-		if patch, err := patch.MarshalJSON(); err == nil {
-			out = append(out, patch)
-		}
-	}
-	return out
-}

--- a/pkg/engine/mutate/mutation_test.go
+++ b/pkg/engine/mutate/mutation_test.go
@@ -10,6 +10,7 @@ import (
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/engine/jmespath"
+	"github.com/kyverno/kyverno/pkg/engine/mutate/patch"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"gotest.tools/assert"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -58,7 +59,7 @@ func applyPatches(rule *types.Rule, resource unstructured.Unstructured) (*engine
 		engineapi.Mutation,
 		mutateResp.Message,
 	).WithPatches(
-		ConvertPatches(mutateResp.Patches...)...,
+		patch.ConvertPatches(mutateResp.Patches...)...,
 	), mutateResp.PatchedResource
 }
 

--- a/pkg/engine/mutate/mutation_test.go
+++ b/pkg/engine/mutate/mutation_test.go
@@ -1,200 +1,206 @@
 package mutate
 
-// import (
-// 	"encoding/json"
-// 	"testing"
+import (
+	"encoding/json"
+	"testing"
 
-// 	"github.com/go-logr/logr"
-// 	types "github.com/kyverno/kyverno/api/kyverno/v1"
-// 	"github.com/kyverno/kyverno/pkg/config"
-// 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
-// 	"github.com/kyverno/kyverno/pkg/engine/context"
-// 	"github.com/kyverno/kyverno/pkg/engine/jmespath"
-// 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
-// 	"gotest.tools/assert"
-// 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-// 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-// )
+	"github.com/go-logr/logr"
+	types "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/config"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/kyverno/kyverno/pkg/engine/context"
+	"github.com/kyverno/kyverno/pkg/engine/jmespath"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
+	"gotest.tools/assert"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
 
-// // jsonPatch is used to build test patches
-// type jsonPatch struct {
-// 	Path      string             `json:"path,omitempty" yaml:"path,omitempty"`
-// 	Operation string             `json:"op,omitempty" yaml:"op,omitempty"`
-// 	Value     apiextensions.JSON `json:"value,omitempty" yaml:"value,omitempty"`
-// }
+// jsonPatch is used to build test patches
+type jsonPatch struct {
+	Path      string             `json:"path,omitempty" yaml:"path,omitempty"`
+	Operation string             `json:"op,omitempty" yaml:"op,omitempty"`
+	Value     apiextensions.JSON `json:"value,omitempty" yaml:"value,omitempty"`
+}
 
-// const endpointsDocument string = `{
-// 	"kind": "Endpoints",
-// 	"apiVersion": "v1",
-// 	"metadata": {
-// 		"name": "my-endpoint-service",
-// 		"labels": {
-// 			"originalLabel": "isHere"
-// 		}
-// 	},
-// 	"subsets": [
-// 		{
-// 			"addresses": [
-// 				{
-// 					"ip": "1.2.3.4"
-// 				}
-// 			],
-// 			"ports": [
-// 				{
-// 					"port": 9376
-// 				}
-// 			]
-// 		}
-// 	]
-// }`
+const endpointsDocument string = `{
+	"kind": "Endpoints",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "my-endpoint-service",
+		"labels": {
+			"originalLabel": "isHere"
+		}
+	},
+	"subsets": [
+		{
+			"addresses": [
+				{
+					"ip": "1.2.3.4"
+				}
+			],
+			"ports": [
+				{
+					"port": 9376
+				}
+			]
+		}
+	]
+}`
 
-// func applyPatches(rule *types.Rule, resource unstructured.Unstructured) (*engineapi.RuleResponse, unstructured.Unstructured) {
-// 	mutateResp := Mutate(rule, context.NewContext(jmespath.New(config.NewDefaultConfiguration(false))), resource, logr.Discard())
-// 	if mutateResp.Status != engineapi.RuleStatusPass {
-// 		return engineapi.NewRuleResponse("", engineapi.Mutation, mutateResp.Message, mutateResp.Status), resource
-// 	}
-// 	return engineapi.RulePass("", engineapi.Mutation, mutateResp.Message).WithPatches(mutateResp.Patches...), mutateResp.PatchedResource
-// }
+func applyPatches(rule *types.Rule, resource unstructured.Unstructured) (*engineapi.RuleResponse, unstructured.Unstructured) {
+	mutateResp := Mutate(rule, context.NewContext(jmespath.New(config.NewDefaultConfiguration(false))), resource, logr.Discard())
+	if mutateResp.Status != engineapi.RuleStatusPass {
+		return engineapi.NewRuleResponse("", engineapi.Mutation, mutateResp.Message, mutateResp.Status), resource
+	}
+	return engineapi.RulePass(
+		"",
+		engineapi.Mutation,
+		mutateResp.Message,
+	).WithPatches(
+		ConvertPatches(mutateResp.Patches...)...,
+	), mutateResp.PatchedResource
+}
 
-// func TestProcessPatches_EmptyPatches(t *testing.T) {
-// 	emptyRule := &types.Rule{Name: "emptyRule"}
-// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
+func TestProcessPatches_EmptyPatches(t *testing.T) {
+	emptyRule := &types.Rule{Name: "emptyRule"}
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+	if err != nil {
+		t.Error(err)
+	}
 
-// 	rr, _ := applyPatches(emptyRule, *resourceUnstructured)
-// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusError)
-// 	assert.Assert(t, len(rr.Patches()) == 0)
-// }
+	rr, _ := applyPatches(emptyRule, *resourceUnstructured)
+	assert.Equal(t, rr.Status(), engineapi.RuleStatusError)
+	assert.Assert(t, len(rr.Patches()) == 0)
+}
 
-// func makeAddIsMutatedLabelPatch() jsonPatch {
-// 	return jsonPatch{
-// 		Path:      "/metadata/labels/is-mutated",
-// 		Operation: "add",
-// 		Value:     "true",
-// 	}
-// }
+func makeAddIsMutatedLabelPatch() jsonPatch {
+	return jsonPatch{
+		Path:      "/metadata/labels/is-mutated",
+		Operation: "add",
+		Value:     "true",
+	}
+}
 
-// func makeRuleWithPatch(t *testing.T, patch jsonPatch) *types.Rule {
-// 	patches := []jsonPatch{patch}
-// 	return makeRuleWithPatches(t, patches)
-// }
+func makeRuleWithPatch(t *testing.T, patch jsonPatch) *types.Rule {
+	patches := []jsonPatch{patch}
+	return makeRuleWithPatches(t, patches)
+}
 
-// func makeRuleWithPatches(t *testing.T, patches []jsonPatch) *types.Rule {
-// 	jsonPatches, err := json.Marshal(patches)
-// 	if err != nil {
-// 		t.Errorf("failed to marshal patch: %v", err)
-// 	}
+func makeRuleWithPatches(t *testing.T, patches []jsonPatch) *types.Rule {
+	jsonPatches, err := json.Marshal(patches)
+	if err != nil {
+		t.Errorf("failed to marshal patch: %v", err)
+	}
 
-// 	mutation := types.Mutation{
-// 		PatchesJSON6902: string(jsonPatches),
-// 	}
-// 	return &types.Rule{
-// 		Mutation: mutation,
-// 	}
-// }
+	mutation := types.Mutation{
+		PatchesJSON6902: string(jsonPatches),
+	}
+	return &types.Rule{
+		Mutation: mutation,
+	}
+}
 
-// func TestProcessPatches_EmptyDocument(t *testing.T) {
-// 	rule := makeRuleWithPatch(t, makeAddIsMutatedLabelPatch())
-// 	rr, _ := applyPatches(rule, unstructured.Unstructured{})
-// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusFail)
-// 	assert.Assert(t, len(rr.Patches()) == 0)
-// }
+func TestProcessPatches_EmptyDocument(t *testing.T) {
+	rule := makeRuleWithPatch(t, makeAddIsMutatedLabelPatch())
+	rr, _ := applyPatches(rule, unstructured.Unstructured{})
+	assert.Equal(t, rr.Status(), engineapi.RuleStatusError)
+	assert.Assert(t, len(rr.Patches()) == 0)
+}
 
-// func TestProcessPatches_AllEmpty(t *testing.T) {
-// 	emptyRule := &types.Rule{}
-// 	rr, _ := applyPatches(emptyRule, unstructured.Unstructured{})
-// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusError)
-// 	assert.Assert(t, len(rr.Patches()) == 0)
-// }
+func TestProcessPatches_AllEmpty(t *testing.T) {
+	emptyRule := &types.Rule{}
+	rr, _ := applyPatches(emptyRule, unstructured.Unstructured{})
+	assert.Equal(t, rr.Status(), engineapi.RuleStatusError)
+	assert.Assert(t, len(rr.Patches()) == 0)
+}
 
-// func TestProcessPatches_AddPathDoesntExist(t *testing.T) {
-// 	patch := makeAddIsMutatedLabelPatch()
-// 	patch.Path = "/metadata/additional/is-mutated"
-// 	rule := makeRuleWithPatch(t, patch)
-// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
-// 	rr, _ := applyPatches(rule, *resourceUnstructured)
-// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusSkip)
-// 	assert.Assert(t, len(rr.Patches()) == 0)
-// }
+func TestProcessPatches_AddPathDoesntExist(t *testing.T) {
+	patch := makeAddIsMutatedLabelPatch()
+	patch.Path = "/metadata/additional/is-mutated"
+	rule := makeRuleWithPatch(t, patch)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+	if err != nil {
+		t.Error(err)
+	}
+	rr, _ := applyPatches(rule, *resourceUnstructured)
+	assert.Equal(t, rr.Status(), engineapi.RuleStatusSkip)
+	assert.Assert(t, len(rr.Patches()) == 0)
+}
 
-// func TestProcessPatches_RemovePathDoesntExist(t *testing.T) {
-// 	patch := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
-// 	rule := makeRuleWithPatch(t, patch)
-// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
-// 	rr, _ := applyPatches(rule, *resourceUnstructured)
-// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusSkip)
-// 	assert.Assert(t, len(rr.Patches()) == 0)
-// }
+func TestProcessPatches_RemovePathDoesntExist(t *testing.T) {
+	patch := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
+	rule := makeRuleWithPatch(t, patch)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+	if err != nil {
+		t.Error(err)
+	}
+	rr, _ := applyPatches(rule, *resourceUnstructured)
+	assert.Equal(t, rr.Status(), engineapi.RuleStatusSkip)
+	assert.Assert(t, len(rr.Patches()) == 0)
+}
 
-// func TestProcessPatches_AddAndRemovePathsDontExist_EmptyResult(t *testing.T) {
-// 	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
-// 	patch2 := jsonPatch{Path: "/spec/labels/label3", Operation: "add", Value: "label3Value"}
-// 	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2})
-// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
-// 	rr, _ := applyPatches(rule, *resourceUnstructured)
-// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusPass)
-// 	assert.Equal(t, len(rr.Patches()), 1)
-// }
+func TestProcessPatches_AddAndRemovePathsDontExist_EmptyResult(t *testing.T) {
+	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
+	patch2 := jsonPatch{Path: "/spec/labels/label3", Operation: "add", Value: "label3Value"}
+	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2})
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+	if err != nil {
+		t.Error(err)
+	}
+	rr, _ := applyPatches(rule, *resourceUnstructured)
+	assert.Equal(t, rr.Status(), engineapi.RuleStatusPass)
+	assert.Equal(t, len(rr.Patches()), 1)
+}
 
-// func TestProcessPatches_AddAndRemovePathsDontExist_ContinueOnError_NotEmptyResult(t *testing.T) {
-// 	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
-// 	patch2 := jsonPatch{Path: "/spec/labels/label2", Operation: "remove", Value: "label2Value"}
-// 	patch3 := jsonPatch{Path: "/metadata/labels/label3", Operation: "add", Value: "label3Value"}
-// 	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2, patch3})
-// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
+func TestProcessPatches_AddAndRemovePathsDontExist_ContinueOnError_NotEmptyResult(t *testing.T) {
+	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
+	patch2 := jsonPatch{Path: "/spec/labels/label2", Operation: "remove", Value: "label2Value"}
+	patch3 := jsonPatch{Path: "/metadata/labels/label3", Operation: "add", Value: "label3Value"}
+	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2, patch3})
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+	if err != nil {
+		t.Error(err)
+	}
 
-// 	rr, _ := applyPatches(rule, *resourceUnstructured)
-// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusPass)
-// 	assert.Assert(t, len(rr.Patches()) != 0)
-// 	assertEqStringAndData(t, `{"path":"/metadata/labels/label3","op":"add","value":"label3Value"}`, rr.Patches()[0])
-// }
+	rr, _ := applyPatches(rule, *resourceUnstructured)
+	assert.Equal(t, rr.Status(), engineapi.RuleStatusPass)
+	assert.Assert(t, len(rr.Patches()) != 0)
+	assertEqStringAndData(t, `{"path":"/metadata/labels/label3","op":"add","value":"label3Value"}`, rr.Patches()[0])
+}
 
-// func TestProcessPatches_RemovePathDoesntExist_EmptyResult(t *testing.T) {
-// 	patch := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
-// 	rule := makeRuleWithPatch(t, patch)
-// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
-// 	rr, _ := applyPatches(rule, *resourceUnstructured)
-// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusSkip)
-// 	assert.Assert(t, len(rr.Patches()) == 0)
-// }
+func TestProcessPatches_RemovePathDoesntExist_EmptyResult(t *testing.T) {
+	patch := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
+	rule := makeRuleWithPatch(t, patch)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+	if err != nil {
+		t.Error(err)
+	}
+	rr, _ := applyPatches(rule, *resourceUnstructured)
+	assert.Equal(t, rr.Status(), engineapi.RuleStatusSkip)
+	assert.Assert(t, len(rr.Patches()) == 0)
+}
 
-// func TestProcessPatches_RemovePathDoesntExist_NotEmptyResult(t *testing.T) {
-// 	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
-// 	patch2 := jsonPatch{Path: "/metadata/labels/label2", Operation: "add", Value: "label2Value"}
-// 	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2})
-// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
-// 	rr, _ := applyPatches(rule, *resourceUnstructured)
-// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusPass)
-// 	assert.Assert(t, len(rr.Patches()) == 1)
-// 	assertEqStringAndData(t, `{"path":"/metadata/labels/label2","op":"add","value":"label2Value"}`, rr.Patches()[0])
-// }
+func TestProcessPatches_RemovePathDoesntExist_NotEmptyResult(t *testing.T) {
+	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
+	patch2 := jsonPatch{Path: "/metadata/labels/label2", Operation: "add", Value: "label2Value"}
+	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2})
+	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+	if err != nil {
+		t.Error(err)
+	}
+	rr, _ := applyPatches(rule, *resourceUnstructured)
+	assert.Equal(t, rr.Status(), engineapi.RuleStatusPass)
+	assert.Assert(t, len(rr.Patches()) == 1)
+	assertEqStringAndData(t, `{"path":"/metadata/labels/label2","op":"add","value":"label2Value"}`, rr.Patches()[0])
+}
 
-// func assertEqStringAndData(t *testing.T, str string, data []byte) {
-// 	var p1 jsonPatch
-// 	json.Unmarshal([]byte(str), &p1)
+func assertEqStringAndData(t *testing.T, str string, data []byte) {
+	var p1 jsonPatch
+	json.Unmarshal([]byte(str), &p1)
 
-// 	var p2 jsonPatch
-// 	json.Unmarshal([]byte(data), &p2)
+	var p2 jsonPatch
+	json.Unmarshal([]byte(data), &p2)
 
-// 	assert.Equal(t, p1, p2)
-// }
+	assert.Equal(t, p1, p2)
+}

--- a/pkg/engine/mutate/mutation_test.go
+++ b/pkg/engine/mutate/mutation_test.go
@@ -1,200 +1,200 @@
 package mutate
 
-import (
-	"encoding/json"
-	"testing"
+// import (
+// 	"encoding/json"
+// 	"testing"
 
-	"github.com/go-logr/logr"
-	types "github.com/kyverno/kyverno/api/kyverno/v1"
-	"github.com/kyverno/kyverno/pkg/config"
-	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
-	"github.com/kyverno/kyverno/pkg/engine/context"
-	"github.com/kyverno/kyverno/pkg/engine/jmespath"
-	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
-	"gotest.tools/assert"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-)
+// 	"github.com/go-logr/logr"
+// 	types "github.com/kyverno/kyverno/api/kyverno/v1"
+// 	"github.com/kyverno/kyverno/pkg/config"
+// 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+// 	"github.com/kyverno/kyverno/pkg/engine/context"
+// 	"github.com/kyverno/kyverno/pkg/engine/jmespath"
+// 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
+// 	"gotest.tools/assert"
+// 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+// 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+// )
 
-// jsonPatch is used to build test patches
-type jsonPatch struct {
-	Path      string             `json:"path,omitempty" yaml:"path,omitempty"`
-	Operation string             `json:"op,omitempty" yaml:"op,omitempty"`
-	Value     apiextensions.JSON `json:"value,omitempty" yaml:"value,omitempty"`
-}
+// // jsonPatch is used to build test patches
+// type jsonPatch struct {
+// 	Path      string             `json:"path,omitempty" yaml:"path,omitempty"`
+// 	Operation string             `json:"op,omitempty" yaml:"op,omitempty"`
+// 	Value     apiextensions.JSON `json:"value,omitempty" yaml:"value,omitempty"`
+// }
 
-const endpointsDocument string = `{
-	"kind": "Endpoints",
-	"apiVersion": "v1",
-	"metadata": {
-		"name": "my-endpoint-service",
-		"labels": {
-			"originalLabel": "isHere"
-		}
-	},
-	"subsets": [
-		{
-			"addresses": [
-				{
-					"ip": "1.2.3.4"
-				}
-			],
-			"ports": [
-				{
-					"port": 9376
-				}
-			]
-		}
-	]
-}`
+// const endpointsDocument string = `{
+// 	"kind": "Endpoints",
+// 	"apiVersion": "v1",
+// 	"metadata": {
+// 		"name": "my-endpoint-service",
+// 		"labels": {
+// 			"originalLabel": "isHere"
+// 		}
+// 	},
+// 	"subsets": [
+// 		{
+// 			"addresses": [
+// 				{
+// 					"ip": "1.2.3.4"
+// 				}
+// 			],
+// 			"ports": [
+// 				{
+// 					"port": 9376
+// 				}
+// 			]
+// 		}
+// 	]
+// }`
 
-func applyPatches(rule *types.Rule, resource unstructured.Unstructured) (*engineapi.RuleResponse, unstructured.Unstructured) {
-	mutateResp := Mutate(rule, context.NewContext(jmespath.New(config.NewDefaultConfiguration(false))), resource, logr.Discard())
-	if mutateResp.Status != engineapi.RuleStatusPass {
-		return engineapi.NewRuleResponse("", engineapi.Mutation, mutateResp.Message, mutateResp.Status), resource
-	}
-	return engineapi.RulePass("", engineapi.Mutation, mutateResp.Message).WithPatches(mutateResp.Patches...), mutateResp.PatchedResource
-}
+// func applyPatches(rule *types.Rule, resource unstructured.Unstructured) (*engineapi.RuleResponse, unstructured.Unstructured) {
+// 	mutateResp := Mutate(rule, context.NewContext(jmespath.New(config.NewDefaultConfiguration(false))), resource, logr.Discard())
+// 	if mutateResp.Status != engineapi.RuleStatusPass {
+// 		return engineapi.NewRuleResponse("", engineapi.Mutation, mutateResp.Message, mutateResp.Status), resource
+// 	}
+// 	return engineapi.RulePass("", engineapi.Mutation, mutateResp.Message).WithPatches(mutateResp.Patches...), mutateResp.PatchedResource
+// }
 
-func TestProcessPatches_EmptyPatches(t *testing.T) {
-	emptyRule := &types.Rule{Name: "emptyRule"}
-	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-	if err != nil {
-		t.Error(err)
-	}
+// func TestProcessPatches_EmptyPatches(t *testing.T) {
+// 	emptyRule := &types.Rule{Name: "emptyRule"}
+// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+// 	if err != nil {
+// 		t.Error(err)
+// 	}
 
-	rr, _ := applyPatches(emptyRule, *resourceUnstructured)
-	assert.Equal(t, rr.Status(), engineapi.RuleStatusError)
-	assert.Assert(t, len(rr.Patches()) == 0)
-}
+// 	rr, _ := applyPatches(emptyRule, *resourceUnstructured)
+// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusError)
+// 	assert.Assert(t, len(rr.Patches()) == 0)
+// }
 
-func makeAddIsMutatedLabelPatch() jsonPatch {
-	return jsonPatch{
-		Path:      "/metadata/labels/is-mutated",
-		Operation: "add",
-		Value:     "true",
-	}
-}
+// func makeAddIsMutatedLabelPatch() jsonPatch {
+// 	return jsonPatch{
+// 		Path:      "/metadata/labels/is-mutated",
+// 		Operation: "add",
+// 		Value:     "true",
+// 	}
+// }
 
-func makeRuleWithPatch(t *testing.T, patch jsonPatch) *types.Rule {
-	patches := []jsonPatch{patch}
-	return makeRuleWithPatches(t, patches)
-}
+// func makeRuleWithPatch(t *testing.T, patch jsonPatch) *types.Rule {
+// 	patches := []jsonPatch{patch}
+// 	return makeRuleWithPatches(t, patches)
+// }
 
-func makeRuleWithPatches(t *testing.T, patches []jsonPatch) *types.Rule {
-	jsonPatches, err := json.Marshal(patches)
-	if err != nil {
-		t.Errorf("failed to marshal patch: %v", err)
-	}
+// func makeRuleWithPatches(t *testing.T, patches []jsonPatch) *types.Rule {
+// 	jsonPatches, err := json.Marshal(patches)
+// 	if err != nil {
+// 		t.Errorf("failed to marshal patch: %v", err)
+// 	}
 
-	mutation := types.Mutation{
-		PatchesJSON6902: string(jsonPatches),
-	}
-	return &types.Rule{
-		Mutation: mutation,
-	}
-}
+// 	mutation := types.Mutation{
+// 		PatchesJSON6902: string(jsonPatches),
+// 	}
+// 	return &types.Rule{
+// 		Mutation: mutation,
+// 	}
+// }
 
-func TestProcessPatches_EmptyDocument(t *testing.T) {
-	rule := makeRuleWithPatch(t, makeAddIsMutatedLabelPatch())
-	rr, _ := applyPatches(rule, unstructured.Unstructured{})
-	assert.Equal(t, rr.Status(), engineapi.RuleStatusFail)
-	assert.Assert(t, len(rr.Patches()) == 0)
-}
+// func TestProcessPatches_EmptyDocument(t *testing.T) {
+// 	rule := makeRuleWithPatch(t, makeAddIsMutatedLabelPatch())
+// 	rr, _ := applyPatches(rule, unstructured.Unstructured{})
+// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusFail)
+// 	assert.Assert(t, len(rr.Patches()) == 0)
+// }
 
-func TestProcessPatches_AllEmpty(t *testing.T) {
-	emptyRule := &types.Rule{}
-	rr, _ := applyPatches(emptyRule, unstructured.Unstructured{})
-	assert.Equal(t, rr.Status(), engineapi.RuleStatusError)
-	assert.Assert(t, len(rr.Patches()) == 0)
-}
+// func TestProcessPatches_AllEmpty(t *testing.T) {
+// 	emptyRule := &types.Rule{}
+// 	rr, _ := applyPatches(emptyRule, unstructured.Unstructured{})
+// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusError)
+// 	assert.Assert(t, len(rr.Patches()) == 0)
+// }
 
-func TestProcessPatches_AddPathDoesntExist(t *testing.T) {
-	patch := makeAddIsMutatedLabelPatch()
-	patch.Path = "/metadata/additional/is-mutated"
-	rule := makeRuleWithPatch(t, patch)
-	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-	if err != nil {
-		t.Error(err)
-	}
-	rr, _ := applyPatches(rule, *resourceUnstructured)
-	assert.Equal(t, rr.Status(), engineapi.RuleStatusSkip)
-	assert.Assert(t, len(rr.Patches()) == 0)
-}
+// func TestProcessPatches_AddPathDoesntExist(t *testing.T) {
+// 	patch := makeAddIsMutatedLabelPatch()
+// 	patch.Path = "/metadata/additional/is-mutated"
+// 	rule := makeRuleWithPatch(t, patch)
+// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+// 	if err != nil {
+// 		t.Error(err)
+// 	}
+// 	rr, _ := applyPatches(rule, *resourceUnstructured)
+// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusSkip)
+// 	assert.Assert(t, len(rr.Patches()) == 0)
+// }
 
-func TestProcessPatches_RemovePathDoesntExist(t *testing.T) {
-	patch := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
-	rule := makeRuleWithPatch(t, patch)
-	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-	if err != nil {
-		t.Error(err)
-	}
-	rr, _ := applyPatches(rule, *resourceUnstructured)
-	assert.Equal(t, rr.Status(), engineapi.RuleStatusSkip)
-	assert.Assert(t, len(rr.Patches()) == 0)
-}
+// func TestProcessPatches_RemovePathDoesntExist(t *testing.T) {
+// 	patch := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
+// 	rule := makeRuleWithPatch(t, patch)
+// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+// 	if err != nil {
+// 		t.Error(err)
+// 	}
+// 	rr, _ := applyPatches(rule, *resourceUnstructured)
+// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusSkip)
+// 	assert.Assert(t, len(rr.Patches()) == 0)
+// }
 
-func TestProcessPatches_AddAndRemovePathsDontExist_EmptyResult(t *testing.T) {
-	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
-	patch2 := jsonPatch{Path: "/spec/labels/label3", Operation: "add", Value: "label3Value"}
-	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2})
-	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-	if err != nil {
-		t.Error(err)
-	}
-	rr, _ := applyPatches(rule, *resourceUnstructured)
-	assert.Equal(t, rr.Status(), engineapi.RuleStatusPass)
-	assert.Equal(t, len(rr.Patches()), 1)
-}
+// func TestProcessPatches_AddAndRemovePathsDontExist_EmptyResult(t *testing.T) {
+// 	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
+// 	patch2 := jsonPatch{Path: "/spec/labels/label3", Operation: "add", Value: "label3Value"}
+// 	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2})
+// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+// 	if err != nil {
+// 		t.Error(err)
+// 	}
+// 	rr, _ := applyPatches(rule, *resourceUnstructured)
+// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusPass)
+// 	assert.Equal(t, len(rr.Patches()), 1)
+// }
 
-func TestProcessPatches_AddAndRemovePathsDontExist_ContinueOnError_NotEmptyResult(t *testing.T) {
-	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
-	patch2 := jsonPatch{Path: "/spec/labels/label2", Operation: "remove", Value: "label2Value"}
-	patch3 := jsonPatch{Path: "/metadata/labels/label3", Operation: "add", Value: "label3Value"}
-	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2, patch3})
-	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-	if err != nil {
-		t.Error(err)
-	}
+// func TestProcessPatches_AddAndRemovePathsDontExist_ContinueOnError_NotEmptyResult(t *testing.T) {
+// 	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
+// 	patch2 := jsonPatch{Path: "/spec/labels/label2", Operation: "remove", Value: "label2Value"}
+// 	patch3 := jsonPatch{Path: "/metadata/labels/label3", Operation: "add", Value: "label3Value"}
+// 	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2, patch3})
+// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+// 	if err != nil {
+// 		t.Error(err)
+// 	}
 
-	rr, _ := applyPatches(rule, *resourceUnstructured)
-	assert.Equal(t, rr.Status(), engineapi.RuleStatusPass)
-	assert.Assert(t, len(rr.Patches()) != 0)
-	assertEqStringAndData(t, `{"path":"/metadata/labels/label3","op":"add","value":"label3Value"}`, rr.Patches()[0])
-}
+// 	rr, _ := applyPatches(rule, *resourceUnstructured)
+// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusPass)
+// 	assert.Assert(t, len(rr.Patches()) != 0)
+// 	assertEqStringAndData(t, `{"path":"/metadata/labels/label3","op":"add","value":"label3Value"}`, rr.Patches()[0])
+// }
 
-func TestProcessPatches_RemovePathDoesntExist_EmptyResult(t *testing.T) {
-	patch := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
-	rule := makeRuleWithPatch(t, patch)
-	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-	if err != nil {
-		t.Error(err)
-	}
-	rr, _ := applyPatches(rule, *resourceUnstructured)
-	assert.Equal(t, rr.Status(), engineapi.RuleStatusSkip)
-	assert.Assert(t, len(rr.Patches()) == 0)
-}
+// func TestProcessPatches_RemovePathDoesntExist_EmptyResult(t *testing.T) {
+// 	patch := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
+// 	rule := makeRuleWithPatch(t, patch)
+// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+// 	if err != nil {
+// 		t.Error(err)
+// 	}
+// 	rr, _ := applyPatches(rule, *resourceUnstructured)
+// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusSkip)
+// 	assert.Assert(t, len(rr.Patches()) == 0)
+// }
 
-func TestProcessPatches_RemovePathDoesntExist_NotEmptyResult(t *testing.T) {
-	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
-	patch2 := jsonPatch{Path: "/metadata/labels/label2", Operation: "add", Value: "label2Value"}
-	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2})
-	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
-	if err != nil {
-		t.Error(err)
-	}
-	rr, _ := applyPatches(rule, *resourceUnstructured)
-	assert.Equal(t, rr.Status(), engineapi.RuleStatusPass)
-	assert.Assert(t, len(rr.Patches()) == 1)
-	assertEqStringAndData(t, `{"path":"/metadata/labels/label2","op":"add","value":"label2Value"}`, rr.Patches()[0])
-}
+// func TestProcessPatches_RemovePathDoesntExist_NotEmptyResult(t *testing.T) {
+// 	patch1 := jsonPatch{Path: "/metadata/labels/is-mutated", Operation: "remove"}
+// 	patch2 := jsonPatch{Path: "/metadata/labels/label2", Operation: "add", Value: "label2Value"}
+// 	rule := makeRuleWithPatches(t, []jsonPatch{patch1, patch2})
+// 	resourceUnstructured, err := kubeutils.BytesToUnstructured([]byte(endpointsDocument))
+// 	if err != nil {
+// 		t.Error(err)
+// 	}
+// 	rr, _ := applyPatches(rule, *resourceUnstructured)
+// 	assert.Equal(t, rr.Status(), engineapi.RuleStatusPass)
+// 	assert.Assert(t, len(rr.Patches()) == 1)
+// 	assertEqStringAndData(t, `{"path":"/metadata/labels/label2","op":"add","value":"label2Value"}`, rr.Patches()[0])
+// }
 
-func assertEqStringAndData(t *testing.T, str string, data []byte) {
-	var p1 jsonPatch
-	json.Unmarshal([]byte(str), &p1)
+// func assertEqStringAndData(t *testing.T, str string, data []byte) {
+// 	var p1 jsonPatch
+// 	json.Unmarshal([]byte(str), &p1)
 
-	var p2 jsonPatch
-	json.Unmarshal([]byte(data), &p2)
+// 	var p2 jsonPatch
+// 	json.Unmarshal([]byte(data), &p2)
 
-	assert.Equal(t, p1, p2)
-}
+// 	assert.Equal(t, p1, p2)
+// }

--- a/pkg/engine/mutate/patch/patchJSON6902.go
+++ b/pkg/engine/mutate/patch/patchJSON6902.go
@@ -2,52 +2,22 @@ package patch
 
 import (
 	"fmt"
-	"time"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/go-logr/logr"
-	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 )
 
 // ProcessPatchJSON6902 ...
-func ProcessPatchJSON6902(ruleName string, patchesJSON6902 []byte, resource unstructured.Unstructured, log logr.Logger) (engineapi.RuleResponse, unstructured.Unstructured) {
-	logger := log.WithValues("rule", ruleName)
-	startTime := time.Now()
-	logger.V(4).Info("started JSON6902 patch", "startTime", startTime)
-	defer func() {
-		logger.V(4).Info("applied JSON6902 patch", "processingTime", time.Since(startTime))
-	}()
-	resourceRaw, err := resource.MarshalJSON()
-	if err != nil {
-		logger.Error(err, "failed to marshal resource")
-		return *engineapi.RuleFail(ruleName, engineapi.Mutation, fmt.Sprintf("failed to marshal resource: %v", err)), resource
-	}
-	patchedResourceRaw, err := applyPatchesWithOptions(resourceRaw, patchesJSON6902)
-	if err != nil {
+func ProcessPatchJSON6902(logger logr.Logger, patchesJSON6902 []byte, resource resource) (resource, patches, error) {
+	if patchedResourceRaw, err := applyPatchesWithOptions(resource, patchesJSON6902); err != nil {
 		logger.Error(err, "failed to apply JSON Patch")
-		return *engineapi.RuleFail(ruleName, engineapi.Mutation, fmt.Sprintf("failed to apply JSON Patch: %v", err)), resource
+		return nil, nil, err
+	} else if patchesBytes, err := generatePatches(resource, patchedResourceRaw); err != nil {
+		return nil, nil, err
+	} else {
+		return patchedResourceRaw, patchesBytes, nil
 	}
-	patchesBytes, err := generatePatches(resourceRaw, patchedResourceRaw)
-	if err != nil {
-		logger.Error(err, "unable generate patch bytes from base and patched document, apply patchesJSON6902 directly")
-		return *engineapi.RuleFail(
-			ruleName,
-			engineapi.Mutation,
-			fmt.Sprintf("unable generate patch bytes from base and patched document, apply patchesJSON6902 directly: %v", err),
-		), resource
-	}
-	for _, p := range patchesBytes {
-		log.V(4).Info("generated JSON Patch (RFC 6902)", "patch", string(p))
-	}
-	var patchedResource unstructured.Unstructured
-	err = patchedResource.UnmarshalJSON(patchedResourceRaw)
-	if err != nil {
-		logger.Error(err, "failed to unmarshal resource")
-		return *engineapi.RuleFail(ruleName, engineapi.Mutation, fmt.Sprintf("failed to unmarshal resource: %v", err)), resource
-	}
-	return *engineapi.RulePass(ruleName, engineapi.Mutation, "applied JSON Patch").WithPatches(patchesBytes...), patchedResource
 }
 
 func applyPatchesWithOptions(resource, patch []byte) ([]byte, error) {
@@ -55,13 +25,11 @@ func applyPatchesWithOptions(resource, patch []byte) ([]byte, error) {
 	if err != nil {
 		return resource, fmt.Errorf("failed to decode patches: %v", err)
 	}
-
 	options := &jsonpatch.ApplyOptions{SupportNegativeIndices: true, AllowMissingPathOnRemove: true, EnsurePathExistsOnAdd: true}
 	patchedResource, err := patches.ApplyWithOptions(resource, options)
 	if err != nil {
 		return resource, err
 	}
-
 	return patchedResource, nil
 }
 
@@ -69,7 +37,6 @@ func ConvertPatchesToJSON(patchesJSON6902 string) ([]byte, error) {
 	if len(patchesJSON6902) == 0 {
 		return []byte(patchesJSON6902), nil
 	}
-
 	if patchesJSON6902[0] != '[' {
 		// If the patch doesn't look like a JSON6902 patch, we
 		// try to parse it to json.
@@ -79,6 +46,5 @@ func ConvertPatchesToJSON(patchesJSON6902 string) ([]byte, error) {
 		}
 		return op, nil
 	}
-
 	return []byte(patchesJSON6902), nil
 }

--- a/pkg/engine/mutate/patch/patchJSON6902_test.go
+++ b/pkg/engine/mutate/patch/patchJSON6902_test.go
@@ -1,377 +1,377 @@
 package patch
 
-import (
-	"fmt"
-	"testing"
+// import (
+// 	"fmt"
+// 	"testing"
 
-	"github.com/ghodss/yaml"
-	"github.com/go-logr/logr"
-	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
-	assert "github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-)
+// 	"github.com/ghodss/yaml"
+// 	"github.com/go-logr/logr"
+// 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+// 	assert "github.com/stretchr/testify/assert"
+// 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+// )
 
-var inputBytes = []byte(`
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  replica: 2
-  template:
-    metadata:
-      labels:
-        old-label: old-value
-    spec:
-      containers:
-      - image: nginx
-        name: nginx
-`)
+// var inputBytes = []byte(`
+// apiVersion: apps/v1
+// kind: Deployment
+// metadata:
+//   name: myDeploy
+// spec:
+//   replica: 2
+//   template:
+//     metadata:
+//       labels:
+//         old-label: old-value
+//     spec:
+//       containers:
+//       - image: nginx
+//         name: nginx
+// `)
 
-func TestTypeConversion(t *testing.T) {
-	patchesJSON6902 := []byte(`
-- op: replace
-  path: /spec/template/spec/containers/0/name
-  value: my-nginx
-`)
+// func TestTypeConversion(t *testing.T) {
+// 	patchesJSON6902 := []byte(`
+// - op: replace
+//   path: /spec/template/spec/containers/0/name
+//   value: my-nginx
+// `)
 
-	expectedPatches := [][]byte{
-		[]byte(`{"op":"replace","path":"/spec/template/spec/containers/0/name","value":"my-nginx"}`),
-	}
+// 	expectedPatches := [][]byte{
+// 		[]byte(`{"op":"replace","path":"/spec/template/spec/containers/0/name","value":"my-nginx"}`),
+// 	}
 
-	// serialize resource
-	inputJSON, err := yaml.YAMLToJSON(inputBytes)
-	assert.Nil(t, err)
+// 	// serialize resource
+// 	inputJSON, err := yaml.YAMLToJSON(inputBytes)
+// 	assert.Nil(t, err)
 
-	var resource unstructured.Unstructured
-	err = resource.UnmarshalJSON(inputJSON)
-	assert.Nil(t, err)
+// 	var resource unstructured.Unstructured
+// 	err = resource.UnmarshalJSON(inputJSON)
+// 	assert.Nil(t, err)
 
-	jsonPatches, err := yaml.YAMLToJSON(patchesJSON6902)
-	assert.Nil(t, err)
-	// apply patches
-	resp, _ := ProcessPatchJSON6902("type-conversion", jsonPatches, resource, logr.Discard())
-	if !assert.Equal(t, engineapi.RuleStatusPass, resp.Status()) {
-		t.Fatal(resp.Message())
-	}
+// 	jsonPatches, err := yaml.YAMLToJSON(patchesJSON6902)
+// 	assert.Nil(t, err)
+// 	// apply patches
+// 	resp, _ := ProcessPatchJSON6902("type-conversion", jsonPatches, resource, logr.Discard())
+// 	if !assert.Equal(t, engineapi.RuleStatusPass, resp.Status()) {
+// 		t.Fatal(resp.Message())
+// 	}
 
-	assert.Equal(t, expectedPatches, resp.Patches(),
-		fmt.Sprintf("expectedPatches: %s\ngeneratedPatches: %s", string(expectedPatches[0]), string(resp.Patches()[0])))
-}
+// 	assert.Equal(t, expectedPatches, resp.Patches(),
+// 		fmt.Sprintf("expectedPatches: %s\ngeneratedPatches: %s", string(expectedPatches[0]), string(resp.Patches()[0])))
+// }
 
-func TestJsonPatch(t *testing.T) {
-	testCases := []struct {
-		testName string
-		// patches  []kyverno.Patch
-		patches  string
-		expected []byte
-	}{
-		{
-			testName: "single patch",
-			patches: `
-- op: replace
-  path: /spec/replica
-  value: 5
-`,
-			expected: []byte(`
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  replica: 5
-  template:
-    metadata:
-      labels:
-        old-label: old-value
-    spec:
-      containers:
-      - image: nginx
-        name: nginx
-`),
-		},
-		{
-			testName: "insert to list",
-			patches: `
-- op: add
-  path: /spec/template/spec/containers/1
-  value: {"name":"new-nginx","image":"new-nginx-image"}
-`,
-			expected: []byte(`
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  replica: 2
-  template:
-    metadata:
-      labels:
-        old-label: old-value
-    spec:
-      containers:
-      - image: nginx
-        name: nginx
-      - name: new-nginx
-        image: new-nginx-image
-`),
-		},
-		{
-			testName: "replace first element in list",
-			patches: `
-- op: replace
-  path: /spec/template/spec/containers/0
-  value: {"name":"new-nginx","image":"new-nginx-image"}
-`,
-			expected: []byte(`
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  replica: 2
-  template:
-    metadata:
-      labels:
-        old-label: old-value
-    spec:
-      containers:
-      - name: new-nginx
-        image: new-nginx-image
-`),
-		},
-		{
-			testName: "multiple operations",
-			patches: `
-- op: replace
-  path: /spec/template/spec/containers/0/name
-  value: my-nginx
-- op: add
-  path: /spec/replica
-  value: 999
-- op: add
-  path: /spec/template/spec/volumes
-  value:
-  - emptyDir:
-      medium: Memory
-    name: vault-secret
-`,
-			expected: []byte(`
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  replica: 999
-  template:
-    metadata:
-      labels:
-        old-label: old-value
-    spec:
-      containers:
-      - image: nginx
-        name: my-nginx
-      volumes:
-      - emptyDir:
-          medium: Memory
-        name: vault-secret
-`),
-		},
-	}
+// func TestJsonPatch(t *testing.T) {
+// 	testCases := []struct {
+// 		testName string
+// 		// patches  []kyverno.Patch
+// 		patches  string
+// 		expected []byte
+// 	}{
+// 		{
+// 			testName: "single patch",
+// 			patches: `
+// - op: replace
+//   path: /spec/replica
+//   value: 5
+// `,
+// 			expected: []byte(`
+// apiVersion: apps/v1
+// kind: Deployment
+// metadata:
+//   name: myDeploy
+// spec:
+//   replica: 5
+//   template:
+//     metadata:
+//       labels:
+//         old-label: old-value
+//     spec:
+//       containers:
+//       - image: nginx
+//         name: nginx
+// `),
+// 		},
+// 		{
+// 			testName: "insert to list",
+// 			patches: `
+// - op: add
+//   path: /spec/template/spec/containers/1
+//   value: {"name":"new-nginx","image":"new-nginx-image"}
+// `,
+// 			expected: []byte(`
+// apiVersion: apps/v1
+// kind: Deployment
+// metadata:
+//   name: myDeploy
+// spec:
+//   replica: 2
+//   template:
+//     metadata:
+//       labels:
+//         old-label: old-value
+//     spec:
+//       containers:
+//       - image: nginx
+//         name: nginx
+//       - name: new-nginx
+//         image: new-nginx-image
+// `),
+// 		},
+// 		{
+// 			testName: "replace first element in list",
+// 			patches: `
+// - op: replace
+//   path: /spec/template/spec/containers/0
+//   value: {"name":"new-nginx","image":"new-nginx-image"}
+// `,
+// 			expected: []byte(`
+// apiVersion: apps/v1
+// kind: Deployment
+// metadata:
+//   name: myDeploy
+// spec:
+//   replica: 2
+//   template:
+//     metadata:
+//       labels:
+//         old-label: old-value
+//     spec:
+//       containers:
+//       - name: new-nginx
+//         image: new-nginx-image
+// `),
+// 		},
+// 		{
+// 			testName: "multiple operations",
+// 			patches: `
+// - op: replace
+//   path: /spec/template/spec/containers/0/name
+//   value: my-nginx
+// - op: add
+//   path: /spec/replica
+//   value: 999
+// - op: add
+//   path: /spec/template/spec/volumes
+//   value:
+//   - emptyDir:
+//       medium: Memory
+//     name: vault-secret
+// `,
+// 			expected: []byte(`
+// apiVersion: apps/v1
+// kind: Deployment
+// metadata:
+//   name: myDeploy
+// spec:
+//   replica: 999
+//   template:
+//     metadata:
+//       labels:
+//         old-label: old-value
+//     spec:
+//       containers:
+//       - image: nginx
+//         name: my-nginx
+//       volumes:
+//       - emptyDir:
+//           medium: Memory
+//         name: vault-secret
+// `),
+// 		},
+// 	}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.testName, func(t *testing.T) {
-			expectedBytes, err := yaml.YAMLToJSON(testCase.expected)
-			assert.Nil(t, err)
+// 	for _, testCase := range testCases {
+// 		t.Run(testCase.testName, func(t *testing.T) {
+// 			expectedBytes, err := yaml.YAMLToJSON(testCase.expected)
+// 			assert.Nil(t, err)
 
-			inputBytes, err := yaml.YAMLToJSON(inputBytes)
-			assert.Nil(t, err)
+// 			inputBytes, err := yaml.YAMLToJSON(inputBytes)
+// 			assert.Nil(t, err)
 
-			patches, err := yaml.YAMLToJSON([]byte(testCase.patches))
-			assert.Nil(t, err)
+// 			patches, err := yaml.YAMLToJSON([]byte(testCase.patches))
+// 			assert.Nil(t, err)
 
-			out, err := applyPatchesWithOptions(inputBytes, patches)
-			assert.Nil(t, err)
+// 			out, err := applyPatchesWithOptions(inputBytes, patches)
+// 			assert.Nil(t, err)
 
-			if !assert.Equal(t, string(expectedBytes), string(out), testCase.testName) {
-				t.FailNow()
-			}
-		})
-	}
-}
+// 			if !assert.Equal(t, string(expectedBytes), string(out), testCase.testName) {
+// 				t.FailNow()
+// 			}
+// 		})
+// 	}
+// }
 
-func Test_MissingPaths(t *testing.T) {
-	tests := []struct {
-		name            string
-		resource        string
-		patches         string
-		expectedPatches map[string]bool
-	}{
-		// test
-		{
-			name: "add-map-to-non-exist-path",
-			resource: `
-spec:
-  containers:
-  - name: nginx
-    image: nginx:1.14.2
-`,
-			patches: `
-- path: "/spec/nodeSelector"
-  op: add 
-  value: {"node.kubernetes.io/role": "test"}
-`,
-			expectedPatches: map[string]bool{
-				`{"op":"add","path":"/spec/nodeSelector","value":{"node.kubernetes.io/role":"test"}}`: true,
-			},
-		},
-		// test
-		{
-			name: "add-to-non-exist-array",
-			resource: `
-spec:
-  containers:
-  - name: nginx
-    image: nginx:1.14.2
-`,
-			patches: `
-- path: "/spec/tolerations/0"
-  op: add
-  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
-`,
-			expectedPatches: map[string]bool{
-				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
-			},
-		},
-		// test
-		{
-			name: "add-to-non-exist-array-2",
-			resource: `
-spec:
-  containers:
-  - name: nginx
-    image: nginx:1.14.2
-`,
-			patches: `
-- path: "/spec/tolerations"
-  op: add
-  value: [{"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}]
-`,
-			expectedPatches: map[string]bool{
-				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
-			},
-		},
-		// test
-		{
-			name: "add-to-non-exist-array-3",
-			resource: `
-spec:
-  containers:
-  - name: nginx
-    image: nginx:1.14.2
-`,
-			patches: `
-- path: "/spec/tolerations/-1"
-  op: add
-  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
-`,
-			expectedPatches: map[string]bool{
-				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
-			},
-		},
-		// test
-		{
-			name: "add-to-exist-array",
-			resource: `
-spec:
-  containers:
-  - name: nginx
-    image: nginx:1.14.2
-  tolerations:
-  - effect: NoExecute
-    key: node.kubernetes.io/not-ready
-    operator: Exists
-    tolerationSeconds: 300
-`,
-			patches: `
-- path: "/spec/tolerations"
-  op: add
-  value: [{"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}]
-`,
-			expectedPatches: map[string]bool{
-				`{"op":"replace","path":"/spec/tolerations/0/effect","value":"NoSchedule"}`:                true,
-				`{"op":"replace","path":"/spec/tolerations/0/key","value":"node-role.kubernetes.io/test"}`: true,
-				`{"op":"remove","path":"/spec/tolerations/0/tolerationSeconds"}`:                           true,
-			},
-		},
-		// test
-		{
-			name: "add-to-exist-array-2",
-			resource: `
-spec:
-  containers:
-  - name: nginx
-    image: nginx:1.14.2
-  tolerations:
-  - effect: NoExecute
-    key: node.kubernetes.io/not-ready
-    operator: Exists
-    tolerationSeconds: 300
-`,
-			patches: `
-- path: "/spec/tolerations/-"
-  op: add
-  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
-`,
-			expectedPatches: map[string]bool{
-				`{"op":"add","path":"/spec/tolerations/1","value":{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}}`: true,
-			},
-		},
-		// test
-		{
-			name: "add-to-exist-array-3",
-			resource: `
-spec:
-  containers:
-  - name: nginx
-    image: nginx:1.14.2
-  tolerations:
-  - effect: NoExecute
-    key: node.kubernetes.io/not-ready
-    operator: Exists
-    tolerationSeconds: 300
-  - key: "node.kubernetes.io/unreachable"
-    operator: "Exists"
-    effect: "NoExecute"
-    tolerationSeconds: 6000
-`,
-			patches: `
-- path: "/spec/tolerations/-1"
-  op: add
-  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
-`,
-			expectedPatches: map[string]bool{
-				`{"op":"add","path":"/spec/tolerations/2","value":{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}}`: true,
-			},
-		},
-	}
+// func Test_MissingPaths(t *testing.T) {
+// 	tests := []struct {
+// 		name            string
+// 		resource        string
+// 		patches         string
+// 		expectedPatches map[string]bool
+// 	}{
+// 		// test
+// 		{
+// 			name: "add-map-to-non-exist-path",
+// 			resource: `
+// spec:
+//   containers:
+//   - name: nginx
+//     image: nginx:1.14.2
+// `,
+// 			patches: `
+// - path: "/spec/nodeSelector"
+//   op: add
+//   value: {"node.kubernetes.io/role": "test"}
+// `,
+// 			expectedPatches: map[string]bool{
+// 				`{"op":"add","path":"/spec/nodeSelector","value":{"node.kubernetes.io/role":"test"}}`: true,
+// 			},
+// 		},
+// 		// test
+// 		{
+// 			name: "add-to-non-exist-array",
+// 			resource: `
+// spec:
+//   containers:
+//   - name: nginx
+//     image: nginx:1.14.2
+// `,
+// 			patches: `
+// - path: "/spec/tolerations/0"
+//   op: add
+//   value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
+// `,
+// 			expectedPatches: map[string]bool{
+// 				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
+// 			},
+// 		},
+// 		// test
+// 		{
+// 			name: "add-to-non-exist-array-2",
+// 			resource: `
+// spec:
+//   containers:
+//   - name: nginx
+//     image: nginx:1.14.2
+// `,
+// 			patches: `
+// - path: "/spec/tolerations"
+//   op: add
+//   value: [{"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}]
+// `,
+// 			expectedPatches: map[string]bool{
+// 				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
+// 			},
+// 		},
+// 		// test
+// 		{
+// 			name: "add-to-non-exist-array-3",
+// 			resource: `
+// spec:
+//   containers:
+//   - name: nginx
+//     image: nginx:1.14.2
+// `,
+// 			patches: `
+// - path: "/spec/tolerations/-1"
+//   op: add
+//   value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
+// `,
+// 			expectedPatches: map[string]bool{
+// 				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
+// 			},
+// 		},
+// 		// test
+// 		{
+// 			name: "add-to-exist-array",
+// 			resource: `
+// spec:
+//   containers:
+//   - name: nginx
+//     image: nginx:1.14.2
+//   tolerations:
+//   - effect: NoExecute
+//     key: node.kubernetes.io/not-ready
+//     operator: Exists
+//     tolerationSeconds: 300
+// `,
+// 			patches: `
+// - path: "/spec/tolerations"
+//   op: add
+//   value: [{"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}]
+// `,
+// 			expectedPatches: map[string]bool{
+// 				`{"op":"replace","path":"/spec/tolerations/0/effect","value":"NoSchedule"}`:                true,
+// 				`{"op":"replace","path":"/spec/tolerations/0/key","value":"node-role.kubernetes.io/test"}`: true,
+// 				`{"op":"remove","path":"/spec/tolerations/0/tolerationSeconds"}`:                           true,
+// 			},
+// 		},
+// 		// test
+// 		{
+// 			name: "add-to-exist-array-2",
+// 			resource: `
+// spec:
+//   containers:
+//   - name: nginx
+//     image: nginx:1.14.2
+//   tolerations:
+//   - effect: NoExecute
+//     key: node.kubernetes.io/not-ready
+//     operator: Exists
+//     tolerationSeconds: 300
+// `,
+// 			patches: `
+// - path: "/spec/tolerations/-"
+//   op: add
+//   value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
+// `,
+// 			expectedPatches: map[string]bool{
+// 				`{"op":"add","path":"/spec/tolerations/1","value":{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}}`: true,
+// 			},
+// 		},
+// 		// test
+// 		{
+// 			name: "add-to-exist-array-3",
+// 			resource: `
+// spec:
+//   containers:
+//   - name: nginx
+//     image: nginx:1.14.2
+//   tolerations:
+//   - effect: NoExecute
+//     key: node.kubernetes.io/not-ready
+//     operator: Exists
+//     tolerationSeconds: 300
+//   - key: "node.kubernetes.io/unreachable"
+//     operator: "Exists"
+//     effect: "NoExecute"
+//     tolerationSeconds: 6000
+// `,
+// 			patches: `
+// - path: "/spec/tolerations/-1"
+//   op: add
+//   value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
+// `,
+// 			expectedPatches: map[string]bool{
+// 				`{"op":"add","path":"/spec/tolerations/2","value":{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}}`: true,
+// 			},
+// 		},
+// 	}
 
-	for _, test := range tests {
-		r, err := yaml.YAMLToJSON([]byte(test.resource))
-		assert.Nil(t, err)
+// 	for _, test := range tests {
+// 		r, err := yaml.YAMLToJSON([]byte(test.resource))
+// 		assert.Nil(t, err)
 
-		patches, err := yaml.YAMLToJSON([]byte(test.patches))
-		assert.Nil(t, err)
+// 		patches, err := yaml.YAMLToJSON([]byte(test.patches))
+// 		assert.Nil(t, err)
 
-		patchedResource, err := applyPatchesWithOptions(r, patches)
-		assert.Nil(t, err)
+// 		patchedResource, err := applyPatchesWithOptions(r, patches)
+// 		assert.Nil(t, err)
 
-		generatedP, err := generatePatches(r, patchedResource)
-		assert.Nil(t, err)
+// 		generatedP, err := generatePatches(r, patchedResource)
+// 		assert.Nil(t, err)
 
-		for _, p := range generatedP {
-			assert.Equal(t, test.expectedPatches[string(p)], true,
-				fmt.Sprintf("test: %s\nunexpected patch: %s\nexpect one of: %v", test.name, string(p), test.expectedPatches))
-		}
-	}
-}
+// 		for _, p := range generatedP {
+// 			assert.Equal(t, test.expectedPatches[string(p)], true,
+// 				fmt.Sprintf("test: %s\nunexpected patch: %s\nexpect one of: %v", test.name, string(p), test.expectedPatches))
+// 		}
+// 	}
+// }

--- a/pkg/engine/mutate/patch/patchJSON6902_test.go
+++ b/pkg/engine/mutate/patch/patchJSON6902_test.go
@@ -1,377 +1,375 @@
 package patch
 
-// import (
-// 	"fmt"
-// 	"testing"
+import (
+	"testing"
 
-// 	"github.com/ghodss/yaml"
-// 	"github.com/go-logr/logr"
-// 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
-// 	assert "github.com/stretchr/testify/assert"
-// 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-// )
+	"github.com/ghodss/yaml"
+	"github.com/go-logr/logr"
+	assert "github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
 
-// var inputBytes = []byte(`
-// apiVersion: apps/v1
-// kind: Deployment
-// metadata:
-//   name: myDeploy
-// spec:
-//   replica: 2
-//   template:
-//     metadata:
-//       labels:
-//         old-label: old-value
-//     spec:
-//       containers:
-//       - image: nginx
-//         name: nginx
-// `)
+var inputBytes = []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeploy
+spec:
+  replica: 2
+  template:
+    metadata:
+      labels:
+        old-label: old-value
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+`)
 
-// func TestTypeConversion(t *testing.T) {
-// 	patchesJSON6902 := []byte(`
-// - op: replace
-//   path: /spec/template/spec/containers/0/name
-//   value: my-nginx
-// `)
+func TestTypeConversion(t *testing.T) {
+	patchesJSON6902 := []byte(`
+- op: replace
+  path: /spec/template/spec/containers/0/name
+  value: my-nginx
+`)
 
-// 	expectedPatches := [][]byte{
-// 		[]byte(`{"op":"replace","path":"/spec/template/spec/containers/0/name","value":"my-nginx"}`),
-// 	}
+	expectedPatches := [][]byte{
+		[]byte(`{"op":"replace","path":"/spec/template/spec/containers/0/name","value":"my-nginx"}`),
+	}
 
-// 	// serialize resource
-// 	inputJSON, err := yaml.YAMLToJSON(inputBytes)
-// 	assert.Nil(t, err)
+	// serialize resource
+	inputJSON, err := yaml.YAMLToJSON(inputBytes)
+	assert.Nil(t, err)
 
-// 	var resource unstructured.Unstructured
-// 	err = resource.UnmarshalJSON(inputJSON)
-// 	assert.Nil(t, err)
+	var resource unstructured.Unstructured
+	err = resource.UnmarshalJSON(inputJSON)
+	assert.Nil(t, err)
 
-// 	jsonPatches, err := yaml.YAMLToJSON(patchesJSON6902)
-// 	assert.Nil(t, err)
-// 	// apply patches
-// 	resp, _ := ProcessPatchJSON6902("type-conversion", jsonPatches, resource, logr.Discard())
-// 	if !assert.Equal(t, engineapi.RuleStatusPass, resp.Status()) {
-// 		t.Fatal(resp.Message())
-// 	}
+	jsonPatches, err := yaml.YAMLToJSON(patchesJSON6902)
+	assert.Nil(t, err)
+	// apply patches
+	resourceBytes, err := resource.MarshalJSON()
+	assert.Nil(t, err)
+	resourceBytes, patches, err := ProcessPatchJSON6902(logr.Discard(), jsonPatches, resourceBytes)
+	if !assert.Nil(t, err) {
+		t.Fatal()
+	}
 
-// 	assert.Equal(t, expectedPatches, resp.Patches(),
-// 		fmt.Sprintf("expectedPatches: %s\ngeneratedPatches: %s", string(expectedPatches[0]), string(resp.Patches()[0])))
-// }
+	assert.Equal(t, expectedPatches, ConvertPatches(patches...))
+}
 
-// func TestJsonPatch(t *testing.T) {
-// 	testCases := []struct {
-// 		testName string
-// 		// patches  []kyverno.Patch
-// 		patches  string
-// 		expected []byte
-// 	}{
-// 		{
-// 			testName: "single patch",
-// 			patches: `
-// - op: replace
-//   path: /spec/replica
-//   value: 5
-// `,
-// 			expected: []byte(`
-// apiVersion: apps/v1
-// kind: Deployment
-// metadata:
-//   name: myDeploy
-// spec:
-//   replica: 5
-//   template:
-//     metadata:
-//       labels:
-//         old-label: old-value
-//     spec:
-//       containers:
-//       - image: nginx
-//         name: nginx
-// `),
-// 		},
-// 		{
-// 			testName: "insert to list",
-// 			patches: `
-// - op: add
-//   path: /spec/template/spec/containers/1
-//   value: {"name":"new-nginx","image":"new-nginx-image"}
-// `,
-// 			expected: []byte(`
-// apiVersion: apps/v1
-// kind: Deployment
-// metadata:
-//   name: myDeploy
-// spec:
-//   replica: 2
-//   template:
-//     metadata:
-//       labels:
-//         old-label: old-value
-//     spec:
-//       containers:
-//       - image: nginx
-//         name: nginx
-//       - name: new-nginx
-//         image: new-nginx-image
-// `),
-// 		},
-// 		{
-// 			testName: "replace first element in list",
-// 			patches: `
-// - op: replace
-//   path: /spec/template/spec/containers/0
-//   value: {"name":"new-nginx","image":"new-nginx-image"}
-// `,
-// 			expected: []byte(`
-// apiVersion: apps/v1
-// kind: Deployment
-// metadata:
-//   name: myDeploy
-// spec:
-//   replica: 2
-//   template:
-//     metadata:
-//       labels:
-//         old-label: old-value
-//     spec:
-//       containers:
-//       - name: new-nginx
-//         image: new-nginx-image
-// `),
-// 		},
-// 		{
-// 			testName: "multiple operations",
-// 			patches: `
-// - op: replace
-//   path: /spec/template/spec/containers/0/name
-//   value: my-nginx
-// - op: add
-//   path: /spec/replica
-//   value: 999
-// - op: add
-//   path: /spec/template/spec/volumes
-//   value:
-//   - emptyDir:
-//       medium: Memory
-//     name: vault-secret
-// `,
-// 			expected: []byte(`
-// apiVersion: apps/v1
-// kind: Deployment
-// metadata:
-//   name: myDeploy
-// spec:
-//   replica: 999
-//   template:
-//     metadata:
-//       labels:
-//         old-label: old-value
-//     spec:
-//       containers:
-//       - image: nginx
-//         name: my-nginx
-//       volumes:
-//       - emptyDir:
-//           medium: Memory
-//         name: vault-secret
-// `),
-// 		},
-// 	}
+func TestJsonPatch(t *testing.T) {
+	testCases := []struct {
+		testName string
+		// patches  []kyverno.Patch
+		patches  string
+		expected []byte
+	}{
+		{
+			testName: "single patch",
+			patches: `
+- op: replace
+  path: /spec/replica
+  value: 5
+`,
+			expected: []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeploy
+spec:
+  replica: 5
+  template:
+    metadata:
+      labels:
+        old-label: old-value
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+`),
+		},
+		{
+			testName: "insert to list",
+			patches: `
+- op: add
+  path: /spec/template/spec/containers/1
+  value: {"name":"new-nginx","image":"new-nginx-image"}
+`,
+			expected: []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeploy
+spec:
+  replica: 2
+  template:
+    metadata:
+      labels:
+        old-label: old-value
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+      - name: new-nginx
+        image: new-nginx-image
+`),
+		},
+		{
+			testName: "replace first element in list",
+			patches: `
+- op: replace
+  path: /spec/template/spec/containers/0
+  value: {"name":"new-nginx","image":"new-nginx-image"}
+`,
+			expected: []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeploy
+spec:
+  replica: 2
+  template:
+    metadata:
+      labels:
+        old-label: old-value
+    spec:
+      containers:
+      - name: new-nginx
+        image: new-nginx-image
+`),
+		},
+		{
+			testName: "multiple operations",
+			patches: `
+- op: replace
+  path: /spec/template/spec/containers/0/name
+  value: my-nginx
+- op: add
+  path: /spec/replica
+  value: 999
+- op: add
+  path: /spec/template/spec/volumes
+  value:
+  - emptyDir:
+      medium: Memory
+    name: vault-secret
+`,
+			expected: []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeploy
+spec:
+  replica: 999
+  template:
+    metadata:
+      labels:
+        old-label: old-value
+    spec:
+      containers:
+      - image: nginx
+        name: my-nginx
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: vault-secret
+`),
+		},
+	}
 
-// 	for _, testCase := range testCases {
-// 		t.Run(testCase.testName, func(t *testing.T) {
-// 			expectedBytes, err := yaml.YAMLToJSON(testCase.expected)
-// 			assert.Nil(t, err)
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			expectedBytes, err := yaml.YAMLToJSON(testCase.expected)
+			assert.Nil(t, err)
 
-// 			inputBytes, err := yaml.YAMLToJSON(inputBytes)
-// 			assert.Nil(t, err)
+			inputBytes, err := yaml.YAMLToJSON(inputBytes)
+			assert.Nil(t, err)
 
-// 			patches, err := yaml.YAMLToJSON([]byte(testCase.patches))
-// 			assert.Nil(t, err)
+			patches, err := yaml.YAMLToJSON([]byte(testCase.patches))
+			assert.Nil(t, err)
 
-// 			out, err := applyPatchesWithOptions(inputBytes, patches)
-// 			assert.Nil(t, err)
+			out, err := applyPatchesWithOptions(inputBytes, patches)
+			assert.Nil(t, err)
 
-// 			if !assert.Equal(t, string(expectedBytes), string(out), testCase.testName) {
-// 				t.FailNow()
-// 			}
-// 		})
-// 	}
-// }
+			if !assert.Equal(t, string(expectedBytes), string(out), testCase.testName) {
+				t.FailNow()
+			}
+		})
+	}
+}
 
-// func Test_MissingPaths(t *testing.T) {
-// 	tests := []struct {
-// 		name            string
-// 		resource        string
-// 		patches         string
-// 		expectedPatches map[string]bool
-// 	}{
-// 		// test
-// 		{
-// 			name: "add-map-to-non-exist-path",
-// 			resource: `
-// spec:
-//   containers:
-//   - name: nginx
-//     image: nginx:1.14.2
-// `,
-// 			patches: `
-// - path: "/spec/nodeSelector"
-//   op: add
-//   value: {"node.kubernetes.io/role": "test"}
-// `,
-// 			expectedPatches: map[string]bool{
-// 				`{"op":"add","path":"/spec/nodeSelector","value":{"node.kubernetes.io/role":"test"}}`: true,
-// 			},
-// 		},
-// 		// test
-// 		{
-// 			name: "add-to-non-exist-array",
-// 			resource: `
-// spec:
-//   containers:
-//   - name: nginx
-//     image: nginx:1.14.2
-// `,
-// 			patches: `
-// - path: "/spec/tolerations/0"
-//   op: add
-//   value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
-// `,
-// 			expectedPatches: map[string]bool{
-// 				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
-// 			},
-// 		},
-// 		// test
-// 		{
-// 			name: "add-to-non-exist-array-2",
-// 			resource: `
-// spec:
-//   containers:
-//   - name: nginx
-//     image: nginx:1.14.2
-// `,
-// 			patches: `
-// - path: "/spec/tolerations"
-//   op: add
-//   value: [{"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}]
-// `,
-// 			expectedPatches: map[string]bool{
-// 				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
-// 			},
-// 		},
-// 		// test
-// 		{
-// 			name: "add-to-non-exist-array-3",
-// 			resource: `
-// spec:
-//   containers:
-//   - name: nginx
-//     image: nginx:1.14.2
-// `,
-// 			patches: `
-// - path: "/spec/tolerations/-1"
-//   op: add
-//   value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
-// `,
-// 			expectedPatches: map[string]bool{
-// 				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
-// 			},
-// 		},
-// 		// test
-// 		{
-// 			name: "add-to-exist-array",
-// 			resource: `
-// spec:
-//   containers:
-//   - name: nginx
-//     image: nginx:1.14.2
-//   tolerations:
-//   - effect: NoExecute
-//     key: node.kubernetes.io/not-ready
-//     operator: Exists
-//     tolerationSeconds: 300
-// `,
-// 			patches: `
-// - path: "/spec/tolerations"
-//   op: add
-//   value: [{"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}]
-// `,
-// 			expectedPatches: map[string]bool{
-// 				`{"op":"replace","path":"/spec/tolerations/0/effect","value":"NoSchedule"}`:                true,
-// 				`{"op":"replace","path":"/spec/tolerations/0/key","value":"node-role.kubernetes.io/test"}`: true,
-// 				`{"op":"remove","path":"/spec/tolerations/0/tolerationSeconds"}`:                           true,
-// 			},
-// 		},
-// 		// test
-// 		{
-// 			name: "add-to-exist-array-2",
-// 			resource: `
-// spec:
-//   containers:
-//   - name: nginx
-//     image: nginx:1.14.2
-//   tolerations:
-//   - effect: NoExecute
-//     key: node.kubernetes.io/not-ready
-//     operator: Exists
-//     tolerationSeconds: 300
-// `,
-// 			patches: `
-// - path: "/spec/tolerations/-"
-//   op: add
-//   value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
-// `,
-// 			expectedPatches: map[string]bool{
-// 				`{"op":"add","path":"/spec/tolerations/1","value":{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}}`: true,
-// 			},
-// 		},
-// 		// test
-// 		{
-// 			name: "add-to-exist-array-3",
-// 			resource: `
-// spec:
-//   containers:
-//   - name: nginx
-//     image: nginx:1.14.2
-//   tolerations:
-//   - effect: NoExecute
-//     key: node.kubernetes.io/not-ready
-//     operator: Exists
-//     tolerationSeconds: 300
-//   - key: "node.kubernetes.io/unreachable"
-//     operator: "Exists"
-//     effect: "NoExecute"
-//     tolerationSeconds: 6000
-// `,
-// 			patches: `
-// - path: "/spec/tolerations/-1"
-//   op: add
-//   value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
-// `,
-// 			expectedPatches: map[string]bool{
-// 				`{"op":"add","path":"/spec/tolerations/2","value":{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}}`: true,
-// 			},
-// 		},
-// 	}
+func Test_MissingPaths(t *testing.T) {
+	tests := []struct {
+		name            string
+		resource        string
+		patches         string
+		expectedPatches map[string]bool
+	}{
+		// test
+		{
+			name: "add-map-to-non-exist-path",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+`,
+			patches: `
+- path: "/spec/nodeSelector"
+  op: add
+  value: {"node.kubernetes.io/role": "test"}
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"add","path":"/spec/nodeSelector","value":{"node.kubernetes.io/role":"test"}}`: true,
+			},
+		},
+		// test
+		{
+			name: "add-to-non-exist-array",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+`,
+			patches: `
+- path: "/spec/tolerations/0"
+  op: add
+  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
+			},
+		},
+		// test
+		{
+			name: "add-to-non-exist-array-2",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+`,
+			patches: `
+- path: "/spec/tolerations"
+  op: add
+  value: [{"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}]
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
+			},
+		},
+		// test
+		{
+			name: "add-to-non-exist-array-3",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+`,
+			patches: `
+- path: "/spec/tolerations/-1"
+  op: add
+  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"add","path":"/spec/tolerations","value":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}]}`: true,
+			},
+		},
+		// test
+		{
+			name: "add-to-exist-array",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+`,
+			patches: `
+- path: "/spec/tolerations"
+  op: add
+  value: [{"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}]
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"replace","path":"/spec/tolerations/0/effect","value":"NoSchedule"}`:                true,
+				`{"op":"replace","path":"/spec/tolerations/0/key","value":"node-role.kubernetes.io/test"}`: true,
+				`{"op":"remove","path":"/spec/tolerations/0/tolerationSeconds"}`:                           true,
+			},
+		},
+		// test
+		{
+			name: "add-to-exist-array-2",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+`,
+			patches: `
+- path: "/spec/tolerations/-"
+  op: add
+  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"add","path":"/spec/tolerations/1","value":{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}}`: true,
+			},
+		},
+		// test
+		{
+			name: "add-to-exist-array-3",
+			resource: `
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - key: "node.kubernetes.io/unreachable"
+    operator: "Exists"
+    effect: "NoExecute"
+    tolerationSeconds: 6000
+`,
+			patches: `
+- path: "/spec/tolerations/-1"
+  op: add
+  value: {"key": "node-role.kubernetes.io/test", "effect": "NoSchedule", "operator": "Exists"}
+`,
+			expectedPatches: map[string]bool{
+				`{"op":"add","path":"/spec/tolerations/2","value":{"effect":"NoSchedule","key":"node-role.kubernetes.io/test","operator":"Exists"}}`: true,
+			},
+		},
+	}
 
-// 	for _, test := range tests {
-// 		r, err := yaml.YAMLToJSON([]byte(test.resource))
-// 		assert.Nil(t, err)
+	for _, test := range tests {
+		r, err := yaml.YAMLToJSON([]byte(test.resource))
+		assert.Nil(t, err)
 
-// 		patches, err := yaml.YAMLToJSON([]byte(test.patches))
-// 		assert.Nil(t, err)
+		patches, err := yaml.YAMLToJSON([]byte(test.patches))
+		assert.Nil(t, err)
 
-// 		patchedResource, err := applyPatchesWithOptions(r, patches)
-// 		assert.Nil(t, err)
+		patchedResource, err := applyPatchesWithOptions(r, patches)
+		assert.Nil(t, err)
 
-// 		generatedP, err := generatePatches(r, patchedResource)
-// 		assert.Nil(t, err)
+		generatedP, err := generatePatches(r, patchedResource)
+		assert.Nil(t, err)
 
-// 		for _, p := range generatedP {
-// 			assert.Equal(t, test.expectedPatches[string(p)], true,
-// 				fmt.Sprintf("test: %s\nunexpected patch: %s\nexpect one of: %v", test.name, string(p), test.expectedPatches))
-// 		}
-// 	}
-// }
+		for _, p := range generatedP {
+			assert.Equal(t, test.expectedPatches[string(p.Json())], true)
+		}
+	}
+}

--- a/pkg/engine/mutate/patch/patches.go
+++ b/pkg/engine/mutate/patch/patches.go
@@ -2,65 +2,51 @@ package patch
 
 import (
 	"github.com/go-logr/logr"
-	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/mattbaird/jsonpatch"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type (
+	resource = []byte
+	patches  = []jsonpatch.JsonPatchOperation
 )
 
 // Patcher patches the resource
 type Patcher interface {
-	Patch() (resp engineapi.RuleResponse, newPatchedResource unstructured.Unstructured)
+	Patch(logr.Logger, resource) (resource, patches, error)
 }
 
 // patchStrategicMergeHandler
 type patchStrategicMergeHandler struct {
-	ruleName        string
-	patch           apiextensions.JSON
-	patchedResource unstructured.Unstructured
-	logger          logr.Logger
+	patch apiextensions.JSON
 }
 
-func NewPatchStrategicMerge(ruleName string, patch apiextensions.JSON, patchedResource unstructured.Unstructured, logger logr.Logger) Patcher {
+func NewPatchStrategicMerge(patch apiextensions.JSON) Patcher {
 	return patchStrategicMergeHandler{
-		ruleName:        ruleName,
-		patch:           patch,
-		patchedResource: patchedResource,
-		logger:          logger,
+		patch: patch,
 	}
 }
 
-func (h patchStrategicMergeHandler) Patch() (engineapi.RuleResponse, unstructured.Unstructured) {
-	return ProcessStrategicMergePatch(h.ruleName, h.patch, h.patchedResource, h.logger)
+func (h patchStrategicMergeHandler) Patch(logger logr.Logger, resource resource) (resource, patches, error) {
+	return ProcessStrategicMergePatch(logger, h.patch, resource)
 }
 
 // patchesJSON6902Handler
 type patchesJSON6902Handler struct {
-	ruleName        string
-	patches         string
-	patchedResource unstructured.Unstructured
-	logger          logr.Logger
+	patches string
 }
 
-func NewPatchesJSON6902(ruleName string, patches string, patchedResource unstructured.Unstructured, logger logr.Logger) Patcher {
+func NewPatchesJSON6902(patches string) Patcher {
 	return patchesJSON6902Handler{
-		ruleName:        ruleName,
-		patches:         patches,
-		patchedResource: patchedResource,
-		logger:          logger,
+		patches: patches,
 	}
 }
 
-func (h patchesJSON6902Handler) Patch() (engineapi.RuleResponse, unstructured.Unstructured) {
+func (h patchesJSON6902Handler) Patch(logger logr.Logger, resource resource) (resource, patches, error) {
 	patchesJSON6902, err := ConvertPatchesToJSON(h.patches)
 	if err != nil {
-		resp := engineapi.RuleFail(
-			h.ruleName,
-			engineapi.Mutation,
-			err.Error(),
-		)
-		h.logger.Error(err, "error in type conversion")
-		return *resp, unstructured.Unstructured{}
+		logger.Error(err, "error in type conversion")
+		return nil, nil, err
 	}
-
-	return ProcessPatchJSON6902(h.ruleName, patchesJSON6902, h.patchedResource, h.logger)
+	return ProcessPatchJSON6902(logger, patchesJSON6902, resource)
 }

--- a/pkg/engine/mutate/patch/patchesUtils.go
+++ b/pkg/engine/mutate/patch/patchesUtils.go
@@ -9,6 +9,16 @@ import (
 	"github.com/mattbaird/jsonpatch"
 )
 
+func ConvertPatches(in ...jsonpatch.JsonPatchOperation) [][]byte {
+	var out [][]byte
+	for _, patch := range in {
+		if patch, err := patch.MarshalJSON(); err == nil {
+			out = append(out, patch)
+		}
+	}
+	return out
+}
+
 func generatePatches(src, dst []byte) ([]jsonpatch.JsonPatchOperation, error) {
 	if pp, err := jsonpatch.CreatePatch(src, dst); err != nil {
 		return nil, err

--- a/pkg/engine/mutate/patch/patchesUtils.go
+++ b/pkg/engine/mutate/patch/patchesUtils.go
@@ -9,24 +9,12 @@ import (
 	"github.com/mattbaird/jsonpatch"
 )
 
-func generatePatches(src, dst []byte) ([][]byte, error) {
-	var patchesBytes [][]byte
-	pp, err := jsonpatch.CreatePatch(src, dst)
-	if err != nil {
+func generatePatches(src, dst []byte) ([]jsonpatch.JsonPatchOperation, error) {
+	if pp, err := jsonpatch.CreatePatch(src, dst); err != nil {
 		return nil, err
+	} else {
+		return FilterAndSortPatches(pp), err
 	}
-
-	sortedPatches := FilterAndSortPatches(pp)
-	for _, p := range sortedPatches {
-		pbytes, err := p.MarshalJSON()
-		if err != nil {
-			return patchesBytes, err
-		}
-
-		patchesBytes = append(patchesBytes, pbytes)
-	}
-
-	return patchesBytes, err
 }
 
 // FilterAndSortPatches

--- a/pkg/engine/mutate/patch/patchesUtils_test.go
+++ b/pkg/engine/mutate/patch/patchesUtils_test.go
@@ -1,407 +1,407 @@
 package patch
 
-import (
-	"fmt"
-	"testing"
+// import (
+// 	"fmt"
+// 	"testing"
 
-	"github.com/go-logr/logr"
-	"github.com/mattbaird/jsonpatch"
-	assertnew "github.com/stretchr/testify/assert"
-	"gotest.tools/assert"
-)
+// 	"github.com/go-logr/logr"
+// 	"github.com/mattbaird/jsonpatch"
+// 	assertnew "github.com/stretchr/testify/assert"
+// 	"gotest.tools/assert"
+// )
 
-func Test_GeneratePatches(t *testing.T) {
-	out, err := strategicMergePatch(logr.Discard(), string(baseBytes), string(overlayBytes))
-	assert.NilError(t, err)
+// func Test_GeneratePatches(t *testing.T) {
+// 	out, err := strategicMergePatch(logr.Discard(), string(baseBytes), string(overlayBytes))
+// 	assert.NilError(t, err)
 
-	expectedPatches := map[string]bool{
-		`{"op":"remove","path":"/spec/template/spec/containers/0"}`:                                       true,
-		`{"op":"add","path":"/spec/template/spec/containers/0","value":{"image":"nginx","name":"nginx"}}`: true,
-		`{"op":"add","path":"/spec/template/spec/containers/1","value":{"env":[{"name":"WORDPRESS_DB_HOST","value":"$(MYSQL_SERVICE)"},{"name":"WORDPRESS_DB_PASSWORD","valueFrom":{"secretKeyRef":{"key":"password","name":"mysql-pass"}}}],"image":"wordpress:4.8-apache","name":"wordpress","ports":[{"containerPort":80,"name":"wordpress"}],"volumeMounts":[{"mountPath":"/var/www/html","name":"wordpress-persistent-storage"}]}}`: true,
-		`{"op":"add","path":"/spec/template/spec/initContainers","value":[{"command":["echo $(WORDPRESS_SERVICE)","echo $(MYSQL_SERVICE)"],"image":"debian","name":"init-command"}]}`:                                                                                                                                                                                                                                                    true,
-	}
-	patches, err := generatePatches(baseBytes, out)
-	assert.NilError(t, err)
+// 	expectedPatches := map[string]bool{
+// 		`{"op":"remove","path":"/spec/template/spec/containers/0"}`:                                       true,
+// 		`{"op":"add","path":"/spec/template/spec/containers/0","value":{"image":"nginx","name":"nginx"}}`: true,
+// 		`{"op":"add","path":"/spec/template/spec/containers/1","value":{"env":[{"name":"WORDPRESS_DB_HOST","value":"$(MYSQL_SERVICE)"},{"name":"WORDPRESS_DB_PASSWORD","valueFrom":{"secretKeyRef":{"key":"password","name":"mysql-pass"}}}],"image":"wordpress:4.8-apache","name":"wordpress","ports":[{"containerPort":80,"name":"wordpress"}],"volumeMounts":[{"mountPath":"/var/www/html","name":"wordpress-persistent-storage"}]}}`: true,
+// 		`{"op":"add","path":"/spec/template/spec/initContainers","value":[{"command":["echo $(WORDPRESS_SERVICE)","echo $(MYSQL_SERVICE)"],"image":"debian","name":"init-command"}]}`:                                                                                                                                                                                                                                                    true,
+// 	}
+// 	patches, err := generatePatches(baseBytes, out)
+// 	assert.NilError(t, err)
 
-	for _, p := range patches {
-		assertnew.Equal(t, expectedPatches[string(p)], true)
-	}
-}
+// 	for _, p := range patches {
+// 		assertnew.Equal(t, expectedPatches[string(p)], true)
+// 	}
+// }
 
-var baseBytes = []byte(`
-{
-  "apiVersion": "apps/v1",
-  "kind": "Deployment",
-  "metadata": {
-    "name": "wordpress",
-    "labels": {
-      "app": "wordpress"
-    }
-  },
-  "spec": {
-    "selector": {
-      "matchLabels": {
-        "app": "wordpress"
-      }
-    },
-    "strategy": {
-      "type": "Recreate"
-    },
-    "template": {
-      "metadata": {
-        "labels": {
-          "app": "wordpress"
-        }
-      },
-      "spec": {
-        "containers": [
-          {
-            "image": "wordpress:4.8-apache",
-            "name": "wordpress",
-            "ports": [
-              {
-                "containerPort": 80,
-                "name": "wordpress"
-              }
-            ],
-            "volumeMounts": [
-              {
-                "name": "wordpress-persistent-storage",
-                "mountPath": "/var/www/html"
-              }
-            ]
-          }
-        ],
-        "volumes": [
-          {
-            "name": "wordpress-persistent-storage"
-          }
-        ]
-      }
-    }
-  }
-}
-`)
+// var baseBytes = []byte(`
+// {
+//   "apiVersion": "apps/v1",
+//   "kind": "Deployment",
+//   "metadata": {
+//     "name": "wordpress",
+//     "labels": {
+//       "app": "wordpress"
+//     }
+//   },
+//   "spec": {
+//     "selector": {
+//       "matchLabels": {
+//         "app": "wordpress"
+//       }
+//     },
+//     "strategy": {
+//       "type": "Recreate"
+//     },
+//     "template": {
+//       "metadata": {
+//         "labels": {
+//           "app": "wordpress"
+//         }
+//       },
+//       "spec": {
+//         "containers": [
+//           {
+//             "image": "wordpress:4.8-apache",
+//             "name": "wordpress",
+//             "ports": [
+//               {
+//                 "containerPort": 80,
+//                 "name": "wordpress"
+//               }
+//             ],
+//             "volumeMounts": [
+//               {
+//                 "name": "wordpress-persistent-storage",
+//                 "mountPath": "/var/www/html"
+//               }
+//             ]
+//           }
+//         ],
+//         "volumes": [
+//           {
+//             "name": "wordpress-persistent-storage"
+//           }
+//         ]
+//       }
+//     }
+//   }
+// }
+// `)
 
-var overlayBytes = []byte(`
-{
-  "apiVersion": "apps/v1",
-  "kind": "Deployment",
-  "metadata": {
-    "name": "wordpress"
-  },
-  "spec": {
-    "template": {
-      "spec": {
-        "initContainers": [
-          {
-            "name": "init-command",
-            "image": "debian",
-            "command": [
-              "echo $(WORDPRESS_SERVICE)",
-              "echo $(MYSQL_SERVICE)"
-            ]
-          }
-        ],
-        "containers": [
-          {
-            "name": "nginx",
-            "image": "nginx"
-          },
-          {
-            "name": "wordpress",
-            "env": [
-              {
-                "name": "WORDPRESS_DB_HOST",
-                "value": "$(MYSQL_SERVICE)"
-              },
-              {
-                "name": "WORDPRESS_DB_PASSWORD",
-                "valueFrom": {
-                  "secretKeyRef": {
-                    "name": "mysql-pass",
-                    "key": "password"
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    }
-  }
-}
-`)
+// var overlayBytes = []byte(`
+// {
+//   "apiVersion": "apps/v1",
+//   "kind": "Deployment",
+//   "metadata": {
+//     "name": "wordpress"
+//   },
+//   "spec": {
+//     "template": {
+//       "spec": {
+//         "initContainers": [
+//           {
+//             "name": "init-command",
+//             "image": "debian",
+//             "command": [
+//               "echo $(WORDPRESS_SERVICE)",
+//               "echo $(MYSQL_SERVICE)"
+//             ]
+//           }
+//         ],
+//         "containers": [
+//           {
+//             "name": "nginx",
+//             "image": "nginx"
+//           },
+//           {
+//             "name": "wordpress",
+//             "env": [
+//               {
+//                 "name": "WORDPRESS_DB_HOST",
+//                 "value": "$(MYSQL_SERVICE)"
+//               },
+//               {
+//                 "name": "WORDPRESS_DB_PASSWORD",
+//                 "valueFrom": {
+//                   "secretKeyRef": {
+//                     "name": "mysql-pass",
+//                     "key": "password"
+//                   }
+//                 }
+//               }
+//             ]
+//           }
+//         ]
+//       }
+//     }
+//   }
+// }
+// `)
 
-var expectBytes = []byte(`{"apiVersion": "apps/v1","kind": "Deployment","metadata": {"name": "wordpress","labels": {"app": "wordpress"}},"spec": {"selector": {"matchLabels": {"app": "wordpress"}},"strategy": {"type": "Recreate"},"template": {"metadata": {"labels": {"app": "wordpress"}},"spec": {"containers": [{"name": "nginx","image": "nginx"},{"image": "wordpress:4.8-apache","name": "wordpress","ports": [{"containerPort": 80,"name": "wordpress"}],"volumeMounts": [{"name": "wordpress-persistent-storage","mountPath": "/var/www/html"}],"env": [{"name": "WORDPRESS_DB_HOST","value": "$(MYSQL_SERVICE)"},{"name": "WORDPRESS_DB_PASSWORD","valueFrom": {"secretKeyRef": {"name": "mysql-pass","key": "password"}}}]}],"volumes": [{"name": "wordpress-persistent-storage"}],"initContainers": [{"name": "init-command","image": "debian","command": ["echo $(WORDPRESS_SERVICE)","echo $(MYSQL_SERVICE)"]}]}}}}`)
+// var expectBytes = []byte(`{"apiVersion": "apps/v1","kind": "Deployment","metadata": {"name": "wordpress","labels": {"app": "wordpress"}},"spec": {"selector": {"matchLabels": {"app": "wordpress"}},"strategy": {"type": "Recreate"},"template": {"metadata": {"labels": {"app": "wordpress"}},"spec": {"containers": [{"name": "nginx","image": "nginx"},{"image": "wordpress:4.8-apache","name": "wordpress","ports": [{"containerPort": 80,"name": "wordpress"}],"volumeMounts": [{"name": "wordpress-persistent-storage","mountPath": "/var/www/html"}],"env": [{"name": "WORDPRESS_DB_HOST","value": "$(MYSQL_SERVICE)"},{"name": "WORDPRESS_DB_PASSWORD","valueFrom": {"secretKeyRef": {"name": "mysql-pass","key": "password"}}}]}],"volumes": [{"name": "wordpress-persistent-storage"}],"initContainers": [{"name": "init-command","image": "debian","command": ["echo $(WORDPRESS_SERVICE)","echo $(MYSQL_SERVICE)"]}]}}}}`)
 
-func Test_ignorePath(t *testing.T) {
-	tests := []struct {
-		path   string
-		ignore bool
-	}{
-		{
-			path:   "/",
-			ignore: false,
-		},
-		{
-			path:   "/metadata",
-			ignore: false,
-		},
-		{
-			path:   "/metadata/name",
-			ignore: false,
-		},
-		{
-			path:   "spec/template/metadata/name",
-			ignore: false,
-		},
-		{
-			path:   "/metadata/namespace",
-			ignore: false,
-		},
-		{
-			path:   "/metadata/annotations",
-			ignore: false,
-		},
-		{
-			path:   "/metadata/labels",
-			ignore: false,
-		},
-		{
-			path:   "/metadata/ownerReferences",
-			ignore: false,
-		},
-		{
-			path:   "/metadata/finalizers",
-			ignore: false,
-		},
-		{
-			path:   "/metadata/generateName",
-			ignore: false,
-		},
-		{
-			path:   "/metadata/creationTimestamp",
-			ignore: true,
-		},
-		{
-			path:   "spec/template/metadata/creationTimestamp",
-			ignore: true,
-		},
-		{
-			path:   "/metadata/resourceVersion",
-			ignore: true,
-		},
-		{
-			path:   "/status",
-			ignore: false,
-		},
-		{
-			path:   "/spec",
-			ignore: false,
-		},
-		{
-			path:   "/kind",
-			ignore: false,
-		},
-		{
-			path:   "/spec/triggers/0/metadata/serverAddress",
-			ignore: false,
-		},
-	}
+// func Test_ignorePath(t *testing.T) {
+// 	tests := []struct {
+// 		path   string
+// 		ignore bool
+// 	}{
+// 		{
+// 			path:   "/",
+// 			ignore: false,
+// 		},
+// 		{
+// 			path:   "/metadata",
+// 			ignore: false,
+// 		},
+// 		{
+// 			path:   "/metadata/name",
+// 			ignore: false,
+// 		},
+// 		{
+// 			path:   "spec/template/metadata/name",
+// 			ignore: false,
+// 		},
+// 		{
+// 			path:   "/metadata/namespace",
+// 			ignore: false,
+// 		},
+// 		{
+// 			path:   "/metadata/annotations",
+// 			ignore: false,
+// 		},
+// 		{
+// 			path:   "/metadata/labels",
+// 			ignore: false,
+// 		},
+// 		{
+// 			path:   "/metadata/ownerReferences",
+// 			ignore: false,
+// 		},
+// 		{
+// 			path:   "/metadata/finalizers",
+// 			ignore: false,
+// 		},
+// 		{
+// 			path:   "/metadata/generateName",
+// 			ignore: false,
+// 		},
+// 		{
+// 			path:   "/metadata/creationTimestamp",
+// 			ignore: true,
+// 		},
+// 		{
+// 			path:   "spec/template/metadata/creationTimestamp",
+// 			ignore: true,
+// 		},
+// 		{
+// 			path:   "/metadata/resourceVersion",
+// 			ignore: true,
+// 		},
+// 		{
+// 			path:   "/status",
+// 			ignore: false,
+// 		},
+// 		{
+// 			path:   "/spec",
+// 			ignore: false,
+// 		},
+// 		{
+// 			path:   "/kind",
+// 			ignore: false,
+// 		},
+// 		{
+// 			path:   "/spec/triggers/0/metadata/serverAddress",
+// 			ignore: false,
+// 		},
+// 	}
 
-	for _, test := range tests {
-		res := ignorePatch(test.path)
-		assertnew.Equal(t, test.ignore, res, fmt.Sprintf("test fails at %s", test.path))
-	}
-}
+// 	for _, test := range tests {
+// 		res := ignorePatch(test.path)
+// 		assertnew.Equal(t, test.ignore, res, fmt.Sprintf("test fails at %s", test.path))
+// 	}
+// }
 
-func Test_GeneratePatches_sortRemovalPatches(t *testing.T) {
-	base := []byte(`{"apiVersion": "apps/v1","kind": "Deployment","metadata": {"name": "nginx-deployment","labels": {"app": "nginx"}},"spec": {"selector": {"matchLabels": {"app": "nginx"}},"replicas": 1,"template": {"metadata": {"labels": {"app": "nginx"}},"spec": {"containers": [{"name": "nginx","image": "nginx:1.14.2","ports": [{"containerPort": 80}]}],"tolerations": [{"effect": "NoExecute","key": "node.kubernetes.io/not-ready","operator": "Exists","tolerationSeconds": 300},{"effect": "NoExecute","key": "node.kubernetes.io/unreachable","operator": "Exists","tolerationSeconds": 300}]}}}}`)
-	patchedResource := []byte(`{"apiVersion": "apps/v1","kind": "Deployment","metadata": {"name": "nginx-deployment","labels": {"app": "nginx"}},"spec": {"selector": {"matchLabels": {"app": "nginx"}},"replicas": 1,"template": {"metadata": {"labels": {"app": "nginx"}},"spec": {"containers": [{"name": "nginx","image": "nginx:1.14.2","ports": [{"containerPort": 80}]}],"tolerations": [{"effect": "NoSchedule","key": "networkzone","operator": "Equal","value": "dmz"}]}}}}`)
-	expectedPatches := [][]byte{[]byte(`{"op":"remove","path":"/spec/template/spec/tolerations/1"}`), []byte(`{"op":"remove","path":"/spec/template/spec/tolerations/0"}`), []byte(`{"op":"add","path":"/spec/template/spec/tolerations/0","value":{"effect":"NoSchedule","key":"networkzone","operator":"Equal","value":"dmz"}}`)}
-	patches, err := generatePatches(base, patchedResource)
-	fmt.Println(patches)
-	assertnew.Nil(t, err)
-	assertnew.Equal(t, expectedPatches, patches)
-}
+// func Test_GeneratePatches_sortRemovalPatches(t *testing.T) {
+// 	base := []byte(`{"apiVersion": "apps/v1","kind": "Deployment","metadata": {"name": "nginx-deployment","labels": {"app": "nginx"}},"spec": {"selector": {"matchLabels": {"app": "nginx"}},"replicas": 1,"template": {"metadata": {"labels": {"app": "nginx"}},"spec": {"containers": [{"name": "nginx","image": "nginx:1.14.2","ports": [{"containerPort": 80}]}],"tolerations": [{"effect": "NoExecute","key": "node.kubernetes.io/not-ready","operator": "Exists","tolerationSeconds": 300},{"effect": "NoExecute","key": "node.kubernetes.io/unreachable","operator": "Exists","tolerationSeconds": 300}]}}}}`)
+// 	patchedResource := []byte(`{"apiVersion": "apps/v1","kind": "Deployment","metadata": {"name": "nginx-deployment","labels": {"app": "nginx"}},"spec": {"selector": {"matchLabels": {"app": "nginx"}},"replicas": 1,"template": {"metadata": {"labels": {"app": "nginx"}},"spec": {"containers": [{"name": "nginx","image": "nginx:1.14.2","ports": [{"containerPort": 80}]}],"tolerations": [{"effect": "NoSchedule","key": "networkzone","operator": "Equal","value": "dmz"}]}}}}`)
+// 	expectedPatches := [][]byte{[]byte(`{"op":"remove","path":"/spec/template/spec/tolerations/1"}`), []byte(`{"op":"remove","path":"/spec/template/spec/tolerations/0"}`), []byte(`{"op":"add","path":"/spec/template/spec/tolerations/0","value":{"effect":"NoSchedule","key":"networkzone","operator":"Equal","value":"dmz"}}`)}
+// 	patches, err := generatePatches(base, patchedResource)
+// 	fmt.Println(patches)
+// 	assertnew.Nil(t, err)
+// 	assertnew.Equal(t, expectedPatches, patches)
+// }
 
-func Test_sortRemovalPatches(t *testing.T) {
-	tests := []struct {
-		patches  []jsonpatch.JsonPatchOperation
-		expected []jsonpatch.JsonPatchOperation
-	}{
-		{
-			patches:  []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}},
-			expected: []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}},
-		},
-		{
-			patches:  []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}, {Operation: "remove", Path: "/a"}},
-			expected: []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}, {Operation: "remove", Path: "/a"}},
-		},
-		{
-			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/a/0"}},
-			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/a/0"}},
-		},
-		{
-			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/a/1"}, {Operation: "remove", Path: "/a/2"}},
-			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/2"}, {Operation: "remove", Path: "/a/1"}, {Operation: "remove", Path: "/a/0"}},
-		},
-		{
-			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}},
-			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}},
-		},
-		{
-			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
-			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/c/0"}},
-		},
-		{
-			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/z"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
-			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/z"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/c/0"}},
-		},
-		{
-			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}, {Operation: "add", Path: "/b/c/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
-			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}, {Operation: "add", Path: "/b/c/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
-		},
-		{
-			patches: []jsonpatch.JsonPatchOperation{
-				{Operation: "remove", Path: "/spec/containers/0/args/7"},
-				{Operation: "remove", Path: "/spec/containers/0/args/6"},
-				{Operation: "remove", Path: "/spec/containers/0/args/5"},
-				{Operation: "remove", Path: "/spec/containers/0/args/4"},
-				{Operation: "remove", Path: "/spec/containers/0/args/3"},
-				{Operation: "remove", Path: "/spec/containers/0/args/2"},
-				{Operation: "remove", Path: "/spec/containers/0/args/1"},
-				{Operation: "remove", Path: "/spec/containers/0/args/0"},
-				{Operation: "add", Path: "/spec/containers/0/args/0", Value: "--logtostderr"},
-				{Operation: "add", Path: "/spec/containers/0/args/1", Value: "--secure-listen-address=[$(IP)]:9100"},
-				{Operation: "add", Path: "/spec/containers/0/args/2", Value: "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"},
-				{Operation: "add", Path: "/spec/containers/0/args/3", Value: "--upstream=http://127.0.0.1:9100/"},
-				{Operation: "remove", Path: "/spec/containers/1/args/3"},
-				{Operation: "remove", Path: "/spec/containers/1/args/2"},
-				{Operation: "remove", Path: "/spec/containers/1/args/1"},
-				{Operation: "remove", Path: "/spec/containers/1/args/0"},
-				{Operation: "add", Path: "/spec/containers/1/args/0", Value: "--web.listen-address=127.0.0.1:9100"},
-				{Operation: "add", Path: "/spec/containers/1/args/1", Value: "--Path.procfs=/host/proc"},
-				{Operation: "add", Path: "/spec/containers/1/args/2", Value: "--Path.sysfs=/host/sys"},
-				{Operation: "add", Path: "/spec/containers/1/args/3", Value: "--Path.rootfs=/host/root"},
-				{Operation: "add", Path: "/spec/containers/1/args/4", Value: "--no-collector.wifi"},
-				{Operation: "add", Path: "/spec/containers/1/args/5", Value: "--no-collector.hwmon"},
-				{Operation: "add", Path: "/spec/containers/1/args/6", Value: "--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)"},
-				{Operation: "add", Path: "/spec/containers/1/args/7", Value: "--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|tracefs)$"},
-			},
-			expected: []jsonpatch.JsonPatchOperation{
-				{Operation: "remove", Path: "/spec/containers/0/args/0"},
-				{Operation: "remove", Path: "/spec/containers/0/args/1"},
-				{Operation: "remove", Path: "/spec/containers/0/args/2"},
-				{Operation: "remove", Path: "/spec/containers/0/args/3"},
-				{Operation: "remove", Path: "/spec/containers/0/args/4"},
-				{Operation: "remove", Path: "/spec/containers/0/args/5"},
-				{Operation: "remove", Path: "/spec/containers/0/args/6"},
-				{Operation: "remove", Path: "/spec/containers/0/args/7"},
-				{Operation: "add", Path: "/spec/containers/0/args/0", Value: "--logtostderr"},
-				{Operation: "add", Path: "/spec/containers/0/args/1", Value: "--secure-listen-address=[$(IP)]:9100"},
-				{Operation: "add", Path: "/spec/containers/0/args/2", Value: "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"},
-				{Operation: "add", Path: "/spec/containers/0/args/3", Value: "--upstream=http://127.0.0.1:9100/"},
-				{Operation: "remove", Path: "/spec/containers/1/args/0"},
-				{Operation: "remove", Path: "/spec/containers/1/args/1"},
-				{Operation: "remove", Path: "/spec/containers/1/args/2"},
-				{Operation: "remove", Path: "/spec/containers/1/args/3"},
-				{Operation: "add", Path: "/spec/containers/1/args/0", Value: "--web.listen-address=127.0.0.1:9100"},
-				{Operation: "add", Path: "/spec/containers/1/args/1", Value: "--Path.procfs=/host/proc"},
-				{Operation: "add", Path: "/spec/containers/1/args/2", Value: "--Path.sysfs=/host/sys"},
-				{Operation: "add", Path: "/spec/containers/1/args/3", Value: "--Path.rootfs=/host/root"},
-				{Operation: "add", Path: "/spec/containers/1/args/4", Value: "--no-collector.wifi"},
-				{Operation: "add", Path: "/spec/containers/1/args/5", Value: "--no-collector.hwmon"},
-				{Operation: "add", Path: "/spec/containers/1/args/6", Value: "--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)"},
-				{Operation: "add", Path: "/spec/containers/1/args/7", Value: "--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|tracefs)$"},
-			},
-		},
-	}
+// func Test_sortRemovalPatches(t *testing.T) {
+// 	tests := []struct {
+// 		patches  []jsonpatch.JsonPatchOperation
+// 		expected []jsonpatch.JsonPatchOperation
+// 	}{
+// 		{
+// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}},
+// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}},
+// 		},
+// 		{
+// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}, {Operation: "remove", Path: "/a"}},
+// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}, {Operation: "remove", Path: "/a"}},
+// 		},
+// 		{
+// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/a/0"}},
+// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/a/0"}},
+// 		},
+// 		{
+// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/a/1"}, {Operation: "remove", Path: "/a/2"}},
+// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/2"}, {Operation: "remove", Path: "/a/1"}, {Operation: "remove", Path: "/a/0"}},
+// 		},
+// 		{
+// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}},
+// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}},
+// 		},
+// 		{
+// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
+// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/c/0"}},
+// 		},
+// 		{
+// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/z"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
+// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/z"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/c/0"}},
+// 		},
+// 		{
+// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}, {Operation: "add", Path: "/b/c/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
+// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}, {Operation: "add", Path: "/b/c/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
+// 		},
+// 		{
+// 			patches: []jsonpatch.JsonPatchOperation{
+// 				{Operation: "remove", Path: "/spec/containers/0/args/7"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/6"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/5"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/4"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/3"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/2"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/1"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/0"},
+// 				{Operation: "add", Path: "/spec/containers/0/args/0", Value: "--logtostderr"},
+// 				{Operation: "add", Path: "/spec/containers/0/args/1", Value: "--secure-listen-address=[$(IP)]:9100"},
+// 				{Operation: "add", Path: "/spec/containers/0/args/2", Value: "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"},
+// 				{Operation: "add", Path: "/spec/containers/0/args/3", Value: "--upstream=http://127.0.0.1:9100/"},
+// 				{Operation: "remove", Path: "/spec/containers/1/args/3"},
+// 				{Operation: "remove", Path: "/spec/containers/1/args/2"},
+// 				{Operation: "remove", Path: "/spec/containers/1/args/1"},
+// 				{Operation: "remove", Path: "/spec/containers/1/args/0"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/0", Value: "--web.listen-address=127.0.0.1:9100"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/1", Value: "--Path.procfs=/host/proc"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/2", Value: "--Path.sysfs=/host/sys"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/3", Value: "--Path.rootfs=/host/root"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/4", Value: "--no-collector.wifi"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/5", Value: "--no-collector.hwmon"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/6", Value: "--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/7", Value: "--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|tracefs)$"},
+// 			},
+// 			expected: []jsonpatch.JsonPatchOperation{
+// 				{Operation: "remove", Path: "/spec/containers/0/args/0"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/1"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/2"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/3"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/4"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/5"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/6"},
+// 				{Operation: "remove", Path: "/spec/containers/0/args/7"},
+// 				{Operation: "add", Path: "/spec/containers/0/args/0", Value: "--logtostderr"},
+// 				{Operation: "add", Path: "/spec/containers/0/args/1", Value: "--secure-listen-address=[$(IP)]:9100"},
+// 				{Operation: "add", Path: "/spec/containers/0/args/2", Value: "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"},
+// 				{Operation: "add", Path: "/spec/containers/0/args/3", Value: "--upstream=http://127.0.0.1:9100/"},
+// 				{Operation: "remove", Path: "/spec/containers/1/args/0"},
+// 				{Operation: "remove", Path: "/spec/containers/1/args/1"},
+// 				{Operation: "remove", Path: "/spec/containers/1/args/2"},
+// 				{Operation: "remove", Path: "/spec/containers/1/args/3"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/0", Value: "--web.listen-address=127.0.0.1:9100"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/1", Value: "--Path.procfs=/host/proc"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/2", Value: "--Path.sysfs=/host/sys"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/3", Value: "--Path.rootfs=/host/root"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/4", Value: "--no-collector.wifi"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/5", Value: "--no-collector.hwmon"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/6", Value: "--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)"},
+// 				{Operation: "add", Path: "/spec/containers/1/args/7", Value: "--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|tracefs)$"},
+// 			},
+// 		},
+// 	}
 
-	for i, test := range tests {
-		sortedPatches := FilterAndSortPatches(test.patches)
-		assertnew.Equal(t, test.expected, sortedPatches, fmt.Sprintf("%dth test fails", i))
-	}
-}
+// 	for i, test := range tests {
+// 		sortedPatches := FilterAndSortPatches(test.patches)
+// 		assertnew.Equal(t, test.expected, sortedPatches, fmt.Sprintf("%dth test fails", i))
+// 	}
+// }
 
-func Test_getRemoveInterval(t *testing.T) {
-	tests := []struct {
-		removalPaths  []string
-		expectedIndex [][]int
-	}{
-		{
-			removalPaths:  []string{"/a/0", "/b/0", "/b/1", "/c/0"},
-			expectedIndex: [][]int{{1, 2}},
-		},
-		{
-			removalPaths:  []string{},
-			expectedIndex: [][]int{},
-		},
-		{
-			removalPaths:  []string{"/a"},
-			expectedIndex: [][]int{},
-		},
-		{
-			removalPaths:  []string{"/a/0"},
-			expectedIndex: [][]int{},
-		},
-		{
-			removalPaths:  []string{"/a/0", "/a/1"},
-			expectedIndex: [][]int{{0, 1}},
-		},
-		{
-			removalPaths:  []string{"/a/0", "/a"},
-			expectedIndex: [][]int{},
-		},
-		{
-			removalPaths:  []string{"/a", "/a/0"},
-			expectedIndex: [][]int{},
-		},
-		{
-			removalPaths:  []string{"/a", "/a"},
-			expectedIndex: [][]int{},
-		},
-		{
-			removalPaths:  []string{"/a/0", "/b/0"},
-			expectedIndex: [][]int{},
-		},
-		{
-			removalPaths:  []string{"/a/0", "/a/1", "/a/2"},
-			expectedIndex: [][]int{{0, 2}},
-		},
-		{
-			removalPaths:  []string{"/a/0", "/a/1", "/a/b"},
-			expectedIndex: [][]int{{0, 1}},
-		},
-		{
-			removalPaths:  []string{"/a", "/a/0", "/a/1"},
-			expectedIndex: [][]int{{1, 2}},
-		},
-		{
-			removalPaths:  []string{"/", "/a", "/b/0"},
-			expectedIndex: [][]int{},
-		},
-		{
-			removalPaths:  []string{"/a/b", "/a/c", "/b/0", "/b/1", "/c"},
-			expectedIndex: [][]int{{2, 3}},
-		},
-		{
-			removalPaths:  []string{"/a/0", "/b/c", "/b/d", "/b/e", "/c/0"},
-			expectedIndex: [][]int{},
-		},
-		{
-			removalPaths:  []string{"/a/0", "/a/1", "/b/z", "/c/0", "/c/1", "/c/2", "/d/z", "/e/0"},
-			expectedIndex: [][]int{{0, 1}, {3, 5}},
-		},
-		{
-			removalPaths:  []string{"/a/0", "/a/1", "/a/2", "/a/3"},
-			expectedIndex: [][]int{{0, 3}},
-		},
-	}
+// func Test_getRemoveInterval(t *testing.T) {
+// 	tests := []struct {
+// 		removalPaths  []string
+// 		expectedIndex [][]int
+// 	}{
+// 		{
+// 			removalPaths:  []string{"/a/0", "/b/0", "/b/1", "/c/0"},
+// 			expectedIndex: [][]int{{1, 2}},
+// 		},
+// 		{
+// 			removalPaths:  []string{},
+// 			expectedIndex: [][]int{},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a"},
+// 			expectedIndex: [][]int{},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a/0"},
+// 			expectedIndex: [][]int{},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a/0", "/a/1"},
+// 			expectedIndex: [][]int{{0, 1}},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a/0", "/a"},
+// 			expectedIndex: [][]int{},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a", "/a/0"},
+// 			expectedIndex: [][]int{},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a", "/a"},
+// 			expectedIndex: [][]int{},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a/0", "/b/0"},
+// 			expectedIndex: [][]int{},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a/0", "/a/1", "/a/2"},
+// 			expectedIndex: [][]int{{0, 2}},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a/0", "/a/1", "/a/b"},
+// 			expectedIndex: [][]int{{0, 1}},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a", "/a/0", "/a/1"},
+// 			expectedIndex: [][]int{{1, 2}},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/", "/a", "/b/0"},
+// 			expectedIndex: [][]int{},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a/b", "/a/c", "/b/0", "/b/1", "/c"},
+// 			expectedIndex: [][]int{{2, 3}},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a/0", "/b/c", "/b/d", "/b/e", "/c/0"},
+// 			expectedIndex: [][]int{},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a/0", "/a/1", "/b/z", "/c/0", "/c/1", "/c/2", "/d/z", "/e/0"},
+// 			expectedIndex: [][]int{{0, 1}, {3, 5}},
+// 		},
+// 		{
+// 			removalPaths:  []string{"/a/0", "/a/1", "/a/2", "/a/3"},
+// 			expectedIndex: [][]int{{0, 3}},
+// 		},
+// 	}
 
-	for i, test := range tests {
-		res := getRemoveInterval(test.removalPaths)
-		assertnew.Equal(t, test.expectedIndex, res, fmt.Sprintf("%d-th test fails at path %v", i, test.removalPaths))
-	}
-}
+// 	for i, test := range tests {
+// 		res := getRemoveInterval(test.removalPaths)
+// 		assertnew.Equal(t, test.expectedIndex, res, fmt.Sprintf("%d-th test fails at path %v", i, test.removalPaths))
+// 	}
+// }

--- a/pkg/engine/mutate/patch/patchesUtils_test.go
+++ b/pkg/engine/mutate/patch/patchesUtils_test.go
@@ -1,407 +1,407 @@
 package patch
 
-// import (
-// 	"fmt"
-// 	"testing"
+import (
+	"fmt"
+	"testing"
 
-// 	"github.com/go-logr/logr"
-// 	"github.com/mattbaird/jsonpatch"
-// 	assertnew "github.com/stretchr/testify/assert"
-// 	"gotest.tools/assert"
-// )
+	"github.com/go-logr/logr"
+	"github.com/mattbaird/jsonpatch"
+	assertnew "github.com/stretchr/testify/assert"
+	"gotest.tools/assert"
+)
 
-// func Test_GeneratePatches(t *testing.T) {
-// 	out, err := strategicMergePatch(logr.Discard(), string(baseBytes), string(overlayBytes))
-// 	assert.NilError(t, err)
+func Test_GeneratePatches(t *testing.T) {
+	out, err := strategicMergePatch(logr.Discard(), string(baseBytes), string(overlayBytes))
+	assert.NilError(t, err)
 
-// 	expectedPatches := map[string]bool{
-// 		`{"op":"remove","path":"/spec/template/spec/containers/0"}`:                                       true,
-// 		`{"op":"add","path":"/spec/template/spec/containers/0","value":{"image":"nginx","name":"nginx"}}`: true,
-// 		`{"op":"add","path":"/spec/template/spec/containers/1","value":{"env":[{"name":"WORDPRESS_DB_HOST","value":"$(MYSQL_SERVICE)"},{"name":"WORDPRESS_DB_PASSWORD","valueFrom":{"secretKeyRef":{"key":"password","name":"mysql-pass"}}}],"image":"wordpress:4.8-apache","name":"wordpress","ports":[{"containerPort":80,"name":"wordpress"}],"volumeMounts":[{"mountPath":"/var/www/html","name":"wordpress-persistent-storage"}]}}`: true,
-// 		`{"op":"add","path":"/spec/template/spec/initContainers","value":[{"command":["echo $(WORDPRESS_SERVICE)","echo $(MYSQL_SERVICE)"],"image":"debian","name":"init-command"}]}`:                                                                                                                                                                                                                                                    true,
-// 	}
-// 	patches, err := generatePatches(baseBytes, out)
-// 	assert.NilError(t, err)
+	expectedPatches := map[string]bool{
+		`{"op":"remove","path":"/spec/template/spec/containers/0"}`:                                       true,
+		`{"op":"add","path":"/spec/template/spec/containers/0","value":{"image":"nginx","name":"nginx"}}`: true,
+		`{"op":"add","path":"/spec/template/spec/containers/1","value":{"env":[{"name":"WORDPRESS_DB_HOST","value":"$(MYSQL_SERVICE)"},{"name":"WORDPRESS_DB_PASSWORD","valueFrom":{"secretKeyRef":{"key":"password","name":"mysql-pass"}}}],"image":"wordpress:4.8-apache","name":"wordpress","ports":[{"containerPort":80,"name":"wordpress"}],"volumeMounts":[{"mountPath":"/var/www/html","name":"wordpress-persistent-storage"}]}}`: true,
+		`{"op":"add","path":"/spec/template/spec/initContainers","value":[{"command":["echo $(WORDPRESS_SERVICE)","echo $(MYSQL_SERVICE)"],"image":"debian","name":"init-command"}]}`:                                                                                                                                                                                                                                                    true,
+	}
+	patches, err := generatePatches(baseBytes, out)
+	assert.NilError(t, err)
 
-// 	for _, p := range patches {
-// 		assertnew.Equal(t, expectedPatches[string(p)], true)
-// 	}
-// }
+	for _, p := range patches {
+		assertnew.Equal(t, expectedPatches[p.Json()], true)
+	}
+}
 
-// var baseBytes = []byte(`
-// {
-//   "apiVersion": "apps/v1",
-//   "kind": "Deployment",
-//   "metadata": {
-//     "name": "wordpress",
-//     "labels": {
-//       "app": "wordpress"
-//     }
-//   },
-//   "spec": {
-//     "selector": {
-//       "matchLabels": {
-//         "app": "wordpress"
-//       }
-//     },
-//     "strategy": {
-//       "type": "Recreate"
-//     },
-//     "template": {
-//       "metadata": {
-//         "labels": {
-//           "app": "wordpress"
-//         }
-//       },
-//       "spec": {
-//         "containers": [
-//           {
-//             "image": "wordpress:4.8-apache",
-//             "name": "wordpress",
-//             "ports": [
-//               {
-//                 "containerPort": 80,
-//                 "name": "wordpress"
-//               }
-//             ],
-//             "volumeMounts": [
-//               {
-//                 "name": "wordpress-persistent-storage",
-//                 "mountPath": "/var/www/html"
-//               }
-//             ]
-//           }
-//         ],
-//         "volumes": [
-//           {
-//             "name": "wordpress-persistent-storage"
-//           }
-//         ]
-//       }
-//     }
-//   }
-// }
-// `)
+var baseBytes = []byte(`
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "wordpress",
+    "labels": {
+      "app": "wordpress"
+    }
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "app": "wordpress"
+      }
+    },
+    "strategy": {
+      "type": "Recreate"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "wordpress"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "wordpress:4.8-apache",
+            "name": "wordpress",
+            "ports": [
+              {
+                "containerPort": 80,
+                "name": "wordpress"
+              }
+            ],
+            "volumeMounts": [
+              {
+                "name": "wordpress-persistent-storage",
+                "mountPath": "/var/www/html"
+              }
+            ]
+          }
+        ],
+        "volumes": [
+          {
+            "name": "wordpress-persistent-storage"
+          }
+        ]
+      }
+    }
+  }
+}
+`)
 
-// var overlayBytes = []byte(`
-// {
-//   "apiVersion": "apps/v1",
-//   "kind": "Deployment",
-//   "metadata": {
-//     "name": "wordpress"
-//   },
-//   "spec": {
-//     "template": {
-//       "spec": {
-//         "initContainers": [
-//           {
-//             "name": "init-command",
-//             "image": "debian",
-//             "command": [
-//               "echo $(WORDPRESS_SERVICE)",
-//               "echo $(MYSQL_SERVICE)"
-//             ]
-//           }
-//         ],
-//         "containers": [
-//           {
-//             "name": "nginx",
-//             "image": "nginx"
-//           },
-//           {
-//             "name": "wordpress",
-//             "env": [
-//               {
-//                 "name": "WORDPRESS_DB_HOST",
-//                 "value": "$(MYSQL_SERVICE)"
-//               },
-//               {
-//                 "name": "WORDPRESS_DB_PASSWORD",
-//                 "valueFrom": {
-//                   "secretKeyRef": {
-//                     "name": "mysql-pass",
-//                     "key": "password"
-//                   }
-//                 }
-//               }
-//             ]
-//           }
-//         ]
-//       }
-//     }
-//   }
-// }
-// `)
+var overlayBytes = []byte(`
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "wordpress"
+  },
+  "spec": {
+    "template": {
+      "spec": {
+        "initContainers": [
+          {
+            "name": "init-command",
+            "image": "debian",
+            "command": [
+              "echo $(WORDPRESS_SERVICE)",
+              "echo $(MYSQL_SERVICE)"
+            ]
+          }
+        ],
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "nginx"
+          },
+          {
+            "name": "wordpress",
+            "env": [
+              {
+                "name": "WORDPRESS_DB_HOST",
+                "value": "$(MYSQL_SERVICE)"
+              },
+              {
+                "name": "WORDPRESS_DB_PASSWORD",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "mysql-pass",
+                    "key": "password"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+`)
 
-// var expectBytes = []byte(`{"apiVersion": "apps/v1","kind": "Deployment","metadata": {"name": "wordpress","labels": {"app": "wordpress"}},"spec": {"selector": {"matchLabels": {"app": "wordpress"}},"strategy": {"type": "Recreate"},"template": {"metadata": {"labels": {"app": "wordpress"}},"spec": {"containers": [{"name": "nginx","image": "nginx"},{"image": "wordpress:4.8-apache","name": "wordpress","ports": [{"containerPort": 80,"name": "wordpress"}],"volumeMounts": [{"name": "wordpress-persistent-storage","mountPath": "/var/www/html"}],"env": [{"name": "WORDPRESS_DB_HOST","value": "$(MYSQL_SERVICE)"},{"name": "WORDPRESS_DB_PASSWORD","valueFrom": {"secretKeyRef": {"name": "mysql-pass","key": "password"}}}]}],"volumes": [{"name": "wordpress-persistent-storage"}],"initContainers": [{"name": "init-command","image": "debian","command": ["echo $(WORDPRESS_SERVICE)","echo $(MYSQL_SERVICE)"]}]}}}}`)
+var expectBytes = []byte(`{"apiVersion": "apps/v1","kind": "Deployment","metadata": {"name": "wordpress","labels": {"app": "wordpress"}},"spec": {"selector": {"matchLabels": {"app": "wordpress"}},"strategy": {"type": "Recreate"},"template": {"metadata": {"labels": {"app": "wordpress"}},"spec": {"containers": [{"name": "nginx","image": "nginx"},{"image": "wordpress:4.8-apache","name": "wordpress","ports": [{"containerPort": 80,"name": "wordpress"}],"volumeMounts": [{"name": "wordpress-persistent-storage","mountPath": "/var/www/html"}],"env": [{"name": "WORDPRESS_DB_HOST","value": "$(MYSQL_SERVICE)"},{"name": "WORDPRESS_DB_PASSWORD","valueFrom": {"secretKeyRef": {"name": "mysql-pass","key": "password"}}}]}],"volumes": [{"name": "wordpress-persistent-storage"}],"initContainers": [{"name": "init-command","image": "debian","command": ["echo $(WORDPRESS_SERVICE)","echo $(MYSQL_SERVICE)"]}]}}}}`)
 
-// func Test_ignorePath(t *testing.T) {
-// 	tests := []struct {
-// 		path   string
-// 		ignore bool
-// 	}{
-// 		{
-// 			path:   "/",
-// 			ignore: false,
-// 		},
-// 		{
-// 			path:   "/metadata",
-// 			ignore: false,
-// 		},
-// 		{
-// 			path:   "/metadata/name",
-// 			ignore: false,
-// 		},
-// 		{
-// 			path:   "spec/template/metadata/name",
-// 			ignore: false,
-// 		},
-// 		{
-// 			path:   "/metadata/namespace",
-// 			ignore: false,
-// 		},
-// 		{
-// 			path:   "/metadata/annotations",
-// 			ignore: false,
-// 		},
-// 		{
-// 			path:   "/metadata/labels",
-// 			ignore: false,
-// 		},
-// 		{
-// 			path:   "/metadata/ownerReferences",
-// 			ignore: false,
-// 		},
-// 		{
-// 			path:   "/metadata/finalizers",
-// 			ignore: false,
-// 		},
-// 		{
-// 			path:   "/metadata/generateName",
-// 			ignore: false,
-// 		},
-// 		{
-// 			path:   "/metadata/creationTimestamp",
-// 			ignore: true,
-// 		},
-// 		{
-// 			path:   "spec/template/metadata/creationTimestamp",
-// 			ignore: true,
-// 		},
-// 		{
-// 			path:   "/metadata/resourceVersion",
-// 			ignore: true,
-// 		},
-// 		{
-// 			path:   "/status",
-// 			ignore: false,
-// 		},
-// 		{
-// 			path:   "/spec",
-// 			ignore: false,
-// 		},
-// 		{
-// 			path:   "/kind",
-// 			ignore: false,
-// 		},
-// 		{
-// 			path:   "/spec/triggers/0/metadata/serverAddress",
-// 			ignore: false,
-// 		},
-// 	}
+func Test_ignorePath(t *testing.T) {
+	tests := []struct {
+		path   string
+		ignore bool
+	}{
+		{
+			path:   "/",
+			ignore: false,
+		},
+		{
+			path:   "/metadata",
+			ignore: false,
+		},
+		{
+			path:   "/metadata/name",
+			ignore: false,
+		},
+		{
+			path:   "spec/template/metadata/name",
+			ignore: false,
+		},
+		{
+			path:   "/metadata/namespace",
+			ignore: false,
+		},
+		{
+			path:   "/metadata/annotations",
+			ignore: false,
+		},
+		{
+			path:   "/metadata/labels",
+			ignore: false,
+		},
+		{
+			path:   "/metadata/ownerReferences",
+			ignore: false,
+		},
+		{
+			path:   "/metadata/finalizers",
+			ignore: false,
+		},
+		{
+			path:   "/metadata/generateName",
+			ignore: false,
+		},
+		{
+			path:   "/metadata/creationTimestamp",
+			ignore: true,
+		},
+		{
+			path:   "spec/template/metadata/creationTimestamp",
+			ignore: true,
+		},
+		{
+			path:   "/metadata/resourceVersion",
+			ignore: true,
+		},
+		{
+			path:   "/status",
+			ignore: false,
+		},
+		{
+			path:   "/spec",
+			ignore: false,
+		},
+		{
+			path:   "/kind",
+			ignore: false,
+		},
+		{
+			path:   "/spec/triggers/0/metadata/serverAddress",
+			ignore: false,
+		},
+	}
 
-// 	for _, test := range tests {
-// 		res := ignorePatch(test.path)
-// 		assertnew.Equal(t, test.ignore, res, fmt.Sprintf("test fails at %s", test.path))
-// 	}
-// }
+	for _, test := range tests {
+		res := ignorePatch(test.path)
+		assertnew.Equal(t, test.ignore, res, fmt.Sprintf("test fails at %s", test.path))
+	}
+}
 
-// func Test_GeneratePatches_sortRemovalPatches(t *testing.T) {
-// 	base := []byte(`{"apiVersion": "apps/v1","kind": "Deployment","metadata": {"name": "nginx-deployment","labels": {"app": "nginx"}},"spec": {"selector": {"matchLabels": {"app": "nginx"}},"replicas": 1,"template": {"metadata": {"labels": {"app": "nginx"}},"spec": {"containers": [{"name": "nginx","image": "nginx:1.14.2","ports": [{"containerPort": 80}]}],"tolerations": [{"effect": "NoExecute","key": "node.kubernetes.io/not-ready","operator": "Exists","tolerationSeconds": 300},{"effect": "NoExecute","key": "node.kubernetes.io/unreachable","operator": "Exists","tolerationSeconds": 300}]}}}}`)
-// 	patchedResource := []byte(`{"apiVersion": "apps/v1","kind": "Deployment","metadata": {"name": "nginx-deployment","labels": {"app": "nginx"}},"spec": {"selector": {"matchLabels": {"app": "nginx"}},"replicas": 1,"template": {"metadata": {"labels": {"app": "nginx"}},"spec": {"containers": [{"name": "nginx","image": "nginx:1.14.2","ports": [{"containerPort": 80}]}],"tolerations": [{"effect": "NoSchedule","key": "networkzone","operator": "Equal","value": "dmz"}]}}}}`)
-// 	expectedPatches := [][]byte{[]byte(`{"op":"remove","path":"/spec/template/spec/tolerations/1"}`), []byte(`{"op":"remove","path":"/spec/template/spec/tolerations/0"}`), []byte(`{"op":"add","path":"/spec/template/spec/tolerations/0","value":{"effect":"NoSchedule","key":"networkzone","operator":"Equal","value":"dmz"}}`)}
-// 	patches, err := generatePatches(base, patchedResource)
-// 	fmt.Println(patches)
-// 	assertnew.Nil(t, err)
-// 	assertnew.Equal(t, expectedPatches, patches)
-// }
+func Test_GeneratePatches_sortRemovalPatches(t *testing.T) {
+	base := []byte(`{"apiVersion": "apps/v1","kind": "Deployment","metadata": {"name": "nginx-deployment","labels": {"app": "nginx"}},"spec": {"selector": {"matchLabels": {"app": "nginx"}},"replicas": 1,"template": {"metadata": {"labels": {"app": "nginx"}},"spec": {"containers": [{"name": "nginx","image": "nginx:1.14.2","ports": [{"containerPort": 80}]}],"tolerations": [{"effect": "NoExecute","key": "node.kubernetes.io/not-ready","operator": "Exists","tolerationSeconds": 300},{"effect": "NoExecute","key": "node.kubernetes.io/unreachable","operator": "Exists","tolerationSeconds": 300}]}}}}`)
+	patchedResource := []byte(`{"apiVersion": "apps/v1","kind": "Deployment","metadata": {"name": "nginx-deployment","labels": {"app": "nginx"}},"spec": {"selector": {"matchLabels": {"app": "nginx"}},"replicas": 1,"template": {"metadata": {"labels": {"app": "nginx"}},"spec": {"containers": [{"name": "nginx","image": "nginx:1.14.2","ports": [{"containerPort": 80}]}],"tolerations": [{"effect": "NoSchedule","key": "networkzone","operator": "Equal","value": "dmz"}]}}}}`)
+	expectedPatches := [][]byte{[]byte(`{"op":"remove","path":"/spec/template/spec/tolerations/1"}`), []byte(`{"op":"remove","path":"/spec/template/spec/tolerations/0"}`), []byte(`{"op":"add","path":"/spec/template/spec/tolerations/0","value":{"effect":"NoSchedule","key":"networkzone","operator":"Equal","value":"dmz"}}`)}
+	patches, err := generatePatches(base, patchedResource)
+	fmt.Println(patches)
+	assertnew.Nil(t, err)
+	assertnew.Equal(t, expectedPatches, ConvertPatches(patches...))
+}
 
-// func Test_sortRemovalPatches(t *testing.T) {
-// 	tests := []struct {
-// 		patches  []jsonpatch.JsonPatchOperation
-// 		expected []jsonpatch.JsonPatchOperation
-// 	}{
-// 		{
-// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}},
-// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}},
-// 		},
-// 		{
-// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}, {Operation: "remove", Path: "/a"}},
-// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}, {Operation: "remove", Path: "/a"}},
-// 		},
-// 		{
-// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/a/0"}},
-// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/a/0"}},
-// 		},
-// 		{
-// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/a/1"}, {Operation: "remove", Path: "/a/2"}},
-// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/2"}, {Operation: "remove", Path: "/a/1"}, {Operation: "remove", Path: "/a/0"}},
-// 		},
-// 		{
-// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}},
-// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}},
-// 		},
-// 		{
-// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
-// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/c/0"}},
-// 		},
-// 		{
-// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/z"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
-// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/z"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/c/0"}},
-// 		},
-// 		{
-// 			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}, {Operation: "add", Path: "/b/c/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
-// 			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}, {Operation: "add", Path: "/b/c/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
-// 		},
-// 		{
-// 			patches: []jsonpatch.JsonPatchOperation{
-// 				{Operation: "remove", Path: "/spec/containers/0/args/7"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/6"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/5"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/4"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/3"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/2"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/1"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/0"},
-// 				{Operation: "add", Path: "/spec/containers/0/args/0", Value: "--logtostderr"},
-// 				{Operation: "add", Path: "/spec/containers/0/args/1", Value: "--secure-listen-address=[$(IP)]:9100"},
-// 				{Operation: "add", Path: "/spec/containers/0/args/2", Value: "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"},
-// 				{Operation: "add", Path: "/spec/containers/0/args/3", Value: "--upstream=http://127.0.0.1:9100/"},
-// 				{Operation: "remove", Path: "/spec/containers/1/args/3"},
-// 				{Operation: "remove", Path: "/spec/containers/1/args/2"},
-// 				{Operation: "remove", Path: "/spec/containers/1/args/1"},
-// 				{Operation: "remove", Path: "/spec/containers/1/args/0"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/0", Value: "--web.listen-address=127.0.0.1:9100"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/1", Value: "--Path.procfs=/host/proc"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/2", Value: "--Path.sysfs=/host/sys"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/3", Value: "--Path.rootfs=/host/root"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/4", Value: "--no-collector.wifi"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/5", Value: "--no-collector.hwmon"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/6", Value: "--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/7", Value: "--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|tracefs)$"},
-// 			},
-// 			expected: []jsonpatch.JsonPatchOperation{
-// 				{Operation: "remove", Path: "/spec/containers/0/args/0"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/1"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/2"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/3"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/4"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/5"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/6"},
-// 				{Operation: "remove", Path: "/spec/containers/0/args/7"},
-// 				{Operation: "add", Path: "/spec/containers/0/args/0", Value: "--logtostderr"},
-// 				{Operation: "add", Path: "/spec/containers/0/args/1", Value: "--secure-listen-address=[$(IP)]:9100"},
-// 				{Operation: "add", Path: "/spec/containers/0/args/2", Value: "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"},
-// 				{Operation: "add", Path: "/spec/containers/0/args/3", Value: "--upstream=http://127.0.0.1:9100/"},
-// 				{Operation: "remove", Path: "/spec/containers/1/args/0"},
-// 				{Operation: "remove", Path: "/spec/containers/1/args/1"},
-// 				{Operation: "remove", Path: "/spec/containers/1/args/2"},
-// 				{Operation: "remove", Path: "/spec/containers/1/args/3"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/0", Value: "--web.listen-address=127.0.0.1:9100"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/1", Value: "--Path.procfs=/host/proc"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/2", Value: "--Path.sysfs=/host/sys"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/3", Value: "--Path.rootfs=/host/root"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/4", Value: "--no-collector.wifi"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/5", Value: "--no-collector.hwmon"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/6", Value: "--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)"},
-// 				{Operation: "add", Path: "/spec/containers/1/args/7", Value: "--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|tracefs)$"},
-// 			},
-// 		},
-// 	}
+func Test_sortRemovalPatches(t *testing.T) {
+	tests := []struct {
+		patches  []jsonpatch.JsonPatchOperation
+		expected []jsonpatch.JsonPatchOperation
+	}{
+		{
+			patches:  []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}},
+			expected: []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}},
+		},
+		{
+			patches:  []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}, {Operation: "remove", Path: "/a"}},
+			expected: []jsonpatch.JsonPatchOperation{{Operation: "add", Path: "/a"}, {Operation: "remove", Path: "/a"}},
+		},
+		{
+			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/a/0"}},
+			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/a/0"}},
+		},
+		{
+			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/a/1"}, {Operation: "remove", Path: "/a/2"}},
+			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/2"}, {Operation: "remove", Path: "/a/1"}, {Operation: "remove", Path: "/a/0"}},
+		},
+		{
+			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}},
+			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}},
+		},
+		{
+			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
+			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/c/0"}},
+		},
+		{
+			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/z"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
+			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "add", Path: "/z"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/b/0"}, {Operation: "remove", Path: "/c/0"}},
+		},
+		{
+			patches:  []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}, {Operation: "add", Path: "/b/c/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
+			expected: []jsonpatch.JsonPatchOperation{{Operation: "remove", Path: "/a/0"}, {Operation: "remove", Path: "/b/0"}, {Operation: "add", Path: "/b/c/0"}, {Operation: "remove", Path: "/b/1"}, {Operation: "remove", Path: "/c/0"}},
+		},
+		{
+			patches: []jsonpatch.JsonPatchOperation{
+				{Operation: "remove", Path: "/spec/containers/0/args/7"},
+				{Operation: "remove", Path: "/spec/containers/0/args/6"},
+				{Operation: "remove", Path: "/spec/containers/0/args/5"},
+				{Operation: "remove", Path: "/spec/containers/0/args/4"},
+				{Operation: "remove", Path: "/spec/containers/0/args/3"},
+				{Operation: "remove", Path: "/spec/containers/0/args/2"},
+				{Operation: "remove", Path: "/spec/containers/0/args/1"},
+				{Operation: "remove", Path: "/spec/containers/0/args/0"},
+				{Operation: "add", Path: "/spec/containers/0/args/0", Value: "--logtostderr"},
+				{Operation: "add", Path: "/spec/containers/0/args/1", Value: "--secure-listen-address=[$(IP)]:9100"},
+				{Operation: "add", Path: "/spec/containers/0/args/2", Value: "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"},
+				{Operation: "add", Path: "/spec/containers/0/args/3", Value: "--upstream=http://127.0.0.1:9100/"},
+				{Operation: "remove", Path: "/spec/containers/1/args/3"},
+				{Operation: "remove", Path: "/spec/containers/1/args/2"},
+				{Operation: "remove", Path: "/spec/containers/1/args/1"},
+				{Operation: "remove", Path: "/spec/containers/1/args/0"},
+				{Operation: "add", Path: "/spec/containers/1/args/0", Value: "--web.listen-address=127.0.0.1:9100"},
+				{Operation: "add", Path: "/spec/containers/1/args/1", Value: "--Path.procfs=/host/proc"},
+				{Operation: "add", Path: "/spec/containers/1/args/2", Value: "--Path.sysfs=/host/sys"},
+				{Operation: "add", Path: "/spec/containers/1/args/3", Value: "--Path.rootfs=/host/root"},
+				{Operation: "add", Path: "/spec/containers/1/args/4", Value: "--no-collector.wifi"},
+				{Operation: "add", Path: "/spec/containers/1/args/5", Value: "--no-collector.hwmon"},
+				{Operation: "add", Path: "/spec/containers/1/args/6", Value: "--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)"},
+				{Operation: "add", Path: "/spec/containers/1/args/7", Value: "--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|tracefs)$"},
+			},
+			expected: []jsonpatch.JsonPatchOperation{
+				{Operation: "remove", Path: "/spec/containers/0/args/0"},
+				{Operation: "remove", Path: "/spec/containers/0/args/1"},
+				{Operation: "remove", Path: "/spec/containers/0/args/2"},
+				{Operation: "remove", Path: "/spec/containers/0/args/3"},
+				{Operation: "remove", Path: "/spec/containers/0/args/4"},
+				{Operation: "remove", Path: "/spec/containers/0/args/5"},
+				{Operation: "remove", Path: "/spec/containers/0/args/6"},
+				{Operation: "remove", Path: "/spec/containers/0/args/7"},
+				{Operation: "add", Path: "/spec/containers/0/args/0", Value: "--logtostderr"},
+				{Operation: "add", Path: "/spec/containers/0/args/1", Value: "--secure-listen-address=[$(IP)]:9100"},
+				{Operation: "add", Path: "/spec/containers/0/args/2", Value: "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"},
+				{Operation: "add", Path: "/spec/containers/0/args/3", Value: "--upstream=http://127.0.0.1:9100/"},
+				{Operation: "remove", Path: "/spec/containers/1/args/0"},
+				{Operation: "remove", Path: "/spec/containers/1/args/1"},
+				{Operation: "remove", Path: "/spec/containers/1/args/2"},
+				{Operation: "remove", Path: "/spec/containers/1/args/3"},
+				{Operation: "add", Path: "/spec/containers/1/args/0", Value: "--web.listen-address=127.0.0.1:9100"},
+				{Operation: "add", Path: "/spec/containers/1/args/1", Value: "--Path.procfs=/host/proc"},
+				{Operation: "add", Path: "/spec/containers/1/args/2", Value: "--Path.sysfs=/host/sys"},
+				{Operation: "add", Path: "/spec/containers/1/args/3", Value: "--Path.rootfs=/host/root"},
+				{Operation: "add", Path: "/spec/containers/1/args/4", Value: "--no-collector.wifi"},
+				{Operation: "add", Path: "/spec/containers/1/args/5", Value: "--no-collector.hwmon"},
+				{Operation: "add", Path: "/spec/containers/1/args/6", Value: "--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)"},
+				{Operation: "add", Path: "/spec/containers/1/args/7", Value: "--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|tracefs)$"},
+			},
+		},
+	}
 
-// 	for i, test := range tests {
-// 		sortedPatches := FilterAndSortPatches(test.patches)
-// 		assertnew.Equal(t, test.expected, sortedPatches, fmt.Sprintf("%dth test fails", i))
-// 	}
-// }
+	for i, test := range tests {
+		sortedPatches := FilterAndSortPatches(test.patches)
+		assertnew.Equal(t, test.expected, sortedPatches, fmt.Sprintf("%dth test fails", i))
+	}
+}
 
-// func Test_getRemoveInterval(t *testing.T) {
-// 	tests := []struct {
-// 		removalPaths  []string
-// 		expectedIndex [][]int
-// 	}{
-// 		{
-// 			removalPaths:  []string{"/a/0", "/b/0", "/b/1", "/c/0"},
-// 			expectedIndex: [][]int{{1, 2}},
-// 		},
-// 		{
-// 			removalPaths:  []string{},
-// 			expectedIndex: [][]int{},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a"},
-// 			expectedIndex: [][]int{},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a/0"},
-// 			expectedIndex: [][]int{},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a/0", "/a/1"},
-// 			expectedIndex: [][]int{{0, 1}},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a/0", "/a"},
-// 			expectedIndex: [][]int{},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a", "/a/0"},
-// 			expectedIndex: [][]int{},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a", "/a"},
-// 			expectedIndex: [][]int{},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a/0", "/b/0"},
-// 			expectedIndex: [][]int{},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a/0", "/a/1", "/a/2"},
-// 			expectedIndex: [][]int{{0, 2}},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a/0", "/a/1", "/a/b"},
-// 			expectedIndex: [][]int{{0, 1}},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a", "/a/0", "/a/1"},
-// 			expectedIndex: [][]int{{1, 2}},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/", "/a", "/b/0"},
-// 			expectedIndex: [][]int{},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a/b", "/a/c", "/b/0", "/b/1", "/c"},
-// 			expectedIndex: [][]int{{2, 3}},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a/0", "/b/c", "/b/d", "/b/e", "/c/0"},
-// 			expectedIndex: [][]int{},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a/0", "/a/1", "/b/z", "/c/0", "/c/1", "/c/2", "/d/z", "/e/0"},
-// 			expectedIndex: [][]int{{0, 1}, {3, 5}},
-// 		},
-// 		{
-// 			removalPaths:  []string{"/a/0", "/a/1", "/a/2", "/a/3"},
-// 			expectedIndex: [][]int{{0, 3}},
-// 		},
-// 	}
+func Test_getRemoveInterval(t *testing.T) {
+	tests := []struct {
+		removalPaths  []string
+		expectedIndex [][]int
+	}{
+		{
+			removalPaths:  []string{"/a/0", "/b/0", "/b/1", "/c/0"},
+			expectedIndex: [][]int{{1, 2}},
+		},
+		{
+			removalPaths:  []string{},
+			expectedIndex: [][]int{},
+		},
+		{
+			removalPaths:  []string{"/a"},
+			expectedIndex: [][]int{},
+		},
+		{
+			removalPaths:  []string{"/a/0"},
+			expectedIndex: [][]int{},
+		},
+		{
+			removalPaths:  []string{"/a/0", "/a/1"},
+			expectedIndex: [][]int{{0, 1}},
+		},
+		{
+			removalPaths:  []string{"/a/0", "/a"},
+			expectedIndex: [][]int{},
+		},
+		{
+			removalPaths:  []string{"/a", "/a/0"},
+			expectedIndex: [][]int{},
+		},
+		{
+			removalPaths:  []string{"/a", "/a"},
+			expectedIndex: [][]int{},
+		},
+		{
+			removalPaths:  []string{"/a/0", "/b/0"},
+			expectedIndex: [][]int{},
+		},
+		{
+			removalPaths:  []string{"/a/0", "/a/1", "/a/2"},
+			expectedIndex: [][]int{{0, 2}},
+		},
+		{
+			removalPaths:  []string{"/a/0", "/a/1", "/a/b"},
+			expectedIndex: [][]int{{0, 1}},
+		},
+		{
+			removalPaths:  []string{"/a", "/a/0", "/a/1"},
+			expectedIndex: [][]int{{1, 2}},
+		},
+		{
+			removalPaths:  []string{"/", "/a", "/b/0"},
+			expectedIndex: [][]int{},
+		},
+		{
+			removalPaths:  []string{"/a/b", "/a/c", "/b/0", "/b/1", "/c"},
+			expectedIndex: [][]int{{2, 3}},
+		},
+		{
+			removalPaths:  []string{"/a/0", "/b/c", "/b/d", "/b/e", "/c/0"},
+			expectedIndex: [][]int{},
+		},
+		{
+			removalPaths:  []string{"/a/0", "/a/1", "/b/z", "/c/0", "/c/1", "/c/2", "/d/z", "/e/0"},
+			expectedIndex: [][]int{{0, 1}, {3, 5}},
+		},
+		{
+			removalPaths:  []string{"/a/0", "/a/1", "/a/2", "/a/3"},
+			expectedIndex: [][]int{{0, 3}},
+		},
+	}
 
-// 	for i, test := range tests {
-// 		res := getRemoveInterval(test.removalPaths)
-// 		assertnew.Equal(t, test.expectedIndex, res, fmt.Sprintf("%d-th test fails at path %v", i, test.removalPaths))
-// 	}
-// }
+	for i, test := range tests {
+		res := getRemoveInterval(test.removalPaths)
+		assertnew.Equal(t, test.expectedIndex, res, fmt.Sprintf("%d-th test fails at path %v", i, test.removalPaths))
+	}
+}

--- a/pkg/engine/mutate/patch/strategicMergePatch.go
+++ b/pkg/engine/mutate/patch/strategicMergePatch.go
@@ -27,7 +27,7 @@ func ProcessStrategicMergePatch(logger logr.Logger, overlay interface{}, resourc
 	if err != nil {
 		return nil, nil, err
 	}
-	return overlayBytes, patches, nil
+	return patchedBytes, patches, nil
 }
 
 func strategicMergePatch(logger logr.Logger, base, overlay string) ([]byte, error) {

--- a/pkg/engine/mutate/patch/strategicMergePatch.go
+++ b/pkg/engine/mutate/patch/strategicMergePatch.go
@@ -4,65 +4,30 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
-	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/kustomize/api/filters/patchstrategicmerge"
 	filtersutil "sigs.k8s.io/kustomize/kyaml/filtersutil"
 	yaml "sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 // ProcessStrategicMergePatch ...
-func ProcessStrategicMergePatch(ruleName string, overlay interface{}, resource unstructured.Unstructured, log logr.Logger) (engineapi.RuleResponse, unstructured.Unstructured) {
-	startTime := time.Now()
-	logger := log.WithName("ProcessStrategicMergePatch").WithValues("rule", ruleName)
-	logger.V(4).Info("started applying strategicMerge patch", "startTime", startTime)
-
-	defer func() {
-		logger.V(4).Info("finished applying strategicMerge patch", "processingTime", time.Since(startTime))
-	}()
-
+func ProcessStrategicMergePatch(logger logr.Logger, overlay interface{}, resource resource) (resource, patches, error) {
 	overlayBytes, err := json.Marshal(overlay)
 	if err != nil {
 		logger.Error(err, "failed to marshal resource")
-		return *engineapi.RuleFail(ruleName, engineapi.Mutation, fmt.Sprintf("failed to process patchStrategicMerge: %v", err)), resource
+		return nil, nil, err
 	}
-
-	base, err := json.Marshal(resource.Object)
+	patchedBytes, err := strategicMergePatch(logger, string(resource), string(overlayBytes))
 	if err != nil {
-		logger.Error(err, "failed to marshal resource")
-		return *engineapi.RuleFail(ruleName, engineapi.Mutation, fmt.Sprintf("failed to process patchStrategicMerge: %v", err)), resource
+		logger.Error(err, "failed to apply patchStrategicMerge")
+		return nil, nil, err
 	}
-	patchedBytes, err := strategicMergePatch(logger, string(base), string(overlayBytes))
+	patches, err := generatePatches(resource, patchedBytes)
 	if err != nil {
-		log.Error(err, "failed to apply patchStrategicMerge")
-		msg := fmt.Sprintf("failed to apply patchStrategicMerge: %v", err)
-		return *engineapi.RuleFail(ruleName, engineapi.Mutation, msg), resource
+		return nil, nil, err
 	}
-
-	var patchedResource unstructured.Unstructured
-	err = patchedResource.UnmarshalJSON(patchedBytes)
-	if err != nil {
-		logger.Error(err, "failed to unmarshal resource")
-		return *engineapi.RuleFail(ruleName, engineapi.Mutation, fmt.Sprintf("failed to process patchStrategicMerge: %v", err)), resource
-	}
-
-	log.V(6).Info("generating JSON patches from patched resource", "patchedResource", patchedResource.Object)
-
-	jsonPatches, err := generatePatches(base, patchedBytes)
-	if err != nil {
-		msg := fmt.Sprintf("failed to generated JSON patches from patched resource: %v", err.Error())
-		log.V(2).Info(msg)
-		return *engineapi.RuleFail(ruleName, engineapi.Mutation, msg), patchedResource
-	}
-
-	for _, p := range jsonPatches {
-		log.V(5).Info("generated patch", "patch", string(p))
-	}
-
-	return *engineapi.RulePass(ruleName, engineapi.Mutation, "applied strategic merge patch").WithPatches(jsonPatches...), patchedResource
+	return overlayBytes, patches, nil
 }
 
 func strategicMergePatch(logger logr.Logger, base, overlay string) ([]byte, error) {

--- a/pkg/engine/mutate/patch/strategicMergePatch_test.go
+++ b/pkg/engine/mutate/patch/strategicMergePatch_test.go
@@ -1,263 +1,263 @@
 package patch
 
-import (
-	"encoding/json"
-	"testing"
+// import (
+// 	"encoding/json"
+// 	"testing"
 
-	"github.com/go-logr/logr"
-	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
-	"github.com/kyverno/kyverno/pkg/autogen"
-	assertnew "github.com/stretchr/testify/assert"
-	"gotest.tools/assert"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-)
+// 	"github.com/go-logr/logr"
+// 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+// 	"github.com/kyverno/kyverno/pkg/autogen"
+// 	assertnew "github.com/stretchr/testify/assert"
+// 	"gotest.tools/assert"
+// 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+// )
 
-func TestMergePatch(t *testing.T) {
-	testCases := []struct {
-		rawPolicy   []byte
-		rawResource []byte
-		expected    []byte
-	}{
-		{
-			rawPolicy:   overlayBytes,
-			rawResource: baseBytes,
-			expected:    expectBytes,
-		},
-		{
-			// condition matches the first element of the array
-			rawPolicy: []byte(`{
-        "spec": {
-          "containers": [
-            {
-              "(image)": "gcr.io/google-containers/busybox:*"
-            }
-          ],
-          "imagePullSecrets": [
-            {
-              "name": "regcred"
-            }
-          ]
-        }
-      }`),
-			rawResource: []byte(`{
-        "apiVersion": "v1",
-        "kind": "Pod",
-        "metadata": {
-          "name": "hello"
-        },
-        "spec": {
-          "containers": [
-            {
-              "name": "hello",
-              "image": "gcr.io/google-containers/busybox:latest"
-            },
-            {
-              "name": "hello2",
-              "image": "gcr.io/google-containers/busybox:latest"
-            },
-            {
-              "name": "hello3",
-              "image": "gcr.io/google-containers/nginx:latest"
-            }
-          ]
-        }
-      }`),
-			expected: []byte(`{
-        "apiVersion": "v1",
-        "kind": "Pod",
-        "metadata": {
-          "name": "hello"
-        },
-        "spec": {
-          "containers": [
-            {
-              "image": "gcr.io/google-containers/busybox:latest",
-              "name": "hello"
-            },
-            {
-              "image": "gcr.io/google-containers/busybox:latest",
-              "name": "hello2"
-            },
-            {
-              "image": "gcr.io/google-containers/nginx:latest",
-              "name": "hello3"
-            }
-          ],
-          "imagePullSecrets": [
-            {
-              "name": "regcred"
-            }
-          ]
-        }
-      }`),
-		},
-		{
-			// condition matches the third element of the array
-			rawPolicy: []byte(`{
-        "spec": {
-          "containers": [
-            {
-              "(image)": "gcr.io/google-containers/nginx:*"
-            }
-          ],
-          "imagePullSecrets": [
-            {
-              "name": "regcred"
-            }
-          ]
-        }
-      }`),
-			rawResource: []byte(`{
-        "apiVersion": "v1",
-        "kind": "Pod",
-        "metadata": {
-          "name": "hello"
-        },
-        "spec": {
-          "containers": [
-            {
-              "name": "hello",
-              "image": "gcr.io/google-containers/busybox:latest"
-            },
-            {
-              "name": "hello2",
-              "image": "gcr.io/google-containers/busybox:latest"
-            },
-            {
-              "name": "hello3",
-              "image": "gcr.io/google-containers/nginx:latest"
-            }
-          ]
-        }
-      }`),
-			expected: []byte(`{
-        "apiVersion": "v1",
-        "kind": "Pod",
-        "metadata": {
-          "name": "hello"
-        },
-        "spec": {
-          "containers": [
-            {
-              "image": "gcr.io/google-containers/busybox:latest",
-              "name": "hello"
-            },
-            {
-              "image": "gcr.io/google-containers/busybox:latest",
-              "name": "hello2"
-            },
-            {
-              "image": "gcr.io/google-containers/nginx:latest",
-              "name": "hello3"
-            }
-          ],
-          "imagePullSecrets": [
-            {
-              "name": "regcred"
-            }
-          ]
-        }
-      }`),
-		},
-	}
+// func TestMergePatch(t *testing.T) {
+// 	testCases := []struct {
+// 		rawPolicy   []byte
+// 		rawResource []byte
+// 		expected    []byte
+// 	}{
+// 		{
+// 			rawPolicy:   overlayBytes,
+// 			rawResource: baseBytes,
+// 			expected:    expectBytes,
+// 		},
+// 		{
+// 			// condition matches the first element of the array
+// 			rawPolicy: []byte(`{
+//         "spec": {
+//           "containers": [
+//             {
+//               "(image)": "gcr.io/google-containers/busybox:*"
+//             }
+//           ],
+//           "imagePullSecrets": [
+//             {
+//               "name": "regcred"
+//             }
+//           ]
+//         }
+//       }`),
+// 			rawResource: []byte(`{
+//         "apiVersion": "v1",
+//         "kind": "Pod",
+//         "metadata": {
+//           "name": "hello"
+//         },
+//         "spec": {
+//           "containers": [
+//             {
+//               "name": "hello",
+//               "image": "gcr.io/google-containers/busybox:latest"
+//             },
+//             {
+//               "name": "hello2",
+//               "image": "gcr.io/google-containers/busybox:latest"
+//             },
+//             {
+//               "name": "hello3",
+//               "image": "gcr.io/google-containers/nginx:latest"
+//             }
+//           ]
+//         }
+//       }`),
+// 			expected: []byte(`{
+//         "apiVersion": "v1",
+//         "kind": "Pod",
+//         "metadata": {
+//           "name": "hello"
+//         },
+//         "spec": {
+//           "containers": [
+//             {
+//               "image": "gcr.io/google-containers/busybox:latest",
+//               "name": "hello"
+//             },
+//             {
+//               "image": "gcr.io/google-containers/busybox:latest",
+//               "name": "hello2"
+//             },
+//             {
+//               "image": "gcr.io/google-containers/nginx:latest",
+//               "name": "hello3"
+//             }
+//           ],
+//           "imagePullSecrets": [
+//             {
+//               "name": "regcred"
+//             }
+//           ]
+//         }
+//       }`),
+// 		},
+// 		{
+// 			// condition matches the third element of the array
+// 			rawPolicy: []byte(`{
+//         "spec": {
+//           "containers": [
+//             {
+//               "(image)": "gcr.io/google-containers/nginx:*"
+//             }
+//           ],
+//           "imagePullSecrets": [
+//             {
+//               "name": "regcred"
+//             }
+//           ]
+//         }
+//       }`),
+// 			rawResource: []byte(`{
+//         "apiVersion": "v1",
+//         "kind": "Pod",
+//         "metadata": {
+//           "name": "hello"
+//         },
+//         "spec": {
+//           "containers": [
+//             {
+//               "name": "hello",
+//               "image": "gcr.io/google-containers/busybox:latest"
+//             },
+//             {
+//               "name": "hello2",
+//               "image": "gcr.io/google-containers/busybox:latest"
+//             },
+//             {
+//               "name": "hello3",
+//               "image": "gcr.io/google-containers/nginx:latest"
+//             }
+//           ]
+//         }
+//       }`),
+// 			expected: []byte(`{
+//         "apiVersion": "v1",
+//         "kind": "Pod",
+//         "metadata": {
+//           "name": "hello"
+//         },
+//         "spec": {
+//           "containers": [
+//             {
+//               "image": "gcr.io/google-containers/busybox:latest",
+//               "name": "hello"
+//             },
+//             {
+//               "image": "gcr.io/google-containers/busybox:latest",
+//               "name": "hello2"
+//             },
+//             {
+//               "image": "gcr.io/google-containers/nginx:latest",
+//               "name": "hello3"
+//             }
+//           ],
+//           "imagePullSecrets": [
+//             {
+//               "name": "regcred"
+//             }
+//           ]
+//         }
+//       }`),
+// 		},
+// 	}
 
-	for i, test := range testCases {
-		t.Logf("Running test %d...", i+1)
-		out, err := strategicMergePatch(logr.Discard(), string(test.rawResource), string(test.rawPolicy))
-		assert.NilError(t, err)
-		assert.DeepEqual(t, toJSON(t, test.expected), toJSON(t, out))
-	}
-}
+// 	for i, test := range testCases {
+// 		t.Logf("Running test %d...", i+1)
+// 		out, err := strategicMergePatch(logr.Discard(), string(test.rawResource), string(test.rawPolicy))
+// 		assert.NilError(t, err)
+// 		assert.DeepEqual(t, toJSON(t, test.expected), toJSON(t, out))
+// 	}
+// }
 
-func Test_PolicyDeserilize(t *testing.T) {
-	rawPolicy := []byte(`
-{
-  "apiVersion": "kyverno.io/v1",
-  "kind": "ClusterPolicy",
-  "metadata": {
-    "name": "set-image-pull-policy"
-  },
-  "spec": {
-    "validationFailureAction": "enforce",
-    "rules": [
-      {
-        "name": "set-image-pull-policy",
-        "match": {
-          "resources": {
-            "kinds": [
-              "Pod"
-            ]
-          }
-        },
-        "mutate": {
-          "patchStrategicMerge": {
-            "spec": {
-              "template": {
-                "spec": {
-                  "containers": [
-                    {
-                      "name": "nginx",
-                      "image": "nginx"
-                    },
-                    {
-                      "name": "wordpress",
-                      "env": [
-                        {
-                          "name": "WORDPRESS_DB_HOST",
-                          "value": "$(MYSQL_SERVICE)"
-                        },
-                        {
-                          "name": "WORDPRESS_DB_PASSWORD",
-                          "valueFrom": {
-                            "secretKeyRef": {
-                              "name": "mysql-pass",
-                              "key": "password"
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  ],
-                  "initContainers": [
-                    {
-                      "name": "init-command",
-                      "image": "debian",
-                      "command": [
-                        "echo $(WORDPRESS_SERVICE)",
-                        "echo $(MYSQL_SERVICE)"
-                      ]
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    ]
-  }
-}
-`)
+// func Test_PolicyDeserilize(t *testing.T) {
+// 	rawPolicy := []byte(`
+// {
+//   "apiVersion": "kyverno.io/v1",
+//   "kind": "ClusterPolicy",
+//   "metadata": {
+//     "name": "set-image-pull-policy"
+//   },
+//   "spec": {
+//     "validationFailureAction": "enforce",
+//     "rules": [
+//       {
+//         "name": "set-image-pull-policy",
+//         "match": {
+//           "resources": {
+//             "kinds": [
+//               "Pod"
+//             ]
+//           }
+//         },
+//         "mutate": {
+//           "patchStrategicMerge": {
+//             "spec": {
+//               "template": {
+//                 "spec": {
+//                   "containers": [
+//                     {
+//                       "name": "nginx",
+//                       "image": "nginx"
+//                     },
+//                     {
+//                       "name": "wordpress",
+//                       "env": [
+//                         {
+//                           "name": "WORDPRESS_DB_HOST",
+//                           "value": "$(MYSQL_SERVICE)"
+//                         },
+//                         {
+//                           "name": "WORDPRESS_DB_PASSWORD",
+//                           "valueFrom": {
+//                             "secretKeyRef": {
+//                               "name": "mysql-pass",
+//                               "key": "password"
+//                             }
+//                           }
+//                         }
+//                       ]
+//                     }
+//                   ],
+//                   "initContainers": [
+//                     {
+//                       "name": "init-command",
+//                       "image": "debian",
+//                       "command": [
+//                         "echo $(WORDPRESS_SERVICE)",
+//                         "echo $(MYSQL_SERVICE)"
+//                       ]
+//                     }
+//                   ]
+//                 }
+//               }
+//             }
+//           }
+//         }
+//       }
+//     ]
+//   }
+// }
+// `)
 
-	var policy kyvernov1.ClusterPolicy
-	err := json.Unmarshal(rawPolicy, &policy)
-	assert.NilError(t, err)
+// 	var policy kyvernov1.ClusterPolicy
+// 	err := json.Unmarshal(rawPolicy, &policy)
+// 	assert.NilError(t, err)
 
-	overlayPatches := autogen.ComputeRules(&policy)[0].Mutation.GetPatchStrategicMerge()
-	patchString, err := json.Marshal(overlayPatches)
-	assert.NilError(t, err)
+// 	overlayPatches := autogen.ComputeRules(&policy)[0].Mutation.GetPatchStrategicMerge()
+// 	patchString, err := json.Marshal(overlayPatches)
+// 	assert.NilError(t, err)
 
-	out, err := strategicMergePatch(logr.Discard(), string(baseBytes), string(patchString))
-	assert.NilError(t, err)
+// 	out, err := strategicMergePatch(logr.Discard(), string(baseBytes), string(patchString))
+// 	assert.NilError(t, err)
 
-	var ep unstructured.Unstructured
-	err = json.Unmarshal(expectBytes, &ep)
-	assert.NilError(t, err)
+// 	var ep unstructured.Unstructured
+// 	err = json.Unmarshal(expectBytes, &ep)
+// 	assert.NilError(t, err)
 
-	eb, err := json.Marshal(ep.Object)
-	assert.NilError(t, err)
+// 	eb, err := json.Marshal(ep.Object)
+// 	assert.NilError(t, err)
 
-	if !assertnew.Equal(t, string(eb), string(out)) {
-		t.FailNow()
-	}
-}
+// 	if !assertnew.Equal(t, string(eb), string(out)) {
+// 		t.FailNow()
+// 	}
+// }

--- a/pkg/engine/mutate/patch/strategicMergePatch_test.go
+++ b/pkg/engine/mutate/patch/strategicMergePatch_test.go
@@ -1,263 +1,263 @@
 package patch
 
-// import (
-// 	"encoding/json"
-// 	"testing"
+import (
+	"encoding/json"
+	"testing"
 
-// 	"github.com/go-logr/logr"
-// 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
-// 	"github.com/kyverno/kyverno/pkg/autogen"
-// 	assertnew "github.com/stretchr/testify/assert"
-// 	"gotest.tools/assert"
-// 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-// )
+	"github.com/go-logr/logr"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/autogen"
+	assertnew "github.com/stretchr/testify/assert"
+	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
 
-// func TestMergePatch(t *testing.T) {
-// 	testCases := []struct {
-// 		rawPolicy   []byte
-// 		rawResource []byte
-// 		expected    []byte
-// 	}{
-// 		{
-// 			rawPolicy:   overlayBytes,
-// 			rawResource: baseBytes,
-// 			expected:    expectBytes,
-// 		},
-// 		{
-// 			// condition matches the first element of the array
-// 			rawPolicy: []byte(`{
-//         "spec": {
-//           "containers": [
-//             {
-//               "(image)": "gcr.io/google-containers/busybox:*"
-//             }
-//           ],
-//           "imagePullSecrets": [
-//             {
-//               "name": "regcred"
-//             }
-//           ]
-//         }
-//       }`),
-// 			rawResource: []byte(`{
-//         "apiVersion": "v1",
-//         "kind": "Pod",
-//         "metadata": {
-//           "name": "hello"
-//         },
-//         "spec": {
-//           "containers": [
-//             {
-//               "name": "hello",
-//               "image": "gcr.io/google-containers/busybox:latest"
-//             },
-//             {
-//               "name": "hello2",
-//               "image": "gcr.io/google-containers/busybox:latest"
-//             },
-//             {
-//               "name": "hello3",
-//               "image": "gcr.io/google-containers/nginx:latest"
-//             }
-//           ]
-//         }
-//       }`),
-// 			expected: []byte(`{
-//         "apiVersion": "v1",
-//         "kind": "Pod",
-//         "metadata": {
-//           "name": "hello"
-//         },
-//         "spec": {
-//           "containers": [
-//             {
-//               "image": "gcr.io/google-containers/busybox:latest",
-//               "name": "hello"
-//             },
-//             {
-//               "image": "gcr.io/google-containers/busybox:latest",
-//               "name": "hello2"
-//             },
-//             {
-//               "image": "gcr.io/google-containers/nginx:latest",
-//               "name": "hello3"
-//             }
-//           ],
-//           "imagePullSecrets": [
-//             {
-//               "name": "regcred"
-//             }
-//           ]
-//         }
-//       }`),
-// 		},
-// 		{
-// 			// condition matches the third element of the array
-// 			rawPolicy: []byte(`{
-//         "spec": {
-//           "containers": [
-//             {
-//               "(image)": "gcr.io/google-containers/nginx:*"
-//             }
-//           ],
-//           "imagePullSecrets": [
-//             {
-//               "name": "regcred"
-//             }
-//           ]
-//         }
-//       }`),
-// 			rawResource: []byte(`{
-//         "apiVersion": "v1",
-//         "kind": "Pod",
-//         "metadata": {
-//           "name": "hello"
-//         },
-//         "spec": {
-//           "containers": [
-//             {
-//               "name": "hello",
-//               "image": "gcr.io/google-containers/busybox:latest"
-//             },
-//             {
-//               "name": "hello2",
-//               "image": "gcr.io/google-containers/busybox:latest"
-//             },
-//             {
-//               "name": "hello3",
-//               "image": "gcr.io/google-containers/nginx:latest"
-//             }
-//           ]
-//         }
-//       }`),
-// 			expected: []byte(`{
-//         "apiVersion": "v1",
-//         "kind": "Pod",
-//         "metadata": {
-//           "name": "hello"
-//         },
-//         "spec": {
-//           "containers": [
-//             {
-//               "image": "gcr.io/google-containers/busybox:latest",
-//               "name": "hello"
-//             },
-//             {
-//               "image": "gcr.io/google-containers/busybox:latest",
-//               "name": "hello2"
-//             },
-//             {
-//               "image": "gcr.io/google-containers/nginx:latest",
-//               "name": "hello3"
-//             }
-//           ],
-//           "imagePullSecrets": [
-//             {
-//               "name": "regcred"
-//             }
-//           ]
-//         }
-//       }`),
-// 		},
-// 	}
+func TestMergePatch(t *testing.T) {
+	testCases := []struct {
+		rawPolicy   []byte
+		rawResource []byte
+		expected    []byte
+	}{
+		{
+			rawPolicy:   overlayBytes,
+			rawResource: baseBytes,
+			expected:    expectBytes,
+		},
+		{
+			// condition matches the first element of the array
+			rawPolicy: []byte(`{
+        "spec": {
+          "containers": [
+            {
+              "(image)": "gcr.io/google-containers/busybox:*"
+            }
+          ],
+          "imagePullSecrets": [
+            {
+              "name": "regcred"
+            }
+          ]
+        }
+      }`),
+			rawResource: []byte(`{
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "name": "hello"
+        },
+        "spec": {
+          "containers": [
+            {
+              "name": "hello",
+              "image": "gcr.io/google-containers/busybox:latest"
+            },
+            {
+              "name": "hello2",
+              "image": "gcr.io/google-containers/busybox:latest"
+            },
+            {
+              "name": "hello3",
+              "image": "gcr.io/google-containers/nginx:latest"
+            }
+          ]
+        }
+      }`),
+			expected: []byte(`{
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "name": "hello"
+        },
+        "spec": {
+          "containers": [
+            {
+              "image": "gcr.io/google-containers/busybox:latest",
+              "name": "hello"
+            },
+            {
+              "image": "gcr.io/google-containers/busybox:latest",
+              "name": "hello2"
+            },
+            {
+              "image": "gcr.io/google-containers/nginx:latest",
+              "name": "hello3"
+            }
+          ],
+          "imagePullSecrets": [
+            {
+              "name": "regcred"
+            }
+          ]
+        }
+      }`),
+		},
+		{
+			// condition matches the third element of the array
+			rawPolicy: []byte(`{
+        "spec": {
+          "containers": [
+            {
+              "(image)": "gcr.io/google-containers/nginx:*"
+            }
+          ],
+          "imagePullSecrets": [
+            {
+              "name": "regcred"
+            }
+          ]
+        }
+      }`),
+			rawResource: []byte(`{
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "name": "hello"
+        },
+        "spec": {
+          "containers": [
+            {
+              "name": "hello",
+              "image": "gcr.io/google-containers/busybox:latest"
+            },
+            {
+              "name": "hello2",
+              "image": "gcr.io/google-containers/busybox:latest"
+            },
+            {
+              "name": "hello3",
+              "image": "gcr.io/google-containers/nginx:latest"
+            }
+          ]
+        }
+      }`),
+			expected: []byte(`{
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "name": "hello"
+        },
+        "spec": {
+          "containers": [
+            {
+              "image": "gcr.io/google-containers/busybox:latest",
+              "name": "hello"
+            },
+            {
+              "image": "gcr.io/google-containers/busybox:latest",
+              "name": "hello2"
+            },
+            {
+              "image": "gcr.io/google-containers/nginx:latest",
+              "name": "hello3"
+            }
+          ],
+          "imagePullSecrets": [
+            {
+              "name": "regcred"
+            }
+          ]
+        }
+      }`),
+		},
+	}
 
-// 	for i, test := range testCases {
-// 		t.Logf("Running test %d...", i+1)
-// 		out, err := strategicMergePatch(logr.Discard(), string(test.rawResource), string(test.rawPolicy))
-// 		assert.NilError(t, err)
-// 		assert.DeepEqual(t, toJSON(t, test.expected), toJSON(t, out))
-// 	}
-// }
+	for i, test := range testCases {
+		t.Logf("Running test %d...", i+1)
+		out, err := strategicMergePatch(logr.Discard(), string(test.rawResource), string(test.rawPolicy))
+		assert.NilError(t, err)
+		assert.DeepEqual(t, toJSON(t, test.expected), toJSON(t, out))
+	}
+}
 
-// func Test_PolicyDeserilize(t *testing.T) {
-// 	rawPolicy := []byte(`
-// {
-//   "apiVersion": "kyverno.io/v1",
-//   "kind": "ClusterPolicy",
-//   "metadata": {
-//     "name": "set-image-pull-policy"
-//   },
-//   "spec": {
-//     "validationFailureAction": "enforce",
-//     "rules": [
-//       {
-//         "name": "set-image-pull-policy",
-//         "match": {
-//           "resources": {
-//             "kinds": [
-//               "Pod"
-//             ]
-//           }
-//         },
-//         "mutate": {
-//           "patchStrategicMerge": {
-//             "spec": {
-//               "template": {
-//                 "spec": {
-//                   "containers": [
-//                     {
-//                       "name": "nginx",
-//                       "image": "nginx"
-//                     },
-//                     {
-//                       "name": "wordpress",
-//                       "env": [
-//                         {
-//                           "name": "WORDPRESS_DB_HOST",
-//                           "value": "$(MYSQL_SERVICE)"
-//                         },
-//                         {
-//                           "name": "WORDPRESS_DB_PASSWORD",
-//                           "valueFrom": {
-//                             "secretKeyRef": {
-//                               "name": "mysql-pass",
-//                               "key": "password"
-//                             }
-//                           }
-//                         }
-//                       ]
-//                     }
-//                   ],
-//                   "initContainers": [
-//                     {
-//                       "name": "init-command",
-//                       "image": "debian",
-//                       "command": [
-//                         "echo $(WORDPRESS_SERVICE)",
-//                         "echo $(MYSQL_SERVICE)"
-//                       ]
-//                     }
-//                   ]
-//                 }
-//               }
-//             }
-//           }
-//         }
-//       }
-//     ]
-//   }
-// }
-// `)
+func Test_PolicyDeserilize(t *testing.T) {
+	rawPolicy := []byte(`
+{
+  "apiVersion": "kyverno.io/v1",
+  "kind": "ClusterPolicy",
+  "metadata": {
+    "name": "set-image-pull-policy"
+  },
+  "spec": {
+    "validationFailureAction": "enforce",
+    "rules": [
+      {
+        "name": "set-image-pull-policy",
+        "match": {
+          "resources": {
+            "kinds": [
+              "Pod"
+            ]
+          }
+        },
+        "mutate": {
+          "patchStrategicMerge": {
+            "spec": {
+              "template": {
+                "spec": {
+                  "containers": [
+                    {
+                      "name": "nginx",
+                      "image": "nginx"
+                    },
+                    {
+                      "name": "wordpress",
+                      "env": [
+                        {
+                          "name": "WORDPRESS_DB_HOST",
+                          "value": "$(MYSQL_SERVICE)"
+                        },
+                        {
+                          "name": "WORDPRESS_DB_PASSWORD",
+                          "valueFrom": {
+                            "secretKeyRef": {
+                              "name": "mysql-pass",
+                              "key": "password"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "initContainers": [
+                    {
+                      "name": "init-command",
+                      "image": "debian",
+                      "command": [
+                        "echo $(WORDPRESS_SERVICE)",
+                        "echo $(MYSQL_SERVICE)"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+`)
 
-// 	var policy kyvernov1.ClusterPolicy
-// 	err := json.Unmarshal(rawPolicy, &policy)
-// 	assert.NilError(t, err)
+	var policy kyvernov1.ClusterPolicy
+	err := json.Unmarshal(rawPolicy, &policy)
+	assert.NilError(t, err)
 
-// 	overlayPatches := autogen.ComputeRules(&policy)[0].Mutation.GetPatchStrategicMerge()
-// 	patchString, err := json.Marshal(overlayPatches)
-// 	assert.NilError(t, err)
+	overlayPatches := autogen.ComputeRules(&policy)[0].Mutation.GetPatchStrategicMerge()
+	patchString, err := json.Marshal(overlayPatches)
+	assert.NilError(t, err)
 
-// 	out, err := strategicMergePatch(logr.Discard(), string(baseBytes), string(patchString))
-// 	assert.NilError(t, err)
+	out, err := strategicMergePatch(logr.Discard(), string(baseBytes), string(patchString))
+	assert.NilError(t, err)
 
-// 	var ep unstructured.Unstructured
-// 	err = json.Unmarshal(expectBytes, &ep)
-// 	assert.NilError(t, err)
+	var ep unstructured.Unstructured
+	err = json.Unmarshal(expectBytes, &ep)
+	assert.NilError(t, err)
 
-// 	eb, err := json.Marshal(ep.Object)
-// 	assert.NilError(t, err)
+	eb, err := json.Marshal(ep.Object)
+	assert.NilError(t, err)
 
-// 	if !assertnew.Equal(t, string(eb), string(out)) {
-// 		t.FailNow()
-// 	}
-// }
+	if !assertnew.Equal(t, string(eb), string(out)) {
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
## Explanation

This PR refactors engine patchers:
- decouples the creation of the patcher and the `Patch` method invocation
- uses more typed json patches
- reduce the adherence to engine api in return types
