### PR TITLE
feat: add policy validation to restrict the generate policy types

### DIFF
--- a/api/kyverno/v1/common_types.go
+++ b/api/kyverno/v1/common_types.go
@@ -621,10 +621,6 @@ type CloneList struct {
 }
 
 func (g *Generation) Validate(path *field.Path, clusterResources sets.Set[string]) (errs field.ErrorList) {
-	if (g.Clone.Name != "" || g.CloneList.Kinds != nil) && g.RawData != nil {
-		errs = append(errs, field.Forbidden(path.Child("generate"), "cannot define both clone and data rules within the same policy"))
-	}
-
 	if err := g.validateTargetsScope(clusterResources); err != nil {
 		errs = append(errs, field.Forbidden(path.Child("generate").Child("namespace"), fmt.Sprintf("target resource scope mismatched: %v ", err)))
 	}

--- a/api/kyverno/v1/common_types.go
+++ b/api/kyverno/v1/common_types.go
@@ -621,6 +621,10 @@ type CloneList struct {
 }
 
 func (g *Generation) Validate(path *field.Path, clusterResources sets.Set[string]) (errs field.ErrorList) {
+	if (g.Clone.Name != "" || g.CloneList.Kinds != nil) && g.RawData != nil {
+		errs = append(errs, field.Forbidden(path.Child("generate"), "cannot define both clone and data rules within the same policy"))
+	}
+
 	if err := g.validateTargetsScope(clusterResources); err != nil {
 		errs = append(errs, field.Forbidden(path.Child("generate").Child("namespace"), fmt.Sprintf("target resource scope mismatched: %v ", err)))
 	}

--- a/api/kyverno/v1/spec_types.go
+++ b/api/kyverno/v1/spec_types.go
@@ -270,7 +270,7 @@ func (s *Spec) ValidateRules(path *field.Path, namespaced bool, policyNamespace 
 }
 
 func validateGenerateRuleType(rules []Rule) bool {
-	var types sets.Set[string]
+	types := sets.New[string]()
 	for _, rule := range rules {
 		t, _ := rule.GetGenerateTypeAndSync()
 		types.Insert(string(t))

--- a/api/kyverno/v2beta1/rule_types.go
+++ b/api/kyverno/v2beta1/rule_types.go
@@ -123,18 +123,11 @@ func (r *Rule) IsMutateExisting() bool {
 	return r.Mutation.Targets != nil
 }
 
-// IsCloneSyncGenerate checks if the generate rule has the clone block with sync=true
-func (r *Rule) GetCloneSyncForGenerate() (clone bool, sync bool) {
+func (r *Rule) GetGenerateTypeAndSync() (_ kyvernov1.GenerateType, sync bool) {
 	if !r.HasGenerate() {
 		return
 	}
-
-	if r.Generation.Clone.Name != "" {
-		clone = true
-	}
-
-	sync = r.Generation.Synchronize
-	return
+	return r.Generation.GetTypeAndSync()
 }
 
 // ValidateRuleType checks only one type of rule is defined per rule

--- a/api/kyverno/v2beta1/spec_types.go
+++ b/api/kyverno/v2beta1/spec_types.go
@@ -227,7 +227,7 @@ func (s *Spec) ValidateRules(path *field.Path, namespaced bool, clusterResources
 	return errs
 }
 func validateGenerateRuleType(rules []Rule) bool {
-	var types sets.Set[string]
+	types := sets.New[string]()
 	for _, rule := range rules {
 		t, _ := rule.GetGenerateTypeAndSync()
 		types.Insert(string(t))

--- a/api/kyverno/v2beta1/spec_types.go
+++ b/api/kyverno/v2beta1/spec_types.go
@@ -226,6 +226,7 @@ func (s *Spec) ValidateRules(path *field.Path, namespaced bool, clusterResources
 	}
 	return errs
 }
+
 func validateGenerateRuleType(rules []Rule) bool {
 	types := sets.New[string]()
 	for _, rule := range rules {

--- a/test/conformance/kuttl/generate/validation/clusterpolicy/combined-rule-types/01-cluster-policy.yaml
+++ b/test/conformance/kuttl/generate/validation/clusterpolicy/combined-rule-types/01-cluster-policy.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- policy.yaml
+  shouldFail: true

--- a/test/conformance/kuttl/generate/validation/clusterpolicy/combined-rule-types/README.md
+++ b/test/conformance/kuttl/generate/validation/clusterpolicy/combined-rule-types/README.md
@@ -1,0 +1,12 @@
+## Description
+
+This test ensures a generate policy cannot have combined rule types.
+
+## Expected Behavior
+
+The test fails if the policy creation is allowed, otherwise passes.
+
+
+## Reference Issue(s)
+
+https://github.com/kyverno/kyverno/issues/7502

--- a/test/conformance/kuttl/generate/validation/clusterpolicy/combined-rule-types/policy-ready.yaml
+++ b/test/conformance/kuttl/generate/validation/clusterpolicy/combined-rule-types/policy-ready.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v2beta1
+kind: ClusterPolicy
+metadata:
+  name: generate-update-clone
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/kuttl/generate/validation/clusterpolicy/combined-rule-types/policy.yaml
+++ b/test/conformance/kuttl/generate/validation/clusterpolicy/combined-rule-types/policy.yaml
@@ -1,0 +1,50 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cpol-combined-rule-types
+spec:
+  generateExisting: false
+  rules:
+  - name: cpol-combined-rule-types-rule
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+          - default
+          - kube-public
+          - kyverno
+    generate:
+      synchronize: true
+      apiVersion: v1
+      kind: ConfigMap
+      name: zk-kafka-address
+      namespace: "{{request.object.metadata.name}}"
+      data:
+        kind: ConfigMap
+        metadata:
+          labels:
+            somekey: somevalue
+        data:
+          ZK_ADDRESS: "192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181"
+          KAFKA_ADDRESS: "192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092"
+  - name: clone-secret
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+    generate:
+      apiVersion: v1
+      kind: Secret
+      name: regcred
+      namespace: "{{request.object.metadata.name}}"
+      synchronize: true
+      clone:
+        namespace: default
+        name: ichangethis


### PR DESCRIPTION
## Explanation
This PR validates a generate policy cannot have both rule types (data and clone) combined.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes https://github.com/kyverno/kyverno/issues/7502.

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.10.1
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/enhancement
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
