### PR TITLE
fix: kyverno test are applying previous mutation rules to subsequent test cases causing failures

### DIFF
--- a/test/cli/test-mutate/karpenter-annotations-to-nodeselector/kyverno-test.yaml
+++ b/test/cli/test-mutate/karpenter-annotations-to-nodeselector/kyverno-test.yaml
@@ -1,0 +1,17 @@
+name: karpenter-annotations-to-nodeselector
+policies:
+  - policy.yaml
+resources:
+  - resource.yaml
+results:
+  - policy: karpenter-annotations-to-nodeselector
+    rule: hard-nodeselector-lifecycle-on-demand
+    resource: soft-pod-antiaffinity-1
+    patchedResource: patched.yaml
+    kind: Pod
+    result: pass
+  - policy: karpenter-annotations-to-nodeselector
+    rule: hard-nodeselector-lifecycle-on-demand
+    resource: soft-pod-antiaffinity-1-copy
+    kind: Pod
+    result: pass

--- a/test/cli/test-mutate/karpenter-annotations-to-nodeselector/patched.yaml
+++ b/test/cli/test-mutate/karpenter-annotations-to-nodeselector/patched.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: soft-pod-antiaffinity-1
+  namespace: sample
+  annotations:
+    spot-toleration: 'false'
+  ownerReferences:
+    - controller: true
+      kind: Deployment
+      apiVersion: v1
+      uid: test
+      name: test
+spec:
+  containers:
+    - name: echo-server
+      image: hashicorp/http-echo:0.2.3
+      imagePullPolicy: IfNotPresent
+      args:
+        - -listen=:8080
+        - -text="hello world"
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: karpenter.sh/capacity-type
+                operator: In
+                values:
+                  - on-demand
+              - key: karpenter.sh/capacity-type
+                operator: NotIn
+                values:
+                  - spot
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: test-pod
+            topologyKey: kubernetes.io/hostname
+          weight: 100

--- a/test/cli/test-mutate/karpenter-annotations-to-nodeselector/policy.yaml
+++ b/test/cli/test-mutate/karpenter-annotations-to-nodeselector/policy.yaml
@@ -1,0 +1,79 @@
+# https://github.com/kyverno/kyverno/issues/6816
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: karpenter-annotations-to-nodeselector
+spec:
+  rules:
+    - name: nodeselector-lifecycle-on-demand
+      preconditions:
+        all:
+          - key: "{{ request.operation }}"
+            operator: Equals
+            value: CREATE
+          - key: "{{ request.object.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution || '' }}" 
+            operator: Equals
+            value: ''
+          - key: "{{ request.object.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution || '' }}"
+            operator: Equals
+            value: ''
+      exclude:
+        any:
+          - resources:
+              annotations:
+                reserved-nodes: "*"
+          - resources:
+              annotations:
+                special-hardware: "*"
+      match:
+        all:
+          - resources:
+              kinds:
+                - Pod 
+              annotations:
+                spot-toleration: "false"
+      mutate:
+        patchesJson6902: |-
+          - op: add
+            path: "/spec/affinity/nodeAffinity"
+            value:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: karpenter.sh/capacity-type
+                        operator: In
+                        values:
+                          - on-demand
+    - name: hard-nodeselector-lifecycle-on-demand
+      preconditions:
+        all:
+          - key: "{{ request.operation }}"
+            operator: Equals
+            value: CREATE
+          - key: "{{ request.object.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution || '' }}"
+            operator: NotEquals
+            value: ''
+      exclude:
+        any:
+          - resources:
+              annotations:
+                reserved-nodes: "*"
+          - resources:
+              annotations:
+                special-hardware: "*"
+      match:
+        all:
+          - resources:
+              kinds:
+                - Pod
+              annotations:
+                spot-toleration: "false"
+      mutate:
+        patchesJson6902: |-
+          - op: add
+            path: "/spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/0/matchExpressions/-"
+            value:
+              key: karpenter.sh/capacity-type
+              operator: NotIn
+              values:
+                - spot

--- a/test/cli/test-mutate/karpenter-annotations-to-nodeselector/resource.yaml
+++ b/test/cli/test-mutate/karpenter-annotations-to-nodeselector/resource.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: soft-pod-antiaffinity-1
+  namespace: sample
+  annotations:
+    spot-toleration: 'false'
+  ownerReferences:
+    - controller: true
+      kind: Deployment
+      apiVersion: v1
+      uid: test
+      name: test
+spec:
+  containers:
+    - name: echo-server
+      image: hashicorp/http-echo:0.2.3
+      imagePullPolicy: IfNotPresent
+      args:
+        - -listen=:8080
+        - -text="hello world"
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: test-pod
+            topologyKey: kubernetes.io/hostname
+          weight: 100
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: soft-pod-antiaffinity-1-copy
+  namespace: sample
+  annotations:
+    spot-toleration: 'false'
+  ownerReferences:
+    - controller: true
+      kind: Deployment
+      apiVersion: v1
+      uid: test
+      name: test
+spec:
+  containers:
+    - name: echo-server
+      image: hashicorp/http-echo:0.2.3
+      imagePullPolicy: IfNotPresent
+      args:
+        - -listen=:8080
+        - -text="hello world"
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: test-pod
+            topologyKey: kubernetes.io/hostname
+          weight: 100


### PR DESCRIPTION
## Explanation

This PR fixes: kyverno test are applying previous mutation rules to subsequent test cases causing failures.

## Related issue

Fixes #6816 