### PR TITLE
fix: config map name in helm chart

### DIFF
--- a/charts/kyverno/templates/background-controller/deployment.yaml
+++ b/charts/kyverno/templates/background-controller/deployment.yaml
@@ -119,6 +119,8 @@ spec:
             {{- end }}
             {{- end }}
           env:
+          - name: INIT_CONFIG
+            value: {{ template "kyverno.config.configMapName" . }}
           - name: METRICS_CONFIG
             value: {{ template "kyverno.config.metricsConfigMapName" . }}
           - name: KYVERNO_POD_NAME

--- a/charts/kyverno/templates/cleanup-controller/deployment.yaml
+++ b/charts/kyverno/templates/cleanup-controller/deployment.yaml
@@ -115,6 +115,8 @@ spec:
             {{- end }}
             {{- end }}
           env:
+          - name: INIT_CONFIG
+            value: {{ template "kyverno.config.configMapName" . }}
           - name: METRICS_CONFIG
             value: {{ template "kyverno.config.metricsConfigMapName" . }}
           - name: KYVERNO_POD_NAME

--- a/charts/kyverno/templates/reports-controller/deployment.yaml
+++ b/charts/kyverno/templates/reports-controller/deployment.yaml
@@ -123,6 +123,8 @@ spec:
             {{- end }}
             {{- end }}
           env:
+          - name: INIT_CONFIG
+            value: {{ template "kyverno.config.configMapName" . }}
           - name: METRICS_CONFIG
             value: {{ template "kyverno.config.metricsConfigMapName" . }}
           - name: KYVERNO_POD_NAME

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -35441,6 +35441,8 @@ spec:
             - --v=2
             - --enablePolicyException=false
           env:
+          - name: INIT_CONFIG
+            value: kyverno
           - name: METRICS_CONFIG
             value: kyverno-metrics
           - name: KYVERNO_POD_NAME
@@ -35531,6 +35533,8 @@ spec:
             - --loggingFormat=text
             - --v=2
           env:
+          - name: INIT_CONFIG
+            value: kyverno
           - name: METRICS_CONFIG
             value: kyverno-metrics
           - name: KYVERNO_POD_NAME
@@ -35661,6 +35665,8 @@ spec:
             - --allowInsecureRegistry=false
             - --registryCredentialHelpers=default,google,amazon,azure,github
           env:
+          - name: INIT_CONFIG
+            value: kyverno
           - name: METRICS_CONFIG
             value: kyverno-metrics
           - name: KYVERNO_POD_NAME


### PR DESCRIPTION
## Explanation

This PR fixes config map name in helm chart when the chart is deployed with a specific name.

The `INIT_CONFIG` env var was not set.

## Related issue

Fixes https://github.com/kyverno/kyverno/issues/7335
