### PR TITLE
chore: remove validating admission policy support from v1.26

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -295,8 +295,6 @@ jobs:
               - standard
               - generate-validating-admission-policy
         k8s-version:
-          - name: v1.26
-            version: v1.26.6
           - name: v1.27
             version: v1.27.3
         tests:

--- a/charts/kyverno/templates/NOTES.txt
+++ b/charts/kyverno/templates/NOTES.txt
@@ -38,7 +38,7 @@ The following components have been installed in your cluster:
 {{- end }}
 
 {{- with .Values.features.generateValidatingAdmissionPolicy.enabled }}
-⚠️  WARNING: Generating validating admission policy requires a Kubernetes 1.26+ cluster with `ValidatingAdmissionPolicy` feature gate and `admissionregistration.k8s.io` API group enabled.
+⚠️  WARNING: Generating validating admission policy requires a Kubernetes 1.27+ cluster with `ValidatingAdmissionPolicy` feature gate and `admissionregistration.k8s.io` API group enabled.
 {{- end }}
 
 {{- with .Values.features.validatingAdmissionPolicyReports.enabled }}


### PR DESCRIPTION
## Explanation
This PR is to remove the support of generating validating admission policies from Kyverno policies from K8s cluster v1.26 due to [this](https://github.com/kyverno/kyverno/issues/8288) issue. 

