### PR TITLE
fix: Swap any/all in the error message.

### DIFF
--- a/pkg/validation/policy/background.go
+++ b/pkg/validation/policy/background.go
@@ -67,7 +67,7 @@ func hasUserMatchExclude(idx int, rule *kyvernov1.Rule) error {
 	if len(rule.ExcludeResources.All) > 0 {
 		for i, value := range rule.ExcludeResources.All {
 			if path := userInfoDefined(value.UserInfo); path != "" {
-				return fmt.Errorf("invalid variable used at path: spec/rules[%d]/exclude/any[%d]/%s", idx, i, path)
+				return fmt.Errorf("invalid variable used at path: spec/rules[%d]/exclude/all[%d]/%s", idx, i, path)
 			}
 		}
 	}
@@ -75,7 +75,7 @@ func hasUserMatchExclude(idx int, rule *kyvernov1.Rule) error {
 	if len(rule.ExcludeResources.Any) > 0 {
 		for i, value := range rule.ExcludeResources.Any {
 			if path := userInfoDefined(value.UserInfo); path != "" {
-				return fmt.Errorf("invalid variable used at path: spec/rules[%d]/exclude/all[%d]/%s", idx, i, path)
+				return fmt.Errorf("invalid variable used at path: spec/rules[%d]/exclude/any[%d]/%s", idx, i, path)
 			}
 		}
 	}


### PR DESCRIPTION
## Explanation

Error messages corresponding to `rule.ExcludeResources.Any` and `rule.ExcludeResources.All` are written as "invalid variable used at path: spec/rules[%d]/exclude/**all**[%d]/%s" and "invalid variable used at path: spec/rules[%d]/exclude/**any**[%d]/%s", respectively.

The PR swaps the word "any" and "all".

## Related issue

Related PR: #2451 


## What type of PR is this

/kind cleanup


### Proof Manifest

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-privileged-containers
spec:
  validationFailureAction: Enforce
  rules:
  - name: privileged-containers
    match:
      any:
      - resources:
          kinds:
          - Pod
    exclude:
      all:
      - resources:
          kinds:
          - BANANA
      - subjects:
        - kind: Group
          name: "system:masters"
    validate:
      pattern:
        spec:
          =(ephemeralContainers):
          - =(securityContext):
              =(privileged): "false"
          =(initContainers):
          - =(securityContext):
              =(privileged): "false"
          containers:
          - =(securityContext):
              =(privileged): "false"
```

Before:
```
$ kubectl apply -f disallow-privileged-containers.yml
Error from server: error when creating "disallow-privileged-containers.yml": admission webhook "validate-policy.kyverno.svc" denied the request: only select variables are allowed in background mode. Set spec.background=false to disable background mode for this policy rule: invalid variable used at path: spec/rules[0]/exclude/any[1]/subjects 
```

After:
```
Error from server: error when creating "disallow-privileged-containers.yml": admission webhook "validate-policy.kyverno.svc" denied the request: only select variables are allowed in background mode. Set spec.background=false to disable background mode for this policy rule: invalid variable used at path: spec/rules[0]/exclude/all[1]/subjects 
```


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->
