### PR TITLE
fix: make configuring max procs not exit in case of error

### DIFF
--- a/cmd/internal/maxprocs.go
+++ b/cmd/internal/maxprocs.go
@@ -17,6 +17,8 @@ func setupMaxProcs(logger logr.Logger) func() {
 			},
 		),
 	)
-	checkError(logger, err, "failed to configure maxprocs")
+	if err != nil {
+		logger.Error(err, "WARNING: failed to configure maxprocs")
+	}
 	return undo
 }

--- a/cmd/internal/maxprocs.go
+++ b/cmd/internal/maxprocs.go
@@ -18,7 +18,7 @@ func setupMaxProcs(logger logr.Logger) func() {
 		),
 	)
 	if err != nil {
-		logger.Error(err, "WARNING: failed to configure maxprocs")
+		logger.Error(err, "failed to configure maxprocs")
 	}
 	return undo
 }


### PR DESCRIPTION
## Explanation

This PR makes configuring max procs not exit in case of error.
