### PR TITLE
chore: replace usage of v1alpha1 with v1beta1 for cel subrule

### DIFF
--- a/api/kyverno/v1/common_types.go
+++ b/api/kyverno/v1/common_types.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine/variables/regex"
 	"github.com/sigstore/k8s-manifest-sigstore/pkg/k8smanifest"
 	admissionv1 "k8s.io/api/admission/v1"
-	"k8s.io/api/admissionregistration/v1alpha1"
+	"k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -434,30 +434,30 @@ type PodSecurityStandard struct {
 // CEL allows validation checks using the Common Expression Language (https://kubernetes.io/docs/reference/using-api/cel/).
 type CEL struct {
 	// Expressions is a list of CELExpression types.
-	Expressions []v1alpha1.Validation `json:"expressions,omitempty" yaml:"expressions,omitempty"`
+	Expressions []v1beta1.Validation `json:"expressions,omitempty" yaml:"expressions,omitempty"`
 
 	// ParamKind is a tuple of Group Kind and Version.
 	// +optional
-	ParamKind *v1alpha1.ParamKind `json:"paramKind,omitempty" yaml:"paramKind,omitempty"`
+	ParamKind *v1beta1.ParamKind `json:"paramKind,omitempty" yaml:"paramKind,omitempty"`
 
 	// ParamRef references a parameter resource.
 	// +optional
-	ParamRef *v1alpha1.ParamRef `json:"paramRef,omitempty" yaml:"paramRef,omitempty"`
+	ParamRef *v1beta1.ParamRef `json:"paramRef,omitempty" yaml:"paramRef,omitempty"`
 
 	// AuditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request.
 	// +optional
-	AuditAnnotations []v1alpha1.AuditAnnotation `json:"auditAnnotations,omitempty" yaml:"auditAnnotations,omitempty"`
+	AuditAnnotations []v1beta1.AuditAnnotation `json:"auditAnnotations,omitempty" yaml:"auditAnnotations,omitempty"`
 }
 
 func (c *CEL) HasParam() bool {
 	return c.ParamKind != nil && c.ParamRef != nil
 }
 
-func (c *CEL) GetParamKind() v1alpha1.ParamKind {
+func (c *CEL) GetParamKind() v1beta1.ParamKind {
 	return *c.ParamKind
 }
 
-func (c *CEL) GetParamRef() v1alpha1.ParamRef {
+func (c *CEL) GetParamRef() v1beta1.ParamRef {
 	return *c.ParamRef
 }
 

--- a/api/kyverno/v1/zz_generated.deepcopy.go
+++ b/api/kyverno/v1/zz_generated.deepcopy.go
@@ -24,7 +24,7 @@ package v1
 import (
 	k8smanifest "github.com/sigstore/k8s-manifest-sigstore/pkg/k8smanifest"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	v1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -218,24 +218,24 @@ func (in *CEL) DeepCopyInto(out *CEL) {
 	*out = *in
 	if in.Expressions != nil {
 		in, out := &in.Expressions, &out.Expressions
-		*out = make([]v1alpha1.Validation, len(*in))
+		*out = make([]v1beta1.Validation, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.ParamKind != nil {
 		in, out := &in.ParamKind, &out.ParamKind
-		*out = new(v1alpha1.ParamKind)
+		*out = new(v1beta1.ParamKind)
 		**out = **in
 	}
 	if in.ParamRef != nil {
 		in, out := &in.ParamRef, &out.ParamRef
-		*out = new(v1alpha1.ParamRef)
+		*out = new(v1beta1.ParamRef)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.AuditAnnotations != nil {
 		in, out := &in.AuditAnnotations, &out.AuditAnnotations
-		*out = make([]v1alpha1.AuditAnnotation, len(*in))
+		*out = make([]v1beta1.AuditAnnotation, len(*in))
 		copy(*out, *in)
 	}
 	return

--- a/charts/kyverno/templates/crds/crds.yaml
+++ b/charts/kyverno/templates/crds/crds.yaml
@@ -6421,10 +6421,14 @@ spec:
                               description: ParamRef references a parameter resource.
                               properties:
                                 name:
-                                  description: "`name` is the name of the resource
-                                    being referenced. \n `name` and `selector` are
-                                    mutually exclusive properties. If one is set,
-                                    the other must be unset."
+                                  description: "name is the name of the resource being
+                                    referenced. \n One of `name` or `selector` must
+                                    be set, but `name` and `selector` are mutually
+                                    exclusive properties. If one is set, the other
+                                    must be unset. \n A single parameter used for
+                                    all admission requests can be configured by setting
+                                    the `name` field, leaving `selector` blank, and
+                                    setting namespace if `paramKind` is namespace-scoped."
                                   type: string
                                 namespace:
                                   description: "namespace is the namespace of the
@@ -6452,7 +6456,7 @@ spec:
                                     binding. If set to `Deny`, then no matched parameters
                                     will be subject to the `failurePolicy` of the
                                     policy. \n Allowed values are `Allow` or `Deny`
-                                    Default to `Deny`"
+                                    \n Required"
                                   type: string
                                 selector:
                                   description: "selector can be used to match multiple
@@ -10729,10 +10733,15 @@ spec:
                                   description: ParamRef references a parameter resource.
                                   properties:
                                     name:
-                                      description: "`name` is the name of the resource
-                                        being referenced. \n `name` and `selector`
-                                        are mutually exclusive properties. If one
-                                        is set, the other must be unset."
+                                      description: "name is the name of the resource
+                                        being referenced. \n One of `name` or `selector`
+                                        must be set, but `name` and `selector` are
+                                        mutually exclusive properties. If one is set,
+                                        the other must be unset. \n A single parameter
+                                        used for all admission requests can be configured
+                                        by setting the `name` field, leaving `selector`
+                                        blank, and setting namespace if `paramKind`
+                                        is namespace-scoped."
                                       type: string
                                     namespace:
                                       description: "namespace is the namespace of
@@ -10762,7 +10771,7 @@ spec:
                                         by the binding. If set to `Deny`, then no
                                         matched parameters will be subject to the
                                         `failurePolicy` of the policy. \n Allowed
-                                        values are `Allow` or `Deny` Default to `Deny`"
+                                        values are `Allow` or `Deny` \n Required"
                                       type: string
                                     selector:
                                       description: "selector can be used to match
@@ -14763,10 +14772,14 @@ spec:
                               description: ParamRef references a parameter resource.
                               properties:
                                 name:
-                                  description: "`name` is the name of the resource
-                                    being referenced. \n `name` and `selector` are
-                                    mutually exclusive properties. If one is set,
-                                    the other must be unset."
+                                  description: "name is the name of the resource being
+                                    referenced. \n One of `name` or `selector` must
+                                    be set, but `name` and `selector` are mutually
+                                    exclusive properties. If one is set, the other
+                                    must be unset. \n A single parameter used for
+                                    all admission requests can be configured by setting
+                                    the `name` field, leaving `selector` blank, and
+                                    setting namespace if `paramKind` is namespace-scoped."
                                   type: string
                                 namespace:
                                   description: "namespace is the namespace of the
@@ -14794,7 +14807,7 @@ spec:
                                     binding. If set to `Deny`, then no matched parameters
                                     will be subject to the `failurePolicy` of the
                                     policy. \n Allowed values are `Allow` or `Deny`
-                                    Default to `Deny`"
+                                    \n Required"
                                   type: string
                                 selector:
                                   description: "selector can be used to match multiple
@@ -19125,10 +19138,15 @@ spec:
                                   description: ParamRef references a parameter resource.
                                   properties:
                                     name:
-                                      description: "`name` is the name of the resource
-                                        being referenced. \n `name` and `selector`
-                                        are mutually exclusive properties. If one
-                                        is set, the other must be unset."
+                                      description: "name is the name of the resource
+                                        being referenced. \n One of `name` or `selector`
+                                        must be set, but `name` and `selector` are
+                                        mutually exclusive properties. If one is set,
+                                        the other must be unset. \n A single parameter
+                                        used for all admission requests can be configured
+                                        by setting the `name` field, leaving `selector`
+                                        blank, and setting namespace if `paramKind`
+                                        is namespace-scoped."
                                       type: string
                                     namespace:
                                       description: "namespace is the namespace of
@@ -19158,7 +19176,7 @@ spec:
                                         by the binding. If set to `Deny`, then no
                                         matched parameters will be subject to the
                                         `failurePolicy` of the policy. \n Allowed
-                                        values are `Allow` or `Deny` Default to `Deny`"
+                                        values are `Allow` or `Deny` \n Required"
                                       type: string
                                     selector:
                                       description: "selector can be used to match
@@ -23524,10 +23542,14 @@ spec:
                               description: ParamRef references a parameter resource.
                               properties:
                                 name:
-                                  description: "`name` is the name of the resource
-                                    being referenced. \n `name` and `selector` are
-                                    mutually exclusive properties. If one is set,
-                                    the other must be unset."
+                                  description: "name is the name of the resource being
+                                    referenced. \n One of `name` or `selector` must
+                                    be set, but `name` and `selector` are mutually
+                                    exclusive properties. If one is set, the other
+                                    must be unset. \n A single parameter used for
+                                    all admission requests can be configured by setting
+                                    the `name` field, leaving `selector` blank, and
+                                    setting namespace if `paramKind` is namespace-scoped."
                                   type: string
                                 namespace:
                                   description: "namespace is the namespace of the
@@ -23555,7 +23577,7 @@ spec:
                                     binding. If set to `Deny`, then no matched parameters
                                     will be subject to the `failurePolicy` of the
                                     policy. \n Allowed values are `Allow` or `Deny`
-                                    Default to `Deny`"
+                                    \n Required"
                                   type: string
                                 selector:
                                   description: "selector can be used to match multiple
@@ -27833,10 +27855,15 @@ spec:
                                   description: ParamRef references a parameter resource.
                                   properties:
                                     name:
-                                      description: "`name` is the name of the resource
-                                        being referenced. \n `name` and `selector`
-                                        are mutually exclusive properties. If one
-                                        is set, the other must be unset."
+                                      description: "name is the name of the resource
+                                        being referenced. \n One of `name` or `selector`
+                                        must be set, but `name` and `selector` are
+                                        mutually exclusive properties. If one is set,
+                                        the other must be unset. \n A single parameter
+                                        used for all admission requests can be configured
+                                        by setting the `name` field, leaving `selector`
+                                        blank, and setting namespace if `paramKind`
+                                        is namespace-scoped."
                                       type: string
                                     namespace:
                                       description: "namespace is the namespace of
@@ -27866,7 +27893,7 @@ spec:
                                         by the binding. If set to `Deny`, then no
                                         matched parameters will be subject to the
                                         `failurePolicy` of the policy. \n Allowed
-                                        values are `Allow` or `Deny` Default to `Deny`"
+                                        values are `Allow` or `Deny` \n Required"
                                       type: string
                                     selector:
                                       description: "selector can be used to match
@@ -31868,10 +31895,14 @@ spec:
                               description: ParamRef references a parameter resource.
                               properties:
                                 name:
-                                  description: "`name` is the name of the resource
-                                    being referenced. \n `name` and `selector` are
-                                    mutually exclusive properties. If one is set,
-                                    the other must be unset."
+                                  description: "name is the name of the resource being
+                                    referenced. \n One of `name` or `selector` must
+                                    be set, but `name` and `selector` are mutually
+                                    exclusive properties. If one is set, the other
+                                    must be unset. \n A single parameter used for
+                                    all admission requests can be configured by setting
+                                    the `name` field, leaving `selector` blank, and
+                                    setting namespace if `paramKind` is namespace-scoped."
                                   type: string
                                 namespace:
                                   description: "namespace is the namespace of the
@@ -31899,7 +31930,7 @@ spec:
                                     binding. If set to `Deny`, then no matched parameters
                                     will be subject to the `failurePolicy` of the
                                     policy. \n Allowed values are `Allow` or `Deny`
-                                    Default to `Deny`"
+                                    \n Required"
                                   type: string
                                 selector:
                                   description: "selector can be used to match multiple
@@ -36230,10 +36261,15 @@ spec:
                                   description: ParamRef references a parameter resource.
                                   properties:
                                     name:
-                                      description: "`name` is the name of the resource
-                                        being referenced. \n `name` and `selector`
-                                        are mutually exclusive properties. If one
-                                        is set, the other must be unset."
+                                      description: "name is the name of the resource
+                                        being referenced. \n One of `name` or `selector`
+                                        must be set, but `name` and `selector` are
+                                        mutually exclusive properties. If one is set,
+                                        the other must be unset. \n A single parameter
+                                        used for all admission requests can be configured
+                                        by setting the `name` field, leaving `selector`
+                                        blank, and setting namespace if `paramKind`
+                                        is namespace-scoped."
                                       type: string
                                     namespace:
                                       description: "namespace is the namespace of
@@ -36263,7 +36299,7 @@ spec:
                                         by the binding. If set to `Deny`, then no
                                         matched parameters will be subject to the
                                         `failurePolicy` of the policy. \n Allowed
-                                        values are `Allow` or `Deny` Default to `Deny`"
+                                        values are `Allow` or `Deny` \n Required"
                                       type: string
                                     selector:
                                       description: "selector can be used to match

--- a/config/crds/kyverno.io_clusterpolicies.yaml
+++ b/config/crds/kyverno.io_clusterpolicies.yaml
@@ -2604,10 +2604,14 @@ spec:
                               description: ParamRef references a parameter resource.
                               properties:
                                 name:
-                                  description: "`name` is the name of the resource
-                                    being referenced. \n `name` and `selector` are
-                                    mutually exclusive properties. If one is set,
-                                    the other must be unset."
+                                  description: "name is the name of the resource being
+                                    referenced. \n One of `name` or `selector` must
+                                    be set, but `name` and `selector` are mutually
+                                    exclusive properties. If one is set, the other
+                                    must be unset. \n A single parameter used for
+                                    all admission requests can be configured by setting
+                                    the `name` field, leaving `selector` blank, and
+                                    setting namespace if `paramKind` is namespace-scoped."
                                   type: string
                                 namespace:
                                   description: "namespace is the namespace of the
@@ -2635,7 +2639,7 @@ spec:
                                     binding. If set to `Deny`, then no matched parameters
                                     will be subject to the `failurePolicy` of the
                                     policy. \n Allowed values are `Allow` or `Deny`
-                                    Default to `Deny`"
+                                    \n Required"
                                   type: string
                                 selector:
                                   description: "selector can be used to match multiple
@@ -6912,10 +6916,15 @@ spec:
                                   description: ParamRef references a parameter resource.
                                   properties:
                                     name:
-                                      description: "`name` is the name of the resource
-                                        being referenced. \n `name` and `selector`
-                                        are mutually exclusive properties. If one
-                                        is set, the other must be unset."
+                                      description: "name is the name of the resource
+                                        being referenced. \n One of `name` or `selector`
+                                        must be set, but `name` and `selector` are
+                                        mutually exclusive properties. If one is set,
+                                        the other must be unset. \n A single parameter
+                                        used for all admission requests can be configured
+                                        by setting the `name` field, leaving `selector`
+                                        blank, and setting namespace if `paramKind`
+                                        is namespace-scoped."
                                       type: string
                                     namespace:
                                       description: "namespace is the namespace of
@@ -6945,7 +6954,7 @@ spec:
                                         by the binding. If set to `Deny`, then no
                                         matched parameters will be subject to the
                                         `failurePolicy` of the policy. \n Allowed
-                                        values are `Allow` or `Deny` Default to `Deny`"
+                                        values are `Allow` or `Deny` \n Required"
                                       type: string
                                     selector:
                                       description: "selector can be used to match
@@ -10946,10 +10955,14 @@ spec:
                               description: ParamRef references a parameter resource.
                               properties:
                                 name:
-                                  description: "`name` is the name of the resource
-                                    being referenced. \n `name` and `selector` are
-                                    mutually exclusive properties. If one is set,
-                                    the other must be unset."
+                                  description: "name is the name of the resource being
+                                    referenced. \n One of `name` or `selector` must
+                                    be set, but `name` and `selector` are mutually
+                                    exclusive properties. If one is set, the other
+                                    must be unset. \n A single parameter used for
+                                    all admission requests can be configured by setting
+                                    the `name` field, leaving `selector` blank, and
+                                    setting namespace if `paramKind` is namespace-scoped."
                                   type: string
                                 namespace:
                                   description: "namespace is the namespace of the
@@ -10977,7 +10990,7 @@ spec:
                                     binding. If set to `Deny`, then no matched parameters
                                     will be subject to the `failurePolicy` of the
                                     policy. \n Allowed values are `Allow` or `Deny`
-                                    Default to `Deny`"
+                                    \n Required"
                                   type: string
                                 selector:
                                   description: "selector can be used to match multiple
@@ -15308,10 +15321,15 @@ spec:
                                   description: ParamRef references a parameter resource.
                                   properties:
                                     name:
-                                      description: "`name` is the name of the resource
-                                        being referenced. \n `name` and `selector`
-                                        are mutually exclusive properties. If one
-                                        is set, the other must be unset."
+                                      description: "name is the name of the resource
+                                        being referenced. \n One of `name` or `selector`
+                                        must be set, but `name` and `selector` are
+                                        mutually exclusive properties. If one is set,
+                                        the other must be unset. \n A single parameter
+                                        used for all admission requests can be configured
+                                        by setting the `name` field, leaving `selector`
+                                        blank, and setting namespace if `paramKind`
+                                        is namespace-scoped."
                                       type: string
                                     namespace:
                                       description: "namespace is the namespace of
@@ -15341,7 +15359,7 @@ spec:
                                         by the binding. If set to `Deny`, then no
                                         matched parameters will be subject to the
                                         `failurePolicy` of the policy. \n Allowed
-                                        values are `Allow` or `Deny` Default to `Deny`"
+                                        values are `Allow` or `Deny` \n Required"
                                       type: string
                                     selector:
                                       description: "selector can be used to match

--- a/config/crds/kyverno.io_policies.yaml
+++ b/config/crds/kyverno.io_policies.yaml
@@ -2605,10 +2605,14 @@ spec:
                               description: ParamRef references a parameter resource.
                               properties:
                                 name:
-                                  description: "`name` is the name of the resource
-                                    being referenced. \n `name` and `selector` are
-                                    mutually exclusive properties. If one is set,
-                                    the other must be unset."
+                                  description: "name is the name of the resource being
+                                    referenced. \n One of `name` or `selector` must
+                                    be set, but `name` and `selector` are mutually
+                                    exclusive properties. If one is set, the other
+                                    must be unset. \n A single parameter used for
+                                    all admission requests can be configured by setting
+                                    the `name` field, leaving `selector` blank, and
+                                    setting namespace if `paramKind` is namespace-scoped."
                                   type: string
                                 namespace:
                                   description: "namespace is the namespace of the
@@ -2636,7 +2640,7 @@ spec:
                                     binding. If set to `Deny`, then no matched parameters
                                     will be subject to the `failurePolicy` of the
                                     policy. \n Allowed values are `Allow` or `Deny`
-                                    Default to `Deny`"
+                                    \n Required"
                                   type: string
                                 selector:
                                   description: "selector can be used to match multiple
@@ -6914,10 +6918,15 @@ spec:
                                   description: ParamRef references a parameter resource.
                                   properties:
                                     name:
-                                      description: "`name` is the name of the resource
-                                        being referenced. \n `name` and `selector`
-                                        are mutually exclusive properties. If one
-                                        is set, the other must be unset."
+                                      description: "name is the name of the resource
+                                        being referenced. \n One of `name` or `selector`
+                                        must be set, but `name` and `selector` are
+                                        mutually exclusive properties. If one is set,
+                                        the other must be unset. \n A single parameter
+                                        used for all admission requests can be configured
+                                        by setting the `name` field, leaving `selector`
+                                        blank, and setting namespace if `paramKind`
+                                        is namespace-scoped."
                                       type: string
                                     namespace:
                                       description: "namespace is the namespace of
@@ -6947,7 +6956,7 @@ spec:
                                         by the binding. If set to `Deny`, then no
                                         matched parameters will be subject to the
                                         `failurePolicy` of the policy. \n Allowed
-                                        values are `Allow` or `Deny` Default to `Deny`"
+                                        values are `Allow` or `Deny` \n Required"
                                       type: string
                                     selector:
                                       description: "selector can be used to match
@@ -10949,10 +10958,14 @@ spec:
                               description: ParamRef references a parameter resource.
                               properties:
                                 name:
-                                  description: "`name` is the name of the resource
-                                    being referenced. \n `name` and `selector` are
-                                    mutually exclusive properties. If one is set,
-                                    the other must be unset."
+                                  description: "name is the name of the resource being
+                                    referenced. \n One of `name` or `selector` must
+                                    be set, but `name` and `selector` are mutually
+                                    exclusive properties. If one is set, the other
+                                    must be unset. \n A single parameter used for
+                                    all admission requests can be configured by setting
+                                    the `name` field, leaving `selector` blank, and
+                                    setting namespace if `paramKind` is namespace-scoped."
                                   type: string
                                 namespace:
                                   description: "namespace is the namespace of the
@@ -10980,7 +10993,7 @@ spec:
                                     binding. If set to `Deny`, then no matched parameters
                                     will be subject to the `failurePolicy` of the
                                     policy. \n Allowed values are `Allow` or `Deny`
-                                    Default to `Deny`"
+                                    \n Required"
                                   type: string
                                 selector:
                                   description: "selector can be used to match multiple
@@ -15311,10 +15324,15 @@ spec:
                                   description: ParamRef references a parameter resource.
                                   properties:
                                     name:
-                                      description: "`name` is the name of the resource
-                                        being referenced. \n `name` and `selector`
-                                        are mutually exclusive properties. If one
-                                        is set, the other must be unset."
+                                      description: "name is the name of the resource
+                                        being referenced. \n One of `name` or `selector`
+                                        must be set, but `name` and `selector` are
+                                        mutually exclusive properties. If one is set,
+                                        the other must be unset. \n A single parameter
+                                        used for all admission requests can be configured
+                                        by setting the `name` field, leaving `selector`
+                                        blank, and setting namespace if `paramKind`
+                                        is namespace-scoped."
                                       type: string
                                     namespace:
                                       description: "namespace is the namespace of
@@ -15344,7 +15362,7 @@ spec:
                                         by the binding. If set to `Deny`, then no
                                         matched parameters will be subject to the
                                         `failurePolicy` of the policy. \n Allowed
-                                        values are `Allow` or `Deny` Default to `Deny`"
+                                        values are `Allow` or `Deny` \n Required"
                                       type: string
                                     selector:
                                       description: "selector can be used to match

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -6624,10 +6624,14 @@ spec:
                               description: ParamRef references a parameter resource.
                               properties:
                                 name:
-                                  description: "`name` is the name of the resource
-                                    being referenced. \n `name` and `selector` are
-                                    mutually exclusive properties. If one is set,
-                                    the other must be unset."
+                                  description: "name is the name of the resource being
+                                    referenced. \n One of `name` or `selector` must
+                                    be set, but `name` and `selector` are mutually
+                                    exclusive properties. If one is set, the other
+                                    must be unset. \n A single parameter used for
+                                    all admission requests can be configured by setting
+                                    the `name` field, leaving `selector` blank, and
+                                    setting namespace if `paramKind` is namespace-scoped."
                                   type: string
                                 namespace:
                                   description: "namespace is the namespace of the
@@ -6655,7 +6659,7 @@ spec:
                                     binding. If set to `Deny`, then no matched parameters
                                     will be subject to the `failurePolicy` of the
                                     policy. \n Allowed values are `Allow` or `Deny`
-                                    Default to `Deny`"
+                                    \n Required"
                                   type: string
                                 selector:
                                   description: "selector can be used to match multiple
@@ -10932,10 +10936,15 @@ spec:
                                   description: ParamRef references a parameter resource.
                                   properties:
                                     name:
-                                      description: "`name` is the name of the resource
-                                        being referenced. \n `name` and `selector`
-                                        are mutually exclusive properties. If one
-                                        is set, the other must be unset."
+                                      description: "name is the name of the resource
+                                        being referenced. \n One of `name` or `selector`
+                                        must be set, but `name` and `selector` are
+                                        mutually exclusive properties. If one is set,
+                                        the other must be unset. \n A single parameter
+                                        used for all admission requests can be configured
+                                        by setting the `name` field, leaving `selector`
+                                        blank, and setting namespace if `paramKind`
+                                        is namespace-scoped."
                                       type: string
                                     namespace:
                                       description: "namespace is the namespace of
@@ -10965,7 +10974,7 @@ spec:
                                         by the binding. If set to `Deny`, then no
                                         matched parameters will be subject to the
                                         `failurePolicy` of the policy. \n Allowed
-                                        values are `Allow` or `Deny` Default to `Deny`"
+                                        values are `Allow` or `Deny` \n Required"
                                       type: string
                                     selector:
                                       description: "selector can be used to match
@@ -14966,10 +14975,14 @@ spec:
                               description: ParamRef references a parameter resource.
                               properties:
                                 name:
-                                  description: "`name` is the name of the resource
-                                    being referenced. \n `name` and `selector` are
-                                    mutually exclusive properties. If one is set,
-                                    the other must be unset."
+                                  description: "name is the name of the resource being
+                                    referenced. \n One of `name` or `selector` must
+                                    be set, but `name` and `selector` are mutually
+                                    exclusive properties. If one is set, the other
+                                    must be unset. \n A single parameter used for
+                                    all admission requests can be configured by setting
+                                    the `name` field, leaving `selector` blank, and
+                                    setting namespace if `paramKind` is namespace-scoped."
                                   type: string
                                 namespace:
                                   description: "namespace is the namespace of the
@@ -14997,7 +15010,7 @@ spec:
                                     binding. If set to `Deny`, then no matched parameters
                                     will be subject to the `failurePolicy` of the
                                     policy. \n Allowed values are `Allow` or `Deny`
-                                    Default to `Deny`"
+                                    \n Required"
                                   type: string
                                 selector:
                                   description: "selector can be used to match multiple
@@ -19328,10 +19341,15 @@ spec:
                                   description: ParamRef references a parameter resource.
                                   properties:
                                     name:
-                                      description: "`name` is the name of the resource
-                                        being referenced. \n `name` and `selector`
-                                        are mutually exclusive properties. If one
-                                        is set, the other must be unset."
+                                      description: "name is the name of the resource
+                                        being referenced. \n One of `name` or `selector`
+                                        must be set, but `name` and `selector` are
+                                        mutually exclusive properties. If one is set,
+                                        the other must be unset. \n A single parameter
+                                        used for all admission requests can be configured
+                                        by setting the `name` field, leaving `selector`
+                                        blank, and setting namespace if `paramKind`
+                                        is namespace-scoped."
                                       type: string
                                     namespace:
                                       description: "namespace is the namespace of
@@ -19361,7 +19379,7 @@ spec:
                                         by the binding. If set to `Deny`, then no
                                         matched parameters will be subject to the
                                         `failurePolicy` of the policy. \n Allowed
-                                        values are `Allow` or `Deny` Default to `Deny`"
+                                        values are `Allow` or `Deny` \n Required"
                                       type: string
                                     selector:
                                       description: "selector can be used to match
@@ -23727,10 +23745,14 @@ spec:
                               description: ParamRef references a parameter resource.
                               properties:
                                 name:
-                                  description: "`name` is the name of the resource
-                                    being referenced. \n `name` and `selector` are
-                                    mutually exclusive properties. If one is set,
-                                    the other must be unset."
+                                  description: "name is the name of the resource being
+                                    referenced. \n One of `name` or `selector` must
+                                    be set, but `name` and `selector` are mutually
+                                    exclusive properties. If one is set, the other
+                                    must be unset. \n A single parameter used for
+                                    all admission requests can be configured by setting
+                                    the `name` field, leaving `selector` blank, and
+                                    setting namespace if `paramKind` is namespace-scoped."
                                   type: string
                                 namespace:
                                   description: "namespace is the namespace of the
@@ -23758,7 +23780,7 @@ spec:
                                     binding. If set to `Deny`, then no matched parameters
                                     will be subject to the `failurePolicy` of the
                                     policy. \n Allowed values are `Allow` or `Deny`
-                                    Default to `Deny`"
+                                    \n Required"
                                   type: string
                                 selector:
                                   description: "selector can be used to match multiple
@@ -28036,10 +28058,15 @@ spec:
                                   description: ParamRef references a parameter resource.
                                   properties:
                                     name:
-                                      description: "`name` is the name of the resource
-                                        being referenced. \n `name` and `selector`
-                                        are mutually exclusive properties. If one
-                                        is set, the other must be unset."
+                                      description: "name is the name of the resource
+                                        being referenced. \n One of `name` or `selector`
+                                        must be set, but `name` and `selector` are
+                                        mutually exclusive properties. If one is set,
+                                        the other must be unset. \n A single parameter
+                                        used for all admission requests can be configured
+                                        by setting the `name` field, leaving `selector`
+                                        blank, and setting namespace if `paramKind`
+                                        is namespace-scoped."
                                       type: string
                                     namespace:
                                       description: "namespace is the namespace of
@@ -28069,7 +28096,7 @@ spec:
                                         by the binding. If set to `Deny`, then no
                                         matched parameters will be subject to the
                                         `failurePolicy` of the policy. \n Allowed
-                                        values are `Allow` or `Deny` Default to `Deny`"
+                                        values are `Allow` or `Deny` \n Required"
                                       type: string
                                     selector:
                                       description: "selector can be used to match
@@ -32071,10 +32098,14 @@ spec:
                               description: ParamRef references a parameter resource.
                               properties:
                                 name:
-                                  description: "`name` is the name of the resource
-                                    being referenced. \n `name` and `selector` are
-                                    mutually exclusive properties. If one is set,
-                                    the other must be unset."
+                                  description: "name is the name of the resource being
+                                    referenced. \n One of `name` or `selector` must
+                                    be set, but `name` and `selector` are mutually
+                                    exclusive properties. If one is set, the other
+                                    must be unset. \n A single parameter used for
+                                    all admission requests can be configured by setting
+                                    the `name` field, leaving `selector` blank, and
+                                    setting namespace if `paramKind` is namespace-scoped."
                                   type: string
                                 namespace:
                                   description: "namespace is the namespace of the
@@ -32102,7 +32133,7 @@ spec:
                                     binding. If set to `Deny`, then no matched parameters
                                     will be subject to the `failurePolicy` of the
                                     policy. \n Allowed values are `Allow` or `Deny`
-                                    Default to `Deny`"
+                                    \n Required"
                                   type: string
                                 selector:
                                   description: "selector can be used to match multiple
@@ -36433,10 +36464,15 @@ spec:
                                   description: ParamRef references a parameter resource.
                                   properties:
                                     name:
-                                      description: "`name` is the name of the resource
-                                        being referenced. \n `name` and `selector`
-                                        are mutually exclusive properties. If one
-                                        is set, the other must be unset."
+                                      description: "name is the name of the resource
+                                        being referenced. \n One of `name` or `selector`
+                                        must be set, but `name` and `selector` are
+                                        mutually exclusive properties. If one is set,
+                                        the other must be unset. \n A single parameter
+                                        used for all admission requests can be configured
+                                        by setting the `name` field, leaving `selector`
+                                        blank, and setting namespace if `paramKind`
+                                        is namespace-scoped."
                                       type: string
                                     namespace:
                                       description: "namespace is the namespace of
@@ -36466,7 +36502,7 @@ spec:
                                         by the binding. If set to `Deny`, then no
                                         matched parameters will be subject to the
                                         `failurePolicy` of the policy. \n Allowed
-                                        values are `Allow` or `Deny` Default to `Deny`"
+                                        values are `Allow` or `Deny` \n Required"
                                       type: string
                                     selector:
                                       description: "selector can be used to match

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -1015,8 +1015,8 @@ attributes for keyless verification, or a nested attestor declaration.</p>
 <td>
 <code>expressions</code><br/>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#validation-v1alpha1-admissionregistration">
-[]Kubernetes admissionregistration/v1alpha1.Validation
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#validation-v1beta1-admissionregistration">
+[]Kubernetes admissionregistration/v1beta1.Validation
 </a>
 </em>
 </td>
@@ -1028,8 +1028,8 @@ attributes for keyless verification, or a nested attestor declaration.</p>
 <td>
 <code>paramKind</code><br/>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#paramkind-v1alpha1-admissionregistration">
-Kubernetes admissionregistration/v1alpha1.ParamKind
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#paramkind-v1beta1-admissionregistration">
+Kubernetes admissionregistration/v1beta1.ParamKind
 </a>
 </em>
 </td>
@@ -1042,8 +1042,8 @@ Kubernetes admissionregistration/v1alpha1.ParamKind
 <td>
 <code>paramRef</code><br/>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#paramref-v1alpha1-admissionregistration">
-Kubernetes admissionregistration/v1alpha1.ParamRef
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#paramref-v1beta1-admissionregistration">
+Kubernetes admissionregistration/v1beta1.ParamRef
 </a>
 </em>
 </td>
@@ -1056,8 +1056,8 @@ Kubernetes admissionregistration/v1alpha1.ParamRef
 <td>
 <code>auditAnnotations</code><br/>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#auditannotation-v1alpha1-admissionregistration">
-[]Kubernetes admissionregistration/v1alpha1.AuditAnnotation
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#auditannotation-v1beta1-admissionregistration">
+[]Kubernetes admissionregistration/v1beta1.AuditAnnotation
 </a>
 </em>
 </td>

--- a/pkg/client/applyconfigurations/kyverno/v1/cel.go
+++ b/pkg/client/applyconfigurations/kyverno/v1/cel.go
@@ -19,16 +19,16 @@ limitations under the License.
 package v1
 
 import (
-	v1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 )
 
 // CELApplyConfiguration represents an declarative configuration of the CEL type for use
 // with apply.
 type CELApplyConfiguration struct {
-	Expressions      []v1alpha1.Validation      `json:"expressions,omitempty"`
-	ParamKind        *v1alpha1.ParamKind        `json:"paramKind,omitempty"`
-	ParamRef         *v1alpha1.ParamRef         `json:"paramRef,omitempty"`
-	AuditAnnotations []v1alpha1.AuditAnnotation `json:"auditAnnotations,omitempty"`
+	Expressions      []v1beta1.Validation      `json:"expressions,omitempty"`
+	ParamKind        *v1beta1.ParamKind        `json:"paramKind,omitempty"`
+	ParamRef         *v1beta1.ParamRef         `json:"paramRef,omitempty"`
+	AuditAnnotations []v1beta1.AuditAnnotation `json:"auditAnnotations,omitempty"`
 }
 
 // CELApplyConfiguration constructs an declarative configuration of the CEL type for use with
@@ -40,7 +40,7 @@ func CEL() *CELApplyConfiguration {
 // WithExpressions adds the given value to the Expressions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Expressions field.
-func (b *CELApplyConfiguration) WithExpressions(values ...v1alpha1.Validation) *CELApplyConfiguration {
+func (b *CELApplyConfiguration) WithExpressions(values ...v1beta1.Validation) *CELApplyConfiguration {
 	for i := range values {
 		b.Expressions = append(b.Expressions, values[i])
 	}
@@ -50,7 +50,7 @@ func (b *CELApplyConfiguration) WithExpressions(values ...v1alpha1.Validation) *
 // WithParamKind sets the ParamKind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ParamKind field is set to the value of the last call.
-func (b *CELApplyConfiguration) WithParamKind(value v1alpha1.ParamKind) *CELApplyConfiguration {
+func (b *CELApplyConfiguration) WithParamKind(value v1beta1.ParamKind) *CELApplyConfiguration {
 	b.ParamKind = &value
 	return b
 }
@@ -58,7 +58,7 @@ func (b *CELApplyConfiguration) WithParamKind(value v1alpha1.ParamKind) *CELAppl
 // WithParamRef sets the ParamRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ParamRef field is set to the value of the last call.
-func (b *CELApplyConfiguration) WithParamRef(value v1alpha1.ParamRef) *CELApplyConfiguration {
+func (b *CELApplyConfiguration) WithParamRef(value v1beta1.ParamRef) *CELApplyConfiguration {
 	b.ParamRef = &value
 	return b
 }
@@ -66,7 +66,7 @@ func (b *CELApplyConfiguration) WithParamRef(value v1alpha1.ParamRef) *CELApplyC
 // WithAuditAnnotations adds the given value to the AuditAnnotations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AuditAnnotations field.
-func (b *CELApplyConfiguration) WithAuditAnnotations(values ...v1alpha1.AuditAnnotation) *CELApplyConfiguration {
+func (b *CELApplyConfiguration) WithAuditAnnotations(values ...v1beta1.AuditAnnotation) *CELApplyConfiguration {
 	for i := range values {
 		b.AuditAnnotations = append(b.AuditAnnotations, values[i])
 	}


### PR DESCRIPTION
## Explanation
This PR is to bump the fields defined in `validate.cel` subrule to v1beta1.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.11.0
<!--


Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/kind cleanup
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
```
type CEL struct {
	// Expressions is a list of CELExpression types.
	Expressions []v1beta1.Validation `json:"expressions,omitempty" yaml:"expressions,omitempty"`

	// ParamKind is a tuple of Group Kind and Version.
	// +optional
	ParamKind *v1beta1.ParamKind `json:"paramKind,omitempty" yaml:"paramKind,omitempty"`

	// ParamRef references a parameter resource.
	// +optional
	ParamRef *v1beta1.ParamRef `json:"paramRef,omitempty" yaml:"paramRef,omitempty"`

	// AuditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request.
	// +optional
	AuditAnnotations []v1beta1.AuditAnnotation `json:"auditAnnotations,omitempty" yaml:"auditAnnotations,omitempty"`
}
```

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
