### PR TITLE
fix: log kind/namespace/name in scan errors

### DIFF
--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -47,16 +47,17 @@ func (s *scanner) ScanResource(ctx context.Context, resource unstructured.Unstru
 	results := map[kyvernov1.PolicyInterface]ScanResult{}
 	for _, policy := range policies {
 		var errors []error
+		logger := s.logger.WithValues("kind", resource.GetKind(), "namespace", resource.GetNamespace(), "name", resource.GetName())
 		response, err := s.validateResource(ctx, resource, nsLabels, policy)
 		if err != nil {
-			s.logger.Error(err, "failed to scan resource")
+			logger.Error(err, "failed to scan resource")
 			errors = append(errors, err)
 		}
 		spec := policy.GetSpec()
 		if spec.HasVerifyImages() {
 			ivResponse, err := s.validateImages(ctx, resource, nsLabels, policy)
 			if err != nil {
-				s.logger.Error(err, "failed to scan images")
+				logger.Error(err, "failed to scan images")
 				errors = append(errors, err)
 			}
 			if response == nil {


### PR DESCRIPTION
## Explanation

If error happen on image scan errors in the mutation webhook, only the failing image is logged. 
There's not info about the resource processed.


## Milestone of this PR
/milestone v1.10.1

## What type of PR is this

/kind cleanup

## Proposed Changes

Log kind, namespace and name of the processed resoruce.


## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
