### PR TITLE
Adds ordering to the matched deferred loaders when added via AddDeferredLoader

### DIFF
--- a/pkg/engine/context/context.go
+++ b/pkg/engine/context/context.go
@@ -111,6 +111,7 @@ type context struct {
 	jsonRawCheckpoints [][]byte
 	images             map[string]map[string]apiutils.ImageInfo
 	deferred           deferredLoaders
+	deferredOrder      []string
 }
 
 type deferredLoaders struct {
@@ -132,6 +133,7 @@ func NewContextFromRaw(jp jmespath.Interface, raw []byte) Interface {
 		deferred: deferredLoaders{
 			loaders: make(map[string]DeferredLoader),
 		},
+		deferredOrder: make([]string, 0),
 	}
 }
 
@@ -356,5 +358,6 @@ func (ctx *context) reset(remove bool) {
 func (ctx *context) AddDeferredLoader(name string, loader DeferredLoader) {
 	ctx.deferred.mutex.Lock()
 	defer ctx.deferred.mutex.Unlock()
+	ctx.deferredOrder = append(ctx.deferredOrder, name)
 	ctx.deferred.loaders[name] = loader
 }

--- a/pkg/engine/context/evaluate.go
+++ b/pkg/engine/context/evaluate.go
@@ -54,10 +54,13 @@ func (ctx *context) getMatchingLoaders(query string) []DeferredLoader {
 	defer ctx.deferred.mutex.Unlock()
 
 	var matchingLoaders []DeferredLoader
-	for name, deferredLoader := range ctx.deferred.loaders {
+	for _, name := range ctx.deferredOrder {
 		if strings.Contains(query, name) {
-			matchingLoaders = append(matchingLoaders, deferredLoader)
-			delete(ctx.deferred.loaders, name)
+			deferredLoader, ok := ctx.deferred.loaders[name]
+			if ok {
+				matchingLoaders = append(matchingLoaders, deferredLoader)
+				delete(ctx.deferred.loaders, name)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Explanation

This PR attempts to add ordering to the matching of deferred loaders, when policy evaluation takes place and variables need  substituting, this can sometimes mean that overlapping variable names can cause issues, or when multiple context variables are dependent on the order they are written in the policy document (I believe it was referred to as lazily evaluating the deferred loaders in the issue below).

## Related issue

https://github.com/kyverno/kyverno/issues/7486
https://github.com/kyverno/kyverno/issues/7532

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:

/kind bug
> /kind api-change
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

The proposed changes introduce a slice that keeps the order of the keys for the context's deferred loaders, so that the deferred loaders occur in the order they are defined.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

Example `Namespace`, and a `ConfigMap` containing target labels:
```yaml
apiVersion: v1
data:
  script: '#!/usr/bin/env bash\n sleep 1'
kind: ConfigMap
metadata:
  name: foo
  namespace: test
```

Kyverno Policy with >1 Context Variable:
```yaml
apiVersion: kyverno.io/v1
kind: Policy
metadata:
  name: default-labels
  namespace: test
spec:
  rules:
  - name: add-default-labels
    match:
      any:
      - resources:
          kinds:
          - Pod
    context:
    - name: foo
      variable:
        jmesPath: request.object.metadata.name
    - name: foobar
      apiCall:
        urlPath: "/api/v1/namespaces/{{ request.namespace }}/configmaps/{{ foo }}"
    preconditions:
      all:
      - key: "{{request.operation || 'BACKGROUND'}}"
        operator: Equals
        value: CREATE
      - key: "{{ foo }}"
        operator: NotEquals
        value: ""
    mutate:
      patchStrategicMerge:
        metadata:
          labels:
            configMapReference: "{{ foobar.metadata.name }}"
```

Kubernetes Resource (`Pod`) for which target labels should be applied:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: foo
  namespace: test
  labels:
    app: foo
spec:
  containers:
    - name: web
      image: nginx
      ports:
        - name: web
          containerPort: 80
          protocol: TCP
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

I am not entirely sure how to test this effectively, though I did multiple applies to force the mutation to occur and didn't get any errors/failures. The example here is: `Pods` with a name that matches a `ConfigMap` of the same name, patch the label of the `Pod` with a reference to the `ConfigMap`s name (this might be a rather naive test, I'm happy to take guidance here).
