### PR TITLE
chore: move cert.kyverno.io/managed-by label in constants

### DIFF
--- a/api/kyverno/constants.go
+++ b/api/kyverno/constants.go
@@ -2,7 +2,8 @@ package kyverno
 
 const (
 	// Well known labels
-	LabelAppManagedBy = "app.kubernetes.io/managed-by"
+	LabelAppManagedBy  = "app.kubernetes.io/managed-by"
+	LabelCertManagedBy = "cert.kyverno.io/managed-by"
 	// Well known annotations
 	AnnotationAutogenControllers = "pod-policies.kyverno.io/autogen-controllers"
 	AnnotationPolicyCategory     = "policies.kyverno.io/category"

--- a/pkg/tls/renewer.go
+++ b/pkg/tls/renewer.go
@@ -22,9 +22,7 @@ const (
 	CAValidityDuration = 365 * 24 * time.Hour
 	// TLSValidityDuration is the valid duration for TLS certificates
 	TLSValidityDuration = 150 * 24 * time.Hour
-	// managedByLabel is added to Kyverno managed secrets
-	managedByLabel = "cert.kyverno.io/managed-by"
-	rootCAKey      = "rootCA.crt"
+	rootCAKey           = "rootCA.crt"
 )
 
 type CertValidator interface {
@@ -228,7 +226,7 @@ func (c *certRenewer) writeSecret(ctx context.Context, name string, key *rsa.Pri
 				Name:      name,
 				Namespace: config.KyvernoNamespace(),
 				Labels: map[string]string{
-					managedByLabel: kyverno.ValueKyvernoApp,
+					kyverno.LabelCertManagedBy: kyverno.ValueKyvernoApp,
 				},
 			},
 			Type: corev1.SecretTypeTLS,

--- a/pkg/tls/utils.go
+++ b/pkg/tls/utils.go
@@ -89,7 +89,7 @@ func isSecretManagedByKyverno(secret *corev1.Secret) bool {
 		if labels == nil {
 			return false
 		}
-		if labels[managedByLabel] != kyverno.ValueKyvernoApp {
+		if labels[kyverno.LabelCertManagedBy] != kyverno.ValueKyvernoApp {
 			return false
 		}
 	}


### PR DESCRIPTION
## Explanation

This PR moves `cert.kyverno.io/managed-by` label in constants.
