### PR TITLE
feat: replace KYVERNO_NAME env var with a flag

### DIFF
--- a/cmd/reports-controller/main.go
+++ b/cmd/reports-controller/main.go
@@ -168,6 +168,7 @@ func main() {
 		maxQueuedEvents        int
 		omitEvents             string
 		skipResourceFilters    bool
+		namespace              string
 	)
 	flagset := flag.NewFlagSet("reports-controller", flag.ExitOnError)
 	flagset.BoolVar(&backgroundScan, "backgroundScan", true, "Enable or disable backgound scan.")
@@ -178,6 +179,7 @@ func main() {
 	flagset.IntVar(&maxQueuedEvents, "maxQueuedEvents", 1000, "Maximum events to be queued.")
 	flagset.StringVar(&omitEvents, "omit-events", "", "Set this flag to a comma sperated list of PolicyViolation, PolicyApplied, PolicyError, PolicySkipped to disable events, e.g. --omit-events=PolicyApplied,PolicyViolation")
 	flagset.BoolVar(&skipResourceFilters, "skipResourceFilters", true, "If true, resource filters wont be considered.")
+	flagset.StringVar(&namespace, "namespace", "kyverno", "Kyverno install namespace")
 	// config
 	appConfig := internal.NewConfiguration(
 		internal.WithProfiling(),
@@ -246,7 +248,7 @@ func main() {
 	le, err := leaderelection.New(
 		setup.Logger.WithName("leader-election"),
 		"kyverno-reports-controller",
-		config.KyvernoNamespace(),
+		namespace,
 		setup.LeaderElectionClient,
 		config.KyvernoPodName(),
 		internal.LeaderElectionRetryPeriod(),
@@ -254,7 +256,7 @@ func main() {
 			logger := setup.Logger.WithName("leader")
 			// create leader factories
 			kubeInformer := kubeinformers.NewSharedInformerFactory(setup.KubeClient, resyncPeriod)
-			kubeKyvernoInformer := kubeinformers.NewSharedInformerFactoryWithOptions(setup.KubeClient, resyncPeriod, kubeinformers.WithNamespace(config.KyvernoNamespace()))
+			kubeKyvernoInformer := kubeinformers.NewSharedInformerFactoryWithOptions(setup.KubeClient, resyncPeriod, kubeinformers.WithNamespace(namespace))
 			kyvernoInformer := kyvernoinformer.NewSharedInformerFactory(setup.KyvernoClient, resyncPeriod)
 			metadataInformer := metadatainformers.NewSharedInformerFactory(setup.MetadataClient, 15*time.Minute)
 			// create leader controllers

--- a/pkg/background/common/status.go
+++ b/pkg/background/common/status.go
@@ -9,9 +9,9 @@ import (
 
 // StatusControlInterface provides interface to update status subresource
 type StatusControlInterface interface {
-	Failed(name string, message string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error)
-	Success(name string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error)
-	Skip(name string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error)
+	Failed(namespace string, name string, message string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error)
+	Success(namespace string, name string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error)
+	Skip(namespace string, name string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error)
 }
 
 // statusControl is default implementaation of GRStatusControlInterface
@@ -28,16 +28,16 @@ func NewStatusControl(client versioned.Interface, urLister kyvernov1beta1listers
 }
 
 // Failed sets ur status.state to failed with message
-func (sc *statusControl) Failed(name, message string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error) {
-	return UpdateStatus(sc.client, sc.urLister, name, kyvernov1beta1.Failed, message, genResources)
+func (sc *statusControl) Failed(namespace, name, message string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error) {
+	return UpdateStatus(sc.client, sc.urLister, namespace, name, kyvernov1beta1.Failed, message, genResources)
 }
 
 // Success sets the ur status.state to completed and clears message
-func (sc *statusControl) Success(name string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error) {
-	return UpdateStatus(sc.client, sc.urLister, name, kyvernov1beta1.Completed, "", genResources)
+func (sc *statusControl) Success(namespace, name string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error) {
+	return UpdateStatus(sc.client, sc.urLister, namespace, name, kyvernov1beta1.Completed, "", genResources)
 }
 
 // Success sets the ur status.state to completed and clears message
-func (sc *statusControl) Skip(name string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error) {
-	return UpdateStatus(sc.client, sc.urLister, name, kyvernov1beta1.Skip, "", genResources)
+func (sc *statusControl) Skip(namespace, name string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error) {
+	return UpdateStatus(sc.client, sc.urLister, namespace, name, kyvernov1beta1.Skip, "", genResources)
 }

--- a/pkg/background/common/util.go
+++ b/pkg/background/common/util.go
@@ -7,16 +7,15 @@ import (
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernov1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1beta1"
-	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/logging"
 	errors "github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func UpdateStatus(client versioned.Interface, urLister kyvernov1beta1listers.UpdateRequestNamespaceLister, name string, state kyvernov1beta1.UpdateRequestState, message string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error) {
+func UpdateStatus(client versioned.Interface, urLister kyvernov1beta1listers.UpdateRequestNamespaceLister, namespace, name string, state kyvernov1beta1.UpdateRequestState, message string, genResources []kyvernov1.ResourceSpec) (*kyvernov1beta1.UpdateRequest, error) {
 	var latest *kyvernov1beta1.UpdateRequest
-	ur, err := client.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace()).Get(context.TODO(), name, metav1.GetOptions{})
+	ur, err := client.KyvernoV1beta1().UpdateRequests(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return ur, errors.Wrapf(err, "failed to fetch update request")
 	}
@@ -27,7 +26,7 @@ func UpdateStatus(client versioned.Interface, urLister kyvernov1beta1listers.Upd
 		latest.Status.GeneratedResources = genResources
 	}
 
-	new, err := client.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace()).UpdateStatus(context.TODO(), latest, metav1.UpdateOptions{})
+	new, err := client.KyvernoV1beta1().UpdateRequests(namespace).UpdateStatus(context.TODO(), latest, metav1.UpdateOptions{})
 	if err != nil {
 		return ur, errors.Wrapf(err, "failed to update ur status to %s", string(state))
 	}

--- a/pkg/background/generate/cleanup.go
+++ b/pkg/background/generate/cleanup.go
@@ -30,11 +30,11 @@ func (c *GenerateController) deleteDownstream(policy kyvernov1.PolicyInterface, 
 
 		if len(errs) != 0 {
 			c.log.Error(multierr.Combine(errs...), "failed to clean up downstream resources on policy deletion")
-			_, err = c.statusControl.Failed(ur.GetName(),
+			_, err = c.statusControl.Failed(ur.GetNamespace(), ur.GetName(),
 				fmt.Sprintf("failed to clean up downstream resources on policy deletion: %v", multierr.Combine(errs...)),
 				failedDownstreams)
 		} else {
-			_, err = c.statusControl.Success(ur.GetName(), nil)
+			_, err = c.statusControl.Success(ur.GetNamespace(), ur.GetName(), nil)
 		}
 		return
 	}
@@ -71,11 +71,11 @@ func (c *GenerateController) deleteDownstreamForClone(policy kyvernov1.PolicyInt
 		}
 		if len(errs) != 0 {
 			c.log.Error(multierr.Combine(errs...), "failed to clean up downstream resources on source deletion")
-			_, err = c.statusControl.Failed(ur.GetName(),
+			_, err = c.statusControl.Failed(ur.GetNamespace(), ur.GetName(),
 				fmt.Sprintf("failed to clean up downstream resources on source deletion: %v", multierr.Combine(errs...)),
 				failedDownstreams)
 		} else {
-			_, err = c.statusControl.Success(ur.GetName(), nil)
+			_, err = c.statusControl.Success(ur.GetNamespace(), ur.GetName(), nil)
 		}
 		return err
 	}

--- a/pkg/background/generate/generate.go
+++ b/pkg/background/generate/generate.go
@@ -242,7 +242,7 @@ func (c *GenerateController) applyGenerate(resource unstructured.Unstructured, u
 			}
 
 			for _, v := range urList {
-				err := c.kyvernoClient.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace()).Delete(context.TODO(), v.GetName(), metav1.DeleteOptions{})
+				err := c.kyvernoClient.KyvernoV1beta1().UpdateRequests(v.GetNamespace()).Delete(context.TODO(), v.GetName(), metav1.DeleteOptions{})
 				if err != nil {
 					logger.Error(err, "failed to delete update request")
 				}
@@ -279,11 +279,11 @@ func (c *GenerateController) getPolicySpec(ur kyvernov1beta1.UpdateRequest) (kyv
 
 func updateStatus(statusControl common.StatusControlInterface, ur kyvernov1beta1.UpdateRequest, err error, genResources []kyvernov1.ResourceSpec) error {
 	if err != nil {
-		if _, err := statusControl.Failed(ur.GetName(), err.Error(), genResources); err != nil {
+		if _, err := statusControl.Failed(ur.GetNamespace(), ur.GetName(), err.Error(), genResources); err != nil {
 			return err
 		}
 	} else {
-		if _, err := statusControl.Success(ur.GetName(), genResources); err != nil {
+		if _, err := statusControl.Success(ur.GetNamespace(), ur.GetName(), genResources); err != nil {
 			return err
 		}
 	}

--- a/pkg/background/generate/utils.go
+++ b/pkg/background/generate/utils.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/background/common"
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
-	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -48,13 +47,13 @@ func updateRetryAnnotation(kyvernoClient versioned.Interface, ur *kyvernov1beta1
 		return err
 	}
 	if retry > 3 {
-		err = kyvernoClient.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace()).Delete(context.TODO(), ur.GetName(), metav1.DeleteOptions{})
+		err = kyvernoClient.KyvernoV1beta1().UpdateRequests(ur.GetNamespace()).Delete(context.TODO(), ur.GetName(), metav1.DeleteOptions{})
 		if err != nil {
 			return errors.Wrapf(err, "exceeds retry limit, failed to delete the UR: %s, retry: %v, resourceVersion: %s", ur.Name, retry, ur.GetResourceVersion())
 		}
 	} else {
 		ur.SetAnnotations(urAnnotations)
-		_, err = kyvernoClient.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace()).Update(context.TODO(), ur, metav1.UpdateOptions{})
+		_, err = kyvernoClient.KyvernoV1beta1().UpdateRequests(ur.GetNamespace()).Update(context.TODO(), ur, metav1.UpdateOptions{})
 		if err != nil {
 			return errors.Wrapf(err, "failed to update annotation in update request: %s for the resource, retry: %v, resourceVersion %s, annotations: %v", ur.Name, retry, ur.GetResourceVersion(), urAnnotations)
 		}

--- a/pkg/background/mutate.go
+++ b/pkg/background/mutate.go
@@ -5,7 +5,6 @@ import (
 
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	common "github.com/kyverno/kyverno/pkg/background/common"
-	"github.com/kyverno/kyverno/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -13,7 +12,7 @@ func (c *controller) handleMutatePolicyAbsence(ur *kyvernov1beta1.UpdateRequest)
 	selector := &metav1.LabelSelector{
 		MatchLabels: common.MutateLabelsSet(ur.Spec.Policy, nil),
 	}
-	return c.kyvernoClient.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace()).DeleteCollection(
+	return c.kyvernoClient.KyvernoV1beta1().UpdateRequests(c.namespace).DeleteCollection(
 		context.TODO(),
 		metav1.DeleteOptions{},
 		metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(selector)},

--- a/pkg/background/mutate/mutate.go
+++ b/pkg/background/mutate/mutate.go
@@ -244,11 +244,11 @@ func (c *mutateExistingController) report(err error, policy, rule string, target
 
 func updateURStatus(statusControl common.StatusControlInterface, ur kyvernov1beta1.UpdateRequest, err error) error {
 	if err != nil {
-		if _, err := statusControl.Failed(ur.GetName(), err.Error(), nil); err != nil {
+		if _, err := statusControl.Failed(ur.GetNamespace(), ur.GetName(), err.Error(), nil); err != nil {
 			return err
 		}
 	} else {
-		if _, err := statusControl.Success(ur.GetName(), nil); err != nil {
+		if _, err := statusControl.Success(ur.GetNamespace(), ur.GetName(), nil); err != nil {
 			return err
 		}
 	}

--- a/pkg/clients/dclient/client_test.go
+++ b/pkg/clients/dclient/client_test.go
@@ -49,7 +49,7 @@ func newFixture(t *testing.T) *fixture {
 		kubeutils.NewUnstructured("group/version", "TheKind", "ns-foo", "name-bar"),
 		kubeutils.NewUnstructured("group/version", "TheKind", "ns-foo", "name-baz"),
 		kubeutils.NewUnstructured("group2/version", "TheKind", "ns-foo", "name2-baz"),
-		kubeutils.NewUnstructured("apps/v1", "Deployment", config.KyvernoNamespace(), config.KyvernoDeploymentName()),
+		kubeutils.NewUnstructured("apps/v1", "Deployment", "kyverno", config.KyvernoDeploymentName()),
 	}
 
 	scheme := runtime.NewScheme()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,7 +87,7 @@ const (
 
 var (
 	// kyvernoNamespace is the Kyverno namespace
-	kyvernoNamespace = osutils.GetEnvWithFallback("KYVERNO_NAMESPACE", "kyverno")
+	// kyvernoNamespace = osutils.GetEnvWithFallback("KYVERNO_NAMESPACE", "kyverno")
 	// kyvernoServiceAccountName is the Kyverno service account name
 	kyvernoServiceAccountName = osutils.GetEnvWithFallback("KYVERNO_SERVICEACCOUNT_NAME", "kyverno")
 	// kyvernoDeploymentName is the Kyverno deployment name
@@ -104,9 +104,9 @@ var (
 	kyvernoDryrunNamespace = osutils.GetEnvWithFallback("KYVERNO_DRYRUN_NAMESPACE", "kyverno-dryrun")
 )
 
-func KyvernoNamespace() string {
-	return kyvernoNamespace
-}
+// func KyvernoNamespace() string {
+// 	return kyvernoNamespace
+// }
 
 func KyvernoDryRunNamespace() string {
 	return kyvernoDryrunNamespace
@@ -136,8 +136,8 @@ func KyvernoMetricsConfigMapName() string {
 	return kyvernoMetricsConfigMapName
 }
 
-func KyvernoUserName(serviceaccount string) string {
-	return fmt.Sprintf("system:serviceaccount:%s:%s", kyvernoNamespace, serviceaccount)
+func KyvernoUserName(namespace, serviceaccount string) string {
+	return fmt.Sprintf("system:serviceaccount:%s:%s", namespace, serviceaccount)
 }
 
 // Configuration to be used by consumer to check filters

--- a/pkg/engine/handlers/validation/validate_manifest.go
+++ b/pkg/engine/handlers/validation/validate_manifest.go
@@ -35,10 +35,12 @@ const (
 )
 
 type validateManifestHandler struct {
-	client dclient.Interface
+	namespace string
+	client    dclient.Interface
 }
 
 func NewValidateManifestHandler(
+	namespace string,
 	policyContext engineapi.PolicyContext,
 	client dclient.Interface,
 ) (handlers.Handler, error) {
@@ -46,7 +48,8 @@ func NewValidateManifestHandler(
 		return nil, nil
 	}
 	return validateManifestHandler{
-		client: client,
+		namespace: namespace,
+		client:    client,
 	}, nil
 }
 
@@ -136,7 +139,7 @@ func (h validateManifestHandler) verifyManifest(
 			vo.DisableDryRun = true
 		}
 		// check if kyverno namespace is not used for dryrun
-		ok = checkDryRunNamespace(vo.DryRunNamespace)
+		ok = checkDryRunNamespace(vo.DryRunNamespace, h.namespace)
 		if !ok {
 			logger.V(1).Info("an inappropriate dryrun namespace is set; set a namespace other than kyverno.", "dryrun namespace", vo.DryRunNamespace)
 			vo.DisableDryRun = true
@@ -427,7 +430,7 @@ func checkManifestAnnotations(mnfstAnnotations map[string]string, annotations ma
 	return nil
 }
 
-func checkDryRunNamespace(namespace string) bool {
+func checkDryRunNamespace(namespace, kyvernoNamespace string) bool {
 	// should not use kyverno namespace for dryrun
-	return namespace != config.KyvernoNamespace()
+	return namespace != kyvernoNamespace
 }

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -40,6 +40,7 @@ func (e *engine) validate(
 				hasValidatePss := rule.HasValidatePodSecurity()
 				if hasVerifyManifest {
 					return validation.NewValidateManifestHandler(
+						"TODO",
 						policyContext,
 						e.client,
 					)

--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -22,6 +22,7 @@ func InitMetrics(
 	transportCreds string,
 	kubeClient kubernetes.Interface,
 	logger logr.Logger,
+	namespace string,
 ) (MetricsConfigManager, *http.ServeMux, *sdkmetric.MeterProvider, error) {
 	var err error
 	var metricsServerMux *http.ServeMux
@@ -35,12 +36,13 @@ func InitMetrics(
 				transportCreds,
 				kubeClient,
 				logger,
+				namespace,
 			)
 			if err != nil {
 				return nil, nil, nil, err
 			}
 		} else if otel == "prometheus" {
-			meterProvider, metricsServerMux, err = NewPrometheusConfig(ctx, logger)
+			meterProvider, metricsServerMux, err = NewPrometheusConfig(ctx, logger, namespace)
 			if err != nil {
 				return nil, nil, nil, err
 			}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -106,11 +106,12 @@ func NewOTLPGRPCConfig(
 	certs string,
 	kubeClient kubernetes.Interface,
 	log logr.Logger,
+	namespace string,
 ) (metric.MeterProvider, error) {
 	options := []otlpmetricgrpc.Option{otlpmetricgrpc.WithEndpoint(endpoint), otlpmetricgrpc.WithAggregationSelector(aggregationSelector)}
 	if certs != "" {
 		// here the certificates are stored as configmaps
-		transportCreds, err := tlsutils.FetchCert(ctx, certs, kubeClient)
+		transportCreds, err := tlsutils.FetchCert(ctx, namespace, certs, kubeClient)
 		if err != nil {
 			log.Error(err, "Error fetching certificate from secret")
 			return nil, err
@@ -152,13 +153,14 @@ func NewOTLPGRPCConfig(
 func NewPrometheusConfig(
 	ctx context.Context,
 	log logr.Logger,
+	namespace string,
 ) (metric.MeterProvider, *http.ServeMux, error) {
 	res, err := resource.Merge(
 		resource.Default(),
 		resource.NewWithAttributes(
 			semconv.SchemaURL,
 			semconv.ServiceNameKey.String("kyverno-svc-metrics"),
-			semconv.ServiceNamespaceKey.String(kconfig.KyvernoNamespace()),
+			semconv.ServiceNamespaceKey.String(namespace),
 			semconv.ServiceVersionKey.String(version.BuildVersion),
 		),
 	)

--- a/pkg/policy/mutate.go
+++ b/pkg/policy/mutate.go
@@ -31,7 +31,7 @@ func (pc *policyController) handleMutate(policyKey string, policy kyvernov1.Poli
 				}
 
 				logger.Info("creating new UR for mutate")
-				ur := newUR(policy, backgroundcommon.ResourceSpecFromUnstructured(*trigger), rule.Name, ruleType, false)
+				ur := newUR(policy, backgroundcommon.ResourceSpecFromUnstructured(*trigger), pc.namespace, rule.Name, ruleType, false)
 				skip, err := pc.handleUpdateRequest(ur, trigger, rule, policy)
 				if err != nil {
 					pc.log.Error(err, "failed to create new UR on policy update", "policy", policy.GetName(), "rule", rule.Name, "rule type", ruleType,

--- a/pkg/policy/policy_controller.go
+++ b/pkg/policy/policy_controller.go
@@ -89,6 +89,8 @@ type policyController struct {
 	metricsConfig metrics.MetricsConfigManager
 
 	jp jmespath.Interface
+
+	namespace string
 }
 
 // NewPolicyController create a new PolicyController
@@ -106,6 +108,7 @@ func NewPolicyController(
 	reconcilePeriod time.Duration,
 	metricsConfig metrics.MetricsConfigManager,
 	jp jmespath.Interface,
+	namespace string,
 ) (*policyController, error) {
 	// Event broad caster
 	eventBroadcaster := record.NewBroadcaster()
@@ -127,6 +130,7 @@ func NewPolicyController(
 		metricsConfig:   metricsConfig,
 		log:             log,
 		jp:              jp,
+		namespace:       namespace,
 	}
 
 	pc.pLister = pInformer.Lister()
@@ -424,13 +428,13 @@ func (pc *policyController) handleUpdateRequest(ur *kyvernov1beta1.UpdateRequest
 		}
 
 		pc.log.V(2).Info("creating new UR for generate")
-		created, err := pc.kyvernoClient.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace()).Create(context.TODO(), ur, metav1.CreateOptions{})
+		created, err := pc.kyvernoClient.KyvernoV1beta1().UpdateRequests(pc.namespace).Create(context.TODO(), ur, metav1.CreateOptions{})
 		if err != nil {
 			return false, err
 		}
 		updated := created.DeepCopy()
 		updated.Status.State = kyvernov1beta1.Pending
-		_, err = pc.kyvernoClient.KyvernoV1beta1().UpdateRequests(config.KyvernoNamespace()).UpdateStatus(context.TODO(), updated, metav1.UpdateOptions{})
+		_, err = pc.kyvernoClient.KyvernoV1beta1().UpdateRequests(pc.namespace).UpdateStatus(context.TODO(), updated, metav1.UpdateOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/pkg/policy/updaterequest.go
+++ b/pkg/policy/updaterequest.go
@@ -4,13 +4,12 @@ import (
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
 	common "github.com/kyverno/kyverno/pkg/background/common"
-	"github.com/kyverno/kyverno/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func newUR(policy kyvernov1.PolicyInterface, trigger kyvernov1.ResourceSpec, ruleName string, ruleType kyvernov1beta1.RequestType, deleteDownstream bool) *kyvernov1beta1.UpdateRequest {
+func newUR(policy kyvernov1.PolicyInterface, trigger kyvernov1.ResourceSpec, namespace, ruleName string, ruleType kyvernov1beta1.RequestType, deleteDownstream bool) *kyvernov1beta1.UpdateRequest {
 	var policyNameNamespaceKey string
 
 	if policy.IsNamespaced() {
@@ -33,7 +32,7 @@ func newUR(policy kyvernov1.PolicyInterface, trigger kyvernov1.ResourceSpec, rul
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "ur-",
-			Namespace:    config.KyvernoNamespace(),
+			Namespace:    namespace,
 			Labels:       label,
 		},
 		Spec: kyvernov1beta1.UpdateRequestSpec{

--- a/pkg/tls/keypair.go
+++ b/pkg/tls/keypair.go
@@ -50,13 +50,13 @@ func generateCA(key *rsa.PrivateKey, certValidityDuration time.Duration) (*rsa.P
 
 // generateTLS takes the results of GenerateCACert and uses it to create the
 // PEM-encoded public certificate and private key, respectively
-func generateTLS(server string, caCert *x509.Certificate, caKey *rsa.PrivateKey, certValidityDuration time.Duration) (*rsa.PrivateKey, *x509.Certificate, error) {
+func generateTLS(server string, namespace string, caCert *x509.Certificate, caKey *rsa.PrivateKey, certValidityDuration time.Duration) (*rsa.PrivateKey, *x509.Certificate, error) {
 	now := time.Now()
 	begin, end := now.Add(-1*time.Hour), now.Add(certValidityDuration)
 	dnsNames := []string{
 		config.KyvernoServiceName(),
-		fmt.Sprintf("%s.%s", config.KyvernoServiceName(), config.KyvernoNamespace()),
-		inClusterServiceName(),
+		fmt.Sprintf("%s.%s", config.KyvernoServiceName(), namespace),
+		inClusterServiceName(namespace),
 	}
 	var ips []net.IP
 	if server != "" {

--- a/pkg/tls/reader.go
+++ b/pkg/tls/reader.go
@@ -3,7 +3,6 @@ package tls
 import (
 	"fmt"
 
-	"github.com/kyverno/kyverno/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
@@ -11,8 +10,8 @@ import (
 var ErrorsNotFound = "root CA certificate not found"
 
 // ReadRootCASecret returns the RootCA from the pre-defined secret
-func ReadRootCASecret(client corev1listers.SecretNamespaceLister) ([]byte, error) {
-	sname := GenerateRootCASecretName()
+func ReadRootCASecret(namespace string, client corev1listers.SecretNamespaceLister) ([]byte, error) {
+	sname := GenerateRootCASecretName(namespace)
 	stlsca, err := client.Get(sname)
 	if err != nil {
 		return nil, err
@@ -24,7 +23,7 @@ func ReadRootCASecret(client corev1listers.SecretNamespaceLister) ([]byte, error
 		result = stlsca.Data[rootCAKey]
 	}
 	if len(result) == 0 {
-		return nil, fmt.Errorf("%s in secret %s/%s", ErrorsNotFound, config.KyvernoNamespace(), stlsca.Name)
+		return nil, fmt.Errorf("%s in secret %s", ErrorsNotFound, stlsca.Name)
 	}
 	return result, nil
 }

--- a/pkg/tls/utils.go
+++ b/pkg/tls/utils.go
@@ -97,14 +97,14 @@ func isSecretManagedByKyverno(secret *corev1.Secret) bool {
 }
 
 // inClusterServiceName The generated service name should be the common name for TLS certificate
-func inClusterServiceName() string {
-	return config.KyvernoServiceName() + "." + config.KyvernoNamespace() + ".svc"
+func inClusterServiceName(namespace string) string {
+	return config.KyvernoServiceName() + "." + namespace + ".svc"
 }
 
-func GenerateTLSPairSecretName() string {
-	return inClusterServiceName() + ".kyverno-tls-pair"
+func GenerateTLSPairSecretName(namespace string) string {
+	return inClusterServiceName(namespace) + ".kyverno-tls-pair"
 }
 
-func GenerateRootCASecretName() string {
-	return inClusterServiceName() + ".kyverno-tls-ca"
+func GenerateRootCASecretName(namespace string) string {
+	return inClusterServiceName(namespace) + ".kyverno-tls-ca"
 }

--- a/pkg/tracing/config.go
+++ b/pkg/tracing/config.go
@@ -18,12 +18,12 @@ import (
 )
 
 // NewTraceConfig generates the initial tracing configuration with 'address' as the endpoint to connect to the Opentelemetry Collector
-func NewTraceConfig(log logr.Logger, tracerName, address, certs string, kubeClient kubernetes.Interface) (func(), error) {
+func NewTraceConfig(log logr.Logger, tracerName, address, namespace, certs string, kubeClient kubernetes.Interface) (func(), error) {
 	ctx := context.Background()
 	var client otlptrace.Client
 	if certs != "" {
 		// here the certificates are stored as configmaps
-		transportCreds, err := tlsutils.FetchCert(ctx, certs, kubeClient)
+		transportCreds, err := tlsutils.FetchCert(ctx, namespace, certs, kubeClient)
 		if err != nil {
 			log.Error(err, "Error fetching certificate from secret")
 		}

--- a/pkg/utils/runtime/utils.go
+++ b/pkg/utils/runtime/utils.go
@@ -23,6 +23,7 @@ type runtime struct {
 	deploymentLister appsv1listers.DeploymentLister
 	certValidator    tls.CertValidator
 	logger           logr.Logger
+	namespace        string
 }
 
 func NewRuntime(
@@ -30,12 +31,14 @@ func NewRuntime(
 	serverIP string,
 	deploymentInformer appsv1informers.DeploymentInformer,
 	certValidator tls.CertValidator,
+	namespace string,
 ) Runtime {
 	return &runtime{
 		logger:           logger,
 		serverIP:         serverIP,
 		deploymentLister: deploymentInformer.Lister(),
 		certValidator:    certValidator,
+		namespace:        namespace,
 	}
 }
 
@@ -90,7 +93,7 @@ func (c *runtime) IsGoingDown() bool {
 }
 
 func (c *runtime) getDeployment() (*appsv1.Deployment, error) {
-	return c.deploymentLister.Deployments(config.KyvernoNamespace()).Get(config.KyvernoDeploymentName())
+	return c.deploymentLister.Deployments(c.namespace).Get(config.KyvernoDeploymentName())
 }
 
 func (c *runtime) validateCertificates() bool {

--- a/pkg/utils/tls/cert.go
+++ b/pkg/utils/tls/cert.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 
-	"github.com/kyverno/kyverno/pkg/config"
 	"google.golang.org/grpc/credentials"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -13,10 +12,11 @@ import (
 
 func FetchCert(
 	ctx context.Context,
-	certs string,
+	namespace string,
+	name string,
 	kubeClient kubernetes.Interface,
 ) (credentials.TransportCredentials, error) {
-	secret, err := kubeClient.CoreV1().Secrets(config.KyvernoNamespace()).Get(ctx, certs, metav1.GetOptions{})
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error fetching certificate from secret")
 	}

--- a/pkg/webhooks/handlers/verify.go
+++ b/pkg/webhooks/handlers/verify.go
@@ -5,13 +5,12 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/kyverno/kyverno/pkg/config"
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	jsonutils "github.com/kyverno/kyverno/pkg/utils/json"
 )
 
-func Verify(ctx context.Context, logger logr.Logger, request AdmissionRequest, startTime time.Time) AdmissionResponse {
-	if request.Name != "kyverno-health" || request.Namespace != config.KyvernoNamespace() {
+func Verify(ctx context.Context, logger logr.Logger, namespace string, request AdmissionRequest, startTime time.Time) AdmissionResponse {
+	if request.Name != "kyverno-health" || request.Namespace != namespace {
 		return admissionutils.ResponseSuccess(request.UID)
 	}
 	patch := jsonutils.NewPatchOperation("/metadata/annotations/"+"kyverno.io~1last-request-time", "replace", time.Now().Format(time.RFC3339))

--- a/pkg/webhooks/resource/fake.go
+++ b/pkg/webhooks/resource/fake.go
@@ -37,7 +37,7 @@ func NewFakeHandlers(ctx context.Context, policyCache policycache.Cache) webhook
 
 	dclient := dclient.NewEmptyFakeClient()
 	configuration := config.NewDefaultConfiguration(false)
-	urLister := kyvernoInformers.Kyverno().V1beta1().UpdateRequests().Lister().UpdateRequests(config.KyvernoNamespace())
+	urLister := kyvernoInformers.Kyverno().V1beta1().UpdateRequests().Lister().UpdateRequests("kyverno")
 	peLister := kyvernoInformers.Kyverno().V2alpha1().PolicyExceptions().Lister()
 	rclient := registryclient.NewOrDie()
 	jp := jmespath.New(configuration)


### PR DESCRIPTION
## Explanation

This PR replaces `KYVERNO_NAME` env var with a flag.

It will make detecting errors easier (like forgetting to set the env var).