### PR TITLE
fix: stop hiding flags in the cli

### DIFF
--- a/cmd/cli/kubectl-kyverno/main.go
+++ b/cmd/cli/kubectl-kyverno/main.go
@@ -33,12 +33,6 @@ func main() {
 func configureLogs(cli *cobra.Command) {
 	logging.InitFlags(nil)
 	cli.PersistentFlags().AddGoFlagSet(flag.CommandLine)
-	_ = cli.PersistentFlags().MarkHidden("alsologtostderr")
-	_ = cli.PersistentFlags().MarkHidden("logtostderr")
-	_ = cli.PersistentFlags().MarkHidden("log_dir")
-	_ = cli.PersistentFlags().MarkHidden("log_backtrace_at")
-	_ = cli.PersistentFlags().MarkHidden("stderrthreshold")
-	_ = cli.PersistentFlags().MarkHidden("vmodule")
 }
 
 func enableExperimental() bool {


### PR DESCRIPTION
## Explanation

This PR stops hiding flags in the cli.

## Related issue

Fixes https://github.com/kyverno/kyverno/issues/5334
