### PR TITLE
fix: rule name not required in the crd schema

### DIFF
--- a/api/kyverno/v1/rule_types.go
+++ b/api/kyverno/v1/rule_types.go
@@ -47,7 +47,7 @@ type ImageExtractorConfig struct {
 type Rule struct {
 	// Name is a label to identify the rule, It must be unique within the policy.
 	// +kubebuilder:validation:MaxLength=63
-	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	Name string `json:"name" yaml:"name"`
 
 	// Context defines variables and data sources that can be used during rule execution.
 	// +optional

--- a/api/kyverno/v2beta1/rule_types.go
+++ b/api/kyverno/v2beta1/rule_types.go
@@ -16,7 +16,7 @@ import (
 type Rule struct {
 	// Name is a label to identify the rule, It must be unique within the policy.
 	// +kubebuilder:validation:MaxLength=63
-	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	Name string `json:"name" yaml:"name"`
 
 	// Context defines variables and data sources that can be used during rule execution.
 	// +optional

--- a/charts/kyverno/templates/crds/crds.yaml
+++ b/charts/kyverno/templates/crds/crds.yaml
@@ -7515,6 +7515,8 @@ spec:
                             type: boolean
                         type: object
                       type: array
+                  required:
+                  - name
                   type: object
                 type: array
               schemaValidation:
@@ -11432,6 +11434,8 @@ spec:
                                 type: boolean
                             type: object
                           type: array
+                      required:
+                      - name
                       type: object
                     type: array
                 type: object
@@ -14997,6 +15001,8 @@ spec:
                             type: boolean
                         type: object
                       type: array
+                  required:
+                  - name
                   type: object
                 type: array
               schemaValidation:
@@ -18914,6 +18920,8 @@ spec:
                                 type: boolean
                             type: object
                           type: array
+                      required:
+                      - name
                       type: object
                     type: array
                 type: object
@@ -22790,6 +22798,8 @@ spec:
                             type: boolean
                         type: object
                       type: array
+                  required:
+                  - name
                   type: object
                 type: array
               schemaValidation:
@@ -26708,6 +26718,8 @@ spec:
                                 type: boolean
                             type: object
                           type: array
+                      required:
+                      - name
                       type: object
                     type: array
                 type: object
@@ -30274,6 +30286,8 @@ spec:
                             type: boolean
                         type: object
                       type: array
+                  required:
+                  - name
                   type: object
                 type: array
               schemaValidation:
@@ -34191,6 +34205,8 @@ spec:
                                 type: boolean
                             type: object
                           type: array
+                      required:
+                      - name
                       type: object
                     type: array
                 type: object

--- a/config/crds/kyverno.io_clusterpolicies.yaml
+++ b/config/crds/kyverno.io_clusterpolicies.yaml
@@ -3761,6 +3761,8 @@ spec:
                             type: boolean
                         type: object
                       type: array
+                  required:
+                  - name
                   type: object
                 type: array
               schemaValidation:
@@ -7678,6 +7680,8 @@ spec:
                                 type: boolean
                             type: object
                           type: array
+                      required:
+                      - name
                       type: object
                     type: array
                 type: object
@@ -11243,6 +11247,8 @@ spec:
                             type: boolean
                         type: object
                       type: array
+                  required:
+                  - name
                   type: object
                 type: array
               schemaValidation:
@@ -15160,6 +15166,8 @@ spec:
                                 type: boolean
                             type: object
                           type: array
+                      required:
+                      - name
                       type: object
                     type: array
                 type: object

--- a/config/crds/kyverno.io_policies.yaml
+++ b/config/crds/kyverno.io_policies.yaml
@@ -3762,6 +3762,8 @@ spec:
                             type: boolean
                         type: object
                       type: array
+                  required:
+                  - name
                   type: object
                 type: array
               schemaValidation:
@@ -7680,6 +7682,8 @@ spec:
                                 type: boolean
                             type: object
                           type: array
+                      required:
+                      - name
                       type: object
                     type: array
                 type: object
@@ -11246,6 +11250,8 @@ spec:
                             type: boolean
                         type: object
                       type: array
+                  required:
+                  - name
                   type: object
                 type: array
               schemaValidation:
@@ -15163,6 +15169,8 @@ spec:
                                 type: boolean
                             type: object
                           type: array
+                      required:
+                      - name
                       type: object
                     type: array
                 type: object

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -7718,6 +7718,8 @@ spec:
                             type: boolean
                         type: object
                       type: array
+                  required:
+                  - name
                   type: object
                 type: array
               schemaValidation:
@@ -11635,6 +11637,8 @@ spec:
                                 type: boolean
                             type: object
                           type: array
+                      required:
+                      - name
                       type: object
                     type: array
                 type: object
@@ -15200,6 +15204,8 @@ spec:
                             type: boolean
                         type: object
                       type: array
+                  required:
+                  - name
                   type: object
                 type: array
               schemaValidation:
@@ -19117,6 +19123,8 @@ spec:
                                 type: boolean
                             type: object
                           type: array
+                      required:
+                      - name
                       type: object
                     type: array
                 type: object
@@ -22993,6 +23001,8 @@ spec:
                             type: boolean
                         type: object
                       type: array
+                  required:
+                  - name
                   type: object
                 type: array
               schemaValidation:
@@ -26911,6 +26921,8 @@ spec:
                                 type: boolean
                             type: object
                           type: array
+                      required:
+                      - name
                       type: object
                     type: array
                 type: object
@@ -30477,6 +30489,8 @@ spec:
                             type: boolean
                         type: object
                       type: array
+                  required:
+                  - name
                   type: object
                 type: array
               schemaValidation:
@@ -34394,6 +34408,8 @@ spec:
                                 type: boolean
                             type: object
                           type: array
+                      required:
+                      - name
                       type: object
                     type: array
                 type: object


### PR DESCRIPTION
## Explanation

This PR fixes rule name not required in the crd schema.
Lesson learned, if a field is marked with `omitempty` it CAN'T be required, makes sense i guess.