### PR TITLE
bug: add severity and category in cluster policy report (#7828)

### DIFF
--- a/cmd/cli/kubectl-kyverno/apply/report.go
+++ b/cmd/cli/kubectl-kyverno/apply/report.go
@@ -102,7 +102,9 @@ func buildPolicyResults(auditWarn bool, engineResponses ...engineapi.EngineRespo
 						UID:        engineResponse.Resource.GetUID(),
 					},
 				},
-				Scored: true,
+				Scored:   true,
+				Category: ann[kyverno.AnnotationPolicyCategory],
+				Severity: reportutils.SeverityFromString(ann[kyverno.AnnotationPolicySeverity]),
 			}
 
 			ann := engineResponse.Policy().GetAnnotations()

--- a/cmd/cli/kubectl-kyverno/apply/report.go
+++ b/cmd/cli/kubectl-kyverno/apply/report.go
@@ -10,6 +10,7 @@ import (
 	policyreportv1alpha2 "github.com/kyverno/kyverno/api/policyreport/v1alpha2"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
+	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -80,6 +81,7 @@ func buildPolicyResults(auditWarn bool, engineResponses ...engineapi.EngineRespo
 		policy := engineResponse.Policy()
 		var appname string
 		ns := policy.GetNamespace()
+		ann := policy.GetAnnotations()
 		if ns != "" {
 			appname = fmt.Sprintf("policyreport-ns-%s", ns)
 		} else {
@@ -103,8 +105,8 @@ func buildPolicyResults(auditWarn bool, engineResponses ...engineapi.EngineRespo
 					},
 				},
 				Scored:   true,
-				Category: ann[kyverno.AnnotationPolicyCategory],
-				Severity: reportutils.SeverityFromString(ann[kyverno.AnnotationPolicySeverity]),
+				Category: ann[kyvernov1.AnnotationPolicyCategory],
+				Severity: reportutils.SeverityFromString(ann[kyvernov1.AnnotationPolicySeverity]),
 			}
 
 			ann := engineResponse.Policy().GetAnnotations()

--- a/cmd/cli/kubectl-kyverno/apply/report_test.go
+++ b/cmd/cli/kubectl-kyverno/apply/report_test.go
@@ -18,7 +18,9 @@ var rawPolicy = []byte(`
 	"metadata": {
 	  "name": "pod-requirements",
 	  "annotations": {
-		"pod-policies.kyverno.io/autogen-controllers": "none"
+		"pod-policies.kyverno.io/autogen-controllers": "none",
+		"policies.kyverno.io/severity": "medium",
+		"policies.kyverno.io/category": "Pod Security Standards (Restricted)"
 	  }
 	},
 	"spec": {
@@ -113,6 +115,8 @@ func Test_buildPolicyReports(t *testing.T) {
 			assert.Assert(t,
 				report.UnstructuredContent()["summary"].(map[string]interface{})[preport.StatusPass].(int64) == 1,
 				report.UnstructuredContent()["summary"].(map[string]interface{})[preport.StatusPass].(int64))
+			assert.Equal(t, report.UnstructuredContent()["results"].([]interface{})[0].(map[string]interface{})["severity"], "medium")
+			assert.Equal(t, report.UnstructuredContent()["results"].([]interface{})[0].(map[string]interface{})["category"], "Pod Security Standards (Restricted)")
 		} else {
 			assert.Assert(t, report.GetName() == "policyreport-ns-default")
 			assert.Assert(t, report.GetKind() == "PolicyReport")

--- a/pkg/utils/report/results.go
+++ b/pkg/utils/report/results.go
@@ -69,7 +69,7 @@ func toPolicyResult(status engineapi.RuleStatus) policyreportv1alpha2.PolicyResu
 	return ""
 }
 
-func severityFromString(severity string) policyreportv1alpha2.PolicySeverity {
+func SeverityFromString(severity string) policyreportv1alpha2.PolicySeverity {
 	switch severity {
 	case policyreportv1alpha2.SeverityHigh:
 		return policyreportv1alpha2.SeverityHigh
@@ -97,7 +97,7 @@ func EngineResponseToReportResults(response engineapi.EngineResponse) []policyre
 				Seconds: time.Now().Unix(),
 			},
 			Category: annotations[kyvernov1.AnnotationPolicyCategory],
-			Severity: severityFromString(annotations[kyvernov1.AnnotationPolicySeverity]),
+			Severity: SeverityFromString(annotations[kyvernov1.AnnotationPolicySeverity]),
 		}
 		pss := ruleResult.PodSecurityChecks()
 		if pss != nil {


### PR DESCRIPTION
* test: add test for severity and category

Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>

* fix: add severity and category to cpol report

Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>

* refactor: reuse report util SeverityFromString

Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>

---------

Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>
## Explanation

cherry pick: #7828