### PR TITLE
fix: make `test --fail-only` return 1 if there are failed tests

### DIFF
--- a/cmd/cli/kubectl-kyverno/test/test_command.go
+++ b/cmd/cli/kubectl-kyverno/test/test_command.go
@@ -167,8 +167,10 @@ func testCommandExecute(
 		fmt.Printf("\nTest Summary: %d out of %d tests failed\n", rc.Fail, rc.Pass+rc.Skip+rc.Fail)
 	}
 	fmt.Println()
-	if rc.Fail > 0 && !failOnly {
-		printFailedTestResult(table, compact)
+	if rc.Fail > 0 {
+		if !failOnly {
+			printFailedTestResult(table, compact)
+		}
 		os.Exit(1)
 	}
 	os.Exit(0)


### PR DESCRIPTION
## Explanation

Running `kyverno test --fail-only <target>` right now always return `0` even if there is a failed test. This fixes that behaviour and makes the command return `0` or `1` depending on the existance of failed tests


## Related issue

N/A

## Milestone of this PR

## What type of PR is this

/kind bug

## Proposed Changes

This is a bug fix so there are no proposed changes outside of the code included in the PR

### Proof Manifests

There are no functional changes in the code or behaviour of any section of the application, however, the behaviour can be tested by comparing the old result of this command (with failed tests):

```shell
$ old-kyverno test tests `--fail-only`
...
Test Summary: 1 out of 39 tests failed

$ echo $?
0
```
```shell
$ new-kyverno test tests `--fail-only`
...
Test Summary: 1 out of 39 tests failed

$ echo $?
1
```

Whereas not using `--fail-only` behaves as expected:
```shell
$kyverno test tests
...
Test Summary: 38 tests passed and 1 tests failed

... (output table)

$ echo $?
1
```

## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

n/a