### PR TITLE
fix: replace fmt.Print calls by fmt.Fprint ones

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -3,6 +3,7 @@ package apply
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -75,19 +76,20 @@ func Command() *cobra.Command {
 		Example:      command.FormatExamples(examples...),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			out := cmd.OutOrStdout()
 			color.InitColors(removeColor)
 			applyCommandConfig.PolicyPaths = args
-			rc, _, skipInvalidPolicies, responses, err := applyCommandConfig.applyCommandHelper()
+			rc, _, skipInvalidPolicies, responses, err := applyCommandConfig.applyCommandHelper(out)
 			if err != nil {
 				return err
 			}
-			printSkippedAndInvalidPolicies(skipInvalidPolicies)
+			printSkippedAndInvalidPolicies(out, skipInvalidPolicies)
 			if applyCommandConfig.PolicyReport {
-				printReport(responses, applyCommandConfig.AuditWarn)
+				printReport(out, responses, applyCommandConfig.AuditWarn)
 			} else if table {
 				printTable(detailedResults, applyCommandConfig.AuditWarn, responses...)
 			} else {
-				printViolations(rc)
+				printViolations(out, rc)
 			}
 			return exit(rc, applyCommandConfig.warnExitCode, applyCommandConfig.warnNoPassed)
 		},
@@ -115,7 +117,7 @@ func Command() *cobra.Command {
 	return cmd
 }
 
-func (c *ApplyCommandConfig) applyCommandHelper() (*processor.ResultCounts, []*unstructured.Unstructured, SkippedInvalidPolicies, []engineapi.EngineResponse, error) {
+func (c *ApplyCommandConfig) applyCommandHelper(out io.Writer) (*processor.ResultCounts, []*unstructured.Unstructured, SkippedInvalidPolicies, []engineapi.EngineResponse, error) {
 	rc, resources1, skipInvalidPolicies, responses1, err := c.checkArguments()
 	if err != nil {
 		return rc, resources1, skipInvalidPolicies, responses1, err
@@ -151,7 +153,7 @@ func (c *ApplyCommandConfig) applyCommandHelper() (*processor.ResultCounts, []*u
 	if err != nil {
 		return rc, resources1, skipInvalidPolicies, responses1, err
 	}
-	resources, err := c.loadResources(policies, validatingAdmissionPolicies, dClient)
+	resources, err := c.loadResources(out, policies, validatingAdmissionPolicies, dClient)
 	if err != nil {
 		return rc, resources1, skipInvalidPolicies, responses1, err
 	}
@@ -161,9 +163,10 @@ func (c *ApplyCommandConfig) applyCommandHelper() (*processor.ResultCounts, []*u
 			policyRulesCount += len(autogen.ComputeRules(policy))
 		}
 		policyRulesCount += len(validatingAdmissionPolicies)
-		fmt.Printf("\nApplying %d policy rule(s) to %d resource(s)...\n", policyRulesCount, len(resources))
+		fmt.Fprintf(out, "\nApplying %d policy rule(s) to %d resource(s)...\n", policyRulesCount, len(resources))
 	}
 	rc, resources1, responses1, err = c.applyPolicytoResource(
+		out,
 		variables,
 		policies,
 		resources,
@@ -220,6 +223,7 @@ func (c *ApplyCommandConfig) applyValidatingAdmissionPolicytoResource(
 }
 
 func (c *ApplyCommandConfig) applyPolicytoResource(
+	out io.Writer,
 	vars *variables.Variables,
 	policies []kyvernov1.PolicyInterface,
 	resources []*unstructured.Unstructured,
@@ -254,7 +258,7 @@ func (c *ApplyCommandConfig) applyPolicytoResource(
 		if !vars.HasVariables() && variables.NeedsVariables(matches...) {
 			// check policy in variable file
 			if !vars.HasPolicyVariables(pol.GetName()) {
-				fmt.Printf("test skipped for policy %v (as required variables are not provided by the users) \n \n", pol.GetName())
+				fmt.Fprintf(out, "test skipped for policy %v (as required variables are not provided by the users) \n \n", pol.GetName())
 				continue
 			}
 		}
@@ -278,6 +282,7 @@ func (c *ApplyCommandConfig) applyPolicytoResource(
 			Client:               dClient,
 			AuditWarn:            c.AuditWarn,
 			Subresources:         vars.Subresources(),
+			Out:                  out,
 		}
 		ers, err := processor.ApplyPoliciesOnResource()
 		if err != nil {
@@ -288,8 +293,8 @@ func (c *ApplyCommandConfig) applyPolicytoResource(
 	return &rc, resources, responses, nil
 }
 
-func (c *ApplyCommandConfig) loadResources(policies []kyvernov1.PolicyInterface, validatingAdmissionPolicies []v1alpha1.ValidatingAdmissionPolicy, dClient dclient.Interface) ([]*unstructured.Unstructured, error) {
-	resources, err := common.GetResourceAccordingToResourcePath(nil, c.ResourcePaths, c.Cluster, policies, validatingAdmissionPolicies, dClient, c.Namespace, c.PolicyReport, "")
+func (c *ApplyCommandConfig) loadResources(out io.Writer, policies []kyvernov1.PolicyInterface, validatingAdmissionPolicies []v1alpha1.ValidatingAdmissionPolicy, dClient dclient.Interface) ([]*unstructured.Unstructured, error) {
+	resources, err := common.GetResourceAccordingToResourcePath(out, nil, c.ResourcePaths, c.Cluster, policies, validatingAdmissionPolicies, dClient, c.Namespace, c.PolicyReport, "")
 	if err != nil {
 		return resources, fmt.Errorf("failed to load resources (%w)", err)
 	}
@@ -409,42 +414,42 @@ func (c *ApplyCommandConfig) checkArguments() (*processor.ResultCounts, []*unstr
 	return nil, nil, skipInvalidPolicies, nil, nil
 }
 
-func printSkippedAndInvalidPolicies(skipInvalidPolicies SkippedInvalidPolicies) {
+func printSkippedAndInvalidPolicies(out io.Writer, skipInvalidPolicies SkippedInvalidPolicies) {
 	if len(skipInvalidPolicies.skipped) > 0 {
-		fmt.Println(divider)
-		fmt.Println("Policies Skipped (as required variables are not provided by the user):")
+		fmt.Fprintln(out, divider)
+		fmt.Fprintln(out, "Policies Skipped (as required variables are not provided by the user):")
 		for i, policyName := range skipInvalidPolicies.skipped {
-			fmt.Printf("%d. %s\n", i+1, policyName)
+			fmt.Fprintf(out, "%d. %s\n", i+1, policyName)
 		}
-		fmt.Println(divider)
+		fmt.Fprintln(out, divider)
 	}
 	if len(skipInvalidPolicies.invalid) > 0 {
-		fmt.Println(divider)
-		fmt.Println("Invalid Policies:")
+		fmt.Fprintln(out, divider)
+		fmt.Fprintln(out, "Invalid Policies:")
 		for i, policyName := range skipInvalidPolicies.invalid {
-			fmt.Printf("%d. %s\n", i+1, policyName)
+			fmt.Fprintf(out, "%d. %s\n", i+1, policyName)
 		}
-		fmt.Println(divider)
+		fmt.Fprintln(out, divider)
 	}
 }
 
-func printReport(engineResponses []engineapi.EngineResponse, auditWarn bool) {
+func printReport(out io.Writer, engineResponses []engineapi.EngineResponse, auditWarn bool) {
 	clustered, namespaced := report.ComputePolicyReports(auditWarn, engineResponses...)
 	if len(clustered) > 0 || len(namespaced) > 0 {
-		fmt.Println(divider)
-		fmt.Println("POLICY REPORT:")
-		fmt.Println(divider)
+		fmt.Fprintln(out, divider)
+		fmt.Fprintln(out, "POLICY REPORT:")
+		fmt.Fprintln(out, divider)
 		report := report.MergeClusterReports(clustered)
 		yamlReport, _ := yaml.Marshal(report)
-		fmt.Println(string(yamlReport))
+		fmt.Fprintln(out, string(yamlReport))
 	} else {
-		fmt.Println(divider)
-		fmt.Println("POLICY REPORT: skip generating policy report (no validate policy found/resource skipped)")
+		fmt.Fprintln(out, divider)
+		fmt.Fprintln(out, "POLICY REPORT: skip generating policy report (no validate policy found/resource skipped)")
 	}
 }
 
-func printViolations(rc *processor.ResultCounts) {
-	fmt.Printf("\npass: %d, fail: %d, warn: %d, error: %d, skip: %d \n", rc.Pass(), rc.Fail(), rc.Warn(), rc.Error(), rc.Skip())
+func printViolations(out io.Writer, rc *processor.ResultCounts) {
+	fmt.Fprintf(out, "\npass: %d, fail: %d, warn: %d, error: %d, skip: %d \n", rc.Pass(), rc.Fail(), rc.Warn(), rc.Error(), rc.Skip())
 }
 
 func exit(rc *processor.ResultCounts, warnExitCode int, warnNoPassed bool) error {

--- a/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
@@ -334,7 +334,7 @@ func Test_Apply(t *testing.T) {
 		}
 		desc := fmt.Sprintf("Policies: [%s], / Resources: [%s]", strings.Join(tc.config.PolicyPaths, ","), strings.Join(tc.config.ResourcePaths, ","))
 
-		_, _, _, responses, err := tc.config.applyCommandHelper()
+		_, _, _, responses, err := tc.config.applyCommandHelper(os.Stdout)
 		assert.NoError(t, err, desc)
 
 		clustered, _ := report.ComputePolicyReports(tc.config.AuditWarn, responses...)

--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"fmt"
+	"io"
 	"path/filepath"
 
 	"github.com/go-git/go-billy/v5"
@@ -33,7 +34,7 @@ func Command() *cobra.Command {
 		RunE: func(cmd *cobra.Command, dirPath []string) (err error) {
 			color.InitColors(removeColor)
 			store.SetRegistryAccess(registryAccess)
-			return testCommandExecute(dirPath, fileName, gitBranch, testCase, failOnly, detailedResults)
+			return testCommandExecute(cmd.OutOrStdout(), dirPath, fileName, gitBranch, testCase, failOnly, detailedResults)
 		},
 	}
 	cmd.Flags().StringVarP(&fileName, "file-name", "f", "kyverno-test.yaml", "Test filename")
@@ -53,6 +54,7 @@ type resultCounts struct {
 }
 
 func testCommandExecute(
+	out io.Writer,
 	dirPath []string,
 	fileName string,
 	gitBranch string,
@@ -67,10 +69,10 @@ func testCommandExecute(
 	// parse filter
 	filter, errors := filter.ParseFilter(testCase)
 	if len(errors) > 0 {
-		fmt.Println()
-		fmt.Println("Filter errors:")
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Filter errors:")
 		for _, e := range errors {
-			fmt.Println("  Error:", e)
+			fmt.Fprintln(out, "  Error:", e)
 		}
 	}
 	// init openapi manager
@@ -81,20 +83,20 @@ func testCommandExecute(
 	// load tests
 	tests, err := loadTests(dirPath, fileName, gitBranch)
 	if err != nil {
-		fmt.Println()
-		fmt.Println("Error loading tests:", err)
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Error loading tests:", err)
 		return err
 	}
 	if len(tests) == 0 {
-		fmt.Println()
-		fmt.Println("No test yamls available")
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "No test yamls available")
 	}
 	if errs := tests.Errors(); len(errs) > 0 {
-		fmt.Println()
-		fmt.Println("Test errors:")
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Test errors:")
 		for _, e := range errs {
-			fmt.Println("  Path:", e.Path)
-			fmt.Println("    Error:", e.Err)
+			fmt.Fprintln(out, "  Path:", e.Path)
+			fmt.Fprintln(out, "    Error:", e.Err)
 		}
 	}
 	if len(tests) == 0 {
@@ -120,11 +122,11 @@ func testCommandExecute(
 				continue
 			}
 			resourcePath := filepath.Dir(test.Path)
-			responses, err := runTest(openApiManager, test, false)
+			responses, err := runTest(out, openApiManager, test, false)
 			if err != nil {
 				return fmt.Errorf("failed to run test (%w)", err)
 			}
-			t, err := printTestResult(filteredResults, responses, rc, failOnly, detailedResults, test.Fs, resourcePath)
+			t, err := printTestResult(out, filteredResults, responses, rc, failOnly, detailedResults, test.Fs, resourcePath)
 			if err != nil {
 				return fmt.Errorf("failed to print test result (%w)", err)
 			}
@@ -132,14 +134,14 @@ func testCommandExecute(
 		}
 	}
 	if !failOnly {
-		fmt.Printf("\nTest Summary: %d tests passed and %d tests failed\n", rc.Pass+rc.Skip, rc.Fail)
+		fmt.Fprintf(out, "\nTest Summary: %d tests passed and %d tests failed\n", rc.Pass+rc.Skip, rc.Fail)
 	} else {
-		fmt.Printf("\nTest Summary: %d out of %d tests failed\n", rc.Fail, rc.Pass+rc.Skip+rc.Fail)
+		fmt.Fprintf(out, "\nTest Summary: %d out of %d tests failed\n", rc.Fail, rc.Pass+rc.Skip+rc.Fail)
 	}
-	fmt.Println()
+	fmt.Fprintln(out)
 	if rc.Fail > 0 {
 		if !failOnly {
-			printFailedTestResult(table, detailedResults)
+			printFailedTestResult(out, table, detailedResults)
 		}
 		return fmt.Errorf("%d tests failed", rc.Fail)
 	}

--- a/cmd/cli/kubectl-kyverno/commands/test/output.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/output.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/go-git/go-billy/v5"
 	policyreportv1alpha2 "github.com/kyverno/kyverno/api/policyreport/v1alpha2"
@@ -12,6 +13,7 @@ import (
 )
 
 func printTestResult(
+	out io.Writer,
 	tests []testapi.TestResult,
 	responses []engineapi.EngineResponse,
 	rc *resultCounts,
@@ -95,17 +97,17 @@ func printTestResult(
 			}
 		}
 	}
-	fmt.Printf("\n")
+	fmt.Fprintln(out)
 	printer.Print(resultsTable.Rows(detailedResults))
 	return resultsTable, nil
 }
 
-func printFailedTestResult(resultsTable table.Table, detailedResults bool) {
+func printFailedTestResult(out io.Writer, resultsTable table.Table, detailedResults bool) {
 	printer := table.NewTablePrinter()
 	for i := range resultsTable.RawRows {
 		resultsTable.RawRows[i].ID = i + 1
 	}
-	fmt.Printf("Aggregated Failed Test Cases : ")
-	fmt.Println()
+	fmt.Fprintf(out, "Aggregated Failed Test Cases : ")
+	fmt.Fprintln(out)
 	printer.Print(resultsTable.Rows(detailedResults))
 }

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -168,7 +168,7 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 			}
 			generateResponse := eng.ApplyBackgroundChecks(context.TODO(), policyContext)
 			if !generateResponse.IsEmpty() {
-				newRuleResponse, err := handleGeneratePolicy(&generateResponse, *policyContext, p.RuleToCloneSourceResource)
+				newRuleResponse, err := handleGeneratePolicy(p.Out, &generateResponse, *policyContext, p.RuleToCloneSourceResource)
 				if err != nil {
 					log.Log.Error(err, "failed to apply generate policy")
 				} else {

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor_test.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor_test.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"os"
 	"testing"
 
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/resource"
@@ -112,6 +113,7 @@ func Test_NamespaceSelector(t *testing.T) {
 			UserInfo:             nil,
 			NamespaceSelectorMap: tc.namespaceSelectorMap,
 			Rc:                   rc,
+			Out:                  os.Stdout,
 		}
 		processor.ApplyPoliciesOnResource()
 		assert.Equal(t, int64(rc.Pass()), int64(tc.result.pass))

--- a/cmd/cli/kubectl-kyverno/utils/common/kyverno_resources_types.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/kyverno_resources_types.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"io"
+
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	valuesapi "github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/apis/values"
 	"github.com/kyverno/kyverno/pkg/autogen"
@@ -13,7 +15,7 @@ type KyvernoResources struct {
 	policies []kyvernov1.PolicyInterface
 }
 
-func (r *KyvernoResources) FetchResourcesFromPolicy(resourcePaths []string, dClient dclient.Interface, namespace string, policyReport bool) ([]*unstructured.Unstructured, error) {
+func (r *KyvernoResources) FetchResourcesFromPolicy(out io.Writer, resourcePaths []string, dClient dclient.Interface, namespace string, policyReport bool) ([]*unstructured.Unstructured, error) {
 	var resources []*unstructured.Unstructured
 	var err error
 
@@ -35,7 +37,7 @@ func (r *KyvernoResources) FetchResourcesFromPolicy(resourcePaths []string, dCli
 		resourceTypes = append(resourceTypes, kind)
 	}
 
-	resources, err = whenClusterIsTrue(resourceTypes, subresourceMap, dClient, namespace, resourcePaths, policyReport)
+	resources, err = whenClusterIsTrue(out, resourceTypes, subresourceMap, dClient, namespace, resourcePaths, policyReport)
 
 	return resources, err
 }

--- a/cmd/cli/kubectl-kyverno/utils/common/validating_admission_resources.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/validating_admission_resources.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"io"
+
 	valuesapi "github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/apis/values"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"k8s.io/api/admissionregistration/v1alpha1"
@@ -12,7 +14,7 @@ type ValidatingAdmissionResources struct {
 	policies []v1alpha1.ValidatingAdmissionPolicy
 }
 
-func (r *ValidatingAdmissionResources) FetchResourcesFromPolicy(resourcePaths []string, dClient dclient.Interface, namespace string, policyReport bool) ([]*unstructured.Unstructured, error) {
+func (r *ValidatingAdmissionResources) FetchResourcesFromPolicy(out io.Writer, resourcePaths []string, dClient dclient.Interface, namespace string, policyReport bool) ([]*unstructured.Unstructured, error) {
 	var resources []*unstructured.Unstructured
 	var err error
 
@@ -35,6 +37,6 @@ func (r *ValidatingAdmissionResources) FetchResourcesFromPolicy(resourcePaths []
 		resourceTypes = append(resourceTypes, kind)
 	}
 
-	resources, err = whenClusterIsTrue(resourceTypes, subresourceMap, dClient, namespace, resourcePaths, policyReport)
+	resources, err = whenClusterIsTrue(out, resourceTypes, subresourceMap, dClient, namespace, resourcePaths, policyReport)
 	return resources, err
 }


### PR DESCRIPTION
## Explanation

This PR replaces fmt.Print calls by fmt.Fprint ones so that we can capture the output.
