### PR TITLE
feat: use ubuntu:22.04 in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest@sha256:d24fc795ac86ab8e488a65bfd6695169655f3a43cbec59205121b594cde0c41b
+FROM ubuntu:22.04@sha256:965fbcae990b0467ed5657caceaec165018ef44a4d2d46c7cdea80a9dff0d1ea
 
 RUN apt-get update && apt-get install -y sudo git curl apt-transport-https ca-certificates gnupg-agent software-properties-common
 ARG USERNAME=root
@@ -6,17 +6,17 @@ RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
 # Install Golang
-RUN curl -LO https://dl.google.com/go/go1.20.linux-amd64.tar.gz \
-    && tar -C /usr/local -xzf go1.20.linux-amd64.tar.gz \
-    && rm go1.20.linux-amd64.tar.gz \
+RUN curl -LO https://dl.google.com/go/go1.21.3.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go1.21.3.linux-amd64.tar.gz \
+    && rm go1.21.3.linux-amd64.tar.gz \
     && echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile
 
 # Install Docker
 # Install Docker
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 RUN echo \
-  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+    "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 RUN apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io
 
 # Install kubectl and Minikube


### PR DESCRIPTION
## Explanation

Using latest ubuntu image in dev containers can cause an error where `containerd.io` and `docker-ce-cli` are not found. 

This can be because docker's internal repos are not supported on latest by that time.

Similar issue: https://stackoverflow.com/questions/61401626/docker-installation-failed-on-ubuntu-20-04-ltsvmware

This PR:
- Downgrades to Ubuntu:22.04
- Bumps golang in dev container to 1.21.3 like in CI. 

Related discussion: https://kubernetes.slack.com/archives/CLGR9BJU9/p1697190012878899
