### PR TITLE
fix: flaky kuttl test add-external-secret-prefix

### DIFF
--- a/test/conformance/kuttl/mutate/refactor/add-external-secret-prefix/03-sleep.yaml
+++ b/test/conformance/kuttl/mutate/refactor/add-external-secret-prefix/03-sleep.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: sleep 5
+  - command: sleep 10


### PR DESCRIPTION
## Explanation

This PR tries to fix a flaky kuttl test (`add-external-secret-prefix`).
