### PR TITLE
fix: deep copy before validaitng

### DIFF
--- a/cmd/cli/kubectl-kyverno/policy/load.go
+++ b/cmd/cli/kubectl-kyverno/policy/load.go
@@ -104,7 +104,8 @@ func kubectlValidateLoader(bytes []byte) ([]kyvernov1.PolicyInterface, []v1alpha
 		if err != nil {
 			return nil, nil, err
 		}
-		if err := factory.Validate(untyped); err != nil {
+		// TODO remove DeepCopy when fixed upstream
+		if err := factory.Validate(untyped.DeepCopy()); err != nil {
 			return nil, nil, err
 		}
 		switch gvk {


### PR DESCRIPTION
## Explanation

This PR deep copies the resource before calling kubectl-validate validation (because it mutates the resource).
