### PR TITLE
chore: deprecate imageSignatureRepository flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.11.0
+
+## v1.11.0-rc.1
+
+- Deprecated flag `--imageSignatureRepository`. Will be removed in 1.12. Use per rule configuration `verifyImages.Repository` instead.
+
+### Note
+
 ## v1.10.0
 
 ## v1.10.0-rc.1

--- a/cmd/internal/flag.go
+++ b/cmd/internal/flag.go
@@ -88,7 +88,7 @@ func initConfigMapCachingFlags() {
 }
 
 func initCosignFlags() {
-	flag.StringVar(&imageSignatureRepository, "imageSignatureRepository", "", "Alternate repository for image signatures. Can be overridden per rule via `verifyImages.Repository`.")
+	flag.StringVar(&imageSignatureRepository, "imageSignatureRepository", "", "(DEPRECATED, will be removed in 1.12) Alternate repository for image signatures. Can be overridden per rule via `verifyImages.Repository`.")
 }
 
 func initRegistryClientFlags() {
@@ -176,6 +176,14 @@ func initFlags(config Configuration, opts ...Option) {
 		flagset.VisitAll(func(f *flag.Flag) {
 			flag.CommandLine.Var(f.Value, f.Name, f.Usage)
 		})
+	}
+}
+
+func showWarnings(config Configuration, logger logr.Logger) {
+	if config.UsesCosign() {
+		if imageSignatureRepository != "" {
+			logger.Info("Warning: imageSignatureRepository is deprecated and will be removed in 1.12. Use per rule configuration `verifyImages.Repository` instead.")
+		}
 	}
 }
 

--- a/cmd/internal/setup.go
+++ b/cmd/internal/setup.go
@@ -48,6 +48,7 @@ func Setup(config Configuration, name string, skipResourceFilters bool) (context
 	logger := setupLogger()
 	showVersion(logger)
 	printFlagSettings(logger)
+	showWarnings(config, logger)
 	sdownMaxProcs := setupMaxProcs(logger)
 	setupProfiling(logger)
 	ctx, sdownSignals := setupSignals(logger)


### PR DESCRIPTION
## Explanation

This PR deprecates `imageSignatureRepository` flag.
