### PR TITLE
fix: cache invalidation in FindResources

### DIFF
--- a/pkg/clients/dclient/discovery.go
+++ b/pkg/clients/dclient/discovery.go
@@ -163,10 +163,17 @@ func (c serverResources) FindResource(groupVersion string, kind string) (apiReso
 
 func (c serverResources) FindResources(group, version, kind, subresource string) (map[TopLevelApiDescription]metav1.APIResource, error) {
 	resources, err := c.findResources(group, version, kind, subresource)
-	if err != nil {
-		if !c.cachedClient.Fresh() {
+	// if no resource was found, we have to force cache invalidation
+	if err != nil || len(resources) == 0 {
+		if !c.cachedClient.Fresh() || len(resources) == 0 {
 			c.cachedClient.Invalidate()
-			return c.findResources(group, version, kind, subresource)
+			resources, err := c.findResources(group, version, kind, subresource)
+			if err != nil {
+				return nil, err
+			} else if len(resources) == 0 {
+				return nil, fmt.Errorf("failed to find resource (%s/%s/%s/%s)", group, version, kind, subresource)
+			}
+			return resources, err
 		}
 	}
 	return resources, err

--- a/pkg/engine/adapters/dclient.go
+++ b/pkg/engine/adapters/dclient.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/kyverno/kyverno/pkg/auth"
@@ -58,6 +59,9 @@ func (a *dclientAdapter) IsNamespaced(group, version, kind string) (bool, error)
 	gvrss, err := a.client.Discovery().FindResources(group, version, kind, "")
 	if err != nil {
 		return false, err
+	}
+	if len(gvrss) != 1 {
+		return false, fmt.Errorf("function IsNamespaced expects only one resource, got (%d)", len(gvrss))
 	}
 	for _, apiResource := range gvrss {
 		return apiResource.Namespaced, nil

--- a/pkg/engine/handlers/validation/validate_cel.go
+++ b/pkg/engine/handlers/validation/validate_cel.go
@@ -178,7 +178,7 @@ func collectParams(ctx context.Context, client engineapi.Client, paramKind *admi
 	var paramsNamespace string
 	isNamespaced, err := client.IsNamespaced(gv.Group, gv.Version, kind)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to check if resource is namespaced or not (%w)", err)
 	}
 
 	// check if `paramKind` is namespace-scoped


### PR DESCRIPTION
## Explanation

This PR fixes cache invalidation not happening in FindResources when no resource is found.

## Related issue

#8242
