### PR TITLE
fix goreleaser to 1.8.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -243,10 +243,12 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
         with:
-          version: latest
+          version: 1.8.2
           args: release --rm-dist --debug --release-notes=release/release-notes.out
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Show GoReleaser version
+        run: goreleaser -v
 
   push-and-sign-install-manifest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes the goreleaser version to 1.8.2 due to https://github.com/kyverno/kyverno/actions/runs/5409052815/jobs/9829975770.