### PR TITLE
fix: remove configmaps from cleanup cluster role

### DIFF
--- a/charts/kyverno/templates/cleanup-controller/clusterrole.yaml
+++ b/charts/kyverno/templates/cleanup-controller/clusterrole.yaml
@@ -46,14 +46,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - ''
-    resources:
-      - configmaps
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - batch
     resources:
       - cronjobs


### PR DESCRIPTION
## Explanation

This PR removes configmaps permissions from cleanup cluster role.
