### PR TITLE
chore: move cache enabled label

### DIFF
--- a/api/kyverno/constants.go
+++ b/api/kyverno/constants.go
@@ -4,6 +4,7 @@ const (
 	// Well known labels
 	LabelAppManagedBy     = "app.kubernetes.io/managed-by"
 	LabelAppComponent     = "app.kubernetes.io/component"
+	LabelCacheEnabled     = "cache.kyverno.io/enabled"
 	LabelCertManagedBy    = "cert.kyverno.io/managed-by"
 	LabelWebhookManagedBy = "webhook.kyverno.io/managed-by"
 	// Well known annotations

--- a/pkg/engine/context/resolvers/constants.go
+++ b/pkg/engine/context/resolvers/constants.go
@@ -1,5 +1,0 @@
-package resolvers
-
-const (
-	LabelCacheKey = "cache.kyverno.io/enabled"
-)

--- a/pkg/engine/context/resolvers/resolvers_test.go
+++ b/pkg/engine/context/resolvers/resolvers_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kyverno/kyverno/api/kyverno"
 	"github.com/kyverno/kyverno/pkg/engine/api"
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -34,7 +35,7 @@ func createConfigMaps(ctx context.Context, client *kubefake.Clientset, addLabel 
 		Data: map[string]string{"configmapkey": "key1"},
 	}
 	if addLabel {
-		cm.ObjectMeta.Labels = map[string]string{LabelCacheKey: "true"}
+		cm.ObjectMeta.Labels = map[string]string{kyverno.LabelCacheEnabled: "true"}
 	}
 	_, err := client.CoreV1().ConfigMaps(namespace).Create(
 		ctx, cm, metav1.CreateOptions{})

--- a/pkg/engine/context/resolvers/utils.go
+++ b/pkg/engine/context/resolvers/utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/kyverno/kyverno/api/kyverno"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -13,7 +14,7 @@ import (
 
 func GetCacheSelector() (labels.Selector, error) {
 	selector := labels.Everything()
-	requirement, err := labels.NewRequirement(LabelCacheKey, selection.Exists, nil)
+	requirement, err := labels.NewRequirement(kyverno.LabelCacheEnabled, selection.Exists, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/context/resolvers/utils_test.go
+++ b/pkg/engine/context/resolvers/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kyverno/kyverno/api/kyverno"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -15,7 +16,7 @@ func TestGetCacheSelector(t *testing.T) {
 		wantErr bool
 	}{{
 		name: "ok",
-		want: LabelCacheKey,
+		want: kyverno.LabelCacheEnabled,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Explanation

This PR moves `cache.kyverno.io/enabled` label in the api packge.
