### PR TITLE
fix: use v2beta1 of policy exceptions

### DIFF
--- a/api/kyverno/v2alpha1/policy_exception_types.go
+++ b/api/kyverno/v2alpha1/policy_exception_types.go
@@ -26,7 +26,6 @@ import (
 // +genclient
 // +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=polex,categories=kyverno
 
 // PolicyException declares resources to be excluded from specified policies.

--- a/api/kyverno/v2beta1/policy_exception_types.go
+++ b/api/kyverno/v2beta1/policy_exception_types.go
@@ -28,6 +28,7 @@ import (
 // +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=polex,categories=kyverno
+// +kubebuilder:storageversion
 
 // PolicyException declares resources to be excluded from specified policies.
 type PolicyException struct {

--- a/charts/kyverno/templates/crds/crds.yaml
+++ b/charts/kyverno/templates/crds/crds.yaml
@@ -39312,7 +39312,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
   - name: v2beta1
     schema:
       openAPIV3Schema:
@@ -39811,7 +39811,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policyexceptions.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policyexceptions.yaml
@@ -516,7 +516,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
   - name: v2beta1
     schema:
       openAPIV3Schema:
@@ -1015,4 +1015,4 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true

--- a/cmd/internal/engine.go
+++ b/cmd/internal/engine.go
@@ -63,7 +63,7 @@ func NewExceptionSelector(
 	var exceptionsLister engineapi.PolicyExceptionSelector
 	if enablePolicyException {
 		factory := kyvernoinformer.NewSharedInformerFactory(kyvernoClient, resyncPeriod)
-		lister := factory.Kyverno().V2alpha1().PolicyExceptions().Lister()
+		lister := factory.Kyverno().V2beta1().PolicyExceptions().Lister()
 		if exceptionNamespace != "" {
 			exceptionsLister = lister.PolicyExceptions(exceptionNamespace)
 		} else {

--- a/config/crds/kyverno.io_policyexceptions.yaml
+++ b/config/crds/kyverno.io_policyexceptions.yaml
@@ -516,7 +516,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
   - name: v2beta1
     schema:
       openAPIV3Schema:
@@ -1015,4 +1015,4 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -39515,7 +39515,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
   - name: v2beta1
     schema:
       openAPIV3Schema:
@@ -40014,7 +40014,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/pkg/engine/api/ruleresponse.go
+++ b/pkg/engine/api/ruleresponse.go
@@ -3,7 +3,7 @@ package api
 import (
 	"fmt"
 
-	kyvernov2alpha1 "github.com/kyverno/kyverno/api/kyverno/v2alpha1"
+	kyvernov2beta1 "github.com/kyverno/kyverno/api/kyverno/v2beta1"
 	pssutils "github.com/kyverno/kyverno/pkg/pss/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -43,7 +43,7 @@ type RuleResponse struct {
 	// podSecurityChecks contains pod security checks (only if this is a pod security rule)
 	podSecurityChecks *PodSecurityChecks
 	// exception is the exception applied (if any)
-	exception *kyvernov2alpha1.PolicyException
+	exception *kyvernov2beta1.PolicyException
 }
 
 func NewRuleResponse(name string, ruleType RuleType, msg string, status RuleStatus) *RuleResponse {
@@ -78,7 +78,7 @@ func RuleFail(name string, ruleType RuleType, msg string) *RuleResponse {
 	return NewRuleResponse(name, ruleType, msg, RuleStatusFail)
 }
 
-func (r RuleResponse) WithException(exception *kyvernov2alpha1.PolicyException) *RuleResponse {
+func (r RuleResponse) WithException(exception *kyvernov2beta1.PolicyException) *RuleResponse {
 	r.exception = exception
 	return &r
 }
@@ -109,7 +109,7 @@ func (r *RuleResponse) Stats() ExecutionStats {
 	return r.stats
 }
 
-func (r *RuleResponse) Exception() *kyvernov2alpha1.PolicyException {
+func (r *RuleResponse) Exception() *kyvernov2beta1.PolicyException {
 	return r.exception
 }
 

--- a/pkg/engine/api/selector.go
+++ b/pkg/engine/api/selector.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	kyvernov2alpha1 "github.com/kyverno/kyverno/api/kyverno/v2alpha1"
+	kyvernov2beta1 "github.com/kyverno/kyverno/api/kyverno/v2beta1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -14,4 +14,4 @@ type NamespacedResourceSelector[T any] interface {
 }
 
 // PolicyExceptionSelector is an abstract interface used to resolve poliicy exceptions
-type PolicyExceptionSelector = NamespacedResourceSelector[*kyvernov2alpha1.PolicyException]
+type PolicyExceptionSelector = NamespacedResourceSelector[*kyvernov2beta1.PolicyException]

--- a/pkg/engine/exceptions.go
+++ b/pkg/engine/exceptions.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
-	kyvernov2alpha1 "github.com/kyverno/kyverno/api/kyverno/v2alpha1"
+	kyvernov2beta1 "github.com/kyverno/kyverno/api/kyverno/v2beta1"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	matched "github.com/kyverno/kyverno/pkg/utils/match"
 	"k8s.io/apimachinery/pkg/labels"
@@ -16,7 +16,7 @@ func findExceptions(
 	selector engineapi.PolicyExceptionSelector,
 	policy kyvernov1.PolicyInterface,
 	rule string,
-) ([]*kyvernov2alpha1.PolicyException, error) {
+) ([]*kyvernov2beta1.PolicyException, error) {
 	if selector == nil {
 		return nil, nil
 	}
@@ -24,7 +24,7 @@ func findExceptions(
 	if err != nil {
 		return nil, err
 	}
-	var result []*kyvernov2alpha1.PolicyException
+	var result []*kyvernov2beta1.PolicyException
 	policyName, err := cache.MetaNamespaceKeyFunc(policy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute policy key: %w", err)
@@ -42,7 +42,7 @@ func matchesException(
 	selector engineapi.PolicyExceptionSelector,
 	policyContext engineapi.PolicyContext,
 	rule kyvernov1.Rule,
-) (*kyvernov2alpha1.PolicyException, error) {
+) (*kyvernov2beta1.PolicyException, error) {
 	candidates, err := findExceptions(selector, policyContext.Policy(), rule.Name)
 	if err != nil {
 		return nil, err

--- a/pkg/webhooks/resource/fake.go
+++ b/pkg/webhooks/resource/fake.go
@@ -39,7 +39,7 @@ func NewFakeHandlers(ctx context.Context, policyCache policycache.Cache) webhook
 	dclient := dclient.NewEmptyFakeClient()
 	configuration := config.NewDefaultConfiguration(false)
 	urLister := kyvernoInformers.Kyverno().V1beta1().UpdateRequests().Lister().UpdateRequests(config.KyvernoNamespace())
-	peLister := kyvernoInformers.Kyverno().V2alpha1().PolicyExceptions().Lister()
+	peLister := kyvernoInformers.Kyverno().V2beta1().PolicyExceptions().Lister()
 	jp := jmespath.New(configuration)
 	rclient := registryclient.NewOrDie()
 


### PR DESCRIPTION
## Explanation
This PR uses `v2beta` version of policy exceptions in the code.
Closes #8582 