### PR TITLE
fix: use RawClient in context loader

### DIFF
--- a/cmd/cli/kubectl-kyverno/utils/store/contextloader.go
+++ b/cmd/cli/kubectl-kyverno/utils/store/contextloader.go
@@ -38,7 +38,7 @@ type mockContextLoader struct {
 func (l *mockContextLoader) Load(
 	ctx context.Context,
 	jp jmespath.Interface,
-	client engineapi.Client,
+	client engineapi.RawClient,
 	_ registryclient.Client,
 	contextEntries []kyvernov1.ContextEntry,
 	jsonContext enginecontext.Interface,

--- a/pkg/engine/api/contextloader.go
+++ b/pkg/engine/api/contextloader.go
@@ -20,7 +20,7 @@ type ContextLoader interface {
 	Load(
 		ctx context.Context,
 		jp jmespath.Interface,
-		client Client,
+		client RawClient,
 		rclient registryclient.Client,
 		contextEntries []kyvernov1.ContextEntry,
 		jsonContext enginecontext.Interface,
@@ -46,7 +46,7 @@ type contextLoader struct {
 func (l *contextLoader) Load(
 	ctx context.Context,
 	jp jmespath.Interface,
-	client Client,
+	client RawClient,
 	rclient registryclient.Client,
 	contextEntries []kyvernov1.ContextEntry,
 	jsonContext enginecontext.Interface,
@@ -65,7 +65,7 @@ func (l *contextLoader) Load(
 func (l *contextLoader) newDeferredLoader(
 	ctx context.Context,
 	jp jmespath.Interface,
-	client Client,
+	client RawClient,
 	rclient registryclient.Client,
 	entry kyvernov1.ContextEntry,
 	jsonContext enginecontext.Interface,

--- a/pkg/engine/test/contextloader.go
+++ b/pkg/engine/test/contextloader.go
@@ -45,7 +45,7 @@ type mockContextLoader struct {
 func (l *mockContextLoader) Load(
 	ctx context.Context,
 	jp jmespath.Interface,
-	client engineapi.Client,
+	client engineapi.RawClient,
 	rclient registryclient.Client,
 	contextEntries []kyvernov1.ContextEntry,
 	jsonContext enginecontext.Interface,


### PR DESCRIPTION
## Explanation

This PR uses RawClient in context loader.
