### PR TITLE
updated validKinds()

### DIFF
--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -1203,10 +1203,24 @@ func validateWildcard(kinds []string, background bool, rule kyvernov1.Rule) erro
 // validKinds verifies if an API resource that matches 'kind' is valid kind
 // and found in the cache, returns error if not found. It also returns an error if background scanning
 // is enabled for a subresource.
+
+func contains(kinds []string, kind string) bool {
+	for _, k := range kinds {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
 func validKinds(kinds []string, mock, backgroundScanningEnabled, isValidationPolicy bool, client dclient.Interface) error {
 	if !mock {
 		for _, k := range kinds {
 			group, version, kind, subresource := kubeutils.ParseKindSelector(k)
+			allowedKinds := []string{"User", "Group", "ServiceAccount"}
+			if !contains(allowedKinds, kind) {
+				return fmt.Errorf("Invalid kind %q,allowed kinds are %v", kind, allowedKinds)
+			}
 			gvrss, err := client.Discovery().FindResources(group, version, kind, subresource)
 			if err != nil {
 				return fmt.Errorf("unable to convert GVK to GVR for kinds %s, err: %s", k, err)


### PR DESCRIPTION
## Explanation

<!--
addresses an issue where users were able to create invalid policies by specifying incorrect values in the match.subjects.kind field. The PR adds validation to ensure that only the allowed kinds (User, Group, and ServiceAccount) can be specified. 

THIS IS MANDATORY.
-->

## Related issue

<!--
closes : [7052](https://github.com/kyverno/kyverno/issues/7052)


-->

## Milestone of this PR
<!--

-->

## What type of PR is this

<!--

-->

## Proposed Changes

<!--
The proposed changes to the validKinds function in pkg/validation/policy/validate.go will greatly improve the clarity and correctness of the code. By explicitly defining the allowed kinds (User, Group, and ServiceAccount) and checking if the provided kind is within this list, the function will prevent the creation of invalid policies with unrecognized or incorrect kind values. 

I added some checks in validKinds() and one helper function for that check

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--

------------------------------CHANGE MADE ------------------------------
func contains(kinds []string, kind string) bool {
	for _, k := range kinds {
		if k == kind {
			return true
		}
	}
	return false
}

func validKinds(kinds []string, mock, backgroundScanningEnabled, isValidationPolicy bool, client dclient.Interface) error {
	if !mock {
		for _, k := range kinds {
			group, version, kind, subresource := kubeutils.ParseKindSelector(k)
			allowedKinds := []string{"User", "Group", "ServiceAccount"}
			if !contains(allowedKinds, kind) {
				return fmt.Errorf("Invalid kind %q,allowed kinds are %v", kind, allowedKinds)
			}
			gvrss, err := client.Discovery().FindResources(group, version, kind, subresource)
			if err != nil {
				return fmt.Errorf("unable to convert GVK to GVR for kinds %s, err: %s", k, err)
			}
			if len(gvrss) == 0 {
				return fmt.Errorf("unable to convert GVK to GVR for kinds %s", k)
			}
			if isValidationPolicy && backgroundScanningEnabled {
				for gvrs := range gvrss {
					if gvrs.SubResource != "" {
						return fmt.Errorf("background scan enabled with subresource %s", k)
					}
				}
			}
		}
	}
	return nil
}

------------------------TESTING CODE -----------------------


package main

import (
	"fmt"

	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
)

func contains(kinds []string, kind string) bool {
	for _, k := range kinds {
		if k == kind {
			return true
		}
	}
	return false
}

func validKinds(kinds []string) error {
	for _, k := range kinds {
		group, version, kind, subresource := kubeutils.ParseKindSelector(k)
		allowedKinds := []string{"User", "Group", "ServiceAccount"}
		if !contains(allowedKinds, kind) {
			return fmt.Errorf("Invalid kind %q,allowed kinds are %v", kind, allowedKinds)
		}
		fmt.Println(group, version, subresource)
		// gvrss, err := client.Discovery().FindResources(group, version, kind, subresource)
		// if err != nil {
		// 	return fmt.Errorf("unable to convert GVK to GVR for kinds %s, err: %s", k, err)
		// }
		// if len(gvrss) == 0 {
		// 	return fmt.Errorf("unable to convert GVK to GVR for kinds %s", k)
		// }
		// if isValidationPolicy && backgroundScanningEnabled {
		// 	for gvrs := range gvrss {
		// 		if gvrs.SubResource != "" {
		// 			return fmt.Errorf("background scan enabled with subresource %s", k)
		// 		}
		// 	}
		// }
	}
	return nil
}

func main() {
	err1 := validKinds([]string{"User"})
	if err1 != nil {
		fmt.Println(err1)
	} else {
		fmt.Println("All kinds are valid")
	}

	err2 := validKinds([]string{"Group"})
	if err2 != nil {
		fmt.Println(err2)
	} else {
		fmt.Println("All kinds are valid")
	}

	err3 := validKinds([]string{"ClusterPolicy"})
	if err3 != nil {
		fmt.Println(err3)
	} else {
		fmt.Println("All kinds are valid")
	}

	err4 := validKinds([]string{"ServiceAccount"})
	if err4 != nil {
		fmt.Println(err4)
	} else {
		fmt.Println("All kinds are valid")
	}
}

--------------------------------------------TESTING OUTPUT -----------------------
* * 
All kinds are valid
* * 
All kinds are valid
Invalid kind "ClusterPolicy",allowed kinds are [User Group ServiceAccount]
* * 
All kinds are valid
---------------------------------------------------------------------------------------

-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
