### PR TITLE
fix: creating ClusterAdmissionReports fails for resources with colon in name

### DIFF
--- a/pkg/utils/controller/metadata.go
+++ b/pkg/utils/controller/metadata.go
@@ -58,6 +58,14 @@ func SetAnnotation(obj metav1.Object, key, value string) {
 	obj.SetAnnotations(annotations)
 }
 
+func GetAnnotation(obj metav1.Object, key string) string {
+	labels := obj.GetAnnotations()
+	if labels == nil {
+		return ""
+	}
+	return labels[key]
+}
+
 func HasAnnotation(obj metav1.Object, key string) bool {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {

--- a/pkg/utils/controller/metadata.go
+++ b/pkg/utils/controller/metadata.go
@@ -59,11 +59,11 @@ func SetAnnotation(obj metav1.Object, key, value string) {
 }
 
 func GetAnnotation(obj metav1.Object, key string) string {
-	labels := obj.GetAnnotations()
-	if labels == nil {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
 		return ""
 	}
-	return labels[key]
+	return annotations[key]
 }
 
 func HasAnnotation(obj metav1.Object, key string) bool {

--- a/pkg/utils/report/labels.go
+++ b/pkg/utils/report/labels.go
@@ -21,11 +21,11 @@ import (
 const (
 	LabelDomain = "kyverno.io"
 	//	resource labels
-	LabelResourceHash      = "audit.kyverno.io/resource.hash"
-	LabelResourceUid       = "audit.kyverno.io/resource.uid"
-	LabelResourceGVR       = "audit.kyverno.io/resource.gvr"
-	LabelResourceNamespace = "audit.kyverno.io/resource.namespace"
-	LabelResourceName      = "audit.kyverno.io/resource.name"
+	LabelResourceHash           = "audit.kyverno.io/resource.hash"
+	LabelResourceUid            = "audit.kyverno.io/resource.uid"
+	LabelResourceGVR            = "audit.kyverno.io/resource.gvr"
+	AnnotationResourceNamespace = "audit.kyverno.io/resource.namespace"
+	AnnotationResourceName      = "audit.kyverno.io/resource.name"
 	//	policy labels
 	LabelDomainClusterPolicy             = "cpol.kyverno.io"
 	LabelDomainPolicy                    = "pol.kyverno.io"
@@ -99,8 +99,8 @@ func SetResourceGVR(report kyvernov1alpha2.ReportInterface, gvr schema.GroupVers
 }
 
 func SetResourceNamespaceAndName(report kyvernov1alpha2.ReportInterface, namespace, name string) {
-	controllerutils.SetLabel(report, LabelResourceNamespace, namespace)
-	controllerutils.SetLabel(report, LabelResourceName, name)
+	controllerutils.SetAnnotation(report, AnnotationResourceNamespace, namespace)
+	controllerutils.SetAnnotation(report, AnnotationResourceName, name)
 }
 
 func CalculateResourceHash(resource unstructured.Unstructured) string {
@@ -152,7 +152,7 @@ func GetResourceGVR(report metav1.Object) schema.GroupVersionResource {
 }
 
 func GetResourceNamespaceAndName(report kyvernov1alpha2.ReportInterface) (string, string) {
-	return controllerutils.GetLabel(report, LabelResourceNamespace), controllerutils.GetLabel(report, LabelResourceName)
+	return controllerutils.GetAnnotation(report, AnnotationResourceNamespace), controllerutils.GetLabel(report, AnnotationResourceName)
 }
 
 func GetResourceHash(report metav1.Object) string {

--- a/pkg/utils/report/labels.go
+++ b/pkg/utils/report/labels.go
@@ -152,7 +152,7 @@ func GetResourceGVR(report metav1.Object) schema.GroupVersionResource {
 }
 
 func GetResourceNamespaceAndName(report kyvernov1alpha2.ReportInterface) (string, string) {
-	return controllerutils.GetAnnotation(report, AnnotationResourceNamespace), controllerutils.GetLabel(report, AnnotationResourceName)
+	return controllerutils.GetAnnotation(report, AnnotationResourceNamespace), controllerutils.GetAnnotation(report, AnnotationResourceName)
 }
 
 func GetResourceHash(report metav1.Object) string {

--- a/pkg/utils/report/new.go
+++ b/pkg/utils/report/new.go
@@ -23,6 +23,7 @@ func NewAdmissionReport(namespace, name string, gvr schema.GroupVersionResource,
 	report.SetNamespace(namespace)
 	SetResourceUid(report, resource.GetUID())
 	SetResourceGVR(report, gvr)
+	SetResourceNamespaceAndName(report, resource.GetNamespace(), resource.GetName())
 	SetManagedByKyvernoLabel(report)
 	return report
 }

--- a/pkg/utils/report/new.go
+++ b/pkg/utils/report/new.go
@@ -23,7 +23,6 @@ func NewAdmissionReport(namespace, name string, gvr schema.GroupVersionResource,
 	report.SetNamespace(namespace)
 	SetResourceUid(report, resource.GetUID())
 	SetResourceGVR(report, gvr)
-	SetResourceNamespaceAndName(report, resource.GetNamespace(), resource.GetName())
 	SetManagedByKyvernoLabel(report)
 	return report
 }


### PR DESCRIPTION
## Explanation

This PR fixes: creating ClusterAdmissionReports fails for resources with colon in name.

## Related issue

Fixes #8011 
