### PR TITLE
feat: generate events for CEL policies that generate VAPs

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -116,6 +116,7 @@ func createrLeaderControllers(
 	runtime runtimeutils.Runtime,
 	servicePort int32,
 	configuration config.Configuration,
+	eventGenerator event.Interface,
 ) ([]internal.Controller, func(context.Context) error, error) {
 	var leaderControllers []internal.Controller
 
@@ -188,6 +189,7 @@ func createrLeaderControllers(
 			kyvernoInformer.Kyverno().V1().ClusterPolicies(),
 			kubeInformer.Admissionregistration().V1alpha1().ValidatingAdmissionPolicies(),
 			kubeInformer.Admissionregistration().V1alpha1().ValidatingAdmissionPolicyBindings(),
+			eventGenerator,
 		)
 		leaderControllers = append(leaderControllers, internal.NewController(vapcontroller.ControllerName, vapController, vapcontroller.Workers))
 	}
@@ -409,6 +411,7 @@ func main() {
 				runtime,
 				int32(servicePort),
 				setup.Configuration,
+				eventGenerator,
 			)
 			if err != nil {
 				logger.Error(err, "failed to create leader controllers")

--- a/pkg/controllers/validatingadmissionpolicy-generate/controller.go
+++ b/pkg/controllers/validatingadmissionpolicy-generate/controller.go
@@ -11,11 +11,12 @@ import (
 	kyvernov1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/controllers"
+	"github.com/kyverno/kyverno/pkg/event"
 	"github.com/kyverno/kyverno/pkg/logging"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
 	datautils "github.com/kyverno/kyverno/pkg/utils/data"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
-	"k8s.io/api/admissionregistration/v1alpha1"
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	admissionregistrationv1alpha1informers "k8s.io/client-go/informers/admissionregistration/v1alpha1"
@@ -45,6 +46,8 @@ type controller struct {
 
 	// queue
 	queue workqueue.RateLimitingInterface
+
+	eventGen event.Interface
 }
 
 func NewController(
@@ -55,6 +58,7 @@ func NewController(
 	cpolInformer kyvernov1informers.ClusterPolicyInformer,
 	vapInformer admissionregistrationv1alpha1informers.ValidatingAdmissionPolicyInformer,
 	vapbindingInformer admissionregistrationv1alpha1informers.ValidatingAdmissionPolicyBindingInformer,
+	eventGen event.Interface,
 ) controllers.Controller {
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName)
 	c := &controller{
@@ -65,6 +69,7 @@ func NewController(
 		vapLister:        vapInformer.Lister(),
 		vapbindingLister: vapbindingInformer.Lister(),
 		queue:            queue,
+		eventGen:         eventGen,
 	}
 
 	// Set up an event handler for when Kyverno policies change
@@ -126,22 +131,22 @@ func (c *controller) enqueuePolicy(obj kyvernov1.PolicyInterface) {
 	c.queue.Add(key)
 }
 
-func (c *controller) addVAP(obj *v1alpha1.ValidatingAdmissionPolicy) {
+func (c *controller) addVAP(obj *admissionregistrationv1alpha1.ValidatingAdmissionPolicy) {
 	c.enqueueVAP(obj)
 }
 
-func (c *controller) updateVAP(old, obj *v1alpha1.ValidatingAdmissionPolicy) {
+func (c *controller) updateVAP(old, obj *admissionregistrationv1alpha1.ValidatingAdmissionPolicy) {
 	if datautils.DeepEqual(old.Spec, obj.Spec) {
 		return
 	}
 	c.enqueueVAP(obj)
 }
 
-func (c *controller) deleteVAP(obj *v1alpha1.ValidatingAdmissionPolicy) {
+func (c *controller) deleteVAP(obj *admissionregistrationv1alpha1.ValidatingAdmissionPolicy) {
 	c.enqueueVAP(obj)
 }
 
-func (c *controller) enqueueVAP(v *v1alpha1.ValidatingAdmissionPolicy) {
+func (c *controller) enqueueVAP(v *admissionregistrationv1alpha1.ValidatingAdmissionPolicy) {
 	if len(v.OwnerReferences) == 1 {
 		if v.OwnerReferences[0].Kind == "ClusterPolicy" {
 			cpol, err := c.cpolLister.Get(v.OwnerReferences[0].Name)
@@ -153,22 +158,22 @@ func (c *controller) enqueueVAP(v *v1alpha1.ValidatingAdmissionPolicy) {
 	}
 }
 
-func (c *controller) addVAPbinding(obj *v1alpha1.ValidatingAdmissionPolicyBinding) {
+func (c *controller) addVAPbinding(obj *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding) {
 	c.enqueueVAPbinding(obj)
 }
 
-func (c *controller) updateVAPbinding(old, obj *v1alpha1.ValidatingAdmissionPolicyBinding) {
+func (c *controller) updateVAPbinding(old, obj *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding) {
 	if datautils.DeepEqual(old.Spec, obj.Spec) {
 		return
 	}
 	c.enqueueVAPbinding(obj)
 }
 
-func (c *controller) deleteVAPbinding(obj *v1alpha1.ValidatingAdmissionPolicyBinding) {
+func (c *controller) deleteVAPbinding(obj *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding) {
 	c.enqueueVAPbinding(obj)
 }
 
-func (c *controller) enqueueVAPbinding(vb *v1alpha1.ValidatingAdmissionPolicyBinding) {
+func (c *controller) enqueueVAPbinding(vb *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding) {
 	if len(vb.OwnerReferences) == 1 {
 		if vb.OwnerReferences[0].Kind == "ClusterPolicy" {
 			cpol, err := c.cpolLister.Get(vb.OwnerReferences[0].Name)
@@ -188,7 +193,7 @@ func (c *controller) getClusterPolicy(name string) (*kyvernov1.ClusterPolicy, er
 	return cpolicy, nil
 }
 
-func (c *controller) getValidatingAdmissionPolicy(name string) (*v1alpha1.ValidatingAdmissionPolicy, error) {
+func (c *controller) getValidatingAdmissionPolicy(name string) (*admissionregistrationv1alpha1.ValidatingAdmissionPolicy, error) {
 	vap, err := c.vapLister.Get(name)
 	if err != nil {
 		return nil, err
@@ -196,7 +201,7 @@ func (c *controller) getValidatingAdmissionPolicy(name string) (*v1alpha1.Valida
 	return vap, nil
 }
 
-func (c *controller) getValidatingAdmissionPolicyBinding(name string) (*v1alpha1.ValidatingAdmissionPolicyBinding, error) {
+func (c *controller) getValidatingAdmissionPolicyBinding(name string) (*admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, error) {
 	vapbinding, err := c.vapbindingLister.Get(name)
 	if err != nil {
 		return nil, err
@@ -204,7 +209,7 @@ func (c *controller) getValidatingAdmissionPolicyBinding(name string) (*v1alpha1
 	return vapbinding, nil
 }
 
-func (c *controller) buildValidatingAdmissionPolicy(vap *v1alpha1.ValidatingAdmissionPolicy, cpol kyvernov1.PolicyInterface) error {
+func (c *controller) buildValidatingAdmissionPolicy(vap *admissionregistrationv1alpha1.ValidatingAdmissionPolicy, cpol kyvernov1.PolicyInterface) error {
 	// set owner reference
 	vap.OwnerReferences = []metav1.OwnerReference{
 		{
@@ -216,8 +221,8 @@ func (c *controller) buildValidatingAdmissionPolicy(vap *v1alpha1.ValidatingAdmi
 	}
 
 	// construct validating admission policy resource rules
-	var matchResources v1alpha1.MatchResources
-	var matchRules []v1alpha1.NamedRuleWithOperations
+	var matchResources admissionregistrationv1alpha1.MatchResources
+	var matchRules []admissionregistrationv1alpha1.NamedRuleWithOperations
 
 	rule := cpol.GetSpec().Rules[0]
 	match := rule.MatchResources
@@ -239,7 +244,7 @@ func (c *controller) buildValidatingAdmissionPolicy(vap *v1alpha1.ValidatingAdmi
 	}
 
 	// set validating admission policy spec
-	vap.Spec = v1alpha1.ValidatingAdmissionPolicySpec{
+	vap.Spec = admissionregistrationv1alpha1.ValidatingAdmissionPolicySpec{
 		MatchConstraints: &matchResources,
 		ParamKind:        rule.Validation.CEL.ParamKind,
 		Variables:        rule.Validation.CEL.Variables,
@@ -253,7 +258,7 @@ func (c *controller) buildValidatingAdmissionPolicy(vap *v1alpha1.ValidatingAdmi
 	return nil
 }
 
-func (c *controller) buildValidatingAdmissionPolicyBinding(vapbinding *v1alpha1.ValidatingAdmissionPolicyBinding, cpol kyvernov1.PolicyInterface) error {
+func (c *controller) buildValidatingAdmissionPolicyBinding(vapbinding *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, cpol kyvernov1.PolicyInterface) error {
 	// set owner reference
 	vapbinding.OwnerReferences = []metav1.OwnerReference{
 		{
@@ -265,18 +270,18 @@ func (c *controller) buildValidatingAdmissionPolicyBinding(vapbinding *v1alpha1.
 	}
 
 	// set validation action for vap binding
-	var validationActions []v1alpha1.ValidationAction
+	var validationActions []admissionregistrationv1alpha1.ValidationAction
 	action := cpol.GetSpec().ValidationFailureAction
 	if action.Enforce() {
-		validationActions = append(validationActions, v1alpha1.Deny)
+		validationActions = append(validationActions, admissionregistrationv1alpha1.Deny)
 	} else if action.Audit() {
-		validationActions = append(validationActions, v1alpha1.Audit)
-		validationActions = append(validationActions, v1alpha1.Warn)
+		validationActions = append(validationActions, admissionregistrationv1alpha1.Audit)
+		validationActions = append(validationActions, admissionregistrationv1alpha1.Warn)
 	}
 
 	// set validating admission policy binding spec
 	rule := cpol.GetSpec().Rules[0]
-	vapbinding.Spec = v1alpha1.ValidatingAdmissionPolicyBindingSpec{
+	vapbinding.Spec = admissionregistrationv1alpha1.ValidatingAdmissionPolicyBindingSpec{
 		PolicyName:        cpol.GetName(),
 		ParamRef:          rule.Validation.CEL.ParamRef,
 		ValidationActions: validationActions,
@@ -314,7 +319,7 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 			c.updateClusterPolicyStatus(ctx, *policy, false, err.Error())
 			return err
 		}
-		observedVAP = &v1alpha1.ValidatingAdmissionPolicy{
+		observedVAP = &admissionregistrationv1alpha1.ValidatingAdmissionPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: polName,
 			},
@@ -327,7 +332,7 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 			c.updateClusterPolicyStatus(ctx, *policy, false, err.Error())
 			return err
 		}
-		observedVAPbinding = &v1alpha1.ValidatingAdmissionPolicyBinding{
+		observedVAPbinding = &admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: polName + "-binding",
 			},
@@ -350,7 +355,7 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 			ctx,
 			observedVAP,
 			c.client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicies(),
-			func(observed *v1alpha1.ValidatingAdmissionPolicy) error {
+			func(observed *admissionregistrationv1alpha1.ValidatingAdmissionPolicy) error {
 				return c.buildValidatingAdmissionPolicy(observed, policy)
 			})
 		if err != nil {
@@ -375,7 +380,7 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 			ctx,
 			observedVAPbinding,
 			c.client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicyBindings(),
-			func(observed *v1alpha1.ValidatingAdmissionPolicyBinding) error {
+			func(observed *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding) error {
 				return c.buildValidatingAdmissionPolicyBinding(observed, policy)
 			})
 		if err != nil {
@@ -385,6 +390,9 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 	}
 
 	c.updateClusterPolicyStatus(ctx, *policy, true, "")
+	// generate events
+	e := event.NewValidatingAdmissionPolicyEvent(policy, observedVAP.Name, observedVAPbinding.Name)
+	c.eventGen.Add(e...)
 	return nil
 }
 

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -255,6 +255,34 @@ func NewCleanupPolicyEvent(policy kyvernov2alpha1.CleanupPolicyInterface, resour
 	}
 }
 
+func NewValidatingAdmissionPolicyEvent(policy kyvernov1.PolicyInterface, vapName, vapBindingName string) []Info {
+	vapEvent := Info{
+		Kind:              policy.GetKind(),
+		Namespace:         policy.GetNamespace(),
+		Name:              policy.GetName(),
+		RelatedAPIVersion: "admissionregistration.k8s.io/v1alpha1",
+		RelatedKind:       "ValidatingAdmissionPolicy",
+		RelatedName:       vapName,
+		Source:            GeneratePolicyController,
+		Action:            ResourceGenerated,
+		Reason:            PolicyApplied,
+		Message:           fmt.Sprintf("successfully generated validating admission policy %s from policy %s", vapName, policy.GetName()),
+	}
+	vapBindingEvent := Info{
+		Kind:              policy.GetKind(),
+		Namespace:         policy.GetNamespace(),
+		Name:              policy.GetName(),
+		RelatedAPIVersion: "admissionregistration.k8s.io/v1alpha1",
+		RelatedKind:       "ValidatingAdmissionPolicyBinding",
+		RelatedName:       vapBindingName,
+		Source:            GeneratePolicyController,
+		Action:            ResourceGenerated,
+		Reason:            PolicyApplied,
+		Message:           fmt.Sprintf("successfully generated validating admission policy binding %s from policy %s", vapBindingName, policy.GetName()),
+	}
+	return []Info{vapEvent, vapBindingEvent}
+}
+
 func NewFailedEvent(err error, policy, rule string, source Source, resource kyvernov1.ResourceSpec) Info {
 	return Info{
 		Kind:      resource.GetKind(),


### PR DESCRIPTION
## Explanation
This PR generates events for Kyverno policies that generates VAPs.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
None

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Create a cluster with `ValidatingAdmissionPolicy` feature gate enabled.
2. Enable `--generateValidatingAdmissionPolicy` in the admission controller.
3. Create a policy that uses CEL subrule:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-host-path
spec:
  validationFailureAction: Enforce
  background: true
  rules:
    - name: host-path
      match:
        any:
        - resources:
            kinds:
            - Deployment
            - StatefulSet
            operations:
            - CREATE
            - UPDATE
      validate:
        cel:
          expressions:
            - expression: "!has(object.spec.template.spec.volumes) || object.spec.template.spec.volumes.all(volume, !has(volume.hostPath))"
              message: "HostPath volumes are forbidden. The field spec.template.spec.volumes[*].hostPath must be unset."
```
4. Get the generated VAP and its binding:
```
$ kubectl get validatingadmissionpolicy
NAME                 VALIDATIONS   PARAMKIND   AGE
disallow-host-path   1             <unset>     5s
$ kubectl get validatingadmissionpolicybindings
NAME                         POLICYNAME           PARAMREF   AGE
disallow-host-path-binding   disallow-host-path   <unset>    10s
```
5. Run `kubectl describe cpol disallow-host-path`:
```
Events:
  Type    Reason         Age                From              Message
  ----    ------         ----               ----              -------
  Normal  PolicyApplied  16s (x2 over 16s)  kyverno-generate  successfully generated validating admission policy disallow-host-path from policy disallow-host-path
  Normal  PolicyApplied  16s (x2 over 16s)  kyverno-generate  successfully generated validating admission policy disallow-host-path from policy disallow-host-path
```
6. Run `kubectl get events.events.k8s.io `:
```
55s         Normal   PolicyApplied             clusterpolicy/disallow-host-path   successfully generated validating admission policy disallow-host-path from policy disallow-host-path
55s         Normal   PolicyApplied             clusterpolicy/disallow-host-path   successfully generated validating admission policy binding disallow-host-path-binding from policy disallow-host-path
```
7. Run `kubectl get events.events.k8s.io -o yaml`:
```
- action: Resource Generated
  apiVersion: events.k8s.io/v1
  deprecatedFirstTimestamp: null
  deprecatedLastTimestamp: null
  deprecatedSource: {}
  eventTime: "2023-10-01T11:02:04.240090Z"
  kind: Event
  metadata:
    creationTimestamp: "2023-10-01T11:02:04Z"
    name: disallow-host-path.1789f6d3ce39924e
    namespace: default
    resourceVersion: "4178"
    uid: f0fcad37-231e-4f6e-bf89-c372f9688a03
  note: successfully generated validating admission policy disallow-host-path from
    policy disallow-host-path
  reason: PolicyApplied
  regarding:
    apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    name: disallow-host-path
    resourceVersion: "4172"
    uid: 2b0aaf96-b7b7-4353-8350-4af83255d95d
  related:
    apiVersion: admissionregistration.k8s.io/v1alpha1
    kind: ValidatingAdmissionPolicy
    name: disallow-host-path
  reportingController: kyverno-generate
  reportingInstance: kyverno-generate-mariamfahmy
  series:
    count: 2
    lastObservedTime: "2023-10-01T11:02:04.249453Z"
  type: Normal
- action: Resource Generated
  apiVersion: events.k8s.io/v1
  deprecatedFirstTimestamp: null
  deprecatedLastTimestamp: null
  deprecatedSource: {}
  eventTime: "2023-10-01T11:02:04.240177Z"
  kind: Event
  metadata:
    creationTimestamp: "2023-10-01T11:02:04Z"
    name: disallow-host-path.1789f6d3ce3aa060
    namespace: default
    resourceVersion: "4179"
    uid: f159e89a-6cc0-411d-8414-ba5610190d21
  note: successfully generated validating admission policy binding disallow-host-path-binding
    from policy disallow-host-path
  reason: PolicyApplied
  regarding:
    apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    name: disallow-host-path
    resourceVersion: "4172"
    uid: 2b0aaf96-b7b7-4353-8350-4af83255d95d
  related:
    apiVersion: admissionregistration.k8s.io/v1alpha1
    kind: ValidatingAdmissionPolicyBinding
    name: disallow-host-path-binding
  reportingController: kyverno-generate
  reportingInstance: kyverno-generate-mariamfahmy
  series:
    count: 2
    lastObservedTime: "2023-10-01T11:02:04.249378Z"
  type: Normal
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
