### PR TITLE
fix: quote image in ImageInfo validation error

### DIFF
--- a/pkg/utils/api/image.go
+++ b/pkg/utils/api/image.go
@@ -120,7 +120,7 @@ func extract(
 			value = resultStr
 		}
 		if imageInfo, err := imageutils.GetImageInfo(value, cfg); err != nil {
-			return fmt.Errorf("invalid image %s (%s)", value, err.Error())
+			return fmt.Errorf("invalid image '%s' (%s)", value, err.Error())
 		} else {
 			(*imageInfos)[key] = ImageInfo{*imageInfo, pointer}
 		}


### PR DESCRIPTION
## Explanation

The image validation used in the mutation webhook prints the failing image without quotes. In cases where the image name contains a whitespace, the error is hard to read, as the whitespace is not visible.

## Milestone of this PR
/milestone v1.9.3

## What type of PR is this

/kind cleanup

## Proposed Changes
The image is surrounded with single quotes to make the boundaries if the image string visible.



## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
