### PR TITLE
fix: all tests fails when use mutiple results with generate-clone

### DIFF
--- a/test/cli/test-generate/sync-multiple-resources/cm.yaml
+++ b/test/cli/test-generate/sync-multiple-resources/cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-cluster-controller-config
+  namespace: kube-system
+data:
+  value: "0"

--- a/test/cli/test-generate/sync-multiple-resources/deployment.yaml
+++ b/test/cli/test-generate/sync-multiple-resources/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubernetes-cluster-controller
+  namespace: kube-system
+  labels:
+    app: kubernetes-cluster-controller
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kubernetes-cluster-controller
+  template:
+    metadata:
+      labels:
+        app: kubernetes-cluster-controller
+    spec:
+      containers:
+        - name: front-end
+          image: nginx
+          ports:
+            - containerPort: 8080
+        - name: rss-reader
+          image: nickchase/rss-php-nginx:v1
+          ports:
+            - containerPort: 8080

--- a/test/cli/test-generate/sync-multiple-resources/gen-cm.yaml
+++ b/test/cli/test-generate/sync-multiple-resources/gen-cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-cluster-controller-config
+  namespace: services-system
+data:
+  value: "0"

--- a/test/cli/test-generate/sync-multiple-resources/gen-secret.yaml
+++ b/test/cli/test-generate/sync-multiple-resources/gen-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubernetes-cluster-controller
+  namespace: services-system
+type: Opaque
+data:
+  USER_NAME: YWRtaW4=
+  PASSWORD: YWRtaW4=

--- a/test/cli/test-generate/sync-multiple-resources/kyverno-test.yaml
+++ b/test/cli/test-generate/sync-multiple-resources/kyverno-test.yaml
@@ -1,0 +1,22 @@
+name: sync-controller-data
+policies:
+  - policy.yaml
+resources:
+  - deployment.yaml
+results:
+  - policy: sync-controller-data
+    rule: sync-controller-secret
+    resources:
+      - kubernetes-cluster-controller
+    generatedResource: gen-secret.yaml
+    cloneSourceResource: secret.yaml
+    kind: Deployment
+    result: pass
+  - policy: sync-controller-data
+    rule: sync-controller-configmap
+    resources: 
+      - kubernetes-cluster-controller
+    generatedResource: gen-cm.yaml
+    cloneSourceResource: cm.yaml
+    kind: Deployment
+    result: pass

--- a/test/cli/test-generate/sync-multiple-resources/policy.yaml
+++ b/test/cli/test-generate/sync-multiple-resources/policy.yaml
@@ -1,0 +1,52 @@
+kind: ClusterPolicy
+metadata:
+  name: sync-controller-data
+  annotations:
+    policies.kyverno.io/title: Sync Controller Data
+    policies.kyverno.io/category: RightSizing
+    policies.kyverno.io/subject: io
+    policies.kyverno.io/description: >-
+      Sync Secret and Configmap from kube-system namespace
+spec:
+  failurePolicy: Ignore
+  generateExistingOnPolicyUpdate: true
+  rules:
+  - name: sync-controller-secret
+    match:
+      all:
+      - resources:
+          kinds:
+          - Deployment
+          namespaces:
+          - kube-system
+          names:
+          - kubernetes-cluster-controller
+    generate:
+      apiVersion: v1
+      kind: Secret
+      name: kubernetes-cluster-controller
+      namespace: services-system
+      synchronize: true
+      clone:
+        namespace: kube-system
+        name: kubernetes-cluster-controller
+
+  - name: sync-controller-configmap
+    match:
+      all:
+      - resources:
+          kinds:
+          - Deployment
+          namespaces:
+          - kube-system
+          names:
+          - kubernetes-cluster-controller  
+    generate:
+      apiVersion: v1
+      kind: ConfigMap
+      name: kubernetes-cluster-controller-config
+      namespace: services-system
+      synchronize: true
+      clone:
+        namespace: kube-system
+        name: kubernetes-cluster-controller-config

--- a/test/cli/test-generate/sync-multiple-resources/secret.yaml
+++ b/test/cli/test-generate/sync-multiple-resources/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubernetes-cluster-controller
+  namespace: kube-system
+type: Opaque
+data:
+  USER_NAME: YWRtaW4=
+  PASSWORD: YWRtaW4=


### PR DESCRIPTION
## Explanation

This PR fixes all tests fails when use mutiple results with generate-clone.

## Related issue

Fixes #5452 
