### PR TITLE
fix: do not exclude kube-system service accounts by default

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -258,8 +258,8 @@ The chart values are organised per component.
 | config.annotations | object | `{}` | Additional annotations to add to the configmap. |
 | config.enableDefaultRegistryMutation | bool | `true` | Enable registry mutation for container images. Enabled by default. |
 | config.defaultRegistry | string | `"docker.io"` | The registry hostname used for the image mutation. |
-| config.excludeGroups | list | `["system:serviceaccounts:kube-system","system:nodes"]` | Exclude groups |
-| config.excludeUsernames | list | `["!system:kube-scheduler"]` | Exclude usernames |
+| config.excludeGroups | list | `["system:nodes"]` | Exclude groups |
+| config.excludeUsernames | list | `[]` | Exclude usernames |
 | config.excludeRoles | list | `[]` | Exclude roles |
 | config.excludeClusterRoles | list | `[]` | Exclude roles |
 | config.generateSuccessEvents | bool | `false` | Generate success events. |

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -55,12 +55,11 @@ config:
 
   # -- Exclude groups
   excludeGroups:
-    - system:serviceaccounts:kube-system
     - system:nodes
 
   # -- Exclude usernames
-  excludeUsernames:
-    - '!system:kube-scheduler'
+  excludeUsernames: []
+    # - '!system:kube-scheduler'
 
   # -- Exclude roles
   excludeRoles: []

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -76,8 +76,7 @@ data:
   enableDefaultRegistryMutation: "true"
   defaultRegistry: "docker.io"
   generateSuccessEvents: "false"
-  excludeGroups: "system:serviceaccounts:kube-system,system:nodes"
-  excludeUsernames: "!system:kube-scheduler"
+  excludeGroups: "system:nodes"
   resourceFilters: >-
     [*/*,kyverno,*]
     [Event,*,*]


### PR DESCRIPTION
## Explanation

This PR does not exclude kube-system service accounts by default.
