### PR TITLE
fix: stop using lister in tls renewer

### DIFF
--- a/cmd/cleanup-controller/main.go
+++ b/cmd/cleanup-controller/main.go
@@ -38,11 +38,11 @@ const (
 
 type probes struct{}
 
-func (probes) IsReady() bool {
+func (probes) IsReady(context.Context) bool {
 	return true
 }
 
-func (probes) IsLive() bool {
+func (probes) IsLive(context.Context) bool {
 	return true
 }
 
@@ -86,12 +86,9 @@ func main() {
 			kubeInformer := kubeinformers.NewSharedInformerFactoryWithOptions(setup.KubeClient, resyncPeriod)
 			kyvernoInformer := kyvernoinformer.NewSharedInformerFactory(setup.KyvernoClient, resyncPeriod)
 			kubeKyvernoInformer := kubeinformers.NewSharedInformerFactoryWithOptions(setup.KubeClient, resyncPeriod, kubeinformers.WithNamespace(config.KyvernoNamespace()))
-			// listers
-			secretLister := kubeKyvernoInformer.Core().V1().Secrets().Lister().Secrets(config.KyvernoNamespace())
 			// controllers
 			renewer := tls.NewCertRenewer(
 				setup.KubeClient.CoreV1().Secrets(config.KyvernoNamespace()),
-				secretLister,
 				tls.CertRenewalInterval,
 				tls.CAValidityDuration,
 				tls.TLSValidityDuration,

--- a/cmd/cleanup-controller/server.go
+++ b/cmd/cleanup-controller/server.go
@@ -35,8 +35,8 @@ type (
 )
 
 type Probes interface {
-	IsReady() bool
-	IsLive() bool
+	IsReady(context.Context) bool
+	IsLive(context.Context) bool
 }
 
 // NewServer creates new instance of server accordingly to given configuration

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -244,7 +244,6 @@ func main() {
 	var wg sync.WaitGroup
 	certRenewer := tls.NewCertRenewer(
 		setup.KubeClient.CoreV1().Secrets(config.KyvernoNamespace()),
-		secretLister,
 		tls.CertRenewalInterval,
 		tls.CAValidityDuration,
 		tls.TLSValidityDuration,

--- a/pkg/tls/renewer.go
+++ b/pkg/tls/renewer.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 const (
@@ -30,7 +29,7 @@ const (
 
 type CertValidator interface {
 	// ValidateCert checks the certificates validity
-	ValidateCert() (bool, error)
+	ValidateCert(context.Context) (bool, error)
 }
 
 type CertRenewer interface {
@@ -45,7 +44,6 @@ type CertRenewer interface {
 // renews RootCA at the given interval
 type certRenewer struct {
 	client              controllerutils.ObjectClient[*corev1.Secret]
-	lister              corev1listers.SecretNamespaceLister
 	certRenewalInterval time.Duration
 	caValidityDuration  time.Duration
 	tlsValidityDuration time.Duration
@@ -57,7 +55,6 @@ type certRenewer struct {
 // NewCertRenewer returns an instance of CertRenewer
 func NewCertRenewer(
 	client controllerutils.ObjectClient[*corev1.Secret],
-	lister corev1listers.SecretNamespaceLister,
 	certRenewalInterval,
 	caValidityDuration,
 	tlsValidityDuration time.Duration,
@@ -65,7 +62,6 @@ func NewCertRenewer(
 ) *certRenewer {
 	return &certRenewer{
 		client:              client,
-		lister:              lister,
 		certRenewalInterval: certRenewalInterval,
 		caValidityDuration:  caValidityDuration,
 		tlsValidityDuration: tlsValidityDuration,
@@ -75,7 +71,7 @@ func NewCertRenewer(
 
 // RenewCA renews the CA certificate if needed
 func (c *certRenewer) RenewCA(ctx context.Context) error {
-	secret, key, certs, err := c.decodeCASecret()
+	secret, key, certs, err := c.decodeCASecret(ctx)
 	if err != nil && !apierrors.IsNotFound(err) {
 		logger.Error(err, "failed to read CA")
 		return err
@@ -115,12 +111,12 @@ func (c *certRenewer) RenewCA(ctx context.Context) error {
 
 // RenewTLS renews the TLS certificate if needed
 func (c *certRenewer) RenewTLS(ctx context.Context) error {
-	_, caKey, caCerts, err := c.decodeCASecret()
+	_, caKey, caCerts, err := c.decodeCASecret(ctx)
 	if err != nil {
 		logger.Error(err, "failed to read CA")
 		return err
 	}
-	secret, _, cert, err := c.decodeTLSSecret()
+	secret, _, cert, err := c.decodeTLSSecret(ctx)
 	if err != nil && !apierrors.IsNotFound(err) {
 		logger.Error(err, "failed to read TLS")
 		return err
@@ -157,28 +153,28 @@ func (c *certRenewer) RenewTLS(ctx context.Context) error {
 }
 
 // ValidateCert validates the CA Cert
-func (c *certRenewer) ValidateCert() (bool, error) {
-	_, _, caCerts, err := c.decodeCASecret()
+func (c *certRenewer) ValidateCert(ctx context.Context) (bool, error) {
+	_, _, caCerts, err := c.decodeCASecret(ctx)
 	if err != nil {
 		return false, err
 	}
-	_, _, cert, err := c.decodeTLSSecret()
+	_, _, cert, err := c.decodeTLSSecret(ctx)
 	if err != nil {
 		return false, err
 	}
 	return validateCert(time.Now(), cert, caCerts...), nil
 }
 
-func (c *certRenewer) getSecret(name string) (*corev1.Secret, error) {
-	if s, err := c.lister.Get(name); err != nil {
+func (c *certRenewer) getSecret(ctx context.Context, name string) (*corev1.Secret, error) {
+	if s, err := c.client.Get(ctx, name, metav1.GetOptions{}); err != nil {
 		return nil, err
 	} else {
 		return s, nil
 	}
 }
 
-func (c *certRenewer) decodeSecret(name string) (*corev1.Secret, *rsa.PrivateKey, []*x509.Certificate, error) {
-	secret, err := c.getSecret(name)
+func (c *certRenewer) decodeSecret(ctx context.Context, name string) (*corev1.Secret, *rsa.PrivateKey, []*x509.Certificate, error) {
+	secret, err := c.getSecret(ctx, name)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -201,12 +197,12 @@ func (c *certRenewer) decodeSecret(name string) (*corev1.Secret, *rsa.PrivateKey
 	return secret, key, pemToCertificates(certBytes), nil
 }
 
-func (c *certRenewer) decodeCASecret() (*corev1.Secret, *rsa.PrivateKey, []*x509.Certificate, error) {
-	return c.decodeSecret(GenerateRootCASecretName())
+func (c *certRenewer) decodeCASecret(ctx context.Context) (*corev1.Secret, *rsa.PrivateKey, []*x509.Certificate, error) {
+	return c.decodeSecret(ctx, GenerateRootCASecretName())
 }
 
-func (c *certRenewer) decodeTLSSecret() (*corev1.Secret, *rsa.PrivateKey, *x509.Certificate, error) {
-	secret, key, certs, err := c.decodeSecret(GenerateTLSPairSecretName())
+func (c *certRenewer) decodeTLSSecret(ctx context.Context) (*corev1.Secret, *rsa.PrivateKey, *x509.Certificate, error) {
+	secret, key, certs, err := c.decodeSecret(ctx, GenerateTLSPairSecretName())
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -221,7 +217,7 @@ func (c *certRenewer) decodeTLSSecret() (*corev1.Secret, *rsa.PrivateKey, *x509.
 
 func (c *certRenewer) writeSecret(ctx context.Context, name string, key *rsa.PrivateKey, certs ...*x509.Certificate) error {
 	logger := logger.WithValues("name", name, "namespace", config.KyvernoNamespace())
-	secret, err := c.getSecret(name)
+	secret, err := c.getSecret(ctx, name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		logger.Error(err, "failed to get CA secret")
 		return err

--- a/pkg/utils/runtime/utils.go
+++ b/pkg/utils/runtime/utils.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/tls"
@@ -12,8 +14,8 @@ import (
 
 type Runtime interface {
 	IsDebug() bool
-	IsReady() bool
-	IsLive() bool
+	IsReady(ctx context.Context) bool
+	IsLive(ctx context.Context) bool
 	IsRollingUpdate() bool
 	IsGoingDown() bool
 }
@@ -43,12 +45,12 @@ func (c *runtime) IsDebug() bool {
 	return c.serverIP != ""
 }
 
-func (c *runtime) IsLive() bool {
+func (c *runtime) IsLive(context.Context) bool {
 	return true
 }
 
-func (c *runtime) IsReady() bool {
-	return c.validateCertificates()
+func (c *runtime) IsReady(ctx context.Context) bool {
+	return c.validateCertificates(ctx)
 }
 
 func (c *runtime) IsRollingUpdate() bool {
@@ -93,8 +95,8 @@ func (c *runtime) getDeployment() (*appsv1.Deployment, error) {
 	return c.deploymentLister.Deployments(config.KyvernoNamespace()).Get(config.KyvernoDeploymentName())
 }
 
-func (c *runtime) validateCertificates() bool {
-	validity, err := c.certValidator.ValidateCert()
+func (c *runtime) validateCertificates(ctx context.Context) bool {
+	validity, err := c.certValidator.ValidateCert(ctx)
 	if err != nil {
 		c.logger.Error(err, "failed to validate certificates")
 		return false

--- a/pkg/webhooks/handlers/probe.go
+++ b/pkg/webhooks/handlers/probe.go
@@ -1,11 +1,14 @@
 package handlers
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
-func Probe(check func() bool) http.HandlerFunc {
+func Probe(check func(context.Context) bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if check != nil {
-			if !check() {
+			if !check(r.Context()) {
 				w.WriteHeader(http.StatusInternalServerError)
 			}
 		}


### PR DESCRIPTION
## Explanation

This PR stops using a lister in tls renewer.
