### PR TITLE
fix: flaky github action

### DIFF
--- a/.github/actions/kyverno-wait-ready/action.yaml
+++ b/.github/actions/kyverno-wait-ready/action.yaml
@@ -7,4 +7,4 @@ runs:
   steps:
     - shell: bash
       run: |
-        kubectl wait --namespace kyverno --for=condition=ready pod --all --timeout=60s
+        kubectl wait --namespace kyverno --for=condition=ready pod --selector '!job-name' --timeout=60s


### PR DESCRIPTION
## Explanation

This PR fixes flaky github action when waiting for ready pods (we need to exclude jobs).
