### PR TITLE
feat: add `!` operator in image reference

### DIFF
--- a/pkg/utils/wildcard/match.go
+++ b/pkg/utils/wildcard/match.go
@@ -1,9 +1,14 @@
 package wildcard
 
 import (
+	"strings"
+
 	wildcard "github.com/IGLOU-EU/go-wildcard"
 )
 
 func Match(pattern, name string) bool {
+	if strings.HasPrefix(pattern, "!") {
+		return !Match(strings.TrimPrefix(pattern, "!"), name)
+	}
 	return wildcard.Match(pattern, name)
 }

--- a/pkg/utils/wildcard/match_test.go
+++ b/pkg/utils/wildcard/match_test.go
@@ -347,6 +347,60 @@ func TestMatch(t *testing.T) {
 			text:    "my-bucket/mnopqanda",
 			matched: false,
 		},
+		// Test case 53.
+		{
+			pattern: "!my-bucket/abc?",
+			text:    "my-bucket/abcde",
+			matched: true,
+		},
+		// Test case 54.
+		{
+			pattern: "!my-bucket/oo*",
+			text:    "my-bucket/odo",
+			matched: true,
+		},
+		// Test case 55.
+		{
+			pattern: "!*",
+			text:    "s3:GetObject",
+			matched: false,
+		},
+		// Test case 56.
+		{
+			pattern: "!my-bucket/In*",
+			text:    "my-bucket/Karnataka/India/",
+			matched: true,
+		},
+		// Test case 57.
+		{
+			pattern: "!!my-bucket/abc?",
+			text:    "my-bucket/abcde",
+			matched: false,
+		},
+		// Test case 58.
+		{
+			pattern: "!!my-bucket/oo*",
+			text:    "my-bucket/odo",
+			matched: false,
+		},
+		// Test case 59.
+		{
+			pattern: "!!*",
+			text:    "s3:GetObject",
+			matched: true,
+		},
+		// Test case 60.
+		{
+			pattern: "!!my-bucket/In*",
+			text:    "my-bucket/Karnataka/India/",
+			matched: false,
+		},
+		// Test case 61.
+		{
+			pattern: "!!!*",
+			text:    "s3:GetObject",
+			matched: false,
+		},
 	}
 	// Iterating over the test cases, call the function under test and asert the output.
 	for _, testCase := range testCases {


### PR DESCRIPTION
## Explanation

This PR does the following
* Allows image references of pattern `!my-bucket/oo*`, `!my-bucket/abc?`
* Adds tests