### PR TITLE
fix: generate empty kind

### DIFF
--- a/pkg/controllers/webhook/controller.go
+++ b/pkg/controllers/webhook/controller.go
@@ -859,7 +859,9 @@ func (c *controller) mergeWebhook(dst *webhook, policy kyvernov1.PolicyInterface
 		// matching kinds in generate policies need to be added to both webhook
 		if rule.HasGenerate() {
 			matchedGVK = append(matchedGVK, rule.MatchResources.GetKinds()...)
-			matchedGVK = append(matchedGVK, rule.Generation.ResourceSpec.Kind)
+			if rule.Generation.ResourceSpec.Kind != "" {
+				matchedGVK = append(matchedGVK, rule.Generation.ResourceSpec.Kind)
+			}
 			matchedGVK = append(matchedGVK, rule.Generation.CloneList.Kinds...)
 			continue
 		}


### PR DESCRIPTION
## Explanation

This PR fixes an issue with generate rules where an empty kind would be accepted.
