### PR TITLE
fix: stop recording json patches in rule responses (part 2)

### DIFF
--- a/pkg/engine/handlers/mutation/mutate_image.go
+++ b/pkg/engine/handlers/mutation/mutate_image.go
@@ -74,12 +74,11 @@ func (h mutateImageHandler) Process(
 	}
 	iv := internal.NewImageVerifier(logger, h.rclient, policyContext, *ruleCopy, h.ivm, h.imageSignatureRepository)
 	var engineResponses []*engineapi.RuleResponse
-	for _, imageVerify := range ruleCopy.VerifyImages {
-		engineResponses = append(engineResponses, iv.Verify(ctx, imageVerify, h.images, h.configuration)...)
-	}
 	var patches []jsonpatch.JsonPatchOperation
-	for _, response := range engineResponses {
-		patches = append(patches, response.DeprecatedPatches()...)
+	for _, imageVerify := range ruleCopy.VerifyImages {
+		patch, ruleResponse := iv.Verify(ctx, imageVerify, h.images, h.configuration)
+		patches = append(patches, patch...)
+		engineResponses = append(engineResponses, ruleResponse...)
 	}
 	if len(patches) != 0 {
 		patch := jsonutils.JoinPatches(patch.ConvertPatches(patches...)...)

--- a/pkg/engine/image_verify_test.go
+++ b/pkg/engine/image_verify_test.go
@@ -480,9 +480,13 @@ func Test_SignatureGoodSigned(t *testing.T) {
 	engineResp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.NewOrDie(), nil, policyContext, cfg)
 	assert.Equal(t, len(engineResp.PolicyResponse.Rules), 1)
 	assert.Equal(t, engineResp.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass, engineResp.PolicyResponse.Rules[0].Message())
-	assert.Equal(t, len(engineResp.PolicyResponse.Rules[0].DeprecatedPatches()), 1)
-	patch := engineResp.PolicyResponse.Rules[0].DeprecatedPatches()[0]
-	assert.Equal(t, patch.Json(), "{\"op\":\"replace\",\"path\":\"/spec/containers/0/image\",\"value\":\"ghcr.io/kyverno/test-verify-image:signed@sha256:b31bfb4d0213f254d361e0079deaaebefa4f82ba7aa76ef82e90b4935ad5b105\"}")
+	constainers, found, err := unstructured.NestedSlice(engineResp.PatchedResource.UnstructuredContent(), "spec", "containers")
+	assert.NilError(t, err)
+	assert.Equal(t, true, found)
+	image, found, err := unstructured.NestedMap(constainers[0].(map[string]interface{}), "image")
+	assert.NilError(t, err)
+	assert.Equal(t, true, found)
+	assert.Equal(t, "ghcr.io/kyverno/test-verify-image:signed@sha256:b31bfb4d0213f254d361e0079deaaebefa4f82ba7aa76ef82e90b4935ad5b105", image)
 }
 
 func Test_SignatureUnsigned(t *testing.T) {

--- a/pkg/engine/image_verify_test.go
+++ b/pkg/engine/image_verify_test.go
@@ -483,7 +483,7 @@ func Test_SignatureGoodSigned(t *testing.T) {
 	constainers, found, err := unstructured.NestedSlice(engineResp.PatchedResource.UnstructuredContent(), "spec", "containers")
 	assert.NilError(t, err)
 	assert.Equal(t, true, found)
-	image, found, err := unstructured.NestedMap(constainers[0].(map[string]interface{}), "image")
+	image, found, err := unstructured.NestedString(constainers[0].(map[string]interface{}), "image")
 	assert.NilError(t, err)
 	assert.Equal(t, true, found)
 	assert.Equal(t, "ghcr.io/kyverno/test-verify-image:signed@sha256:b31bfb4d0213f254d361e0079deaaebefa4f82ba7aa76ef82e90b4935ad5b105", image)

--- a/pkg/engine/internal/imageverifier.go
+++ b/pkg/engine/internal/imageverifier.go
@@ -187,8 +187,9 @@ func (iv *ImageVerifier) Verify(
 	imageVerify kyvernov1.ImageVerification,
 	matchedImageInfos []apiutils.ImageInfo,
 	cfg config.Configuration,
-) []*engineapi.RuleResponse {
+) ([]jsonpatch.JsonPatchOperation, []*engineapi.RuleResponse) {
 	var responses []*engineapi.RuleResponse
+	var patches []jsonpatch.JsonPatchOperation
 
 	// for backward compatibility
 	imageVerify = *imageVerify.Convert()
@@ -226,7 +227,7 @@ func (iv *ImageVerifier) Verify(
 				if ruleResp == nil {
 					ruleResp = engineapi.RulePass(iv.rule.Name, engineapi.ImageVerify, "mutated image digest")
 				}
-				ruleResp = ruleResp.WithPatches(*patch)
+				patches = append(patches, *patch)
 				imageInfo.Digest = retrievedDigest
 				image = imageInfo.String()
 			}
@@ -239,7 +240,7 @@ func (iv *ImageVerifier) Verify(
 			responses = append(responses, ruleResp)
 		}
 	}
-	return responses
+	return patches, responses
 }
 
 func (iv *ImageVerifier) verifyImage(


### PR DESCRIPTION
## Explanation

This PR stops recording json patches in rule responses.
This one addresses image verifier.
