### PR TITLE
fix: Testing a generate rule for a custom resource fails

### DIFF
--- a/pkg/clients/dclient/fake.go
+++ b/pkg/clients/dclient/fake.go
@@ -65,7 +65,7 @@ func (c *fakeDiscoveryClient) getGVR(resource string) (schema.GroupVersionResour
 			return gvr, nil
 		}
 	}
-	return schema.GroupVersionResource{}, errors.New("no found")
+	return schema.GroupVersionResource{}, errors.New("not found")
 }
 
 func (c *fakeDiscoveryClient) GetGVKFromGVR(schema.GroupVersionResource) (schema.GroupVersionKind, error) {

--- a/test/cli/test-generate/custom-resource/clone-secret.yaml
+++ b/test/cli/test-generate/custom-resource/clone-secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: devops-docker-pull-image-secret
+  namespace: default
+spec:
+  data:
+  - remoteRef:
+      conversionStrategy: Default
+      decodingStrategy: None
+      key: secrets/devops-docker-pull-image-secret
+      property: dockerconfigjson
+    secretKey: .dockerconfigjson
+  refreshInterval: 10s
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-backend
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: devops-docker-pull-image-secret

--- a/test/cli/test-generate/custom-resource/gen-secret.yaml
+++ b/test/cli/test-generate/custom-resource/gen-secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: devops-docker-pull-image-secret
+  namespace: test-ns
+spec:
+  data:
+  - remoteRef:
+      conversionStrategy: Default
+      decodingStrategy: None
+      key: secrets/devops-docker-pull-image-secret
+      property: dockerconfigjson
+    secretKey: .dockerconfigjson
+  refreshInterval: 10s
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-backend
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: devops-docker-pull-image-secret

--- a/test/cli/test-generate/custom-resource/kyverno-test.yaml
+++ b/test/cli/test-generate/custom-resource/kyverno-test.yaml
@@ -1,0 +1,14 @@
+name: generate-tests
+policies:
+- policy.yaml
+resources:
+- resource.yaml
+results:
+- cloneSourceResource: clone-secret.yaml
+  generatedResource: gen-secret.yaml
+  kind: Namespace
+  policy: sync-pull-image-secrets
+  resources:
+  - test-ns
+  result: pass
+  rule: sync-image-pull-secret

--- a/test/cli/test-generate/custom-resource/policy.yaml
+++ b/test/cli/test-generate/custom-resource/policy.yaml
@@ -1,0 +1,30 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: sync-pull-image-secrets
+  annotations:
+    policies.kyverno.io/title: Sync pull image secrets
+    policies.kyverno.io/category: Secrets
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/subject: secret
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      Copies the pullSecret ESO resources into all namespaces
+      this will mean we're never missing the secret when we need it.         
+spec:
+  rules:
+  - name: sync-image-pull-secret
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+    generate:
+      apiVersion: external-secrets.io/v1beta1
+      kind: ExternalSecret
+      name: devops-docker-pull-image-secret
+      namespace: "{{request.object.metadata.name}}"
+      synchronize: true
+      clone:
+        namespace: default
+        name: devops-docker-pull-image-secret

--- a/test/cli/test-generate/custom-resource/resource.yaml
+++ b/test/cli/test-generate/custom-resource/resource.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns


### PR DESCRIPTION
## Explanation

This PR fixes: Testing a generate rule for a custom resource fails

## Related issue

Fixes #7853 
