### PR TITLE
chore: add .helmignore to .helmignore

### DIFF
--- a/charts/kyverno-policies/.helmignore
+++ b/charts/kyverno-policies/.helmignore
@@ -1,2 +1,3 @@
+.helmignore
 ci/
 README.md.gotmpl

--- a/charts/kyverno/.helmignore
+++ b/charts/kyverno/.helmignore
@@ -1,2 +1,3 @@
+.helmignore
 ci/
 README.md.gotmpl


### PR DESCRIPTION
## Explanation

This PR adds .helmignore to .helmignore.
See https://helm.sh/docs/chart_template_guide/helm_ignore_file/
