### PR TITLE
fix: kyverno test ignores namespace of resources in resource.yaml

### DIFF
--- a/test/cli/test/disallow-service/kyverno-test.yaml
+++ b/test/cli/test/disallow-service/kyverno-test.yaml
@@ -1,0 +1,16 @@
+name: disallow-service
+policies:
+  - policy.yaml
+resources:
+  - resource.yaml
+results:
+  - policy: disallow-service
+    rule: disallow-service
+    resources: [svc1]
+    kind: Service
+    result: skip
+  - policy: disallow-service
+    rule: disallow-service
+    resources: [svc2]
+    kind: Service
+    result: fail

--- a/test/cli/test/disallow-service/policy.yaml
+++ b/test/cli/test/disallow-service/policy.yaml
@@ -1,0 +1,26 @@
+kind: ClusterPolicy
+metadata:
+  name: disallow-service
+spec:
+  validationFailureAction: Validate
+  failurePolicy: Ignore
+  rules:
+    - name: disallow-service
+      match:
+        all:
+          - resources:
+              kinds:
+                - Service
+      preconditions:
+        any:
+          - key: "{{ request.object.metadata.namespace }}"
+            operator: NotEquals
+            value: "ns1"
+          - key: "{{ request.object.metadata.name }}"
+            operator: AnyNotIn
+            value: ["svc1", "svc2"]
+      validate:
+        message: >-
+          Can't create a service. Sorry...
+        anyPattern:
+          - kind: "!Service"

--- a/test/cli/test/disallow-service/resource.yaml
+++ b/test/cli/test/disallow-service/resource.yaml
@@ -1,0 +1,13 @@
+# should be skipped
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc1
+  namespace: ns1
+---
+# should fail (wrong namespace)
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc2
+  namespace: ns3


### PR DESCRIPTION
## Explanation

This PR fixes: kyverno test ignores namespace of resources in resource.yaml.

## Related issue

Fixes #7044 
