### PR TITLE
fix: service account name env var defined twice

### DIFF
--- a/charts/kyverno/templates/cleanup-controller/deployment.yaml
+++ b/charts/kyverno/templates/cleanup-controller/deployment.yaml
@@ -115,8 +115,6 @@ spec:
             {{- end }}
             {{- end }}
           env:
-          - name: KYVERNO_SERVICEACCOUNT_NAME
-            value: {{ template "kyverno.cleanup-controller.serviceAccountName" . }}
           - name: KYVERNO_DEPLOYMENT
             value: {{ template "kyverno.cleanup-controller.name" . }}
           - name: INIT_CONFIG

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -39015,8 +39015,6 @@ spec:
             - --loggingFormat=text
             - --v=2
           env:
-          - name: KYVERNO_SERVICEACCOUNT_NAME
-            value: kyverno-cleanup-controller
           - name: KYVERNO_DEPLOYMENT
             value: kyverno-cleanup-controller
           - name: INIT_CONFIG


### PR DESCRIPTION
## Explanation

This PR fixes service account name env var defined twice.
