### PR TITLE
feat: add `create user-info` cli command

### DIFF
--- a/cmd/cli/kubectl-kyverno/create/command.go
+++ b/cmd/cli/kubectl-kyverno/create/command.go
@@ -2,6 +2,7 @@ package create
 
 import (
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/create/test"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/create/userinfo"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +14,6 @@ func Command() *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	cmd.AddCommand(test.Command())
+	cmd.AddCommand(test.Command(), userinfo.Command())
 	return cmd
 }

--- a/cmd/cli/kubectl-kyverno/create/templates/templates.go
+++ b/cmd/cli/kubectl-kyverno/create/templates/templates.go
@@ -6,3 +6,6 @@ import (
 
 //go:embed test.yaml
 var TestTemplate string
+
+//go:embed user-info.yaml
+var UserInfoTemplate string

--- a/cmd/cli/kubectl-kyverno/create/templates/user-info.yaml
+++ b/cmd/cli/kubectl-kyverno/create/templates/user-info.yaml
@@ -1,0 +1,21 @@
+# list of roles
+roles:
+{{- range .Roles }}
+  - {{ . }}
+{{- end }}
+
+# list of cluster roles
+clusterRoles:
+{{- range .ClusterRoles }}
+  - {{ . }}
+{{- end }}
+
+userInfo:
+  # user name
+  username: {{ .AdmissionUserInfo.Username }}
+
+  # list of groups
+  groups:
+{{- range .AdmissionUserInfo.Groups }}
+    - {{ . }}
+{{- end }}

--- a/cmd/cli/kubectl-kyverno/create/userinfo/command.go
+++ b/cmd/cli/kubectl-kyverno/create/userinfo/command.go
@@ -1,0 +1,52 @@
+package userinfo
+
+import (
+	"os"
+	"text/template"
+
+	"github.com/kyverno/kyverno/api/kyverno/v1beta1"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/create/templates"
+	"github.com/spf13/cobra"
+	authenticationv1 "k8s.io/api/authentication/v1"
+)
+
+func Command() *cobra.Command {
+	var path string
+	var username string
+	var roles, clusterRoles, groups []string
+	cmd := &cobra.Command{
+		Use:     "user-info",
+		Short:   "Create a Kyverno user-info file.",
+		Example: "kyverno create user-info -u molybdenum@somecorp.com -g basic-user -c admin",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			tmpl, err := template.New("userinfo").Parse(templates.UserInfoTemplate)
+			if err != nil {
+				return err
+			}
+			output := os.Stdout
+			if path != "" {
+				file, err := os.Create(path)
+				if err != nil {
+					return err
+				}
+				defer file.Close()
+				output = file
+			}
+			values := v1beta1.RequestInfo{
+				Roles:        roles,
+				ClusterRoles: clusterRoles,
+				AdmissionUserInfo: authenticationv1.UserInfo{
+					Username: username,
+					Groups:   groups,
+				},
+			}
+			return tmpl.Execute(output, values)
+		},
+	}
+	cmd.Flags().StringVarP(&path, "output", "o", "", "Output path (uses standard console output if not set)")
+	cmd.Flags().StringVarP(&username, "username", "u", "", "User name")
+	cmd.Flags().StringSliceVarP(&roles, "role", "r", nil, "Role")
+	cmd.Flags().StringSliceVarP(&clusterRoles, "cluster-role", "c", nil, "Cluster role")
+	cmd.Flags().StringSliceVarP(&groups, "group", "g", nil, "Group")
+	return cmd
+}


### PR DESCRIPTION
## Explanation

This PR adds a `create user-info` cli command.

```
Create a Kyverno user-info file.

Usage:
  kyverno create user-info [flags]

Examples:
kyverno create user-info -u molybdenum@somecorp.com -g basic-user -c admin

Flags:
  -c, --cluster-role strings   Cluster role
  -g, --group strings          Group
  -h, --help                   help for user-info
  -o, --output string          Output path (uses standard console output if not set)
  -r, --role strings           Role
  -u, --username string        User name
```

Example with `create user-info -u molybdenum@somecorp.com -g basic-user -c admin`:

```yaml
# list of roles
roles:

# list of cluster roles
clusterRoles:
  - admin

userInfo:
  # user name
  username: molybdenum@somecorp.com

  # list of groups
  groups:
    - basic-user
```