### PR TITLE
refactor: remove isGit argument from cli funcs

### DIFF
--- a/cmd/cli/kubectl-kyverno/apply/apply_command.go
+++ b/cmd/cli/kubectl-kyverno/apply/apply_command.go
@@ -222,13 +222,13 @@ func (c *ApplyCommandConfig) applyCommandHelper() (*common.ResultCounts, []*unst
 	}
 	var userInfo v1beta1.RequestInfo
 	if c.UserInfoPath != "" {
-		userInfo, err = common.GetUserInfoFromPath(nil, c.UserInfoPath, false, "")
+		userInfo, err = common.GetUserInfoFromPath(nil, c.UserInfoPath, "")
 		if err != nil {
 			fmt.Printf("Error: failed to load request info\nCause: %s\n", err)
 			osExit(1)
 		}
 	}
-	variables, globalValMap, valuesMap, namespaceSelectorMap, subresources, err := common.GetVariable(c.Variables, nil, c.ValuesFile, nil, false, "")
+	variables, globalValMap, valuesMap, namespaceSelectorMap, subresources, err := common.GetVariable(c.Variables, nil, c.ValuesFile, nil, "")
 	if err != nil {
 		if !sanitizederror.IsErrorSanitized(err) {
 			return nil, nil, skipInvalidPolicies, nil, sanitizederror.NewWithError("failed to decode yaml", err)
@@ -365,7 +365,7 @@ func (c *ApplyCommandConfig) applyPolicytoResource(variables map[string]string, 
 }
 
 func (c *ApplyCommandConfig) loadResources(policies []kyvernov1.PolicyInterface, validatingAdmissionPolicies []v1alpha1.ValidatingAdmissionPolicy, dClient dclient.Interface) []*unstructured.Unstructured {
-	resources, err := common.GetResourceAccordingToResourcePath(nil, c.ResourcePaths, c.Cluster, policies, validatingAdmissionPolicies, dClient, c.Namespace, c.PolicyReport, false, "")
+	resources, err := common.GetResourceAccordingToResourcePath(nil, c.ResourcePaths, c.Cluster, policies, validatingAdmissionPolicies, dClient, c.Namespace, c.PolicyReport, "")
 	if err != nil {
 		fmt.Printf("Error: failed to load resources\nCause: %s\n", err)
 		osExit(1)
@@ -381,9 +381,8 @@ func (c *ApplyCommandConfig) loadPolicies(skipInvalidPolicies SkippedInvalidPoli
 
 	for _, policy := range c.PolicyPaths {
 		policyPaths := []string{policy}
-		isGit := common.IsGitSourcePath(policyPaths)
 
-		if isGit {
+		if common.IsGitSourcePath(policyPaths) {
 			gitSourceURL, err := url.Parse(policyPaths[0])
 			if err != nil {
 				fmt.Printf("Error: failed to load policies\nCause: %s\n", err)
@@ -414,7 +413,7 @@ func (c *ApplyCommandConfig) loadPolicies(skipInvalidPolicies SkippedInvalidPoli
 			policyPaths = policyYamls
 		}
 
-		policiesFromFile, admissionPoliciesFromFile, err := common.GetPoliciesFromPaths(fs, policyPaths, isGit, "")
+		policiesFromFile, admissionPoliciesFromFile, err := common.GetPoliciesFromPaths(fs, policyPaths, "")
 		if err != nil {
 			fmt.Printf("Error: failed to load policies\nCause: %s\n", err)
 			osExit(1)

--- a/cmd/cli/kubectl-kyverno/test/test_command.go
+++ b/cmd/cli/kubectl-kyverno/test/test_command.go
@@ -116,7 +116,6 @@ func testCommandExecute(
 		if reports, tests, err := applyPoliciesFromPath(
 			fs,
 			p.test,
-			fs != nil,
 			p.resourcePath,
 			rc,
 			openApiManager,

--- a/cmd/cli/kubectl-kyverno/test/test_command_test.go
+++ b/cmd/cli/kubectl-kyverno/test/test_command_test.go
@@ -62,7 +62,6 @@ func Test_selectResourcesForCheck(t *testing.T) {
 		policies, validatingAdmissionPolicies, err := common.GetPoliciesFromPaths(
 			fs,
 			[]string{filepath.Join(baseTestDir, values.Policies[0])},
-			false,
 			filepath.Join(baseTestDir, values.Resources[0]),
 		)
 		assert.NilError(t, err)
@@ -76,7 +75,6 @@ func Test_selectResourcesForCheck(t *testing.T) {
 			validatingAdmissionPolicies,
 			nil,
 			"",
-			false,
 			false,
 			filepath.Join(baseTestDir, values.Policies[0]),
 		)

--- a/cmd/cli/kubectl-kyverno/utils/common/common.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common.go
@@ -223,8 +223,8 @@ func PrintMutatedOutput(mutateLogPath string, mutateLogPathIsDir bool, yaml stri
 }
 
 // GetPoliciesFromPaths - get policies according to the resource path
-func GetPoliciesFromPaths(fs billy.Filesystem, dirPath []string, isGit bool, policyResourcePath string) (policies []kyvernov1.PolicyInterface, validatingAdmissionPolicies []v1alpha1.ValidatingAdmissionPolicy, err error) {
-	if isGit {
+func GetPoliciesFromPaths(fs billy.Filesystem, dirPath []string, policyResourcePath string) (policies []kyvernov1.PolicyInterface, validatingAdmissionPolicies []v1alpha1.ValidatingAdmissionPolicy, err error) {
+	if fs != nil {
 		for _, pp := range dirPath {
 			filep, err := fs.Open(filepath.Join(policyResourcePath, pp))
 			if err != nil {
@@ -285,10 +285,10 @@ func GetPoliciesFromPaths(fs billy.Filesystem, dirPath []string, isGit bool, pol
 
 // GetResourceAccordingToResourcePath - get resources according to the resource path
 func GetResourceAccordingToResourcePath(fs billy.Filesystem, resourcePaths []string,
-	cluster bool, policies []kyvernov1.PolicyInterface, validatingAdmissionPolicies []v1alpha1.ValidatingAdmissionPolicy, dClient dclient.Interface, namespace string, policyReport bool, isGit bool, policyResourcePath string,
+	cluster bool, policies []kyvernov1.PolicyInterface, validatingAdmissionPolicies []v1alpha1.ValidatingAdmissionPolicy, dClient dclient.Interface, namespace string, policyReport bool, policyResourcePath string,
 ) (resources []*unstructured.Unstructured, err error) {
-	if isGit {
-		resources, err = GetResourcesWithTest(fs, policies, resourcePaths, isGit, policyResourcePath)
+	if fs != nil {
+		resources, err = GetResourcesWithTest(fs, policies, resourcePaths, policyResourcePath)
 		if err != nil {
 			return nil, sanitizederror.NewWithError("failed to extract the resources", err)
 		}
@@ -503,11 +503,11 @@ func getSubresourceKind(groupVersion, parentKind, subresourceName string, subres
 }
 
 // GetResourceFromPath - get patchedResource and generatedResource from given path
-func GetResourceFromPath(fs billy.Filesystem, path string, isGit bool, policyResourcePath string, resourceType string) (unstructured.Unstructured, error) {
+func GetResourceFromPath(fs billy.Filesystem, path string, policyResourcePath string, resourceType string) (unstructured.Unstructured, error) {
 	var resourceBytes []byte
 	var resource unstructured.Unstructured
 	var err error
-	if isGit {
+	if fs != nil {
 		if len(path) > 0 {
 			filep, fileErr := fs.Open(filepath.Join(policyResourcePath, path))
 			if fileErr != nil {
@@ -618,9 +618,9 @@ func handleGeneratePolicy(generateResponse *engineapi.EngineResponse, policyCont
 }
 
 // GetUserInfoFromPath - get the request info as user info from a given path
-func GetUserInfoFromPath(fs billy.Filesystem, path string, isGit bool, policyResourcePath string) (kyvernov1beta1.RequestInfo, error) {
+func GetUserInfoFromPath(fs billy.Filesystem, path string, policyResourcePath string) (kyvernov1beta1.RequestInfo, error) {
 	userInfo := &kyvernov1beta1.RequestInfo{}
-	if isGit {
+	if fs != nil {
 		filep, err := fs.Open(filepath.Join(policyResourcePath, path))
 		if err != nil {
 			fmt.Printf("Unable to open userInfo file: %s. \nerror: %s", path, err)

--- a/cmd/cli/kubectl-kyverno/utils/common/fetch.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/fetch.go
@@ -124,7 +124,7 @@ func whenClusterIsFalse(resourcePaths []string, policyReport bool) ([]*unstructu
 }
 
 // GetResourcesWithTest with gets matched resources by the given policies
-func GetResourcesWithTest(fs billy.Filesystem, policies []kyvernov1.PolicyInterface, resourcePaths []string, isGit bool, policyResourcePath string) ([]*unstructured.Unstructured, error) {
+func GetResourcesWithTest(fs billy.Filesystem, policies []kyvernov1.PolicyInterface, resourcePaths []string, policyResourcePath string) ([]*unstructured.Unstructured, error) {
 	resources := make([]*unstructured.Unstructured, 0)
 	resourceTypesMap := make(map[string]bool)
 	for _, policy := range policies {
@@ -138,7 +138,7 @@ func GetResourcesWithTest(fs billy.Filesystem, policies []kyvernov1.PolicyInterf
 		for _, resourcePath := range resourcePaths {
 			var resourceBytes []byte
 			var err error
-			if isGit {
+			if fs != nil {
 				filep, err := fs.Open(filepath.Join(policyResourcePath, resourcePath))
 				if err != nil {
 					fmt.Printf("Unable to open resource file: %s. error: %s", resourcePath, err)

--- a/cmd/cli/kubectl-kyverno/utils/common/variables.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/variables.go
@@ -29,7 +29,6 @@ func GetVariable(
 	vals *api.Values,
 	valuesFile string,
 	fs billy.Filesystem,
-	isGit bool,
 	policyResourcePath string,
 ) (map[string]string, map[string]string, map[string]map[string]api.Resource, map[string]map[string]string, []api.Subresource, error) {
 	if vals == nil && valuesFile != "" {


### PR DESCRIPTION
## Explanation

This PR removes `isGit` argument from cli funcs, we deduce it using `fs != nil`.
