### PR TITLE
deps: bump to Go 1.21.3

### DIFF
--- a/.github/actions/setup-build-env/action.yaml
+++ b/.github/actions/setup-build-env/action.yaml
@@ -28,7 +28,7 @@ runs:
         git fetch --prune --unshallow
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: ~1.21.1
+        go-version: ~1.21.3
     - shell: bash
       run: |
         go mod download


### PR DESCRIPTION
Bump Go version due to https://github.com/golang/go/issues/63417.