### PR TITLE
feat: migrate to events.k8s.io/v1

### DIFF
--- a/pkg/background/generate/generate.go
+++ b/pkg/background/generate/generate.go
@@ -117,7 +117,9 @@ func (c *GenerateController) ProcessUR(ur *kyvernov1beta1.UpdateRequest) error {
 			return nil
 		}
 
-		events := event.NewBackgroundFailedEvent(err, ur.Spec.Policy, "", event.GeneratePolicyController, trigger)
+		policy, _ := c.getPolicySpec(*ur)
+		events := event.NewBackgroundFailedEvent(err, policy, ur.Spec.Rule, event.GeneratePolicyController,
+			kyvernov1.ResourceSpec{Kind: trigger.GetKind(), Namespace: trigger.GetNamespace(), Name: trigger.GetName()})
 		c.eventGen.Add(events...)
 	}
 
@@ -261,8 +263,7 @@ func (c *GenerateController) applyGenerate(resource unstructured.Unstructured, u
 			c.eventGen.Add(e)
 		}
 
-		unstructuredPol := kubeutils.NewUnstructured("kyverno.io/v1", policy.GetKind(), policy.GetNamespace(), policy.GetName())
-		e := event.NewBackgroundSuccessEvent(ur.Spec.Policy, ur.Spec.Rule, event.GeneratePolicyController, unstructuredPol)
+		e := event.NewBackgroundSuccessEvent(event.GeneratePolicyController, policy, genResources)
 		c.eventGen.Add(e...)
 	}
 

--- a/pkg/clients/dclient/client.go
+++ b/pkg/clients/dclient/client.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/kubernetes"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	eventsv1 "k8s.io/client-go/kubernetes/typed/events/v1"
 	"k8s.io/client-go/rest"
 )
 
@@ -24,7 +24,7 @@ type Interface interface {
 	// GetKubeClient provides typed kube client
 	GetKubeClient() kubernetes.Interface
 	// GetEventsInterface provides typed interface for events
-	GetEventsInterface() corev1.EventInterface
+	GetEventsInterface() eventsv1.EventsV1Interface
 	// GetDynamicInterface fetches underlying dynamic interface
 	GetDynamicInterface() dynamic.Interface
 	// Discovery return the discovery client implementation
@@ -96,8 +96,8 @@ func (c *client) GetKubeClient() kubernetes.Interface {
 }
 
 // GetEventsInterface provides typed interface for events
-func (c *client) GetEventsInterface() corev1.EventInterface {
-	return c.kube.CoreV1().Events(metav1.NamespaceAll)
+func (c *client) GetEventsInterface() eventsv1.EventsV1Interface {
+	return c.kube.EventsV1()
 }
 
 func (c *client) getInterface(apiVersion string, kind string) dynamic.NamespaceableResourceInterface {

--- a/pkg/clients/dclient/client_test.go
+++ b/pkg/clients/dclient/client_test.go
@@ -108,7 +108,7 @@ func TestCRUDResource(t *testing.T) {
 func TestEventInterface(t *testing.T) {
 	f := newFixture(t)
 	iEvent := f.client.GetEventsInterface()
-	_, err := iEvent.List(context.TODO(), metav1.ListOptions{})
+	_, err := iEvent.Events(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Errorf("Testing Event interface not working: %s", err)
 	}

--- a/pkg/event/action.go
+++ b/pkg/event/action.go
@@ -6,7 +6,6 @@ type Action string
 const (
 	ResourceBlocked   Action = "Resource Blocked"
 	ResourcePassed    Action = "Resource Passed"
-	ResourceSkipped   Action = "Resource Skipped"
 	ResourceGenerated Action = "Resource Generated"
 	ResourceMutated   Action = "Resource Mutated"
 	ResourceCleanedUp Action = "Resource Cleaned Up"

--- a/pkg/event/action.go
+++ b/pkg/event/action.go
@@ -1,0 +1,14 @@
+package event
+
+// Action types of Event Actions
+type Action string
+
+const (
+	ResourceBlocked   Action = "Resource Blocked"
+	ResourcePassed    Action = "Resource Passed"
+	ResourceSkipped   Action = "Resource Skipped"
+	ResourceGenerated Action = "Resource Generated"
+	ResourceMutated   Action = "Resource Mutated"
+	ResourceCleanedUp Action = "Resource Cleaned Up"
+	None              Action = "None"
+)

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -207,7 +207,7 @@ func NewPolicyExceptionEvents(engineResponse engineapi.EngineResponse, ruleResp 
 		Reason:            PolicySkipped,
 		Message:           policyMessage,
 		Source:            source,
-		Action:            ResourceSkipped,
+		Action:            ResourcePassed,
 	}
 	exceptionEvent := Info{
 		Kind:              "PolicyException",
@@ -220,7 +220,7 @@ func NewPolicyExceptionEvents(engineResponse engineapi.EngineResponse, ruleResp 
 		Reason:            PolicySkipped,
 		Message:           exceptionMessage,
 		Source:            source,
-		Action:            ResourceSkipped,
+		Action:            ResourcePassed,
 	}
 	return []Info{policyEvent, exceptionEvent}
 }

--- a/pkg/event/info.go
+++ b/pkg/event/info.go
@@ -4,12 +4,17 @@ import "strings"
 
 // Info defines the event details
 type Info struct {
-	Kind      string
-	Name      string
-	Namespace string
-	Reason    Reason
-	Message   string
-	Source    Source
+	Kind              string
+	Name              string
+	Namespace         string
+	RelatedAPIVersion string
+	RelatedKind       string
+	RelatedName       string
+	RelatedNamespace  string
+	Reason            Reason
+	Message           string
+	Action            Action
+	Source            Source
 }
 
 func (i *Info) Resource() string {

--- a/pkg/event/recorder.go
+++ b/pkg/event/recorder.go
@@ -2,25 +2,20 @@ package event
 
 import (
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/scheme"
-	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/tools/record"
+	typedeventsv1 "k8s.io/client-go/kubernetes/typed/events/v1"
+	"k8s.io/client-go/tools/events"
 )
 
-func NewRecorder(source Source, sink typedcorev1.EventInterface) record.EventRecorder {
+func NewRecorder(source Source, sink typedeventsv1.EventsV1Interface) events.EventRecorder {
 	utilruntime.Must(scheme.AddToScheme(scheme.Scheme))
-	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartStructuredLogging(0)
-	eventBroadcaster.StartRecordingToSink(
-		&typedcorev1.EventSinkImpl{
+	eventBroadcaster := events.NewBroadcaster(
+		&events.EventSinkImpl{
 			Interface: sink,
 		},
 	)
-	return eventBroadcaster.NewRecorder(
-		scheme.Scheme,
-		corev1.EventSource{
-			Component: string(source),
-		},
-	)
+	eventBroadcaster.StartStructuredLogging(0)
+	stopCh := make(chan struct{})
+	eventBroadcaster.StartRecordingToSink(stopCh)
+	return eventBroadcaster.NewRecorder(scheme.Scheme, string(source))
 }

--- a/pkg/policy/policy_controller.go
+++ b/pkg/policy/policy_controller.go
@@ -25,7 +25,6 @@ import (
 	engineutils "github.com/kyverno/kyverno/pkg/utils/engine"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	policyvalidation "github.com/kyverno/kyverno/pkg/validation/policy"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -33,10 +32,9 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	corev1informers "k8s.io/client-go/informers/core/v1"
-	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -60,7 +58,7 @@ type policyController struct {
 	npInformer kyvernov1informers.PolicyInformer
 
 	eventGen      event.Interface
-	eventRecorder record.EventRecorder
+	eventRecorder events.EventRecorder
 
 	// Policies that need to be synced
 	queue workqueue.RateLimitingInterface
@@ -108,10 +106,15 @@ func NewPolicyController(
 	jp jmespath.Interface,
 ) (*policyController, error) {
 	// Event broad caster
-	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(log.V(5).Info)
 	eventInterface := client.GetEventsInterface()
-	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: eventInterface})
+	eventBroadcaster := events.NewBroadcaster(
+		&events.EventSinkImpl{
+			Interface: eventInterface,
+		},
+	)
+	eventBroadcaster.StartStructuredLogging(0)
+	stopCh := make(chan struct{})
+	eventBroadcaster.StartRecordingToSink(stopCh)
 
 	pc := policyController{
 		client:          client,
@@ -120,7 +123,7 @@ func NewPolicyController(
 		pInformer:       pInformer,
 		npInformer:      npInformer,
 		eventGen:        eventGen,
-		eventRecorder:   eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "policy_controller"}),
+		eventRecorder:   eventBroadcaster.NewRecorder(scheme.Scheme, "policy_controller"),
 		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "policy"),
 		configuration:   configuration,
 		reconcilePeriod: reconcilePeriod,

--- a/pkg/webhooks/resource/generation/handler.go
+++ b/pkg/webhooks/resource/generation/handler.go
@@ -301,7 +301,8 @@ func (h *generationHandler) processRequest(ctx context.Context, policyContext *e
 
 				ur := buildURSpec(kyvernov1beta1.Generate, pKey, rule.Name, generateutils.TriggerFromLabels(labels), deleteDownstream)
 				if err := h.urGenerator.Apply(ctx, ur); err != nil {
-					e := event.NewBackgroundFailedEvent(err, pKey, pRuleName, event.GeneratePolicyController, &new)
+					e := event.NewBackgroundFailedEvent(err, policy, pRuleName, event.GeneratePolicyController,
+						kyvernov1.ResourceSpec{Kind: new.GetKind(), Namespace: new.GetNamespace(), Name: new.GetName()})
 					h.eventGen.Add(e...)
 					return err
 				}

--- a/test/conformance/kuttl/background-only/cluster-policy/no-admission-event/admission-event.yaml
+++ b/test/conformance/kuttl/background-only/cluster-policy/no-admission-event/admission-event.yaml
@@ -5,5 +5,4 @@ involvedObject:
   name: pod
 kind: Event
 metadata: {}
-source:
-  component: kyverno-admission
+reportingComponent: kyverno-admission

--- a/test/conformance/kuttl/background-only/cluster-policy/no-admission-event/background-event.yaml
+++ b/test/conformance/kuttl/background-only/cluster-policy/no-admission-event/background-event.yaml
@@ -5,5 +5,4 @@ involvedObject:
   name: pod
 kind: Event
 metadata: {}
-source:
-  component: kyverno-scan
+reportingComponent: kyverno-scan

--- a/test/conformance/kuttl/background-only/policy/no-admission-event/admission-event.yaml
+++ b/test/conformance/kuttl/background-only/policy/no-admission-event/admission-event.yaml
@@ -5,5 +5,4 @@ involvedObject:
   name: pod
 kind: Event
 metadata: {}
-source:
-  component: kyverno-admission
+reportingComponent: kyverno-admission

--- a/test/conformance/kuttl/background-only/policy/no-admission-event/background-event.yaml
+++ b/test/conformance/kuttl/background-only/policy/no-admission-event/background-event.yaml
@@ -5,5 +5,4 @@ involvedObject:
   name: pod
 kind: Event
 metadata: {}
-source:
-  component: kyverno-scan
+reportingComponent: kyverno-scan

--- a/test/conformance/kuttl/events/clusterpolicy/generate-events-upon-successful-generation/policy-event.yaml
+++ b/test/conformance/kuttl/events/clusterpolicy/generate-events-upon-successful-generation/policy-event.yaml
@@ -9,5 +9,4 @@ involvedObject:
 type: Normal
 message: resource generated
 reason: PolicyApplied
-source:
-  component: kyverno-generate
+reportingComponent: kyverno-generate

--- a/test/conformance/kuttl/events/clusterpolicy/generate-events-upon-successful-generation/policy-event.yaml
+++ b/test/conformance/kuttl/events/clusterpolicy/generate-events-upon-successful-generation/policy-event.yaml
@@ -9,4 +9,5 @@ involvedObject:
 type: Normal
 message: resource generated
 reason: PolicyApplied
+action: Resource Generated
 reportingComponent: kyverno-generate

--- a/test/conformance/kuttl/events/clusterpolicy/generate-events-upon-successful-generation/resource-event.yaml
+++ b/test/conformance/kuttl/events/clusterpolicy/generate-events-upon-successful-generation/resource-event.yaml
@@ -9,5 +9,4 @@ involvedObject:
   namespace: test-ns
 type: Normal
 reason: PolicyApplied
-source:
-  component: kyverno-generate
+reportingComponent: kyverno-generate

--- a/test/conformance/kuttl/events/clusterpolicy/generate-events-upon-successful-generation/resource-event.yaml
+++ b/test/conformance/kuttl/events/clusterpolicy/generate-events-upon-successful-generation/resource-event.yaml
@@ -9,4 +9,5 @@ involvedObject:
   namespace: test-ns
 type: Normal
 reason: PolicyApplied
+action: None
 reportingComponent: kyverno-generate

--- a/test/conformance/kuttl/events/clusterpolicy/generate-events-upon-successful-mutation/event-assert.yaml
+++ b/test/conformance/kuttl/events/clusterpolicy/generate-events-upon-successful-mutation/event-assert.yaml
@@ -8,5 +8,4 @@ involvedObject:
   name: add-labels
 type: Normal
 reason: PolicyApplied
-source:
-  component: kyverno-admission
+reportingComponent: kyverno-admission

--- a/test/conformance/kuttl/events/clusterpolicy/generate-events-upon-successful-mutation/event-assert.yaml
+++ b/test/conformance/kuttl/events/clusterpolicy/generate-events-upon-successful-mutation/event-assert.yaml
@@ -8,4 +8,5 @@ involvedObject:
   name: add-labels
 type: Normal
 reason: PolicyApplied
+action: Resource Mutated
 reportingComponent: kyverno-admission

--- a/test/conformance/kuttl/events/clusterpolicy/no-events-upon-fail-generation/event.yaml
+++ b/test/conformance/kuttl/events/clusterpolicy/no-events-upon-fail-generation/event.yaml
@@ -6,5 +6,4 @@ involvedObject:
   apiVersion: kyverno.io/v1
   kind: ClusterPolicy
   name: rbac-policy
-source:
-  component: kyverno-generate
+reportingComponent: kyverno-generate

--- a/test/conformance/kuttl/events/clusterpolicy/no-events-upon-skip-generation/event.yaml
+++ b/test/conformance/kuttl/events/clusterpolicy/no-events-upon-skip-generation/event.yaml
@@ -6,5 +6,4 @@ involvedObject:
   apiVersion: kyverno.io/v1
   kind: ClusterPolicy
   name: default
-source:
-  component: kyverno-generate
+reportingComponent: kyverno-generate

--- a/test/conformance/kuttl/events/policy/policy-applied/event-assert.yaml
+++ b/test/conformance/kuttl/events/policy/policy-applied/event-assert.yaml
@@ -7,5 +7,4 @@ involvedObject:
   name: require-labels
 type: Normal
 reason: PolicyApplied
-source:
-  component: kyverno-admission
+reportingComponent: kyverno-admission

--- a/test/conformance/kuttl/events/policy/policy-violation/event-assert.yaml
+++ b/test/conformance/kuttl/events/policy/policy-violation/event-assert.yaml
@@ -7,5 +7,4 @@ involvedObject:
   name: require-labels
 type: Warning
 reason: PolicyViolation
-source:
-  component: kyverno-admission
+reportingComponent: kyverno-admission

--- a/test/conformance/kuttl/exceptions/events-creation/05-assert.yaml
+++ b/test/conformance/kuttl/exceptions/events-creation/05-assert.yaml
@@ -8,8 +8,7 @@ kind: Event
 metadata:
   namespace: policy-exception-events-creation-polex-ns
 reason: PolicySkipped
-source:
-  component: kyverno-admission
+reportingComponent: kyverno-admission
 type: Normal
 ---
 apiVersion: v1
@@ -21,6 +20,5 @@ kind: Event
 metadata:
   namespace: default
 reason: PolicySkipped
-source:
-  component: kyverno-admission
+reportingComponent: kyverno-admission
 type: Normal


### PR DESCRIPTION
## Explanation
Move all Events to the events.k8s.io/v1 group and version.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Fixes #7471
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.11.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
#### Validate Rules
1. policy.yaml:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-ns-purpose-label
spec:
  validationFailureAction: Enforce
  rules:
  - name: require-ns-purpose-label
    match:
      any:
      - resources:
          kinds:
          - Namespace
    validate:
      message: "You must have label `purpose` with value `production` set on all new namespaces."
      pattern:
        metadata:
          labels:
            purpose: production

```
2. `kubectl create ns ns-1`
3. `kubectl get events.events.k8s.io`:
```
2m1s        Warning   PolicyViolation           clusterpolicy/require-ns-purpose-label   Namespace ns-1: [require-ns-purpose-label] fail (blocked); validation error: You must have label  with value  set on all new namespaces. rule require-ns-purpose-label failed at path /metadata/labels/purpose/
```
5. `kubectl get events.events.k8s.io -o yaml`:
```
- action: Resource Blocked
  apiVersion: events.k8s.io/v1
  deprecatedFirstTimestamp: null
  deprecatedLastTimestamp: null
  deprecatedSource: {}
  eventTime: "2023-07-05T11:03:05.595312Z"
  kind: Event
  metadata:
    creationTimestamp: "2023-07-05T11:03:05Z"
    name: require-ns-purpose-label.176ef3d0241ff233
    namespace: default
    resourceVersion: "5274"
    uid: 34ccc9c9-a850-42f2-9051-2b0dd3c642ca
  note: 'Namespace ns-1: [require-ns-purpose-label] fail (blocked); validation error:
    You must have label  with value  set on all new namespaces. rule require-ns-purpose-label
    failed at path /metadata/labels/purpose/'
  reason: PolicyViolation
  regarding:
    apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    name: require-ns-purpose-label
    resourceVersion: "5254"
    uid: 180f1aa5-8396-4c9a-b1a0-a4e52709a5bd
  related:
    apiVersion: v1
    kind: Namespace
    name: ns-1
  reportingController: kyverno-admission
  reportingInstance:  kyverno-admission-kyverno-admission-controller-b9f7fdfcf-gnvvw
  type: Warning
```
6. create a namespace:
```
apiVersion: v1
kind: Namespace
metadata:
  name: prod-bus-app1
  labels:
    purpose: production
```
7. `kubectl get events.events.k8s.io`:
```
7m24s       Normal    PolicyApplied             clusterpolicy/require-ns-purpose-label         Namespace prod-bus-app1: pass
```
8. `kubectl get events.events.k8s.io -o yaml`:
```
- action: Resource Passed
  apiVersion: events.k8s.io/v1
  deprecatedFirstTimestamp: null
  deprecatedLastTimestamp: null
  deprecatedSource: {}
  eventTime: "2023-07-04T12:49:54.771465Z"
  kind: Event
  metadata:
    creationTimestamp: "2023-07-04T12:49:54Z"
    name: require-ns-purpose-label.176eab0fd37be726
    namespace: default
    resourceVersion: "4713"
    uid: ea6d8de6-8c2b-46dc-948a-848fc2e93d9e
  note: 'Namespace prod-bus-app1: pass'
  reason: PolicyApplied
  regarding:
    apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    name: require-ns-purpose-label
    resourceVersion: "2208"
    uid: 971c7135-e12c-412c-b8d4-4b8c08e8878b
  related:
    apiVersion: v1
    kind: Namespace
    name: prod-bus-app1
    resourceVersion: "4709"
    uid: 23ffb880-320b-4707-ab58-501f82e019d9
  reportingController: kyverno-admission
  reportingInstance: kyverno-admission-kyverno-admission-controller-b9f7fdfcf-gnvvw
  type: Normal
```
9. Set ` validationFailureAction` to `Audit` instead of `Enforce`.
10. Create a namespace that violates the rule `kubectl create ns test-ns`
11.  `kubectl get events.events.k8s.io -o yaml`:
```
- action: Resource Passed
  apiVersion: events.k8s.io/v1
  deprecatedFirstTimestamp: null
  deprecatedLastTimestamp: null
  deprecatedSource: {}
  eventTime: "2023-07-21T12:16:19.078112Z"
  kind: Event
  metadata:
    creationTimestamp: "2023-07-21T12:16:19Z"
    name: require-ns-purpose-label.1773e118290b0a6f
    namespace: default
    resourceVersion: "26704"
    uid: 7ef5770e-626e-4562-a815-d2c61ccef791
  note: 'Namespace test-ns: [require-ns-purpose-label] fail; validation error: You
    must have label `purpose` with value `production` set on all new namespaces. rule
    require-ns-purpose-label failed at path /metadata/labels/purpose/'
  reason: PolicyViolation
  regarding:
    apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    name: require-ns-purpose-label
    resourceVersion: "25087"
    uid: d76f3e23-4c49-482a-abb2-cfb0e7ff585d
  related:
    apiVersion: v1
    kind: Namespace
    name: test-ns
  reportingController: kyverno-admission
  reportingInstance: kyverno-admission-kyverno-admission-controller-7b488c9977-wlk2t
  type: Warning
- action: Resource Passed
  apiVersion: events.k8s.io/v1
  deprecatedFirstTimestamp: null
  deprecatedLastTimestamp: null
  deprecatedSource: {}
  eventTime: "2023-07-21T12:16:19.080269Z"
  kind: Event
  metadata:
    creationTimestamp: "2023-07-21T12:16:19Z"
    name: test-ns.1773e118292bee31
    namespace: default
    resourceVersion: "26708"
    uid: 350c2bf4-1c06-42f9-aca6-f1bbcf46ff2e
  note: 'policy require-ns-purpose-label/require-ns-purpose-label fail: validation
    error: You must have label `purpose` with value `production` set on all new namespaces.
    rule require-ns-purpose-label failed at path /metadata/labels/purpose/'
  reason: PolicyViolation
  regarding:
    apiVersion: v1
    kind: Namespace
    name: test-ns
    resourceVersion: "26703"
    uid: 91c31fb2-07c5-49e8-9086-37ecbd4adc59
  reportingController: kyverno-admission
  reportingInstance: kyverno-admission-kyverno-admission-controller-7b488c9977-wlk2t
  type: Warning
``` 

#### Policy Exceptions
1. `policy.yaml`:
```
apiVersion: kyverno.io/v2beta1
kind: ClusterPolicy
metadata:
  name: disallow-host-namespaces
spec:
  validationFailureAction: Enforce
  background: false
  rules:
    - name: host-namespaces
      match:
        any:
        - resources:
            kinds:
              - Pod
      validate:
        message: >-
          Sharing the host namespaces is disallowed. The fields spec.hostNetwork,
          spec.hostIPC, and spec.hostPID must be unset or set to `false`.          
        pattern:
          spec:
            =(hostPID): "false"
            =(hostIPC): "false"
            =(hostNetwork): "false"
```
2. create namespace `delta`.
4. create a PolicyException:
```
apiVersion: kyverno.io/v2alpha1
kind: PolicyException
metadata:
  name: delta-exception
  namespace: delta
spec:
  exceptions:
  - policyName: disallow-host-namespaces
    ruleNames:
    - host-namespaces
    - autogen-host-namespaces
  match:
    any:
    - resources:
        kinds:
        - Pod
        - Deployment
        namespaces:
        - delta
        names:
        - important-tool*
```
5. Create a deployment that matches what's defined in the PolicyException:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: important-tool
  namespace: delta
  labels:
    app: busybox
spec:
  replicas: 1
  selector:
    matchLabels:
      app: busybox
  template:
    metadata:
      labels:
        app: busybox
    spec:
      hostIPC: true
      containers:
      - image: busybox:1.35
        name: busybox
        command: ["sleep", "1d"]
```
6. `kubectl get events.events.k8s.io`:
```
6s          Normal    PolicySkipped             clusterpolicy/disallow-host-namespaces         resource Deployment/delta/important-tool was skipped from rule autogen-host-namespaces due to policy exception delta/delta-exception
6s          Normal    PolicySkipped             clusterpolicy/disallow-host-namespaces         resource Pod/delta/important-tool-6489b4c7db-hrjqc was skipped from rule host-namespaces due to policy exception delta/delta-exception
```
9. `kubectl get events.events.k8s.io -o yaml`:
```
- action: Resource Skipped
  apiVersion: events.k8s.io/v1
  deprecatedFirstTimestamp: null
  deprecatedLastTimestamp: null
  deprecatedSource: {}
  eventTime: "2023-07-04T13:14:54.743656Z"
  kind: Event
  metadata:
    creationTimestamp: "2023-07-04T13:14:54Z"
    name: disallow-host-namespaces.176eac6d10caf52c
    namespace: default
    resourceVersion: "10925"
    uid: 2a8efad6-636d-4d98-b037-65a2347c1f59
  note: resource Deployment/delta/important-tool was skipped from rule autogen-host-namespaces
    due to policy exception delta/delta-exception
  reason: PolicySkipped
  regarding:
    apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    name: disallow-host-namespaces
    resourceVersion: "10155"
    uid: 3f7baf73-3816-4ac9-81e4-34b93cb0177a
  related:
    apiVersion: apps/v1
    kind: Deployment
    name: important-tool
    namespace: delta
    resourceVersion: "10923"
    uid: 659d1c4c-b996-4140-806a-5099875f62a5
  reportingController: kyverno-admission
  reportingInstance: kyverno-admission-kyverno-admission-controller-b9f7fdfcf-gnvvw
  type: Normal
- action: Resource Skipped
  apiVersion: events.k8s.io/v1
  deprecatedFirstTimestamp: null
  deprecatedLastTimestamp: null
  deprecatedSource: {}
  eventTime: "2023-07-04T13:14:54.759287Z"
  kind: Event
  metadata:
    creationTimestamp: "2023-07-04T13:14:54Z"
    name: disallow-host-namespaces.176eac6d11b98b2e
    namespace: default
    resourceVersion: "10935"
    uid: c27decc5-3395-4019-afc7-aceadc4b7914
  note: resource Pod/delta/important-tool-6489b4c7db-hrjqc was skipped from rule host-namespaces
    due to policy exception delta/delta-exception
  reason: PolicySkipped
  regarding:
    apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    name: disallow-host-namespaces
    resourceVersion: "10155"
    uid: 3f7baf73-3816-4ac9-81e4-34b93cb0177a
  related:
    apiVersion: v1
    kind: Pod
    name: important-tool-6489b4c7db-hrjqc
    namespace: delta
    resourceVersion: "10929"
    uid: 176bd64e-5035-485b-9a4c-6d52c6d4c7ca
  reportingController: kyverno-admission
  reportingInstance: kyverno-admission-kyverno-admission-controller-b9f7fdfcf-gnvvw
  type: Normal
```
13. `kubectl get events.events.k8s.io -n delta`:
```
LAST SEEN   TYPE     REASON              OBJECT                                 MESSAGE
8m20s       Normal   PolicySkipped       policyexception/delta-exception        resource Deployment/delta/important-tool was skipped from policy rule disallow-host-namespaces/autogen-host-namespaces
8m20s       Normal   PolicySkipped       policyexception/delta-exception        resource Pod/delta/important-tool-6489b4c7db-hrjqc was skipped from policy rule disallow-host-namespaces/host-namespaces
```
14. `kubectl get events.events.k8s.io -n delta -o yaml`:
```
- action: Resource Skipped
  apiVersion: events.k8s.io/v1
  deprecatedFirstTimestamp: null
  deprecatedLastTimestamp: null
  deprecatedSource: {}
  eventTime: "2023-07-04T13:14:54.742620Z"
  kind: Event
  metadata:
    creationTimestamp: "2023-07-04T13:14:54Z"
    name: delta-exception.176eac6d10bb1d53
    namespace: delta
    resourceVersion: "10924"
    uid: 5490c708-3b7f-42f4-9ee7-1bfcbf7263ee
  note: resource Deployment/delta/important-tool was skipped from policy rule disallow-host-namespaces/autogen-host-namespaces
  reason: PolicySkipped
  regarding:
    apiVersion: kyverno.io/v2alpha1
    kind: PolicyException
    name: delta-exception
    namespace: delta
    resourceVersion: "10500"
    uid: e90189b0-1df5-4d94-a31d-cc66804f0ee9
  related:
    apiVersion: apps/v1
    kind: Deployment
    name: important-tool
    namespace: delta
    resourceVersion: "10923"
    uid: 659d1c4c-b996-4140-806a-5099875f62a5
  reportingController: kyverno-admission
  reportingInstance: kyverno-admission-kyverno-admission-controller-b9f7fdfcf-gnvvw
  type: Normal
- action: Resource Skipped
  apiVersion: events.k8s.io/v1
  deprecatedFirstTimestamp: null
  deprecatedLastTimestamp: null
  deprecatedSource: {}
  eventTime: "2023-07-04T13:14:54.760197Z"
  kind: Event
  metadata:
    creationTimestamp: "2023-07-04T13:14:54Z"
    name: delta-exception.176eac6d11c75587
    namespace: delta
    resourceVersion: "10936"
    uid: 43950327-7471-4507-86bd-f77fd524f1d8
  note: resource Pod/delta/important-tool-6489b4c7db-hrjqc was skipped from policy
    rule disallow-host-namespaces/host-namespaces
  reason: PolicySkipped
  regarding:
    apiVersion: kyverno.io/v2alpha1
    kind: PolicyException
    name: delta-exception
    namespace: delta
    resourceVersion: "10500"
    uid: e90189b0-1df5-4d94-a31d-cc66804f0ee9
  related:
    apiVersion: v1
    kind: Pod
    name: important-tool-6489b4c7db-hrjqc
    namespace: delta
    resourceVersion: "10929"
    uid: 176bd64e-5035-485b-9a4c-6d52c6d4c7ca
  reportingController: kyverno-admission
  reportingInstance: kyverno-admission-kyverno-admission-controller-b9f7fdfcf-gnvvw
  type: Normal
```
#### Cleanup Policies:
1. create a cleanup policy:
```
apiVersion: kyverno.io/v2alpha1
kind: ClusterCleanupPolicy
metadata:
  name: cleandeploy
spec:
  match:
    any:
    - resources:
        kinds:
          - Deployment
        selector:
          matchLabels:
            canremove: "true"
  conditions:
    any:
    - key: "{{ target.spec.replicas }}"
      operator: LessThan
      value: 2
  schedule: "*/2 * * * *"
```
2. create a deployment:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    canremove: "true"
spec:
  replicas: 1
  selector:
    matchLabels:
      canremove: "true"
  template:
    metadata:
      labels:
        canremove: "true"
    spec:
      containers:
      - image: nginx
        name: nginx
```
3. `kubectl get events.events.k8s.io`:
```
LAST SEEN   TYPE     REASON                    OBJECT                             MESSAGE
3m12s       Normal   PolicyApplied             clustercleanuppolicy/cleandeploy   successfully cleaned up the target resource Deployment/default/nginx
```
4. kubectl get events.events.k8s.io -o yaml`:
```
- action: Resource Cleaned Up
  apiVersion: events.k8s.io/v1
  deprecatedFirstTimestamp: null
  deprecatedLastTimestamp: null
  deprecatedSource: {}
  eventTime: "2023-07-21T08:09:36.153292Z"
  kind: Event
  metadata:
    creationTimestamp: "2023-07-21T08:09:36Z"
    name: cleandeploy.1773d3a195f7af59
    namespace: default
    resourceVersion: "5799"
    uid: b1e03d87-3342-4b82-b15b-44b62fa9256e
  note: successfully cleaned up the target resource Deployment/default/nginx
  reason: PolicyApplied
  regarding:
    apiVersion: kyverno.io/v2alpha1
    kind: ClusterCleanupPolicy
    name: cleandeploy
    resourceVersion: "1343"
    uid: 2cd0d54b-cc84-440d-bb7f-1d8755053940
  related:
    apiVersion: apps/v1
    kind: Deployment
    name: nginx
    namespace: default
  reportingController: kyverno-cleanup
  reportingInstance: kyverno-cleanup-kyverno-cleanup-controller-6967c74687-b7d8b
  type: Normal
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
