### PR TITLE
refactor: use GetKind() from the cleanup policy interface

### DIFF
--- a/api/kyverno/v2alpha1/cleanup_policy_types.go
+++ b/api/kyverno/v2alpha1/cleanup_policy_types.go
@@ -91,7 +91,7 @@ func (p *CleanupPolicy) Validate(clusterResources sets.Set[string]) (errs field.
 
 // GetKind returns the resource kind
 func (p *CleanupPolicy) GetKind() string {
-	return p.Kind
+	return "CleanupPolicy"
 }
 
 // GetAPIVersion returns the resource kind
@@ -170,7 +170,7 @@ func (p *ClusterCleanupPolicy) GetNextExecutionTime(time time.Time) (*time.Time,
 
 // GetKind returns the resource kind
 func (p *ClusterCleanupPolicy) GetKind() string {
-	return p.Kind
+	return "ClusterCleanupPolicy"
 }
 
 // GetAPIVersion returns the resource kind

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -53,13 +53,6 @@ func buildPolicyEventMessage(resp engineapi.RuleResponse, resource engineapi.Res
 	return b.String()
 }
 
-func getCleanupPolicyKind(policy kyvernov2alpha1.CleanupPolicyInterface) string {
-	if policy.IsNamespaced() {
-		return "CleanupPolicy"
-	}
-	return "ClusterCleanupPolicy"
-}
-
 func NewPolicyAppliedEvent(source Source, engineResponse engineapi.EngineResponse) Info {
 	resource := engineResponse.Resource
 	var bldr strings.Builder
@@ -226,7 +219,7 @@ func NewPolicyExceptionEvents(engineResponse engineapi.EngineResponse, ruleResp 
 func NewCleanupPolicyEvent(policy kyvernov2alpha1.CleanupPolicyInterface, resource unstructured.Unstructured, err error) Info {
 	if err == nil {
 		return Info{
-			Kind:              getCleanupPolicyKind(policy),
+			Kind:              policy.GetKind(),
 			Namespace:         policy.GetNamespace(),
 			Name:              policy.GetName(),
 			RelatedAPIVersion: resource.GetAPIVersion(),
@@ -240,7 +233,7 @@ func NewCleanupPolicyEvent(policy kyvernov2alpha1.CleanupPolicyInterface, resour
 		}
 	} else {
 		return Info{
-			Kind:              getCleanupPolicyKind(policy),
+			Kind:              policy.GetKind(),
 			Namespace:         policy.GetNamespace(),
 			Name:              policy.GetName(),
 			RelatedAPIVersion: resource.GetAPIVersion(),


### PR DESCRIPTION
## Explanation
This PR uses `GetKind()` from the cleanup policy interface instead of creating a new function to get the kind in the events package.