### PR TITLE
fix: rename --compact to --detailed-results in CLI

### DIFF
--- a/cmd/cli/kubectl-kyverno/apply/apply_command.go
+++ b/cmd/cli/kubectl-kyverno/apply/apply_command.go
@@ -147,7 +147,7 @@ More info: https://kyverno.io/docs/kyverno-cli/
 
 func Command() *cobra.Command {
 	var cmd *cobra.Command
-	var removeColor, compact, table bool
+	var removeColor, detailedResults, table bool
 	applyCommandConfig := &ApplyCommandConfig{}
 	cmd = &cobra.Command{
 		Use:     "apply",
@@ -172,7 +172,7 @@ func Command() *cobra.Command {
 			if applyCommandConfig.PolicyReport {
 				printReport(responses, applyCommandConfig.AuditWarn)
 			} else if table {
-				printTable(compact, applyCommandConfig.AuditWarn, responses...)
+				printTable(detailedResults, applyCommandConfig.AuditWarn, responses...)
 			} else {
 				printViolations(rc)
 			}
@@ -198,7 +198,7 @@ func Command() *cobra.Command {
 	cmd.Flags().IntVar(&applyCommandConfig.warnExitCode, "warn-exit-code", 0, "Set the exit code for warnings; if failures or errors are found, will exit 1")
 	cmd.Flags().BoolVar(&applyCommandConfig.warnNoPassed, "warn-no-pass", false, "Specify if warning exit code should be raised if no objects satisfied a policy; can be used together with --warn-exit-code flag")
 	cmd.Flags().BoolVar(&removeColor, "remove-color", false, "Remove any color from output")
-	cmd.Flags().BoolVar(&compact, "compact", true, "Does not show detailed results")
+	cmd.Flags().BoolVar(&detailedResults, "detailed-results", false, "If set to true, display detailed results")
 	cmd.Flags().BoolVarP(&table, "table", "t", false, "Show results in table format")
 	return cmd
 }

--- a/cmd/cli/kubectl-kyverno/utils/output/table/table.go
+++ b/cmd/cli/kubectl-kyverno/utils/output/table/table.go
@@ -5,7 +5,7 @@ type Table struct {
 }
 
 func (t *Table) Rows(compact bool) interface{} {
-	if !compact {
+	if compact {
 		return t.RawRows
 	}
 	var rows []CompactRow


### PR DESCRIPTION
## Explanation
Rename `--compact` to `--detailed-results` since the default behavior is to not showing messages in the resulted tables. If the user wants to display the Message column, he needs to set `--detailed-results` in both CLI apply and test commands.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
/Closes #7936 

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/kind bug

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
#### CLI Test Command
1. without `--detailed results`:
```
./cmd/cli/kubectl-kyverno/kubectl-kyverno test ../test-dir

Executing disallow-host-namespaces...
applying 1 policy to 2 resources... 

│────│──────────────────────────│─────────────────│─────────────────────────────│────────│
│ ID │ POLICY                   │ RULE            │ RESOURCE                    │ RESULT │
│────│──────────────────────────│─────────────────│─────────────────────────────│────────│
│  1 │ disallow-host-namespaces │ host-namespaces │ Deployment/baddeployment01  │ Pass   │
│  2 │ disallow-host-namespaces │ host-namespaces │ Deployment/gooddeployment01 │ Pass   │
│────│──────────────────────────│─────────────────│─────────────────────────────│────────│

Test Summary: 2 tests passed and 0 tests failed
```
2. with `--detailed-results`:
```
./cmd/cli/kubectl-kyverno/kubectl-kyverno test ../test-dir --detailed-results

Executing disallow-host-namespaces...
applying 1 policy to 2 resources... 

│────│──────────────────────────│─────────────────│─────────────────────────────│────────│─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────│
│ ID │ POLICY                   │ RULE            │ RESOURCE                    │ RESULT │ MESSAGE                                                                                                                                 │
│────│──────────────────────────│─────────────────│─────────────────────────────│────────│─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────│
│  1 │ disallow-host-namespaces │ host-namespaces │ Deployment/baddeployment01  │ Pass   │ validation error: Sharing the host namespaces is disallowed. . rule autogen-host-namespaces failed at path /spec/template/spec/hostPID/ │
│  2 │ disallow-host-namespaces │ host-namespaces │ Deployment/gooddeployment01 │ Pass   │ validation rule 'autogen-host-namespaces' passed.                                                                                       │
│────│──────────────────────────│─────────────────│─────────────────────────────│────────│─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────│

Test Summary: 2 tests passed and 0 tests failed
```
#### CLI Apply Command
1. without `--table --detailed-results`:
```
./cmd/cli/kubectl-kyverno/kubectl-kyverno apply ../test-dir/disallow-host-namespaces.yaml --resource ../test-dir/resource.yaml 
Applying 3 policy rule(s) to 2 resource(s)...

policy disallow-host-namespaces -> resource default/Deployment/baddeployment01 failed: 
1. autogen-host-namespaces: validation error: Sharing the host namespaces is disallowed. . rule autogen-host-namespaces failed at path /spec/template/spec/hostPID/ 

pass: 2, fail: 2, warn: 0, error: 0, skip: 8 
```
2. with `--table --detailed-results`:
```
Applying 3 policy rule(s) to 2 resource(s)...

policy disallow-host-namespaces -> resource default/Deployment/baddeployment01 failed: 
1. autogen-host-namespaces: validation error: Sharing the host namespaces is disallowed. . rule autogen-host-namespaces failed at path /spec/template/spec/hostPID/ 
│────│──────────────────────────│─────────────────────────────────│─────────────────────────────────────│────────│─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────│
│ ID │ POLICY                   │ RULE                            │ RESOURCE                            │ RESULT │ MESSAGE                                                                                                                                 │
│────│──────────────────────────│─────────────────────────────────│─────────────────────────────────────│────────│─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────│
│  1 │ disallow-host-namespaces │ autogen-host-namespaces         │ default/Deployment/baddeployment01  │ Fail   │ validation error: Sharing the host namespaces is disallowed. . rule autogen-host-namespaces failed at path /spec/template/spec/hostPID/ │
│  2 │ disallow-host-namespaces │ host-namespaces                 │ default/Deployment/baddeployment01  │ Skip   │ Sharing the host namespaces is disallowed.                                                                                              │
│  3 │ disallow-host-namespaces │ autogen-cronjob-host-namespaces │ default/Deployment/baddeployment01  │ Skip   │ Sharing the host namespaces is disallowed.                                                                                              │
│  4 │ disallow-host-namespaces │ autogen-host-namespaces         │ default/Deployment/gooddeployment01 │ Pass   │ validation rule 'autogen-host-namespaces' passed.                                                                                       │
│  5 │ disallow-host-namespaces │ host-namespaces                 │ default/Deployment/gooddeployment01 │ Skip   │ Sharing the host namespaces is disallowed.                                                                                              │
│  6 │ disallow-host-namespaces │ autogen-cronjob-host-namespaces │ default/Deployment/gooddeployment01 │ Skip   │ Sharing the host namespaces is disallowed.                                                                                              │
│────│──────────────────────────│─────────────────────────────────│─────────────────────────────────────│────────│─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────│
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
