### PR TITLE
feat: add `images` to allowed variables in substitution

### DIFF
--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -39,10 +39,10 @@ import (
 )
 
 var (
-	allowedVariables                   = regexp.MustCompile(`request\.|serviceAccountName|serviceAccountNamespace|element|elementIndex|@|images\.|image\.|([a-z_0-9]+\()[^{}]`)
-	allowedVariablesBackground         = regexp.MustCompile(`request\.|element|elementIndex|@|images\.|image\.|([a-z_0-9]+\()[^{}]`)
-	allowedVariablesInTarget           = regexp.MustCompile(`request\.|serviceAccountName|serviceAccountNamespace|element|elementIndex|@|images\.|image\.|target\.|([a-z_0-9]+\()[^{}]`)
-	allowedVariablesBackgroundInTarget = regexp.MustCompile(`request\.|element|elementIndex|@|images\.|image\.|target\.|([a-z_0-9]+\()[^{}]`)
+	allowedVariables                   = regexp.MustCompile(`request\.|serviceAccountName|serviceAccountNamespace|element|elementIndex|@|images|images\.|image\.|([a-z_0-9]+\()[^{}]`)
+	allowedVariablesBackground         = regexp.MustCompile(`request\.|element|elementIndex|@|images|images\.|image\.|([a-z_0-9]+\()[^{}]`)
+	allowedVariablesInTarget           = regexp.MustCompile(`request\.|serviceAccountName|serviceAccountNamespace|element|elementIndex|@|images|images\.|image\.|target\.|([a-z_0-9]+\()[^{}]`)
+	allowedVariablesBackgroundInTarget = regexp.MustCompile(`request\.|element|elementIndex|@|images|images\.|image\.|target\.|([a-z_0-9]+\()[^{}]`)
 	// wildCardAllowedVariables represents regex for the allowed fields in wildcards
 	wildCardAllowedVariables = regexp.MustCompile(`\{\{\s*(request\.|serviceAccountName|serviceAccountNamespace)[^{}]*\}\}`)
 	errOperationForbidden    = errors.New("variables are forbidden in the path of a JSONPatch")

--- a/pkg/validation/policy/validate_test.go
+++ b/pkg/validation/policy/validate_test.go
@@ -632,6 +632,78 @@ func Test_BackGroundUserInfo_mutate_patchStrategicMerge1(t *testing.T) {
 	assert.Assert(t, err != nil)
 }
 
+func Test_Context_Variable_Substitution(t *testing.T) {
+	var err error
+	rawPolicy := []byte(`{
+  "apiVersion": "kyverno.io/v1",
+  "kind": "ClusterPolicy",
+  "metadata": {
+    "name": "check-images"
+  },
+  "spec": {
+    "validationFailureAction": "Enforce",
+    "webhookTimeoutSeconds": 30,
+    "rules": [
+      {
+        "name": "call-aws-signer-extension",
+        "match": {
+          "any": [
+            {
+              "resources": {
+                "namespaces": [
+                  "test-notation"
+                ],
+                "kinds": [
+                  "Pod"
+                ]
+              }
+            }
+          ]
+        },
+        "context": [
+          {
+            "name": "response",
+            "apiCall": {
+              "method": "POST",
+              "data": [
+                {
+                  "key": "imagesInfo",
+                  "value": "{{ images }}"
+                }
+              ],
+              "service": {
+                "url": "https://svc.kyverno-notation-aws/checkimages",
+                "caBundle": "-----BEGIN CERTIFICATE-----\nMIICizCCAjGgAwIBAgIRAIUEJcm7TtwJEtRtsI2yUcMwCgYIKoZIzj0EAwIwGzEZ\nMBcGA1UEAxMQbXktc2VsZnNpZ25lZC1jYTAeFw0yMzA1MTAwNTI5MzBaFw0yMzA4\nMDgwNTI5MzBaMDExEDAOBgNVBAoTB25pcm1hdGExHTAbBgNVBAMTFGt5dmVybm8t\nbm90YXRpb24tYXdzMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxrSr\nVXUbuQbF4rhh0/jqDE6agtXqS9jko6vHTEZUF2Y9f0LdSycEdCocIKZmPerWER7l\nVUmMFPQLSGOZrCIM22L9+EXDyL7q2PN3koDxKOyqVOod8j3hKdRL+KIiZuUeD4zD\ncos+AFxA1XAM/220JKfPSUpBL0DAP299Baqjs/Ae5wU5wT4qZVa1I3pcV2uicPvE\nRSZO3ZT+y1nYBWtTTzzXP3f9ou8IHweCl57Sk16mbFFZ+TrCSekewYchzn88z7lq\nL+56LtBUjcJozypLGEWM+kc4S5wBNYUaFPGiCHIrdQ5ScmfnY7mDvO8u47E+xw13\nbz7NUAlT73rBqBv6hQIDAQABo3UwczAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYB\nBQUHAwIwDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBRXZIp2KalD6pjRfPua2kFn\nMBuJJTAjBgNVHREEHDAaghhzdmMua3l2ZXJuby1ub3RhdGlvbi1hd3MwCgYIKoZI\nzj0EAwIDSAAwRQIhAKob5SV/N56VqP8VPdHqCAULRj92qhWwW3hb7fzaGxnHAiBP\n3c8K2Vrxx2KRsjnWwn1vUMz7UyM2Tmib1C4YM3f+xg==\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBdjCCAR2gAwIBAgIRAP1VDXD3R744lE7t/I5MK44wCgYIKoZIzj0EAwIwGzEZ\nMBcGA1UEAxMQbXktc2VsZnNpZ25lZC1jYTAeFw0yMzA1MTAwNTI5MjVaFw0yMzA4\nMDgwNTI5MjVaMBsxGTAXBgNVBAMTEG15LXNlbGZzaWduZWQtY2EwWTATBgcqhkjO\nPQIBBggqhkjOPQMBBwNCAAQrFCRBF8PjKPcT/lrXmyP474fNuhlhGFAlLaoTSUuP\nS3VK2O7hWrlJ/AhCccY8EPBi/DdFEaCB2+hTo00clmvfo0IwQDAOBgNVHQ8BAf8E\nBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUV2SKdimpQ+qY0Xz7mtpB\nZzAbiSUwCgYIKoZIzj0EAwIDRwAwRAIgU3O7Qnk9PGCV4aXgZAXp0h4Iz2O7XUnP\nUfv4SgD7neECIHLb+BDvRFPJ77FpfIYxBO70AHB7Kp0nWKCqyv3FK4aT\n-----END CERTIFICATE-----"
+              }
+            }
+          }
+        ],
+        "validate": {
+          "message": "not allowed",
+          "deny": {
+            "conditions": {
+              "all": [
+                {
+                  "key": "{{ response.verified }}",
+                  "operator": "EQUALS",
+                  "value": false
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}`)
+	var policy *kyverno.ClusterPolicy
+	err = json.Unmarshal(rawPolicy, &policy)
+	assert.NilError(t, err)
+
+	err = ValidateVariables(policy, true)
+	assert.NilError(t, err)
+}
+
 func Test_BackGroundUserInfo_mutate_patchStrategicMerge2(t *testing.T) {
 	var err error
 	rawPolicy := []byte(`


### PR DESCRIPTION
Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>

<!--
In a couple of sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Explaination

While applying the following policy
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: check-images     
spec:
  validationFailureAction: Enforce
  webhookTimeoutSeconds: 30
  rules:
  - name: call-aws-signer-extension
    match:
      any:
      - resources:
          namespaces:
          - test-notation
          kinds:
          - Pod
    context:
    - name: response
      apiCall:
        method: POST
        data:
        - key: imagesInfo
          value: "{{images}}"
        service:
          url: https://svc.kyverno-notation-aws/checkimages
          caBundle: |-
            -----BEGIN CERTIFICATE-----
            -----END CERTIFICATE-----
    validate:
      message: "not allowed"
      deny:
        conditions:
          all:
          - key: "{{ response.verified }}"
            operator: EQUALS
            value: false
```

I encountered the following error
```bash
Error from server: error when creating "configs/samples/kyverno-policy.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: policy contains invalid variables: variable substitution failed for rule call-aws-signer-extension: variable images must match regex "request\.|element|elementIndex|@|images\.|image\.|([a-z_0-9]+\()[^{}]" or patterns [response*]
```

I created [this unit test](https://github.com/kyverno/kyverno/commit/4cdc13e978bdc7c1e6b216885d619cd9b313885b) to check variable substitution in my policy.

It fails in `MockContext.Query()`, it is returning `emptyResult, InvalidVariableError` (last line of the function). We need to change the [regex used for background](https://github.com/kyverno/kyverno/blob/main/pkg/validation/policy/validate.go#L43) in the [buildContext](https://github.com/kyverno/kyverno/blob/main/pkg/validation/policy/validate.go#L566) function to include `images`.


