### PR TITLE
feat: allow pod labels for cleanup jobs

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -48,3 +48,5 @@ annotations:
       description: define resources for cleanupJobs
     - kind: changed
       description: change to enable webhook cleanup hook by default
+    - kind: added
+      description: allow pod labels for cleanup jobs

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -651,6 +651,7 @@ The chart values are organised per component.
 | cleanupJobs.admissionReports.resources | object | `{}` | Job resources |
 | cleanupJobs.admissionReports.tolerations | list | `[]` | List of node taints to tolerate |
 | cleanupJobs.admissionReports.podAnnotations | object | `{}` | Pod Annotations |
+| cleanupJobs.admissionReports.podLabels | object | `{}` | Pod labels |
 | cleanupJobs.clusterAdmissionReports.enabled | bool | `true` | Enable cleanup cronjob |
 | cleanupJobs.clusterAdmissionReports.image.registry | string | `nil` | Image registry |
 | cleanupJobs.clusterAdmissionReports.image.repository | string | `"bitnami/kubectl"` | Image repository |
@@ -665,6 +666,7 @@ The chart values are organised per component.
 | cleanupJobs.clusterAdmissionReports.resources | object | `{}` | Job resources |
 | cleanupJobs.clusterAdmissionReports.tolerations | list | `[]` | List of node taints to tolerate |
 | cleanupJobs.clusterAdmissionReports.podAnnotations | object | `{}` | Pod Annotations |
+| cleanupJobs.clusterAdmissionReports.podLabels | object | `{}` | Pod Labels |
 
 ### Other
 

--- a/charts/kyverno/templates/cleanup/cleanup-admission-reports.yaml
+++ b/charts/kyverno/templates/cleanup/cleanup-admission-reports.yaml
@@ -19,6 +19,10 @@ spec:
           annotations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.cleanupJobs.admissionReports.podLabels }}
+          labels:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         spec:
           serviceAccountName: {{ template "kyverno.name" . }}-cleanup-jobs
           {{- with .Values.cleanupJobs.admissionReports.podSecurityContext }}

--- a/charts/kyverno/templates/cleanup/cleanup-cluster-admission-reports.yaml
+++ b/charts/kyverno/templates/cleanup/cleanup-cluster-admission-reports.yaml
@@ -19,6 +19,10 @@ spec:
           annotations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.cleanupJobs.clusterAdmissionReports.podLabels }}
+          labels:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         spec:
           serviceAccountName: {{ template "kyverno.name" . }}-cleanup-jobs
           {{- with .Values.cleanupJobs.clusterAdmissionReports.podSecurityContext }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -451,6 +451,9 @@ cleanupJobs:
     # -- Pod Annotations
     podAnnotations: {}
 
+    # -- Pod labels
+    podLabels: {}
+
   clusterAdmissionReports:
 
     # -- Enable cleanup cronjob
@@ -506,6 +509,9 @@ cleanupJobs:
 
     # -- Pod Annotations
     podAnnotations: {}
+
+    # -- Pod Labels
+    podLabels: {}
 
 # Admission controller configuration
 admissionController:


### PR DESCRIPTION
## Explanation

Cleanup cronjobs should also allow pod labels. 
I have a usecase, where all pods should have a certain label. This is checked via a kyverno policy. Hence the kyverno pods also should have this label.

This PR allows setting labels on both cleanup cronjobs.

## Related issue



## Milestone of this PR
/v1.10.2

## What type of PR is this


/kind feature

## Proposed Changes

pod labels can be defined for both cleanup cronjobs via values.


## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [x] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
