### PR TITLE
create interpreter once and reuse across searches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kataras/tablewriter v0.0.0-20180708051242-e063d29b7c23
-	github.com/kyverno/go-jmespath v0.4.1-0.20230705123211-d067dc3d6613
+	github.com/kyverno/go-jmespath v0.4.1-0.20230906134905-62fa64b71f91
 	github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7
 	github.com/notaryproject/notation-core-go v1.0.0-rc.4
 	github.com/notaryproject/notation-go v1.0.0-rc.6

--- a/go.sum
+++ b/go.sum
@@ -904,8 +904,8 @@ github.com/kunwardeep/paralleltest v1.0.2/go.mod h1:ZPqNm1fVHPllh5LPVujzbVz1JN2G
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/kyoh86/exportloopref v0.1.8/go.mod h1:1tUcJeiioIs7VWe5gcOObrux3lb66+sBqGZrRkMwPgg=
-github.com/kyverno/go-jmespath v0.4.1-0.20230705123211-d067dc3d6613 h1:M0uOLuCAZydi/vZy7uvNhwaIge0HFMdfqQYOKw7kgnQ=
-github.com/kyverno/go-jmespath v0.4.1-0.20230705123211-d067dc3d6613/go.mod h1:yzDHaKovQy16rjN4kFnjF+IdNoN4p1ndw+va6+B8zUU=
+github.com/kyverno/go-jmespath v0.4.1-0.20230906134905-62fa64b71f91 h1:n63aowZk61f65e6OJxuql8BS/hCv8LZxz/eCO4+2NfM=
+github.com/kyverno/go-jmespath v0.4.1-0.20230906134905-62fa64b71f91/go.mod h1:yzDHaKovQy16rjN4kFnjF+IdNoN4p1ndw+va6+B8zUU=
 github.com/kyverno/go-jmespath/internal/testify v1.5.2-0.20230630133209-945021c749d9 h1:lL311dF3a2aeNibJj8v+uhFU3XkvRHZmCtAdSPOrQYY=
 github.com/kyverno/go-jmespath/internal/testify v1.5.2-0.20230630133209-945021c749d9/go.mod h1:XRxUGHIiCy1WYma1CdfdO1WOhIe8dLPTENaZr5D1ex4=
 github.com/ldez/gomoddirectives v0.2.1/go.mod h1:sGicqkRgBOg//JfpXwkB9Hj0X5RyJ7mlACM5B9f6Me4=

--- a/pkg/engine/jmespath/arithmetic_test.go
+++ b/pkg/engine/jmespath/arithmetic_test.go
@@ -82,7 +82,7 @@ func Test_Add(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.test)
+			jp, err := jmespathInterface.Query(tc.test)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -228,7 +228,7 @@ func Test_Sum(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.test)
+			jp, err := jmespathInterface.Query(tc.test)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -327,7 +327,7 @@ func Test_Subtract(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.test)
+			jp, err := jmespathInterface.Query(tc.test)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -426,7 +426,7 @@ func Test_Multiply(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.test)
+			jp, err := jmespathInterface.Query(tc.test)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -588,7 +588,7 @@ func Test_Divide(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.test)
+			jp, err := jmespathInterface.Query(tc.test)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -744,7 +744,7 @@ func Test_Modulo(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.test)
+			jp, err := jmespathInterface.Query(tc.test)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -813,7 +813,7 @@ func Test_Round(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.test)
+			jp, err := jmespathInterface.Query(tc.test)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -11,7 +11,7 @@ import (
 	"gotest.tools/assert"
 )
 
-var cfg = config.NewDefaultConfiguration(false)
+var jmespathInterface = newImplementation(config.NewDefaultConfiguration(false))
 
 func Test_Compare(t *testing.T) {
 	testCases := []struct {
@@ -33,7 +33,7 @@ func Test_Compare(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.jmesPath, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.jmesPath)
+			jp, err := jmespathInterface.Query(tc.jmesPath)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -60,7 +60,7 @@ func Test_ParseJsonSerde(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, fmt.Sprintf(`to_string(parse_json('%s'))`, tc))
+			jp, err := jmespathInterface.Query(fmt.Sprintf(`to_string(parse_json('%s'))`, tc))
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -91,7 +91,7 @@ func Test_ParseJsonComplex(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.input)
+			jp, err := jmespathInterface.Query(tc.input)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -168,7 +168,7 @@ bar: null
 	}
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, fmt.Sprintf(`parse_yaml('%s')`, tc.input))
+			jp, err := jmespathInterface.Query(fmt.Sprintf(`parse_yaml('%s')`, tc.input))
 			assert.NilError(t, err)
 			result, err := jp.Search("")
 			assert.NilError(t, err)
@@ -197,7 +197,7 @@ func Test_EqualFold(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.jmesPath, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.jmesPath)
+			jp, err := jmespathInterface.Query(tc.jmesPath)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -234,7 +234,7 @@ func Test_Replace(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.jmesPath, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.jmesPath)
+			jp, err := jmespathInterface.Query(tc.jmesPath)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -248,7 +248,7 @@ func Test_Replace(t *testing.T) {
 }
 
 func Test_ReplaceAll(t *testing.T) {
-	jp, err := newJMESPath(cfg, "replace_all('Lorem ipsum dolor sit amet', 'ipsum', 'muspi')")
+	jp, err := jmespathInterface.Query("replace_all('Lorem ipsum dolor sit amet', 'ipsum', 'muspi')")
 	assert.NilError(t, err)
 
 	result, err := jp.Search("")
@@ -279,7 +279,7 @@ func Test_ToUpper(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.jmesPath, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.jmesPath)
+			jp, err := jmespathInterface.Query(tc.jmesPath)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -312,7 +312,7 @@ func Test_ToLower(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.jmesPath, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.jmesPath)
+			jp, err := jmespathInterface.Query(tc.jmesPath)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -326,7 +326,7 @@ func Test_ToLower(t *testing.T) {
 }
 
 func Test_Trim(t *testing.T) {
-	jp, err := newJMESPath(cfg, "trim('¡¡¡Hello, Gophers!!!', '!¡')")
+	jp, err := jmespathInterface.Query("trim('¡¡¡Hello, Gophers!!!', '!¡')")
 	assert.NilError(t, err)
 
 	result, err := jp.Search("")
@@ -397,7 +397,7 @@ func Test_TrimPrefix(t *testing.T) {
 }
 
 func Test_Split(t *testing.T) {
-	jp, err := newJMESPath(cfg, "split('Hello, Gophers', ', ')")
+	jp, err := jmespathInterface.Query("split('Hello, Gophers', ', ')")
 	assert.NilError(t, err)
 
 	result, err := jp.Search("")
@@ -410,7 +410,7 @@ func Test_Split(t *testing.T) {
 }
 
 func Test_HasPrefix(t *testing.T) {
-	jp, err := newJMESPath(cfg, "starts_with('Gophers', 'Go')")
+	jp, err := jmespathInterface.Query("starts_with('Gophers', 'Go')")
 	assert.NilError(t, err)
 
 	result, err := jp.Search("")
@@ -422,7 +422,7 @@ func Test_HasPrefix(t *testing.T) {
 }
 
 func Test_HasSuffix(t *testing.T) {
-	jp, err := newJMESPath(cfg, "ends_with('Amigo', 'go')")
+	jp, err := jmespathInterface.Query("ends_with('Amigo', 'go')")
 	assert.NilError(t, err)
 
 	result, err := jp.Search("")
@@ -437,7 +437,7 @@ func Test_RegexMatch(t *testing.T) {
 	data := make(map[string]interface{})
 	data["foo"] = "hgf'b1a2r'b12g"
 
-	query, err := newJMESPath(cfg, "regex_match('12.*', foo)")
+	query, err := jmespathInterface.Query("regex_match('12.*', foo)")
 	assert.NilError(t, err)
 
 	result, err := query.Search(data)
@@ -449,7 +449,7 @@ func Test_RegexMatchWithNumber(t *testing.T) {
 	data := make(map[string]interface{})
 	data["foo"] = -12.0
 
-	query, err := newJMESPath(cfg, "regex_match('12.*', abs(foo))")
+	query, err := jmespathInterface.Query("regex_match('12.*', abs(foo))")
 	assert.NilError(t, err)
 
 	result, err := query.Search(data)
@@ -461,7 +461,7 @@ func Test_PatternMatch(t *testing.T) {
 	data := make(map[string]interface{})
 	data["foo"] = "prefix-foo"
 
-	query, err := newJMESPath(cfg, "pattern_match('prefix-*', foo)")
+	query, err := jmespathInterface.Query("pattern_match('prefix-*', foo)")
 	assert.NilError(t, err)
 
 	result, err := query.Search(data)
@@ -473,7 +473,7 @@ func Test_PatternMatchWithNumber(t *testing.T) {
 	data := make(map[string]interface{})
 	data["foo"] = -12.0
 
-	query, err := newJMESPath(cfg, "pattern_match('12*', abs(foo))")
+	query, err := jmespathInterface.Query("pattern_match('12*', abs(foo))")
 	assert.NilError(t, err)
 
 	result, err := query.Search(data)
@@ -500,7 +500,7 @@ func Test_RegexReplaceAll(t *testing.T) {
 	var resource interface{}
 	err := json.Unmarshal(resourceRaw, &resource)
 	assert.NilError(t, err)
-	query, err := newJMESPath(cfg, `regex_replace_all('([Hh]e|G)l', spec.field, '${2}G')`)
+	query, err := jmespathInterface.Query(`regex_replace_all('([Hh]e|G)l', spec.field, '${2}G')`)
 	assert.NilError(t, err)
 
 	res, err := query.Search(resource)
@@ -531,7 +531,7 @@ func Test_RegexReplaceAllLiteral(t *testing.T) {
 	err := json.Unmarshal(resourceRaw, &resource)
 	assert.NilError(t, err)
 
-	query, err := newJMESPath(cfg, `regex_replace_all_literal('[Hh]el?', spec.field, 'G')`)
+	query, err := jmespathInterface.Query(`regex_replace_all_literal('[Hh]el?', spec.field, 'G')`)
 	assert.NilError(t, err)
 
 	res, err := query.Search(resource)
@@ -586,7 +586,7 @@ func Test_LabelMatch(t *testing.T) {
 			err := json.Unmarshal(tc.resource, &resource)
 			assert.NilError(t, err)
 
-			query, err := newJMESPath(cfg, "label_match(`"+tc.test+"`, metadata.labels)")
+			query, err := jmespathInterface.Query("label_match(`" + tc.test + "`, metadata.labels)")
 			assert.NilError(t, err)
 
 			res, err := query.Search(resource)
@@ -630,7 +630,7 @@ func Test_JpToBoolean(t *testing.T) {
 }
 
 func Test_Base64Decode(t *testing.T) {
-	jp, err := newJMESPath(cfg, "base64_decode('SGVsbG8sIHdvcmxkIQ==')")
+	jp, err := jmespathInterface.Query("base64_decode('SGVsbG8sIHdvcmxkIQ==')")
 	assert.NilError(t, err)
 
 	result, err := jp.Search("")
@@ -642,7 +642,7 @@ func Test_Base64Decode(t *testing.T) {
 }
 
 func Test_Base64Encode(t *testing.T) {
-	jp, err := newJMESPath(cfg, "base64_encode('Hello, world!')")
+	jp, err := jmespathInterface.Query("base64_encode('Hello, world!')")
 	assert.NilError(t, err)
 
 	result, err := jp.Search("")
@@ -672,7 +672,7 @@ func Test_Base64Decode_Secret(t *testing.T) {
 	err := json.Unmarshal(resourceRaw, &resource)
 	assert.NilError(t, err)
 
-	query, err := newJMESPath(cfg, `base64_decode(data.example1)`)
+	query, err := jmespathInterface.Query(`base64_decode(data.example1)`)
 	assert.NilError(t, err)
 
 	res, err := query.Search(resource)
@@ -747,7 +747,7 @@ func Test_PathCanonicalize(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.jmesPath, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.jmesPath)
+			jp, err := jmespathInterface.Query(tc.jmesPath)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -796,7 +796,7 @@ func Test_Truncate(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.jmesPath, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.jmesPath)
+			jp, err := jmespathInterface.Query(tc.jmesPath)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -833,7 +833,7 @@ func Test_SemverCompare(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.jmesPath, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.jmesPath)
+			jp, err := jmespathInterface.Query(tc.jmesPath)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -992,7 +992,7 @@ func Test_Lookup(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			query, err := newJMESPath(cfg, "lookup(`"+tc.collection+"`,`"+tc.key+"`)")
+			query, err := jmespathInterface.Query("lookup(`" + tc.collection + "`,`" + tc.key + "`)")
 			assert.NilError(t, err)
 
 			result, err := query.Search("")
@@ -1034,7 +1034,7 @@ func Test_Lookup_InvalidArgs(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			query, err := newJMESPath(cfg, "lookup(`"+tc.collection+"`,`"+tc.key+"`)")
+			query, err := jmespathInterface.Query("lookup(`" + tc.collection + "`,`" + tc.key + "`)")
 			assert.NilError(t, err)
 
 			_, err = query.Search("")
@@ -1077,7 +1077,7 @@ func Test_Items(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			query, err := newJMESPath(cfg, "items(`"+tc.object+"`,`"+tc.keyName+"`,`"+tc.valName+"`)")
+			query, err := jmespathInterface.Query("items(`" + tc.object + "`,`" + tc.keyName + "`,`" + tc.valName + "`)")
 			assert.NilError(t, err)
 
 			res, err := query.Search("")
@@ -1128,7 +1128,7 @@ func Test_ObjectFromLists(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			query, err := newJMESPath(cfg, "object_from_lists(`"+tc.keys+"`,`"+tc.values+"`)")
+			query, err := jmespathInterface.Query("object_from_lists(`" + tc.keys + "`,`" + tc.values + "`)")
 			assert.NilError(t, err)
 			res, err := query.Search("")
 			assert.NilError(t, err)
@@ -1245,7 +1245,7 @@ ZDGRs55xuoeLDJ/ZRFf9bI+IaCUd1YrfYcHIl3G87Av+r49YVwqRDT0VDV7uLgqn
 	}
 	for _, tc := range testCases {
 		t.Run(tc.jmesPath, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.jmesPath)
+			jp, err := jmespathInterface.Query(tc.jmesPath)
 			assert.NilError(t, err)
 
 			result, err := jp.Search("")
@@ -1661,7 +1661,7 @@ func Test_ImageNormalize(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.jmesPath, func(t *testing.T) {
-			jp, err := newJMESPath(cfg, tc.jmesPath)
+			jp, err := jmespathInterface.Query(tc.jmesPath)
 			assert.NilError(t, err)
 			result, err := jp.Search("")
 			if tc.wantErr {

--- a/pkg/engine/jmespath/interface.go
+++ b/pkg/engine/jmespath/interface.go
@@ -1,6 +1,9 @@
 package jmespath
 
-import "github.com/kyverno/kyverno/pkg/config"
+import (
+	gojmespath "github.com/kyverno/go-jmespath"
+	"github.com/kyverno/kyverno/pkg/config"
+)
 
 type Query interface {
 	Search(interface{}) (interface{}, error)
@@ -12,23 +15,17 @@ type Interface interface {
 }
 
 type implementation struct {
-	configuration config.Configuration
+	interpreter gojmespath.Interpreter
 }
 
 func New(configuration config.Configuration) Interface {
-	return implementation{
-		configuration: configuration,
-	}
+	return newImplementation(configuration)
 }
 
 func (i implementation) Query(query string) (Query, error) {
-	return newJMESPath(i.configuration, query)
+	return newJMESPath(i.interpreter, query)
 }
 
 func (i implementation) Search(query string, data interface{}) (interface{}, error) {
-	if query, err := i.Query(query); err != nil {
-		return nil, err
-	} else {
-		return query.Search(data)
-	}
+	return newExecution(i.interpreter, query, data)
 }

--- a/pkg/engine/jmespath/new.go
+++ b/pkg/engine/jmespath/new.go
@@ -5,13 +5,34 @@ import (
 	"github.com/kyverno/kyverno/pkg/config"
 )
 
-func newJMESPath(configuration config.Configuration, query string) (*gojmespath.JMESPath, error) {
-	jp, err := gojmespath.Compile(query)
+func newJMESPath(intr gojmespath.Interpreter, query string) (*gojmespath.JMESPath, error) {
+	parser := gojmespath.NewParser()
+	ast, err := parser.Parse(query)
 	if err != nil {
 		return nil, err
 	}
-	for _, function := range GetFunctions(configuration) {
-		jp.Register(function.FunctionEntry)
+
+	return gojmespath.NewJMESPath(ast, intr), nil
+}
+
+func newImplementation(configuration config.Configuration) Interface {
+	i := gojmespath.NewInterpreter()
+	functions := GetFunctions(configuration)
+	for _, f := range functions {
+		i.Register(f.FunctionEntry)
 	}
-	return jp, nil
+
+	return implementation{
+		interpreter: i,
+	}
+}
+
+func newExecution(intr gojmespath.Interpreter, query string, data interface{}) (interface{}, error) {
+	parser := gojmespath.NewParser()
+	ast, err := parser.Parse(query)
+	if err != nil {
+		return nil, err
+	}
+
+	return intr.Execute(ast, data)
 }

--- a/pkg/engine/jmespath/new_test.go
+++ b/pkg/engine/jmespath/new_test.go
@@ -25,7 +25,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := newJMESPath(cfg, tt.args.query)
+			_, err := jmespathInterface.Query(tt.args.query)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/engine/jmespath/time_test.go
+++ b/pkg/engine/jmespath/time_test.go
@@ -25,7 +25,7 @@ func Test_TimeSince(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			query, err := newJMESPath(cfg, tc.test)
+			query, err := jmespathInterface.Query(tc.test)
 			assert.NilError(t, err)
 
 			res, err := query.Search("")
@@ -55,7 +55,7 @@ func Test_TimeToCron(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			query, err := newJMESPath(cfg, tc.test)
+			query, err := jmespathInterface.Query(tc.test)
 			assert.NilError(t, err)
 
 			res, err := query.Search("")
@@ -85,7 +85,7 @@ func Test_TimeAdd(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			query, err := newJMESPath(cfg, tc.test)
+			query, err := jmespathInterface.Query(tc.test)
 			assert.NilError(t, err)
 
 			res, err := query.Search("")
@@ -115,7 +115,7 @@ func Test_TimeParse(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			query, err := newJMESPath(cfg, tc.test)
+			query, err := jmespathInterface.Query(tc.test)
 			assert.NilError(t, err)
 
 			res, err := query.Search("")
@@ -145,7 +145,7 @@ func Test_TimeUtc(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			query, err := newJMESPath(cfg, tc.test)
+			query, err := jmespathInterface.Query(tc.test)
 			assert.NilError(t, err)
 
 			res, err := query.Search("")
@@ -171,7 +171,7 @@ func Test_TimeDiff(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			query, err := newJMESPath(cfg, tc.test)
+			query, err := jmespathInterface.Query(tc.test)
 			assert.NilError(t, err)
 
 			res, err := query.Search("")


### PR DESCRIPTION
## Explanation

Reuse JMESPath interpreter across searches

## Related issue

Fixes https://github.com/kyverno/kyverno/issues/8298

## Milestone of this PR

1.12.0

## What type of PR is this

 /kind feature

## Proposed Changes

Use updated JMESPath library that allows reuse of Interpreter.

### Proof Manifests

N/A; this is an internal change with no changes in behavior.

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
