### PR TITLE
refactor: get the last execution time from the cleanup policy interface

### DIFF
--- a/api/kyverno/v2alpha1/cleanup_policy_interface.go
+++ b/api/kyverno/v2alpha1/cleanup_policy_interface.go
@@ -1,6 +1,8 @@
 package v2alpha1
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -13,7 +15,8 @@ type CleanupPolicyInterface interface {
 	IsNamespaced() bool
 	GetSpec() *CleanupPolicySpec
 	GetStatus() *CleanupPolicyStatus
-	GetLastExecutionTime() metav1.Time
+	GetExecutionTime() (*time.Time, error)
+	GetNextExecutionTime(time.Time) (*time.Time, error)
 	Validate(sets.Set[string]) field.ErrorList
 	GetKind() string
 	GetAPIVersion() string

--- a/api/kyverno/v2alpha1/cleanup_policy_interface.go
+++ b/api/kyverno/v2alpha1/cleanup_policy_interface.go
@@ -13,6 +13,7 @@ type CleanupPolicyInterface interface {
 	IsNamespaced() bool
 	GetSpec() *CleanupPolicySpec
 	GetStatus() *CleanupPolicyStatus
+	GetLastExecutionTime() metav1.Time
 	Validate(sets.Set[string]) field.ErrorList
 	GetKind() string
 	GetAPIVersion() string

--- a/api/kyverno/v2alpha1/cleanup_policy_types.go
+++ b/api/kyverno/v2alpha1/cleanup_policy_types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v2alpha1
 
 import (
+	"time"
+
+	"github.com/aptible/supercronic/cronexpr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov2beta1 "github.com/kyverno/kyverno/api/kyverno/v2beta1"
 	datautils "github.com/kyverno/kyverno/pkg/utils/data"
@@ -58,9 +61,25 @@ func (p *CleanupPolicy) GetStatus() *CleanupPolicyStatus {
 	return &p.Status
 }
 
-// GetLastExecutionTime returns the last execution time of the policy
-func (p *CleanupPolicy) GetLastExecutionTime() metav1.Time {
-	return p.Status.LastExecutionTime
+// GetExecutionTime returns the execution time of the policy
+func (p *CleanupPolicy) GetExecutionTime() (*time.Time, error) {
+	lastExecutionTime := p.Status.LastExecutionTime.Time
+	if lastExecutionTime.IsZero() {
+		creationTime := p.GetCreationTimestamp().Time
+		return p.GetNextExecutionTime(creationTime)
+	} else {
+		return p.GetNextExecutionTime(lastExecutionTime)
+	}
+}
+
+// GetNextExecutionTime returns the next execution time of the policy
+func (p *CleanupPolicy) GetNextExecutionTime(time time.Time) (*time.Time, error) {
+	cronExpr, err := cronexpr.Parse(p.Spec.Schedule)
+	if err != nil {
+		return nil, err
+	}
+	nextExecutionTime := cronExpr.Next(time)
+	return &nextExecutionTime, nil
 }
 
 // Validate implements programmatic validation
@@ -128,9 +147,25 @@ func (p *ClusterCleanupPolicy) GetStatus() *CleanupPolicyStatus {
 	return &p.Status
 }
 
-// GetLastExecutionTime returns the last execution time of the policy
-func (p *ClusterCleanupPolicy) GetLastExecutionTime() metav1.Time {
-	return p.Status.LastExecutionTime
+// GetExecutionTime returns the execution time of the policy
+func (p *ClusterCleanupPolicy) GetExecutionTime() (*time.Time, error) {
+	lastExecutionTime := p.Status.LastExecutionTime.Time
+	if lastExecutionTime.IsZero() {
+		creationTime := p.GetCreationTimestamp().Time
+		return p.GetNextExecutionTime(creationTime)
+	} else {
+		return p.GetNextExecutionTime(lastExecutionTime)
+	}
+}
+
+// GetNextExecutionTime returns the next execution time of the policy
+func (p *ClusterCleanupPolicy) GetNextExecutionTime(time time.Time) (*time.Time, error) {
+	cronExpr, err := cronexpr.Parse(p.Spec.Schedule)
+	if err != nil {
+		return nil, err
+	}
+	nextExecutionTime := cronExpr.Next(time)
+	return &nextExecutionTime, nil
 }
 
 // GetKind returns the resource kind

--- a/api/kyverno/v2alpha1/cleanup_policy_types.go
+++ b/api/kyverno/v2alpha1/cleanup_policy_types.go
@@ -58,6 +58,11 @@ func (p *CleanupPolicy) GetStatus() *CleanupPolicyStatus {
 	return &p.Status
 }
 
+// GetLastExecutionTime returns the last execution time of the policy
+func (p *CleanupPolicy) GetLastExecutionTime() metav1.Time {
+	return p.Status.LastExecutionTime
+}
+
 // Validate implements programmatic validation
 func (p *CleanupPolicy) Validate(clusterResources sets.Set[string]) (errs field.ErrorList) {
 	errs = append(errs, kyvernov1.ValidatePolicyName(field.NewPath("metadata").Child("name"), p.Name)...)
@@ -121,6 +126,11 @@ func (p *ClusterCleanupPolicy) GetSpec() *CleanupPolicySpec {
 // GetStatus returns the policy status
 func (p *ClusterCleanupPolicy) GetStatus() *CleanupPolicyStatus {
 	return &p.Status
+}
+
+// GetLastExecutionTime returns the last execution time of the policy
+func (p *ClusterCleanupPolicy) GetLastExecutionTime() metav1.Time {
+	return p.Status.LastExecutionTime
 }
 
 // GetKind returns the resource kind

--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -334,7 +334,6 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 		return err
 	}
 
-	status := policy.GetStatus()
 	creationTime := policy.GetCreationTimestamp().Time
 	firstExecutionTime := cronExpr.Next(creationTime)
 
@@ -342,10 +341,11 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 	// In case it isn't the first execution of the cleanup policy.
 	if firstExecutionTime.Before(time.Now()) {
 		var executionTime time.Time
-		if status.LastExecutionTime.IsZero() {
+		lastExecutionTime := policy.GetLastExecutionTime()
+		if lastExecutionTime.IsZero() {
 			executionTime = firstExecutionTime
 		} else {
-			executionTime = cronExpr.Next(status.LastExecutionTime.Time)
+			executionTime = cronExpr.Next(lastExecutionTime.Time)
 		}
 		// In case it is the time to do the cleanup process
 		if time.Now().After(executionTime) {

--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/aptible/supercronic/cronexpr"
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov1beta1 "github.com/kyverno/kyverno/api/kyverno/v1beta1"
@@ -327,44 +326,23 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 		logger.Error(err, "unable to get the policy from policy informer")
 		return err
 	}
-	spec := policy.GetSpec()
-	cronExpr, err := cronexpr.Parse(spec.Schedule)
-	if err != nil {
-		logger.Error(err, "unable to parse the schedule")
-		return err
-	}
 
-	creationTime := policy.GetCreationTimestamp().Time
-	firstExecutionTime := cronExpr.Next(creationTime)
-
-	var nextExecutionTime time.Time
-	// In case it isn't the first execution of the cleanup policy.
-	if firstExecutionTime.Before(time.Now()) {
-		var executionTime time.Time
-		lastExecutionTime := policy.GetLastExecutionTime()
-		if lastExecutionTime.IsZero() {
-			executionTime = firstExecutionTime
-		} else {
-			executionTime = cronExpr.Next(lastExecutionTime.Time)
+	var nextExecutionTime *time.Time
+	executionTime, _ := policy.GetExecutionTime()
+	// In case it is the time to do the cleanup process
+	if time.Now().After(*executionTime) {
+		err := c.cleanup(ctx, logger, policy)
+		if err != nil {
+			return err
 		}
-		// In case it is the time to do the cleanup process
-		if time.Now().After(executionTime) {
-			err := c.cleanup(ctx, logger, policy)
-			if err != nil {
-				return err
-			}
-			c.updateCleanupPolicyStatus(ctx, policy, namespace, executionTime)
-			nextExecutionTime = cronExpr.Next(executionTime)
-		} else {
-			nextExecutionTime = executionTime
-		}
+		c.updateCleanupPolicyStatus(ctx, policy, namespace, *executionTime)
+		nextExecutionTime, _ = policy.GetNextExecutionTime(*executionTime)
 	} else {
-		// In case it is the first execution of the cleanup policy.
-		nextExecutionTime = firstExecutionTime
+		nextExecutionTime = executionTime
 	}
 
 	// calculate the remaining time until deletion.
-	timeRemaining := time.Until(nextExecutionTime)
+	timeRemaining := time.Until(*nextExecutionTime)
 	// add the item back to the queue after the remaining time.
 	c.queue.AddAfter(key, timeRemaining)
 	return nil

--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -328,7 +328,11 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 	}
 
 	var nextExecutionTime *time.Time
-	executionTime, _ := policy.GetExecutionTime()
+	executionTime, err := policy.GetExecutionTime()
+	if err != nil {
+		logger.Error(err, "failed to get the policy execution time")
+		return err
+	}
 	// In case it is the time to do the cleanup process
 	if time.Now().After(*executionTime) {
 		err := c.cleanup(ctx, logger, policy)
@@ -336,7 +340,11 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 			return err
 		}
 		c.updateCleanupPolicyStatus(ctx, policy, namespace, *executionTime)
-		nextExecutionTime, _ = policy.GetNextExecutionTime(*executionTime)
+		nextExecutionTime, err = policy.GetNextExecutionTime(*executionTime)
+		if err != nil {
+			logger.Error(err, "failed to get the policy next execution time")
+			return err
+		}
 	} else {
 		nextExecutionTime = executionTime
 	}


### PR DESCRIPTION
## Explanation
This PR adds a new function to the cleanup policy interface to get the last execution time.
