### PR TITLE
fix: Kyverno test ignores variables.yaml file unless context is present

### DIFF
--- a/test/cli/test/deny-modify-platform-label/deny-modify-platform-label.yaml
+++ b/test/cli/test/deny-modify-platform-label/deny-modify-platform-label.yaml
@@ -1,0 +1,33 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-modify-platform-label
+  annotations:
+    policies.kyverno.io/title: Deny Modification of platform owned roles
+    policies.kyverno.io/category: Hardening
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Role
+    policies.kyverno.io/description: >-
+      Restrict modification of platform owned roles to admins only
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+    - name: deny-modify-platform-role
+      match:
+        any:
+          - resources:
+              kinds:
+                - Role
+      preconditions:
+        all:
+          - key: "{{ request.operation }}"
+            operator: AnyIn
+            value: ["UPDATE", "DELETE"]
+          - key: "{{ request.userInfo.groups }}"
+            operator: AllNotIn
+            value: ["system:masters"]
+      validate:
+        message: >-
+            Roles owned by platform team (ones with label hpedevops.net/platform=true) should not be modified by non-admin users.
+        deny: {}

--- a/test/cli/test/deny-modify-platform-label/kyverno-test.yaml
+++ b/test/cli/test/deny-modify-platform-label/kyverno-test.yaml
@@ -1,0 +1,12 @@
+name: modify_with_master_access
+policies:
+  - deny-modify-platform-label.yaml
+resources:
+  - resource.yaml
+variables: variables.yaml
+results:
+  - policy: deny-modify-platform-label
+    rule: deny-modify-platform-role
+    resource: my-role-with-platform
+    kind: Role
+    result: skip

--- a/test/cli/test/deny-modify-platform-label/resource.yaml
+++ b/test/cli/test/deny-modify-platform-label/resource.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: my-role-with-platform
+  labels:
+    "hpedevops.net/platform": "true"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - watch

--- a/test/cli/test/deny-modify-platform-label/variables.yaml
+++ b/test/cli/test/deny-modify-platform-label/variables.yaml
@@ -1,0 +1,12 @@
+# This file sets the values that will be null unless otherwise set explicitly.
+# We are effectively mocking these values because there is no real API call.
+policies:
+  - name: deny-modify-platform-label
+    rules:
+    - name: deny-modify-platform-role
+      values:
+        request:
+          operation: "UPDATE"
+          userInfo:
+            groups:
+             - "system:masters"


### PR DESCRIPTION
## Explanation

This PR fixes: Kyverno test ignores variables.yaml file unless context is present.

## Related issue

Fixes #6206 
