### PR TITLE
feat: add opt-in setting to deploy v3 chart

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -591,6 +591,7 @@ The chart values are organised per component.
 | nameOverride | string | `nil` | Override the name of the chart |
 | fullnameOverride | string | `nil` | Override the expanded name of the chart |
 | namespaceOverride | string | `nil` | Override the namespace the chart deploys to |
+| upgrade.fromV2 | bool | `false` | Upgrading from v2 to v3 is not allowed by default, set this to true once changes have been reviewed. |
 | imagePullSecrets | object | `{}` | Image pull secrets for image verification policies, this will define the `--imagePullSecrets` argument |
 | existingImagePullSecrets | list | `[]` | Existing Image pull secrets for image verification policies, this will define the `--imagePullSecrets` argument |
 | customLabels | object | `{}` | Additional labels |

--- a/charts/kyverno/templates/validate.yaml
+++ b/charts/kyverno/templates/validate.yaml
@@ -1,13 +1,20 @@
-{{- if hasKey .Values "mode" }}
-  {{ fail "mode is not supported anymore, please remove it from your release and use admissionController.replicas instead." }}
-{{- end }}
+{{- if hasKey .Values "mode" -}}
+  {{- fail "mode is not supported anymore, please remove it from your release and use admissionController.replicas instead." -}}
+{{- end -}}
 
-{{- if .Values.admissionController.replicas }}
-  {{- if eq (int .Values.admissionController.replicas) 2 }}
-    {{ fail "Kyverno does not support running with 2 replicas. For a highly-available deployment, select 3 replicas or for standalone select 1 replica." }}
-  {{- end }}
-{{- end }}
+{{- if .Values.admissionController.replicas -}}
+  {{- if eq (int .Values.admissionController.replicas) 2 -}}
+    {{- fail "Kyverno does not support running with 2 replicas. For a highly-available deployment, select 3 replicas or for standalone select 1 replica." -}}
+  {{- end -}}
+{{- end -}}
 
-{{- if eq (include "kyverno.namespace" .) "kube-system" }}
-    {{ fail "Kyverno cannot be installed in namespace kube-system." }}
-{{- end }}
+{{- if eq (include "kyverno.namespace" .) "kube-system" -}}
+  {{- fail "Kyverno cannot be installed in namespace kube-system." -}}
+{{- end -}}
+
+{{- if not .Values.upgrade.fromV2 -}}
+  {{- $v2 := lookup "apps/v1" "Deployment" (include "kyverno.namespace" .) (include "kyverno.fullname" .) -}}
+  {{- if $v2 -}}
+    {{- fail "We detected an earlier version of Kyverno is installed, given the new chart has significant breaking chances we blocked the upgrade. Please review the documentation first and set `upgrade.fromV2: true` once ready." -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -14,6 +14,10 @@ fullnameOverride: ~
 # -- (string) Override the namespace the chart deploys to
 namespaceOverride: ~
 
+upgrade:
+  # -- Upgrading from v2 to v3 is not allowed by default, set this to true once changes have been reviewed.
+  fromV2: false
+
 apiVersionOverride:
   # -- (string) Override api version used to create `PodDisruptionBudget`` resources.
   # When not specified the chart will check if `policy/v1/PodDisruptionBudget` is available to


### PR DESCRIPTION
## Explanation

This PR adds an opt-in setting to deploy v3 chart.
If `upgrade.fromV2` is not set to `true` and we detect an old Kyverno deployment we fail the upgrade.