### PR TITLE
perf(kubectl-kyverno): add concurrency to apply

### DIFF
--- a/cmd/cli/kubectl-kyverno/apply/apply_command_test.go
+++ b/cmd/cli/kubectl-kyverno/apply/apply_command_test.go
@@ -83,6 +83,7 @@ func Test_Apply(t *testing.T) {
 				PolicyPaths:   []string{"../../../../test/cli/apply/policies"},
 				ResourcePaths: []string{"../../../../test/cli/apply/resource"},
 				PolicyReport:  true,
+				worker:        4,
 			},
 			expectedPolicyReports: []preport.PolicyReport{
 				{

--- a/cmd/cli/kubectl-kyverno/utils/common/common.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common.go
@@ -51,6 +51,14 @@ type ResultCounts struct {
 	Skip  int
 }
 
+func (rc *ResultCounts) Add(add ResultCounts) {
+	rc.Pass += add.Pass
+	rc.Fail += add.Fail
+	rc.Warn += add.Warn
+	rc.Error += add.Error
+	rc.Skip += add.Skip
+}
+
 type ApplyPolicyConfig struct {
 	Policy                    kyvernov1.PolicyInterface
 	ValidatingAdmissionPolicy v1alpha1.ValidatingAdmissionPolicy
@@ -891,6 +899,7 @@ func processEngineResponses(responses []engineapi.EngineResponse, c ApplyPolicyC
 					for _, valResponseRule := range response.PolicyResponse.Rules {
 						if rule.Name == valResponseRule.Name() {
 							ruleFoundInEngineResponse = true
+
 							switch valResponseRule.Status() {
 							case engineapi.RuleStatusPass:
 								c.Rc.Pass++


### PR DESCRIPTION
## Explanation

Currently `kyverno apply` is executed synchronously and can take quite some time to execute against a bunch of manifests.

With the current state on my machine apply takes ~4minutes to finish:
```
pass: 1476, fail: 0, warn: 0, error: 0, skip: 39997 

real	3m42.712s
user	4m50.630s
sys	0m4.091s
```

With this pr that execution goes bellow 60s:
```
pass: 1476, fail: 0, warn: 0, error: 0, skip: 39997 

real	0m52.583s
user	9m4.448s
sys	0m8.482s
``` 

## Related issue

Closes #4351 

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
-->

## Proposed Changes
This pr adds concurrency to `apply`. There should be no user facing change regarding the output.
There is a new flag called `--worker` which by default it set to the number of cores.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
