### PR TITLE
chore: add gofiber/fiber/v2@v2.43.0 to nancy ignore

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -22,3 +22,5 @@ CVE-2023-32082 until=2023-09-30
 CVE-2022-34038 until=2023-09-30
 # golang/github.com/jinzhu/gorm@v1.9.1
 CVE-2019-15562 until=2023-09-30
+# golang/github.com/gofiber/fiber/v2@v2.43.0
+CVE-2023-41338 until=2023-09-30


### PR DESCRIPTION
## Explanation

There is a new vulnerability: [CVE-2023-41338](https://github.com/gofiber/fiber/security/advisories/GHSA-3q5p-3558-364f) which is causing Nancy to fail in new PRs: https://github.com/kyverno/kyverno/actions/runs/6155928394/job/16703644963?pr=8337

We do not have github.com/gofiber/fiber/v2 in our `go.mod` because the dependency got pruned but nancy uses a broader dependency graph algorithm.

This PR adds that CVE to `.nancyignore` to fix failing check.