### PR TITLE
fix(kubectl-kyverno): dump error validation response message

### DIFF
--- a/cmd/cli/kubectl-kyverno/utils/common/common.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common.go
@@ -355,6 +355,7 @@ func ProcessValidateEngineResponse(policy kyvernov1.PolicyInterface, validateRes
 						fmt.Printf("%d. %s: %s \n", i+1, valResponseRule.Name(), valResponseRule.Message())
 					}
 				case engineapi.RuleStatusError:
+					fmt.Printf("\npolicy %s -> resource %s error: %s\n", policy.GetName(), resPath, valResponseRule.Message())
 					rc.Error++
 				case engineapi.RuleStatusWarn:
 					rc.Warn++


### PR DESCRIPTION
## Explanation

`kyverno apply` can fail (exit code > 0) without dumping any information for the user (without the report flag).

If apply exits > 0 I would expect that I get the reason why the command failed. The error is also not visible with an increased verbosity. That said the errors are visible in the reports mode.
However I would expect to see errors immediately if a command exits > 0 without the need of supplying flags to actually see the problem. (Also reports contain a lot more information while I only want to see errors.)

For failed policies the errors are actually dumped to stdout but that's not the case for errors. 

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

1. kyverno apply does not dump errors to stdout but apply actually exits > 0 if error count is > 0.
Its' pretty hard to find the cause with this behavior.
```
cat resources | kyverno apply ./policies -r /dev/stdin

Applying 10 policy rules to 532 resources...

pass: 353, fail: 0, warn: 0, error: 44, skip: 9185 
```

2. This pr simply makes apply dumping errors to stdout. Similar to how failures are dumped.
3. Errors are now dumped to stdout as well:
```
Applying 24 policy rule(s) to 532 resource(s)...

policy interval -> resource production/HelmRelease/auth-load-tester error: failed to check deny conditions: failed to substitute variables in condition key: failed to resolve request.object.spec.chart.spec.interval at path : JMESPath query failed: Unknown key "interval" in path 

policy interval -> resource production/HelmRelease/example-svc error: failed to check deny conditions: failed to substitute variables in condition key: failed to resolve request.object.spec.chart.spec.interval at path : JMESPath query failed: Unknown key "interval" in path

pass: 706, fail: 0, warn: 0, error: 88, skip: 9699
```

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
