### PR TITLE
chore: increase setup-build-env timeout

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: cli-test
       - name: Setup TEST_GIT_BRANCH

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: codecov
       - name: Generate Code Coverage Report

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: build-images
       - name: ko build
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: run-conformance
       - name: Create kind cluster
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: run-conformance
       - name: Create kind cluster
@@ -203,7 +203,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: run-conformance
       - name: Create kind cluster
@@ -262,7 +262,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: run-conformance
       - name: Create kind cluster
@@ -354,7 +354,7 @@ jobs:
           path: policies
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: run-conformance
       - name: Create kind cluster

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup build env
         if: steps.checksecret.outputs.result == 'true'
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
       - name: Run FOSSA analysis
         if: steps.checksecret.outputs.result == 'true'
         uses: fossas/fossa-action@f61a4c0c263690f2ddb54b9822a719c25a7b608f # v1.3.1

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:
           python-version: 3.7
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
 
       - name: Install Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: helm-tests
       - name: Setup python

--- a/.github/workflows/images-build.yaml
+++ b/.github/workflows/images-build.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: build-images
       - name: ko build

--- a/.github/workflows/images-publish.yaml
+++ b/.github/workflows/images-publish.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: publish-images
       - name: Run Trivy vulnerability scanner in repo mode

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.5.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: lint
       - name: golangci-lint

--- a/.github/workflows/nancy.yaml
+++ b/.github/workflows/nancy.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
       - name: WriteGoList
         run: go list -json -m all > go.list
       - name: Nancy SAST Scan

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: release-images
       - name: Run Trivy vulnerability scanner in repo mode
@@ -230,7 +230,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
       - uses: creekorful/goreportcard-action@1f35ced8cdac2cba28c9a2f2288a16aacfd507f9 # v1.0
       - name: Install Cosign
         uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3.1.1
@@ -262,7 +262,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
       - name: Setup Flux CLI
         uses: fluxcd/flux2/action@22cf986a79a6da2dd1bcd91b5eef763400f0104b # v2.1.0
         with:
@@ -315,7 +315,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
       - name: Check Tag
         id: check-tag
         run: |

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup build env
         if: steps.checksecret.outputs.result == 'true'
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
       - name: SonarCloud Scan
         if: steps.checksecret.outputs.result == 'true'
         uses: sonarsource/sonarcloud-github-action@db501078e936e4b4c8773d1bb949ba9ddb7b6b6a # v1.9

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: tests
       - name: Unit test

--- a/.github/workflows/verify-codegen.yaml
+++ b/.github/workflows/verify-codegen.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup build env
         uses: ./.github/actions/setup-build-env
-        timeout-minutes: 6
+        timeout-minutes: 10
         with:
           build-cache-key: verify-codegen
       - name: Verify generated code is up to date


### PR DESCRIPTION
## Explanation

This PR increases `setup-build-env` timeout (looks like it was too small in some cases like when the cache is invalidated).
