### PR TITLE
fix: use app.kubernetes.io/name in kyverno manifests

### DIFF
--- a/charts/kyverno/templates/admission-controller/_helpers.tpl
+++ b/charts/kyverno/templates/admission-controller/_helpers.tpl
@@ -15,6 +15,7 @@
 {{- template "kyverno.labels.merge" (list
   (include "kyverno.matchLabels.common" .)
   (include "kyverno.labels.component" "admission-controller")
+  (include "kyverno.labels.name" "admission-controller")
 ) -}}
 {{- end -}}
 

--- a/charts/kyverno/templates/background-controller/_helpers.tpl
+++ b/charts/kyverno/templates/background-controller/_helpers.tpl
@@ -15,6 +15,7 @@
 {{- template "kyverno.labels.merge" (list
   (include "kyverno.matchLabels.common" .)
   (include "kyverno.labels.component" "background-controller")
+  (include "kyverno.labels.name" "background-controller")
 ) -}}
 {{- end -}}
 

--- a/charts/kyverno/templates/cleanup-controller/_helpers.tpl
+++ b/charts/kyverno/templates/cleanup-controller/_helpers.tpl
@@ -15,6 +15,7 @@
 {{- template "kyverno.labels.merge" (list
   (include "kyverno.matchLabels.common" .)
   (include "kyverno.labels.component" "cleanup-controller")
+  (include "kyverno.labels.name" "cleanup-controller")
 ) -}}
 {{- end -}}
 

--- a/charts/kyverno/templates/cleanup/_helpers.tpl
+++ b/charts/kyverno/templates/cleanup/_helpers.tpl
@@ -5,5 +5,6 @@
   (include "kyverno.labels.common" .)
   (include "kyverno.matchLabels.common" .)
   (include "kyverno.labels.component" "cleanup")
+  (include "kyverno.labels.name" "cleanup")
 ) -}}
 {{- end -}}

--- a/charts/kyverno/templates/config/_helpers.tpl
+++ b/charts/kyverno/templates/config/_helpers.tpl
@@ -27,6 +27,7 @@
 {{- template "kyverno.labels.merge" (list
   (include "kyverno.matchLabels.common" .)
   (include "kyverno.labels.component" "config")
+  (include "kyverno.labels.name" "config")
 ) -}}
 {{- end -}}
 

--- a/charts/kyverno/templates/crds/_helpers.tpl
+++ b/charts/kyverno/templates/crds/_helpers.tpl
@@ -11,5 +11,6 @@
 {{- template "kyverno.labels.merge" (list
   (include "kyverno.matchLabels.common" .)
   (include "kyverno.labels.component" "crds")
+  (include "kyverno.labels.name" "crds")
 ) -}}
 {{- end -}}

--- a/charts/kyverno/templates/hooks/_helpers.tpl
+++ b/charts/kyverno/templates/hooks/_helpers.tpl
@@ -11,5 +11,6 @@
 {{- template "kyverno.labels.merge" (list
   (include "kyverno.matchLabels.common" .)
   (include "kyverno.labels.component" "hooks")
+  (include "kyverno.labels.name" "hooks")
 ) -}}
 {{- end -}}

--- a/charts/kyverno/templates/rbac/_helpers.tpl
+++ b/charts/kyverno/templates/rbac/_helpers.tpl
@@ -20,6 +20,7 @@
 {{- template "kyverno.labels.merge" (list
   (include "kyverno.matchLabels.common" .)
   (include "kyverno.labels.component" "rbac")
+  (include "kyverno.labels.name" "rbac")
 ) -}}
 {{- end -}}
 

--- a/charts/kyverno/templates/reports-controller/_helpers.tpl
+++ b/charts/kyverno/templates/reports-controller/_helpers.tpl
@@ -15,6 +15,7 @@
 {{- template "kyverno.labels.merge" (list
   (include "kyverno.matchLabels.common" .)
   (include "kyverno.labels.component" "reports-controller")
+  (include "kyverno.labels.name" "reports-controller")
 ) -}}
 {{- end -}}
 

--- a/charts/kyverno/templates/tests/_helpers.tpl
+++ b/charts/kyverno/templates/tests/_helpers.tpl
@@ -11,6 +11,7 @@
 {{- template "kyverno.labels.merge" (list
   (include "kyverno.matchLabels.common" .)
   (include "kyverno.labels.component" "test")
+  (include "kyverno.labels.name" "test")
 ) -}}
 {{- end -}}
 


### PR DESCRIPTION
## Explanation
In helm chart label helpers, `kyverno.labels.name` is defined but it is never used. This PR uses this label in the manifests.
The defination of `kyverno.labels.name`:
```
{{- define "kyverno.labels.name" -}}
app.kubernetes.io/name: {{ . }}
{{- end -}}
```