### PR TITLE
fix: disables TUF by default

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -315,6 +315,7 @@ The chart values are organised per component.
 | features.registryClient.credentialHelpers | list | `["default","google","amazon","azure","github"]` | Enable registry client helpers |
 | features.reports.chunkSize | int | `1000` | Reports chunk size |
 | features.ttlController.reconciliationInterval | string | `"1m"` | Reconciliation interval for the label based cleanup manager |
+| features.tuf.enable | bool | `false` | Enable tuf |
 | features.tuf.root | string | `nil` | Tuf root |
 | features.tuf.mirror | string | `nil` | Tuf mirror |
 

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -75,6 +75,9 @@
   {{- $flags = append $flags (print "--ttlReconciliationInterval=" .reconciliationInterval) -}}
 {{- end -}}
 {{- with .tuf -}}
+  {{- with .enable -}}
+    {{- $flags = append $flags (print "--enableTuf"=" .) -}}
+  {{- end -}}
   {{- with .mirror -}}
     {{- $flags = append $flags (print "--tufMirror=" .) -}}
   {{- end -}}

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -76,7 +76,7 @@
 {{- end -}}
 {{- with .tuf -}}
   {{- with .enable -}}
-    {{- $flags = append $flags (print "--enableTuf"=" .) -}}
+    {{- $flags = append $flags (print "--enableTuf=" .) -}}
   {{- end -}}
   {{- with .mirror -}}
     {{- $flags = append $flags (print "--tufMirror=" .) -}}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -448,6 +448,8 @@ features:
     # -- Reconciliation interval for the label based cleanup manager
     reconciliationInterval: 1m
   tuf:
+    # -- Enable tuf
+    enable: false
     # -- Tuf root
     root:
     # -- Tuf mirror

--- a/cmd/internal/flag.go
+++ b/cmd/internal/flag.go
@@ -39,6 +39,7 @@ var (
 	enableConfigMapCaching bool
 	// cosign
 	imageSignatureRepository string
+	enableTUF                bool
 	tufMirror                string
 	tufRoot                  string
 	// registry client
@@ -101,7 +102,8 @@ func initDeferredLoadingFlags() {
 
 func initCosignFlags() {
 	flag.StringVar(&imageSignatureRepository, "imageSignatureRepository", "", "(DEPRECATED, will be removed in 1.12) Alternate repository for image signatures. Can be overridden per rule via `verifyImages.Repository`.")
-	flag.StringVar(&tufMirror, "tufMirror", tuf.DefaultRemoteRoot, "Alternate TUF mirror for sigstore. If left blank, public sigstore one is used for cosign verification..")
+	flag.BoolVar(&enableTUF, "enableTuf", false, "enable tuf for private sigstore deployments")
+	flag.StringVar(&tufMirror, "tufMirror", tuf.DefaultRemoteRoot, "Alternate TUF mirror for sigstore. If left blank, public sigstore one is used for cosign verification.")
 	flag.StringVar(&tufRoot, "tufRoot", "", "Alternate TUF root.json for sigstore. If left blank, public sigstore one is used for cosign verification.")
 }
 

--- a/cmd/internal/tuf.go
+++ b/cmd/internal/tuf.go
@@ -10,6 +10,10 @@ import (
 )
 
 func setupSigstoreTUF(ctx context.Context, logger logr.Logger) {
+	if !enableTUF {
+		return
+	}
+
 	logger = logger.WithName("sigstore-tuf").WithValues("tufroot", tufRoot, "tufmirror", tufMirror)
 	logger.Info("setup tuf client for sigstore...")
 	var tufRootBytes []byte

--- a/scripts/config/custom-sigstore/kyverno.yaml
+++ b/scripts/config/custom-sigstore/kyverno.yaml
@@ -1,5 +1,6 @@
 features:
   tuf:
+    enable: true
     root: "$(TUF_MIRROR)/root.json"
     mirror: "$(TUF_MIRROR)"
 


### PR DESCRIPTION
## Explanation

For a cluster in a private subnet with no internet, TUF will fail to initialize causing error, This PR adds a flag called enable TUF which is set to `false` by default.

Discussion: https://kubernetes.slack.com/archives/CLGR9BJU9/p1695369576794329?thread_ts=1695363064.424669&cid=CLGR9BJU9