### PR TITLE
fix: abort validation if value could be processed

### DIFF
--- a/pkg/engine/pattern/pattern.go
+++ b/pkg/engine/pattern/pattern.go
@@ -205,61 +205,65 @@ func split(pattern string, r *regexp.Regexp) (string, string, bool) {
 }
 
 func validateString(log logr.Logger, value interface{}, pattern string, op operator.Operator) bool {
-	return compareDuration(log, value, pattern, op) ||
-		compareQuantity(log, value, pattern, op) ||
-		compareString(log, value, pattern, op)
+	if res, proc := compareDuration(log, value, pattern, op); proc {
+		return res
+	}
+	if res, proc := compareQuantity(log, value, pattern, op); proc {
+		return res
+	}
+	return compareString(log, value, pattern, op)
 }
 
-func compareDuration(log logr.Logger, value interface{}, pattern string, op operator.Operator) bool {
+func compareDuration(_ logr.Logger, value interface{}, pattern string, op operator.Operator) (res bool, processed bool) {
 	if pattern, err := time.ParseDuration(pattern); err != nil {
-		return false
+		return false, false
 	} else if value, err := convertNumberToString(value); err != nil {
-		return false
+		return false, false
 	} else if value, err := time.ParseDuration(value); err != nil {
-		return false
+		return false, false
 	} else {
 		switch op {
 		case operator.Equal:
-			return value == pattern
+			return value == pattern, true
 		case operator.NotEqual:
-			return value != pattern
+			return value != pattern, true
 		case operator.More:
-			return value > pattern
+			return value > pattern, true
 		case operator.Less:
-			return value < pattern
+			return value < pattern, true
 		case operator.MoreEqual:
-			return value >= pattern
+			return value >= pattern, true
 		case operator.LessEqual:
-			return value <= pattern
+			return value <= pattern, true
 		}
-		return false
+		return false, false
 	}
 }
 
-func compareQuantity(log logr.Logger, value interface{}, pattern string, op operator.Operator) bool {
+func compareQuantity(_ logr.Logger, value interface{}, pattern string, op operator.Operator) (res bool, processed bool) {
 	if pattern, err := apiresource.ParseQuantity(pattern); err != nil {
-		return false
+		return false, false
 	} else if value, err := convertNumberToString(value); err != nil {
-		return false
+		return false, false
 	} else if value, err := apiresource.ParseQuantity(value); err != nil {
-		return false
+		return false, false
 	} else {
 		result := value.Cmp(pattern)
 		switch op {
 		case operator.Equal:
-			return result == int(equal)
+			return result == int(equal), true
 		case operator.NotEqual:
-			return result != int(equal)
+			return result != int(equal), true
 		case operator.More:
-			return result == int(greaterThan)
+			return result == int(greaterThan), true
 		case operator.Less:
-			return result == int(lessThan)
+			return result == int(lessThan), true
 		case operator.MoreEqual:
-			return (result == int(equal)) || (result == int(greaterThan))
+			return (result == int(equal)) || (result == int(greaterThan)), true
 		case operator.LessEqual:
-			return (result == int(equal)) || (result == int(lessThan))
+			return (result == int(equal)) || (result == int(lessThan)), true
 		}
-		return false
+		return false, false
 	}
 }
 


### PR DESCRIPTION
## Explanation

The current pattern validation checks in order for duration, quantity and string. The 3 checks are combined with or.
If a quantity value is processed and does not mach, currently the duration and quantity check return false, which results in the string check being executed. 

If now the used pattern is e.g: '>='  the string check logs "Operators >, >=, <, <= are not applicable to strings" which should not happen as it is not a string value.

## Milestone of this PR
/milestone v1.10.0


## What type of PR is this

/kind bug

## Proposed Changes

The different check return a second boolean indicating that the value was handled in the check. If true, the result of the check is returned, if false the next check is executed.

## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
