### PR TITLE
feat: update ivcache `Set()` to use `Wait()`

### DIFF
--- a/pkg/engine/image_verify_test.go
+++ b/pkg/engine/image_verify_test.go
@@ -1063,7 +1063,7 @@ func Test_ImageVerifyCacheCosign(t *testing.T) {
 	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.NewOrDie(), nil, policyContext, cfg)
 	secondOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
-	assert.Check(t, secondOperationTime < firstOperationTime/2, "cache entry is valid, so image verification should be from cache.", firstOperationTime, secondOperationTime)
+	assert.Check(t, secondOperationTime < firstOperationTime/10, "cache entry is valid, so image verification should be from cache.", firstOperationTime, secondOperationTime)
 }
 
 func Test_ImageVerifyCacheExpiredCosign(t *testing.T) {
@@ -1266,7 +1266,7 @@ func Test_ImageVerifyCacheNotary(t *testing.T) {
 	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.NewOrDie(), nil, policyContext, cfg)
 	secondOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
-	assert.Check(t, secondOperationTime < firstOperationTime, "cache entry is valid, so image verification should be from cache.", firstOperationTime, secondOperationTime)
+	assert.Check(t, secondOperationTime < firstOperationTime/10, "cache entry is valid, so image verification should be from cache.", firstOperationTime, secondOperationTime)
 }
 
 func Test_ImageVerifyCacheExpiredNotary(t *testing.T) {

--- a/pkg/imageverifycache/client.go
+++ b/pkg/imageverifycache/client.go
@@ -98,6 +98,7 @@ func (c *cache) Set(ctx context.Context, policy kyvernov1.PolicyInterface, ruleN
 	key := generateKey(policy, ruleName, imageRef)
 
 	stored := c.cache.SetWithTTL(key, nil, 1, c.ttl)
+	c.cache.Wait()
 	if stored {
 		return true, nil
 	}


### PR DESCRIPTION
## Explanation

`Wait()` blocks until all buffered writes have been applied. This ensures a call to `Set()` will be visible to future calls to `Get()`.