### PR TITLE
policy validation: fix assignment to entry in nil map

### DIFF
--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -1262,6 +1262,9 @@ func validateNamespaces(s *kyvernov1.Spec, path *field.Path) error {
 	}
 
 	for i, vfa := range s.ValidationFailureActionOverrides {
+		if !vfa.Action.IsValid() {
+			return fmt.Errorf("invalid action")
+		}
 		patternList, nsList := wildcard.SeperateWildcards(vfa.Namespaces)
 
 		if vfa.Action.Audit() {


### PR DESCRIPTION
## Explanation
OSS-Fuzz has found an issue whereby an action is an "audit" but a key does not exist for it in the `action` map in `validateNamespaces`.

## What type of PR is this
/kind bug

## Proposed Changes
This PR adds a check for whether it is valid at all. Return an error if it is not valid.