### PR TITLE
Replaced gcr crane with gcr remote

### DIFF
--- a/pkg/notary/notary.go
+++ b/pkg/notary/notary.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -139,7 +138,6 @@ func (v *notaryVerifier) FetchAttestations(ctx context.Context, opts images.Opti
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse authenticator: %s", opts.ImageRef)
 	}
-	craneOpts := crane.WithAuth(*authenticator)
 
 	remoteOpts, err := getRemoteOpts(*authenticator)
 	if err != nil {
@@ -148,7 +146,7 @@ func (v *notaryVerifier) FetchAttestations(ctx context.Context, opts images.Opti
 
 	v.log.V(4).Info("client setup done", "repo", ref)
 
-	repoDesc, err := crane.Head(opts.ImageRef, craneOpts)
+	repoDesc, err := remote.Head(ref, remoteOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +184,7 @@ func (v *notaryVerifier) FetchAttestations(ctx context.Context, opts images.Opti
 		}
 
 		v.log.V(4).Info("extracting statements", "desc", referrer, "repo", ref)
-		statements, err = extractStatements(ctx, ref, referrer, craneOpts)
+		statements, err = extractStatements(ctx, ref, referrer, remoteOpts)
 		if err != nil {
 			msg := err.Error()
 			v.log.V(4).Info("failed to extract statements %s", "err", msg)
@@ -267,9 +265,9 @@ func verifyAttestators(ctx context.Context, v *notaryVerifier, ref name.Referenc
 	return targetDesc, nil
 }
 
-func extractStatements(ctx context.Context, repoRef name.Reference, desc v1.Descriptor, craneOpts ...crane.Option) ([]map[string]interface{}, error) {
+func extractStatements(ctx context.Context, repoRef name.Reference, desc v1.Descriptor, remoteOpts []remote.Option) ([]map[string]interface{}, error) {
 	statements := make([]map[string]interface{}, 0)
-	data, err := extractStatement(ctx, repoRef, desc, craneOpts...)
+	data, err := extractStatement(ctx, repoRef, desc, remoteOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -281,14 +279,18 @@ func extractStatements(ctx context.Context, repoRef name.Reference, desc v1.Desc
 	return statements, nil
 }
 
-func extractStatement(ctx context.Context, repoRef name.Reference, desc v1.Descriptor, craneOpts ...crane.Option) (map[string]interface{}, error) {
+func extractStatement(ctx context.Context, repoRef name.Reference, desc v1.Descriptor, remoteOpts []remote.Option) (map[string]interface{}, error) {
 	refStr := repoRef.Context().RegistryStr() + "/" + repoRef.Context().RepositoryStr() + "@" + desc.Digest.String()
 	ref, err := name.ParseReference(refStr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse image reference: %s", refStr)
 	}
 
-	manifestBytes, err := crane.Manifest(refStr, craneOpts...)
+	remoteDesc, err := remote.Get(ref, remoteOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("error in fetching manifest: %w", err)
+	}
+	manifestBytes, err := remoteDesc.RawManifest()
 	if err != nil {
 		return nil, fmt.Errorf("error in fetching statement: %w", err)
 	}
@@ -304,9 +306,8 @@ func extractStatement(ctx context.Context, repoRef name.Reference, desc v1.Descr
 		return nil, fmt.Errorf("multiple layers in predicate not supported: %+v", manifest)
 	}
 	predicateDesc := manifest.Layers[0]
-	predicateRef := ref.Context().RegistryStr() + "/" + ref.Context().RepositoryStr() + "@" + predicateDesc.Digest.String()
 
-	layer, err := crane.PullLayer(predicateRef, craneOpts...)
+	layer, err := remote.Layer(ref.Context().Digest(predicateDesc.Digest.String()), remoteOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/notary/notary_test.go
+++ b/pkg/notary/notary_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"gotest.tools/assert"
@@ -14,7 +13,7 @@ func TestExtractStatements(t *testing.T) {
 	imageRef := "jimnotarytest.azurecr.io/jim/net-monitor:v1"
 	ref, err := name.ParseReference(imageRef)
 	assert.NilError(t, err)
-	repoDesc, err := crane.Head(imageRef)
+	repoDesc, err := remote.Head(ref)
 	assert.NilError(t, err)
 	referrers, err := remote.Referrers(ref.Context().Digest(repoDesc.Digest.String()))
 	assert.NilError(t, err)
@@ -23,7 +22,7 @@ func TestExtractStatements(t *testing.T) {
 
 	for _, referrer := range referrersDescs.Manifests {
 		if referrer.ArtifactType == "application/vnd.cncf.notary.signature" {
-			statements, err := extractStatements(context.Background(), ref, referrer)
+			statements, err := extractStatements(context.Background(), ref, referrer, nil)
 			assert.NilError(t, err)
 			assert.Assert(t, len(statements) == 1)
 			assert.Assert(t, statements[0]["type"] == referrer.ArtifactType)

--- a/pkg/notary/registry.go
+++ b/pkg/notary/registry.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	gcrremote "github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/kyverno/kyverno/pkg/images"
@@ -16,7 +15,6 @@ import (
 
 type parsedReference struct {
 	Repo       notationregistry.Repository
-	CraneOpts  crane.Option
 	RemoteOpts []gcrremote.Option
 	Ref        name.Reference
 	Desc       ocispec.Descriptor
@@ -33,13 +31,12 @@ func parseReferenceCrane(ctx context.Context, ref string, registryClient images.
 		return nil, err
 	}
 
-	craneOpts := crane.WithAuth(*authenticator)
 	remoteOpts, err := getRemoteOpts(*authenticator)
 	if err != nil {
 		return nil, err
 	}
 
-	desc, err := crane.Head(ref, craneOpts)
+	desc, err := gcrremote.Head(nameRef, remoteOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -51,15 +48,14 @@ func parseReferenceCrane(ctx context.Context, ref string, registryClient images.
 		}
 	}
 
-	repository := NewRepository(craneOpts, remoteOpts, nameRef)
-	err = resolveDigestCrane(repository, craneOpts, remoteOpts, nameRef)
+	repository := NewRepository(remoteOpts, nameRef)
+	err = resolveDigestCrane(repository, remoteOpts, nameRef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to resolve digest")
 	}
 
 	return &parsedReference{
 		Repo:       repository,
-		CraneOpts:  craneOpts,
 		RemoteOpts: remoteOpts,
 		Ref:        nameRef,
 		Desc:       v1ToOciSpecDescriptor(*desc),
@@ -124,7 +120,7 @@ func getRemoteOpts(authenticator authn.Authenticator) ([]gcrremote.Option, error
 	return remoteOpts, nil
 }
 
-func resolveDigestCrane(repo notationregistry.Repository, craneOpts crane.Option, remoteOpts []gcrremote.Option, ref name.Reference) error {
+func resolveDigestCrane(repo notationregistry.Repository, remoteOpts []gcrremote.Option, ref name.Reference) error {
 	_, err := repo.Resolve(context.Background(), ref.Name())
 	if err != nil {
 		return err

--- a/pkg/notary/repository_test.go
+++ b/pkg/notary/repository_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	notationregistry "github.com/notaryproject/notation-go/registry"
@@ -18,13 +17,15 @@ var (
 )
 
 func TestResolve(t *testing.T) {
-	repoDesc, err := crane.Head(imageRef)
+	nameRef, err := name.ParseReference(imageRef)
+	assert.NilError(t, err)
+	repoDesc, err := remote.Head(nameRef)
 	assert.NilError(t, err)
 
 	ref, err := name.ParseReference(imageRef)
 	assert.NilError(t, err)
 
-	repositoryClient := NewRepository(nil, nil, ref)
+	repositoryClient := NewRepository(nil, ref)
 
 	desc, err := repositoryClient.Resolve(ctx, repoDesc.Digest.String())
 	assert.NilError(t, err)
@@ -33,7 +34,9 @@ func TestResolve(t *testing.T) {
 }
 
 func TestListSignatures(t *testing.T) {
-	repoDesc, err := crane.Head(imageRef)
+	nameRef, err := name.ParseReference(imageRef)
+	assert.NilError(t, err)
+	repoDesc, err := remote.Head(nameRef)
 	assert.NilError(t, err)
 
 	ociDesc := v1ToOciSpecDescriptor(*repoDesc)
@@ -42,7 +45,7 @@ func TestListSignatures(t *testing.T) {
 	ref, err := name.ParseReference(imageRef)
 	assert.NilError(t, err)
 
-	repositoryClient := NewRepository(nil, nil, ref)
+	repositoryClient := NewRepository(nil, ref)
 	fn := func(_ []ocispec.Descriptor) error {
 		return nil
 	}
@@ -52,7 +55,9 @@ func TestListSignatures(t *testing.T) {
 }
 
 func TestFetchSignatureBlob(t *testing.T) {
-	repoDesc, err := crane.Head(imageRef)
+	nameRef, err := name.ParseReference(imageRef)
+	assert.NilError(t, err)
+	repoDesc, err := remote.Head(nameRef)
 	assert.NilError(t, err)
 
 	ociDesc := v1ToOciSpecDescriptor(*repoDesc)
@@ -61,7 +66,7 @@ func TestFetchSignatureBlob(t *testing.T) {
 	ref, err := name.ParseReference(imageRef)
 	assert.NilError(t, err)
 
-	repositoryClient := NewRepository(nil, nil, ref)
+	repositoryClient := NewRepository(nil, ref)
 
 	referrers, err := remote.Referrers(ref.Context().Digest(ociDesc.Digest.String()))
 	assert.NilError(t, err)


### PR DESCRIPTION
## Explanation

The gcr remote package has an option called [reuse](https://pkg.go.dev/github.com/google/go-containerregistry/pkg/v1/remote#Reuse) which takes a Puller or Pusher and reuses it for remote interactions rather than starting from a clean slate.

While gcr crane doesn't have it. This PR replaces all gcr crane methods with gcr remote equivalents.
This PR, in theory, should make verification faster.
