### PR TITLE
fix(chart): set podSecurityContext for admissionreport jobs

### DIFF
--- a/charts/kyverno/templates/cleanup/cleanup-admission-reports.yaml
+++ b/charts/kyverno/templates/cleanup/cleanup-admission-reports.yaml
@@ -25,10 +25,10 @@ spec:
           {{- end }}
         spec:
           serviceAccountName: {{ template "kyverno.name" . }}-cleanup-jobs
-          {{- with .Values.cleanupJobs.admissionReports.podSecurityContext }}
+            {{- with .Values.cleanupJobs.admissionReports.podSecurityContext }}
           securityContext:
-            {{- tpl (toYaml .) $ | nindent 12 }}
-          {{- end }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           containers:
           - name: cleanup
             image: {{ (include "kyverno.image" .Values.cleanupJobs.admissionReports) | quote }}

--- a/charts/kyverno/templates/cleanup/cleanup-cluster-admission-reports.yaml
+++ b/charts/kyverno/templates/cleanup/cleanup-cluster-admission-reports.yaml
@@ -25,10 +25,10 @@ spec:
           {{- end }}
         spec:
           serviceAccountName: {{ template "kyverno.name" . }}-cleanup-jobs
-          {{- with .Values.cleanupJobs.clusterAdmissionReports.podSecurityContext }}
+            {{- with .Values.cleanupJobs.clusterAdmissionReports.podSecurityContext }}
           securityContext:
-            {{- tpl (toYaml .) $ | nindent 12 }}
-          {{- end }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           containers:
           - name: cleanup
             image: {{ (include "kyverno.image" .Values.cleanupJobs.clusterAdmissionReports) | quote }}


### PR DESCRIPTION
## Explanation

I have tried to set the podsecuritycontext for the `admissionReports` and `clusterAdmissionReports` jobs. I have only set the existing values in the `values.yaml` (podSecurityContext Key), but these values have not been set in the CronJobs.

values.yaml
```bash
# toplevel
cleanupJobs:
  admissionReports:
    podSecurityContext:
      runAsUser: 65534
      runAsGroup: 65534
cleanupJobs:
  clusterAdmissionReports:
    podSecurityContext:
      runAsUser: 65534
      runAsGroup: 65534
```

## What type of PR is this

> /kind bug


## Proposed Changes

After I recreated this locally with `helm template`, I found that the values were not set here either. I only made small changes in the `` and `` and I was able to test the setting and not setting via `helm template` locally successfully.

cleanup-admission-reports.yaml
```yaml
  {{- with .Values.cleanupJobs.admissionReports.podSecurityContext }}
securityContext:
  {{- toYaml . | nindent 12 }}
  {{- end }}
```

cleanup-cluster-admission-reports.yaml
```yaml
  {{- with .Values.cleanupJobs.clusterAdmissionReports.podSecurityContext }}
securityContext:
  {{- toYaml . | nindent 12 }}
  {{- end }}
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective. --> Is this required for this small change?
