### PR TITLE
chore: add --compress to cli test files verification

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -746,5 +746,5 @@ jobs:
         shell: bash
         run: |
           set -e
-          KYVERNO_EXPERIMENTAL=true kyverno fix test ./test/cli --save
+          KYVERNO_EXPERIMENTAL=true kyverno fix test ./test/cli --save --compress
           make verify-cli-tests


### PR DESCRIPTION
## Explanation

This PR adds `--compress` to cli test files verification.
