### PR TITLE
Add category and severity fields in cli policy report

### DIFF
--- a/policy.yaml
+++ b/policy.yaml
@@ -1,0 +1,211 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/description: Adding capabilities other than `NET_BIND_SERVICE`
+      is disallowed. In addition, all containers must explicitly drop `ALL` capabilities.
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow Capabilities (Strict)
+  creationTimestamp: "2023-07-08T06:11:16Z"
+  generation: 1
+  name: disallow-capabilities-strict
+  resourceVersion: "2040"
+  uid: 90995533-6389-4d68-97c2-ce5b1f918d7b
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: require-drop-all
+    preconditions:
+      all:
+      - key: '{{ request.operation || ''BACKGROUND'' }}'
+        operator: NotEquals
+        value: DELETE
+    validate:
+      foreach:
+      - deny:
+          conditions:
+            all:
+            - key: ALL
+              operator: AnyNotIn
+              value: '{{ element.securityContext.capabilities.drop[] || `[]` }}'
+        list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+      message: Containers must drop `ALL` capabilities.
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: adding-capabilities-strict
+    preconditions:
+      all:
+      - key: '{{ request.operation || ''BACKGROUND'' }}'
+        operator: NotEquals
+        value: DELETE
+    validate:
+      foreach:
+      - deny:
+          conditions:
+            all:
+            - key: '{{ element.securityContext.capabilities.add[] || `[]` }}'
+              operator: AnyNotIn
+              value:
+              - NET_BIND_SERVICE
+              - ""
+        list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+      message: Any capabilities added other than NET_BIND_SERVICE are disallowed.
+  validationFailureAction: audit
+status:
+  autogen:
+    rules:
+    - exclude:
+        resources: {}
+      generate:
+        clone: {}
+        cloneList: {}
+      match:
+        any:
+        - resources:
+            kinds:
+            - DaemonSet
+            - Deployment
+            - Job
+            - StatefulSet
+            - ReplicaSet
+            - ReplicationController
+        resources: {}
+      mutate: {}
+      name: autogen-require-drop-all
+      preconditions:
+        all:
+        - key: '{{ request.operation || ''BACKGROUND'' }}'
+          operator: NotEquals
+          value: DELETE
+      validate:
+        foreach:
+        - deny:
+            conditions:
+              all:
+              - key: ALL
+                operator: AnyNotIn
+                value: '{{ element.securityContext.capabilities.drop[] || `[]` }}'
+          list: request.object.spec.template.spec.[ephemeralContainers, initContainers,
+            containers][]
+        message: Containers must drop `ALL` capabilities.
+    - exclude:
+        resources: {}
+      generate:
+        clone: {}
+        cloneList: {}
+      match:
+        any:
+        - resources:
+            kinds:
+            - CronJob
+        resources: {}
+      mutate: {}
+      name: autogen-cronjob-require-drop-all
+      preconditions:
+        all:
+        - key: '{{ request.operation || ''BACKGROUND'' }}'
+          operator: NotEquals
+          value: DELETE
+      validate:
+        foreach:
+        - deny:
+            conditions:
+              all:
+              - key: ALL
+                operator: AnyNotIn
+                value: '{{ element.securityContext.capabilities.drop[] || `[]` }}'
+          list: request.object.spec.jobTemplate.spec.template.spec.[ephemeralContainers,
+            initContainers, containers][]
+        message: Containers must drop `ALL` capabilities.
+    - exclude:
+        resources: {}
+      generate:
+        clone: {}
+        cloneList: {}
+      match:
+        any:
+        - resources:
+            kinds:
+            - DaemonSet
+            - Deployment
+            - Job
+            - StatefulSet
+            - ReplicaSet
+            - ReplicationController
+        resources: {}
+      mutate: {}
+      name: autogen-adding-capabilities-strict
+      preconditions:
+        all:
+        - key: '{{ request.operation || ''BACKGROUND'' }}'
+          operator: NotEquals
+          value: DELETE
+      validate:
+        foreach:
+        - deny:
+            conditions:
+              all:
+              - key: '{{ element.securityContext.capabilities.add[] || `[]` }}'
+                operator: AnyNotIn
+                value:
+                - NET_BIND_SERVICE
+                - ""
+          list: request.object.spec.template.spec.[ephemeralContainers, initContainers,
+            containers][]
+        message: Any capabilities added other than NET_BIND_SERVICE are disallowed.
+    - exclude:
+        resources: {}
+      generate:
+        clone: {}
+        cloneList: {}
+      match:
+        any:
+        - resources:
+            kinds:
+            - CronJob
+        resources: {}
+      mutate: {}
+      name: autogen-cronjob-adding-capabilities-strict
+      preconditions:
+        all:
+        - key: '{{ request.operation || ''BACKGROUND'' }}'
+          operator: NotEquals
+          value: DELETE
+      validate:
+        foreach:
+        - deny:
+            conditions:
+              all:
+              - key: '{{ element.securityContext.capabilities.add[] || `[]` }}'
+                operator: AnyNotIn
+                value:
+                - NET_BIND_SERVICE
+                - ""
+          list: request.object.spec.jobTemplate.spec.template.spec.[ephemeralContainers,
+            initContainers, containers][]
+        message: Any capabilities added other than NET_BIND_SERVICE are disallowed.
+  conditions:
+  - lastTransitionTime: "2023-07-08T06:11:16Z"
+    message: ""
+    reason: Succeeded
+    status: "True"
+    type: Ready
+  ready: true
+  rulecount:
+    generate: 0
+    mutate: 0
+    validate: 2
+    verifyimages: 0

--- a/resource.yaml
+++ b/resource.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx1
+  labels:
+    env: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"


### PR DESCRIPTION
## Explanation

- adds `policies.kyverno.io/category` and `policies.kyverno.io/severity` to `ClusterPolicyReport`
- updates tests to check for the above mentioned fields

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #8000 

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
N/A
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Added changes to add severity and category fields in policy report generated by CLI
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

Create this ClusterPolicy locally and also apply to a cluster.
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  annotations:
    kyverno.io/kubernetes-version: 1.22-1.23
    kyverno.io/kyverno-version: 1.6.0
    policies.kyverno.io/category: Pod Security Standards (Restricted)
    policies.kyverno.io/description: Adding capabilities other than `NET_BIND_SERVICE`
      is disallowed. In addition, all containers must explicitly drop `ALL` capabilities.
    policies.kyverno.io/minversion: 1.6.0
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod
    policies.kyverno.io/title: Disallow Capabilities (Strict)
  creationTimestamp: "2023-07-08T06:11:16Z"
  generation: 1
  name: disallow-capabilities-strict
  resourceVersion: "2040"
  uid: 90995533-6389-4d68-97c2-ce5b1f918d7b
spec:
  background: true
  rules:
  - match:
      any:
      - resources:
          kinds:
          - Pod
    name: require-drop-all
    preconditions:
      all:
      - key: '{{ request.operation || ''BACKGROUND'' }}'
        operator: NotEquals
        value: DELETE
    validate:
      foreach:
      - deny:
          conditions:
            all:
            - key: ALL
              operator: AnyNotIn
              value: '{{ element.securityContext.capabilities.drop[] || `[]` }}'
        list: request.object.spec.[ephemeralContainers, initContainers, containers][]
      message: Containers must drop `ALL` capabilities.
  - match:
      any:
      - resources:
          kinds:
          - Pod
    name: adding-capabilities-strict
    preconditions:
      all:
      - key: '{{ request.operation || ''BACKGROUND'' }}'
        operator: NotEquals
        value: DELETE
    validate:
      foreach:
      - deny:
          conditions:
            all:
            - key: '{{ element.securityContext.capabilities.add[] || `[]` }}'
              operator: AnyNotIn
              value:
              - NET_BIND_SERVICE
              - ""
        list: request.object.spec.[ephemeralContainers, initContainers, containers][]
      message: Any capabilities added other than NET_BIND_SERVICE are disallowed.
  validationFailureAction: audit
status:
  autogen:
    rules:
    - exclude:
        resources: {}
      generate:
        clone: {}
        cloneList: {}
      match:
        any:
        - resources:
            kinds:
            - DaemonSet
            - Deployment
            - Job
            - StatefulSet
            - ReplicaSet
            - ReplicationController
        resources: {}
      mutate: {}
      name: autogen-require-drop-all
      preconditions:
        all:
        - key: '{{ request.operation || ''BACKGROUND'' }}'
          operator: NotEquals
          value: DELETE
      validate:
        foreach:
        - deny:
            conditions:
              all:
              - key: ALL
                operator: AnyNotIn
                value: '{{ element.securityContext.capabilities.drop[] || `[]` }}'
          list: request.object.spec.template.spec.[ephemeralContainers, initContainers,
            containers][]
        message: Containers must drop `ALL` capabilities.
    - exclude:
        resources: {}
      generate:
        clone: {}
        cloneList: {}
      match:
        any:
        - resources:
            kinds:
            - CronJob
        resources: {}
      mutate: {}
      name: autogen-cronjob-require-drop-all
      preconditions:
        all:
        - key: '{{ request.operation || ''BACKGROUND'' }}'
          operator: NotEquals
          value: DELETE
      validate:
        foreach:
        - deny:
            conditions:
              all:
              - key: ALL
                operator: AnyNotIn
                value: '{{ element.securityContext.capabilities.drop[] || `[]` }}'
          list: request.object.spec.jobTemplate.spec.template.spec.[ephemeralContainers,
            initContainers, containers][]
        message: Containers must drop `ALL` capabilities.
    - exclude:
        resources: {}
      generate:
        clone: {}
        cloneList: {}
      match:
        any:
        - resources:
            kinds:
            - DaemonSet
            - Deployment
            - Job
            - StatefulSet
            - ReplicaSet
            - ReplicationController
        resources: {}
      mutate: {}
      name: autogen-adding-capabilities-strict
      preconditions:
        all:
        - key: '{{ request.operation || ''BACKGROUND'' }}'
          operator: NotEquals
          value: DELETE
      validate:
        foreach:
        - deny:
            conditions:
              all:
              - key: '{{ element.securityContext.capabilities.add[] || `[]` }}'
                operator: AnyNotIn
                value:
                - NET_BIND_SERVICE
                - ""
          list: request.object.spec.template.spec.[ephemeralContainers, initContainers,
            containers][]
        message: Any capabilities added other than NET_BIND_SERVICE are disallowed.
    - exclude:
        resources: {}
      generate:
        clone: {}
        cloneList: {}
      match:
        any:
        - resources:
            kinds:
            - CronJob
        resources: {}
      mutate: {}
      name: autogen-cronjob-adding-capabilities-strict
      preconditions:
        all:
        - key: '{{ request.operation || ''BACKGROUND'' }}'
          operator: NotEquals
          value: DELETE
      validate:
        foreach:
        - deny:
            conditions:
              all:
              - key: '{{ element.securityContext.capabilities.add[] || `[]` }}'
                operator: AnyNotIn
                value:
                - NET_BIND_SERVICE
                - ""
          list: request.object.spec.jobTemplate.spec.template.spec.[ephemeralContainers,
            initContainers, containers][]
        message: Any capabilities added other than NET_BIND_SERVICE are disallowed.
  conditions:
  - lastTransitionTime: "2023-07-08T06:11:16Z"
    message: ""
    reason: Succeeded
    status: "True"
    type: Ready
  ready: true
  rulecount:
    generate: 0
    mutate: 0
    validate: 2
    verifyimages: 0
```
Apply the following resource
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx1
  labels:
    env: test
spec:
  containers:
  - name: nginx
    image: nginx
    imagePullPolicy: IfNotPresent
    resources:
      requests:
        memory: "64Mi"
        cpu: "250m"
      limits:
        memory: "128Mi"
        cpu: "500m"
```
Run the command
```yaml
./cmd/cli/kubectl-kyverno/kubectl-kyverno apply policy.yaml -r resource.yaml  --policy-report
```
Result
```yaml
Applying 6 policy rule(s) to 1 resource(s)...
----------------------------------------------------------------------
POLICY REPORT:
----------------------------------------------------------------------
apiVersion: wgpolicyk8s.io/v1alpha2
kind: ClusterPolicyReport
metadata:
  creationTimestamp: null
  name: clusterpolicyreport
results:
- category: Pod Security Standards (Restricted)
  message: 'validation failure: Containers must drop `ALL` capabilities.;'
  policy: disallow-capabilities-strict
  resources:
  - apiVersion: v1
    kind: Pod
    name: nginx1
    namespace: default
  result: fail
  rule: require-drop-all
  scored: true
  severity: medium
  source: kyverno
  timestamp:
    nanos: 0
    seconds: 1691677157
- category: Pod Security Standards (Restricted)
  message: rule passed;
  policy: disallow-capabilities-strict
  resources:
  - apiVersion: v1
    kind: Pod
    name: nginx1
    namespace: default
  result: pass
  rule: adding-capabilities-strict
  scored: true
  severity: medium
  source: kyverno
  timestamp:
    nanos: 0
    seconds: 1691677157
- category: Pod Security Standards (Restricted)
  message: Containers must drop `ALL` capabilities.
  policy: disallow-capabilities-strict
  resources:
  - apiVersion: v1
    kind: Pod
    name: nginx1
    namespace: default
  result: skip
  rule: autogen-require-drop-all
  scored: true
  severity: medium
  source: kyverno
  timestamp:
    nanos: 0
    seconds: 1691677157
- category: Pod Security Standards (Restricted)
  message: Containers must drop `ALL` capabilities.
  policy: disallow-capabilities-strict
  resources:
  - apiVersion: v1
    kind: Pod
    name: nginx1
    namespace: default
  result: skip
  rule: autogen-cronjob-require-drop-all
  scored: true
  severity: medium
  source: kyverno
  timestamp:
    nanos: 0
    seconds: 1691677157
- category: Pod Security Standards (Restricted)
  message: Any capabilities added other than NET_BIND_SERVICE are disallowed.
  policy: disallow-capabilities-strict
  resources:
  - apiVersion: v1
    kind: Pod
    name: nginx1
    namespace: default
  result: skip
  rule: autogen-adding-capabilities-strict
  scored: true
  severity: medium
  source: kyverno
  timestamp:
    nanos: 0
    seconds: 1691677157
- category: Pod Security Standards (Restricted)
  message: Any capabilities added other than NET_BIND_SERVICE are disallowed.
  policy: disallow-capabilities-strict
  resources:
  - apiVersion: v1
    kind: Pod
    name: nginx1
    namespace: default
  result: skip
  rule: autogen-cronjob-adding-capabilities-strict
  scored: true
  severity: medium
  source: kyverno
  timestamp:
    nanos: 0
    seconds: 1691677157
summary:
  error: 0
  fail: 1
  pass: 1
  skip: 4
  warn: 0
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->



<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
