### PR TITLE
fix: image verification with 2+ containers

### DIFF
--- a/pkg/engine/internal/imageverifier.go
+++ b/pkg/engine/internal/imageverifier.go
@@ -207,12 +207,14 @@ func (iv *ImageVerifier) Verify(
 		changed, err := iv.policyContext.JSONContext().HasChanged(pointer)
 		if err == nil && !changed {
 			iv.logger.V(4).Info("no change in image, skipping check", "image", image)
+			iv.ivm.Add(image, true)
 			continue
 		}
 
 		verified, err := isImageVerified(iv.policyContext.NewResource(), image, iv.logger)
 		if err == nil && verified {
 			iv.logger.Info("image was previously verified, skipping check", "image", image)
+			iv.ivm.Add(image, true)
 			continue
 		}
 


### PR DESCRIPTION
## Explanation

This PR fixes image verification with 2+ containers.

## Related issue

Fixes https://github.com/kyverno/kyverno/issues/7651
