### PR TITLE
fix: remove cronjobs from cleanup controller rbac

### DIFF
--- a/charts/kyverno/templates/cleanup-controller/clusterrole.yaml
+++ b/charts/kyverno/templates/cleanup-controller/clusterrole.yaml
@@ -54,17 +54,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - batch
-    resources:
-      - cronjobs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - update
-      - watch
-  - apiGroups:
       - ''
       - events.k8s.io
     resources:


### PR DESCRIPTION
## Explanation

This PR removes cronjobs from cleanup controller rbac.
