### PR TITLE
fix: do not use release name in chart

### DIFF
--- a/charts/kyverno/templates/admission-controller/_helpers.tpl
+++ b/charts/kyverno/templates/admission-controller/_helpers.tpl
@@ -19,7 +19,7 @@
 {{- end -}}
 
 {{- define "kyverno.admission-controller.roleName" -}}
-{{ .Release.Name }}:admission-controller
+{{ include "kyverno.fullname" . }}:admission-controller
 {{- end -}}
 
 {{- define "kyverno.admission-controller.serviceAccountName" -}}

--- a/charts/kyverno/templates/background-controller/_helpers.tpl
+++ b/charts/kyverno/templates/background-controller/_helpers.tpl
@@ -27,7 +27,7 @@
 {{- end -}}
 
 {{- define "kyverno.background-controller.roleName" -}}
-{{ .Release.Name }}:background-controller
+{{ include "kyverno.fullname" . }}:background-controller
 {{- end -}}
 
 {{- define "kyverno.background-controller.serviceAccountName" -}}

--- a/charts/kyverno/templates/cleanup-controller/_helpers.tpl
+++ b/charts/kyverno/templates/cleanup-controller/_helpers.tpl
@@ -27,7 +27,7 @@
 {{- end -}}
 
 {{- define "kyverno.cleanup-controller.roleName" -}}
-{{ .Release.Name }}:cleanup-controller
+{{ include "kyverno.fullname" . }}:cleanup-controller
 {{- end -}}
 
 {{- define "kyverno.cleanup-controller.serviceAccountName" -}}

--- a/charts/kyverno/templates/rbac/_helpers.tpl
+++ b/charts/kyverno/templates/rbac/_helpers.tpl
@@ -24,5 +24,5 @@
 {{- end -}}
 
 {{- define "kyverno.rbac.roleName" -}}
-{{ .Release.Name }}:rbac
+{{ include "kyverno.fullname" . }}:rbac
 {{- end -}}

--- a/charts/kyverno/templates/reports-controller/_helpers.tpl
+++ b/charts/kyverno/templates/reports-controller/_helpers.tpl
@@ -27,7 +27,7 @@
 {{- end -}}
 
 {{- define "kyverno.reports-controller.roleName" -}}
-{{ .Release.Name }}:reports-controller
+{{ include "kyverno.fullname" . }}:reports-controller
 {{- end -}}
 
 {{- define "kyverno.reports-controller.serviceAccountName" -}}


### PR DESCRIPTION
## Explanation

This PR uses `kyverno.fullname` template to create cluster roles instead of `.Release.name`.

## Related issue

Fixes https://github.com/kyverno/kyverno/issues/7246