### PR TITLE
feat: support pod security exemptions in policy exceptions

### DIFF
--- a/api/kyverno/v1/common_types.go
+++ b/api/kyverno/v1/common_types.go
@@ -416,6 +416,11 @@ type PodSecurity struct {
 	Exclude []PodSecurityStandard `json:"exclude,omitempty" yaml:"exclude,omitempty"`
 }
 
+// HasExclude checks if there is a Pod Security Standard controls to be excluded.
+func (p *PodSecurity) HasExclude() bool {
+	return len(p.Exclude) > 0
+}
+
 // PodSecurityStandard specifies the Pod Security Standard controls to be excluded.
 type PodSecurityStandard struct {
 	// ControlName specifies the name of the Pod Security Standard control.

--- a/api/kyverno/v2alpha1/policy_exception_types.go
+++ b/api/kyverno/v2alpha1/policy_exception_types.go
@@ -50,6 +50,11 @@ func (p *PolicyException) Contains(policy string, rule string) bool {
 	return p.Spec.Contains(policy, rule)
 }
 
+// HasPodSecurity checks if podSecurity controls is specified
+func (p *PolicyException) HasPodSecurity() bool {
+	return len(p.Spec.PodSecurity) > 0
+}
+
 // Exception stores infos about a policy and rules
 type Exception = kyvernov2beta1.Exception
 

--- a/api/kyverno/v2beta1/policy_exception_types.go
+++ b/api/kyverno/v2beta1/policy_exception_types.go
@@ -18,6 +18,7 @@ package v2beta1
 import (
 	"fmt"
 
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/engine/variables/regex"
 	"github.com/kyverno/kyverno/pkg/utils/wildcard"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,6 +58,11 @@ func (p *PolicyException) Contains(policy string, rule string) bool {
 	return p.Spec.Contains(policy, rule)
 }
 
+// HasPodSecurity checks if podSecurity controls is specified
+func (p *PolicyException) HasPodSecurity() bool {
+	return len(p.Spec.PodSecurity) > 0
+}
+
 // PolicyExceptionSpec stores policy exception spec
 type PolicyExceptionSpec struct {
 	// Background controls if exceptions are applied to existing policies during a background scan.
@@ -69,6 +75,11 @@ type PolicyExceptionSpec struct {
 
 	// Exceptions is a list policy/rules to be excluded
 	Exceptions []Exception `json:"exceptions" yaml:"exceptions"`
+
+	// PodSecurity specifies the Pod Security Standard controls to be excluded.
+	// Applicable only to policies that have validate.podSecurity subrule.
+	// +optional
+	PodSecurity []kyvernov1.PodSecurityStandard `json:"podSecurity,omitempty" yaml:"podSecurity,omitempty"`
 }
 
 func (p *PolicyExceptionSpec) BackgroundProcessingEnabled() bool {

--- a/api/kyverno/v2beta1/zz_generated.deepcopy.go
+++ b/api/kyverno/v2beta1/zz_generated.deepcopy.go
@@ -542,6 +542,13 @@ func (in *PolicyExceptionSpec) DeepCopyInto(out *PolicyExceptionSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.PodSecurity != nil {
+		in, out := &in.PodSecurity, &out.PodSecurity
+		*out = make([]kyvernov1.PodSecurityStandard, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/api/kyverno/v2beta1/zz_generated.deepcopy.go
+++ b/api/kyverno/v2beta1/zz_generated.deepcopy.go
@@ -544,7 +544,7 @@ func (in *PolicyExceptionSpec) DeepCopyInto(out *PolicyExceptionSpec) {
 	}
 	if in.PodSecurity != nil {
 		in, out := &in.PodSecurity, &out.PodSecurity
-		*out = make([]kyvernov1.PodSecurityStandard, len(*in))
+		*out = make([]v1.PodSecurityStandard, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/charts/kyverno/charts/crds/templates/crds.yaml
+++ b/charts/kyverno/charts/crds/templates/crds.yaml
@@ -41772,6 +41772,48 @@ spec:
                       type: object
                     type: array
                 type: object
+              podSecurity:
+                description: PodSecurity specifies the Pod Security Standard controls
+                  to be excluded. Applicable only to policies that have validate.podSecurity
+                  subrule.
+                items:
+                  description: PodSecurityStandard specifies the Pod Security Standard
+                    controls to be excluded.
+                  properties:
+                    controlName:
+                      description: 'ControlName specifies the name of the Pod Security
+                        Standard control. See: https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                      enum:
+                      - HostProcess
+                      - Host Namespaces
+                      - Privileged Containers
+                      - Capabilities
+                      - HostPath Volumes
+                      - Host Ports
+                      - AppArmor
+                      - SELinux
+                      - /proc Mount Type
+                      - Seccomp
+                      - Sysctls
+                      - Volume Types
+                      - Privilege Escalation
+                      - Running as Non-root
+                      - Running as Non-root user
+                      type: string
+                    images:
+                      description: 'Images selects matching containers and applies
+                        the container level PSS. Each image is the image name consisting
+                        of the registry address, repository, image, and tag. Empty
+                        list matches no containers, PSS checks are applied at the
+                        pod level only. Wildcards (''*'' and ''?'') are allowed. See:
+                        https://kubernetes.io/docs/concepts/containers/images.'
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - controlName
+                  type: object
+                type: array
             required:
             - exceptions
             - match
@@ -42271,6 +42313,48 @@ spec:
                       type: object
                     type: array
                 type: object
+              podSecurity:
+                description: PodSecurity specifies the Pod Security Standard controls
+                  to be excluded. Applicable only to policies that have validate.podSecurity
+                  subrule.
+                items:
+                  description: PodSecurityStandard specifies the Pod Security Standard
+                    controls to be excluded.
+                  properties:
+                    controlName:
+                      description: 'ControlName specifies the name of the Pod Security
+                        Standard control. See: https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                      enum:
+                      - HostProcess
+                      - Host Namespaces
+                      - Privileged Containers
+                      - Capabilities
+                      - HostPath Volumes
+                      - Host Ports
+                      - AppArmor
+                      - SELinux
+                      - /proc Mount Type
+                      - Seccomp
+                      - Sysctls
+                      - Volume Types
+                      - Privilege Escalation
+                      - Running as Non-root
+                      - Running as Non-root user
+                      type: string
+                    images:
+                      description: 'Images selects matching containers and applies
+                        the container level PSS. Each image is the image name consisting
+                        of the registry address, repository, image, and tag. Empty
+                        list matches no containers, PSS checks are applied at the
+                        pod level only. Wildcards (''*'' and ''?'') are allowed. See:
+                        https://kubernetes.io/docs/concepts/containers/images.'
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - controlName
+                  type: object
+                type: array
             required:
             - exceptions
             - match

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policyexceptions.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policyexceptions.yaml
@@ -509,6 +509,48 @@ spec:
                       type: object
                     type: array
                 type: object
+              podSecurity:
+                description: PodSecurity specifies the Pod Security Standard controls
+                  to be excluded. Applicable only to policies that have validate.podSecurity
+                  subrule.
+                items:
+                  description: PodSecurityStandard specifies the Pod Security Standard
+                    controls to be excluded.
+                  properties:
+                    controlName:
+                      description: 'ControlName specifies the name of the Pod Security
+                        Standard control. See: https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                      enum:
+                      - HostProcess
+                      - Host Namespaces
+                      - Privileged Containers
+                      - Capabilities
+                      - HostPath Volumes
+                      - Host Ports
+                      - AppArmor
+                      - SELinux
+                      - /proc Mount Type
+                      - Seccomp
+                      - Sysctls
+                      - Volume Types
+                      - Privilege Escalation
+                      - Running as Non-root
+                      - Running as Non-root user
+                      type: string
+                    images:
+                      description: 'Images selects matching containers and applies
+                        the container level PSS. Each image is the image name consisting
+                        of the registry address, repository, image, and tag. Empty
+                        list matches no containers, PSS checks are applied at the
+                        pod level only. Wildcards (''*'' and ''?'') are allowed. See:
+                        https://kubernetes.io/docs/concepts/containers/images.'
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - controlName
+                  type: object
+                type: array
             required:
             - exceptions
             - match
@@ -1008,6 +1050,48 @@ spec:
                       type: object
                     type: array
                 type: object
+              podSecurity:
+                description: PodSecurity specifies the Pod Security Standard controls
+                  to be excluded. Applicable only to policies that have validate.podSecurity
+                  subrule.
+                items:
+                  description: PodSecurityStandard specifies the Pod Security Standard
+                    controls to be excluded.
+                  properties:
+                    controlName:
+                      description: 'ControlName specifies the name of the Pod Security
+                        Standard control. See: https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                      enum:
+                      - HostProcess
+                      - Host Namespaces
+                      - Privileged Containers
+                      - Capabilities
+                      - HostPath Volumes
+                      - Host Ports
+                      - AppArmor
+                      - SELinux
+                      - /proc Mount Type
+                      - Seccomp
+                      - Sysctls
+                      - Volume Types
+                      - Privilege Escalation
+                      - Running as Non-root
+                      - Running as Non-root user
+                      type: string
+                    images:
+                      description: 'Images selects matching containers and applies
+                        the container level PSS. Each image is the image name consisting
+                        of the registry address, repository, image, and tag. Empty
+                        list matches no containers, PSS checks are applied at the
+                        pod level only. Wildcards (''*'' and ''?'') are allowed. See:
+                        https://kubernetes.io/docs/concepts/containers/images.'
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - controlName
+                  type: object
+                type: array
             required:
             - exceptions
             - match

--- a/config/crds/kyverno.io_policyexceptions.yaml
+++ b/config/crds/kyverno.io_policyexceptions.yaml
@@ -509,6 +509,48 @@ spec:
                       type: object
                     type: array
                 type: object
+              podSecurity:
+                description: PodSecurity specifies the Pod Security Standard controls
+                  to be excluded. Applicable only to policies that have validate.podSecurity
+                  subrule.
+                items:
+                  description: PodSecurityStandard specifies the Pod Security Standard
+                    controls to be excluded.
+                  properties:
+                    controlName:
+                      description: 'ControlName specifies the name of the Pod Security
+                        Standard control. See: https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                      enum:
+                      - HostProcess
+                      - Host Namespaces
+                      - Privileged Containers
+                      - Capabilities
+                      - HostPath Volumes
+                      - Host Ports
+                      - AppArmor
+                      - SELinux
+                      - /proc Mount Type
+                      - Seccomp
+                      - Sysctls
+                      - Volume Types
+                      - Privilege Escalation
+                      - Running as Non-root
+                      - Running as Non-root user
+                      type: string
+                    images:
+                      description: 'Images selects matching containers and applies
+                        the container level PSS. Each image is the image name consisting
+                        of the registry address, repository, image, and tag. Empty
+                        list matches no containers, PSS checks are applied at the
+                        pod level only. Wildcards (''*'' and ''?'') are allowed. See:
+                        https://kubernetes.io/docs/concepts/containers/images.'
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - controlName
+                  type: object
+                type: array
             required:
             - exceptions
             - match
@@ -1008,6 +1050,48 @@ spec:
                       type: object
                     type: array
                 type: object
+              podSecurity:
+                description: PodSecurity specifies the Pod Security Standard controls
+                  to be excluded. Applicable only to policies that have validate.podSecurity
+                  subrule.
+                items:
+                  description: PodSecurityStandard specifies the Pod Security Standard
+                    controls to be excluded.
+                  properties:
+                    controlName:
+                      description: 'ControlName specifies the name of the Pod Security
+                        Standard control. See: https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                      enum:
+                      - HostProcess
+                      - Host Namespaces
+                      - Privileged Containers
+                      - Capabilities
+                      - HostPath Volumes
+                      - Host Ports
+                      - AppArmor
+                      - SELinux
+                      - /proc Mount Type
+                      - Seccomp
+                      - Sysctls
+                      - Volume Types
+                      - Privilege Escalation
+                      - Running as Non-root
+                      - Running as Non-root user
+                      type: string
+                    images:
+                      description: 'Images selects matching containers and applies
+                        the container level PSS. Each image is the image name consisting
+                        of the registry address, repository, image, and tag. Empty
+                        list matches no containers, PSS checks are applied at the
+                        pod level only. Wildcards (''*'' and ''?'') are allowed. See:
+                        https://kubernetes.io/docs/concepts/containers/images.'
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - controlName
+                  type: object
+                type: array
             required:
             - exceptions
             - match

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -41995,6 +41995,48 @@ spec:
                       type: object
                     type: array
                 type: object
+              podSecurity:
+                description: PodSecurity specifies the Pod Security Standard controls
+                  to be excluded. Applicable only to policies that have validate.podSecurity
+                  subrule.
+                items:
+                  description: PodSecurityStandard specifies the Pod Security Standard
+                    controls to be excluded.
+                  properties:
+                    controlName:
+                      description: 'ControlName specifies the name of the Pod Security
+                        Standard control. See: https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                      enum:
+                      - HostProcess
+                      - Host Namespaces
+                      - Privileged Containers
+                      - Capabilities
+                      - HostPath Volumes
+                      - Host Ports
+                      - AppArmor
+                      - SELinux
+                      - /proc Mount Type
+                      - Seccomp
+                      - Sysctls
+                      - Volume Types
+                      - Privilege Escalation
+                      - Running as Non-root
+                      - Running as Non-root user
+                      type: string
+                    images:
+                      description: 'Images selects matching containers and applies
+                        the container level PSS. Each image is the image name consisting
+                        of the registry address, repository, image, and tag. Empty
+                        list matches no containers, PSS checks are applied at the
+                        pod level only. Wildcards (''*'' and ''?'') are allowed. See:
+                        https://kubernetes.io/docs/concepts/containers/images.'
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - controlName
+                  type: object
+                type: array
             required:
             - exceptions
             - match
@@ -42494,6 +42536,48 @@ spec:
                       type: object
                     type: array
                 type: object
+              podSecurity:
+                description: PodSecurity specifies the Pod Security Standard controls
+                  to be excluded. Applicable only to policies that have validate.podSecurity
+                  subrule.
+                items:
+                  description: PodSecurityStandard specifies the Pod Security Standard
+                    controls to be excluded.
+                  properties:
+                    controlName:
+                      description: 'ControlName specifies the name of the Pod Security
+                        Standard control. See: https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                      enum:
+                      - HostProcess
+                      - Host Namespaces
+                      - Privileged Containers
+                      - Capabilities
+                      - HostPath Volumes
+                      - Host Ports
+                      - AppArmor
+                      - SELinux
+                      - /proc Mount Type
+                      - Seccomp
+                      - Sysctls
+                      - Volume Types
+                      - Privilege Escalation
+                      - Running as Non-root
+                      - Running as Non-root user
+                      type: string
+                    images:
+                      description: 'Images selects matching containers and applies
+                        the container level PSS. Each image is the image name consisting
+                        of the registry address, repository, image, and tag. Empty
+                        list matches no containers, PSS checks are applied at the
+                        pod level only. Wildcards (''*'' and ''?'') are allowed. See:
+                        https://kubernetes.io/docs/concepts/containers/images.'
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - controlName
+                  type: object
+                type: array
             required:
             - exceptions
             - match

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -2807,7 +2807,8 @@ Allowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, v1.26, lates
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#kyverno.io/v1.PodSecurity">PodSecurity</a>)
+<a href="#kyverno.io/v1.PodSecurity">PodSecurity</a>, 
+<a href="#kyverno.io/v2beta1.PolicyExceptionSpec">PolicyExceptionSpec</a>)
 </p>
 <p>
 <p>PodSecurityStandard specifies the Pod Security Standard controls to be excluded.</p>
@@ -5806,6 +5807,21 @@ MatchResources
 <p>Exceptions is a list policy/rules to be excluded</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>podSecurity</code><br/>
+<em>
+<a href="#kyverno.io/v1.PodSecurityStandard">
+[]PodSecurityStandard
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PodSecurity specifies the Pod Security Standard controls to be excluded.
+Applicable only to policies that have validate.podSecurity subrule.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -6753,6 +6769,21 @@ MatchResources
 <p>Exceptions is a list policy/rules to be excluded</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>podSecurity</code><br/>
+<em>
+<a href="#kyverno.io/v1.PodSecurityStandard">
+[]PodSecurityStandard
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PodSecurity specifies the Pod Security Standard controls to be excluded.
+Applicable only to policies that have validate.podSecurity subrule.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -7372,6 +7403,21 @@ MatchResources
 </td>
 <td>
 <p>Exceptions is a list policy/rules to be excluded</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podSecurity</code><br/>
+<em>
+<a href="#kyverno.io/v1.PodSecurityStandard">
+[]PodSecurityStandard
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PodSecurity specifies the Pod Security Standard controls to be excluded.
+Applicable only to policies that have validate.podSecurity subrule.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/client/applyconfigurations/kyverno/v2beta1/policyexceptionspec.go
+++ b/pkg/client/applyconfigurations/kyverno/v2beta1/policyexceptionspec.go
@@ -18,12 +18,17 @@ limitations under the License.
 
 package v2beta1
 
+import (
+	v1 "github.com/kyverno/kyverno/pkg/client/applyconfigurations/kyverno/v1"
+)
+
 // PolicyExceptionSpecApplyConfiguration represents an declarative configuration of the PolicyExceptionSpec type for use
 // with apply.
 type PolicyExceptionSpecApplyConfiguration struct {
-	Background *bool                             `json:"background,omitempty"`
-	Match      *MatchResourcesApplyConfiguration `json:"match,omitempty"`
-	Exceptions []ExceptionApplyConfiguration     `json:"exceptions,omitempty"`
+	Background  *bool                                      `json:"background,omitempty"`
+	Match       *MatchResourcesApplyConfiguration          `json:"match,omitempty"`
+	Exceptions  []ExceptionApplyConfiguration              `json:"exceptions,omitempty"`
+	PodSecurity []v1.PodSecurityStandardApplyConfiguration `json:"podSecurity,omitempty"`
 }
 
 // PolicyExceptionSpecApplyConfiguration constructs an declarative configuration of the PolicyExceptionSpec type for use with
@@ -57,6 +62,19 @@ func (b *PolicyExceptionSpecApplyConfiguration) WithExceptions(values ...*Except
 			panic("nil value passed to WithExceptions")
 		}
 		b.Exceptions = append(b.Exceptions, *values[i])
+	}
+	return b
+}
+
+// WithPodSecurity adds the given value to the PodSecurity field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the PodSecurity field.
+func (b *PolicyExceptionSpecApplyConfiguration) WithPodSecurity(values ...*v1.PodSecurityStandardApplyConfiguration) *PolicyExceptionSpecApplyConfiguration {
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithPodSecurity")
+		}
+		b.PodSecurity = append(b.PodSecurity, *values[i])
 	}
 	return b
 }

--- a/pkg/engine/api/ruleresponse.go
+++ b/pkg/engine/api/ruleresponse.go
@@ -5,6 +5,7 @@ import (
 
 	kyvernov2beta1 "github.com/kyverno/kyverno/api/kyverno/v2beta1"
 	pssutils "github.com/kyverno/kyverno/pkg/pss/utils"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/pod-security-admission/api"
@@ -18,6 +19,8 @@ type PodSecurityChecks struct {
 	Version string
 	// Checks contains check result details
 	Checks []pssutils.PSSCheckResult
+	// Pod is the pod on which the pod security control is applied
+	Pod corev1.Pod
 }
 
 // RuleResponse details for each rule application

--- a/pkg/engine/background.go
+++ b/pkg/engine/background.go
@@ -60,10 +60,13 @@ func (e *engine) filterRule(
 		ruleType = engineapi.Generation
 	}
 
-	// check if there is a corresponding policy exception
-	ruleResp := e.hasPolicyExceptions(logger, ruleType, policyContext, rule)
-	if ruleResp != nil {
-		return ruleResp
+	// get policy exceptions that matches both policy and rule name
+	preprocessExceptions, _, _ := e.GetPolicyExceptions(policyContext.Policy(), rule.Name)
+	// preprocess policy exceptions that match the incoming resource if exists
+	if len(preprocessExceptions) != 0 {
+		if ruleResp := PreprocessPolicyExceptions(logger, ruleType, preprocessExceptions, policyContext, rule); ruleResp != nil {
+			return ruleResp
+		}
 	}
 
 	newResource := policyContext.NewResource()

--- a/pkg/engine/handlers/validation/validate_pss.go
+++ b/pkg/engine/handlers/validation/validate_pss.go
@@ -52,6 +52,7 @@ func (h validatePssHandler) Process(
 		Level:   podSecurity.Level,
 		Version: podSecurity.Version,
 		Checks:  pssChecks,
+		Pod:     *pod,
 	}
 	if allowed {
 		msg := fmt.Sprintf("Validation rule '%s' passed.", rule.Name)
@@ -111,7 +112,7 @@ func getSpec(resource unstructured.Unstructured) (podSpec *corev1.PodSpec, metad
 		metadata = &pod.ObjectMeta
 		return podSpec, metadata, nil
 	} else {
-		return nil, nil, fmt.Errorf("Could not find correct resource type")
+		return nil, nil, fmt.Errorf("could not find correct resource type")
 	}
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Explanation
This PR adds the support of excluding pod security control names in policy exceptions.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #6224 

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.12.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/kind feature

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
1. Adding podsecurity in policy exceptions spec as follows:
```
type PolicyExceptionSpec struct {
        // PodSecurity specifies the Pod Security Standard controls to be excluded.
	// Applicable only to policies that have validate.podSecurity subrule.
	// +optional
	PodSecurity []kyvernov1.PodSecurityStandard `json:"podSecurity,omitempty" yaml:"podSecurity,omitempty"`
}
```
2. Policy exceptions that use `spec.podSecurity` needs to be processed after applying the actual policy to the pod. However, processing all exceptions at the end may cause a performance issue i.e. consuming more resources. Therefore all policy exceptions will be applied at the beginning except those who use `spec.podSecurity`.


<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Create a cluster policy:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: psa
spec:
  background: true
  validationFailureAction: Enforce
  rules:
  - name: restricted
    match:
      any:
      - resources:
          kinds:
          - Pod
    validate:
      podSecurity:
        level: restricted
        version: latest
```
2. Create two namespaces: `policy-exception-ns` and `staging-ns`.
3. Create a policy exception in `policy-exception-ns` namespace:
```
apiVersion: kyverno.io/v2alpha1
kind: PolicyException
metadata:
  name: pod-security-exception
  namespace: policy-exception-ns
spec:
  exceptions:
  - policyName: psa
    ruleNames:
    - restricted
  match:
    any:
    - resources:
        namespaces:
        - staging-ns
  podSecurity:
    - controlName: Capabilities
      images:
          - nginx*
          - redis*
```
The above policy exception will allow the creation of any Pod that violates the `Capabilities` in case:
-  The pod image is either `nginx*` or `redis*`.
   AND
-  The pod namespace is `staging-ns`.
4. Create a pod that matches the policy exception and violates the rule:
```
apiVersion: v1
kind: Pod
metadata:
  name: goodpod01
  namespace: staging-ns
spec:
  containers:
  - name: container01
    image: nginx:1.1.9
    securityContext:
      allowPrivilegeEscalation: false
      runAsNonRoot: true
      seccompProfile:
        type: RuntimeDefault
      capabilities:
        add:
        - SYS_ADMIN
        drop:
        - ALL
```
The pod is successfully created!

5. Get events:
```
kubectl get events
LAST SEEN   TYPE      REASON            OBJECT              MESSAGE
24m         Normal    PolicySkipped     clusterpolicy/psa   resource Pod/staging-ns/goodpod01 was skipped from rule restricted due to policy exception policy-exception-ns/pod-security-exception

kubectl get events -n policy-exception-ns 
LAST SEEN   TYPE     REASON          OBJECT                                   MESSAGE
25m         Normal   PolicySkipped   policyexception/pod-security-exception   resource Pod/staging-ns/goodpod01 was skipped from policy rule psa/restricted
```
6. Create the same pod but in the `default` namespace:
```
apiVersion: v1
kind: Pod
metadata:
  name: badpod01
  namespace: default
spec:
  containers:
  - name: container01
    image: nginx:1.1.9
    securityContext:
      allowPrivilegeEscalation: false
      runAsNonRoot: true
      seccompProfile:
        type: RuntimeDefault
      capabilities:
        add:
        - SYS_ADMIN
        drop:
        - ALL
```
The pod creation fails:
```
Error from server: error when creating "STDIN": admission webhook "validate.kyverno.svc-fail" denied the request: 

resource Pod/default/badpod01 was blocked due to the following policies 

psa:
  restricted: |
    Validation rule 'restricted' failed. It violates PodSecurity "restricted:latest": ({Allowed:false ForbiddenReason:non-default capabilities ForbiddenDetail:container "container01" must not include "SYS_ADMIN" in securityContext.capabilities.add})
    ({Allowed:false ForbiddenReason:unrestricted capabilities ForbiddenDetail:container "container01" must not include "SYS_ADMIN" in securityContext.capabilities.add})
```

7. Create another pod in `staging-ns` but with a `busybox:1.28` image:
```
apiVersion: v1
kind: Pod
metadata:
  name: badpod02
  namespace: staging-ns
spec:
  containers:
  - name: container01
    image: busybox:1.28
    securityContext:
      allowPrivilegeEscalation: false
      runAsNonRoot: true
      seccompProfile:
        type: RuntimeDefault
      capabilities:
        add:
        - SYS_ADMIN
        drop:
        - ALL
```
The pod creation fails:
```
Error from server: error when creating "STDIN": admission webhook "validate.kyverno.svc-fail" denied the request: 

resource Pod/staging-ns/badpod02 was blocked due to the following policies 

psa:
  restricted: |
    Validation rule 'restricted' failed. It violates PodSecurity "restricted:latest": ({Allowed:false ForbiddenReason:non-default capabilities ForbiddenDetail:container "container01" must not include "SYS_ADMIN" in securityContext.capabilities.add})
    ({Allowed:false ForbiddenReason:unrestricted capabilities ForbiddenDetail:container "container01" must not include "SYS_ADMIN" in securityContext.capabilities.add})
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
