### PR TITLE
feat: adds ci test for building devcontainer image

### DIFF
--- a/.github/workflows/devcontainer-build.yaml
+++ b/.github/workflows/devcontainer-build.yaml
@@ -3,9 +3,10 @@ name: Build devcontainer
 permissions: {}
 
 on:
-  push:
+  pull_request:
     branches:
-      - '*'
+      - 'main'
+      - 'release*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/devcontainer-build.yaml
+++ b/.github/workflows/devcontainer-build.yaml
@@ -1,4 +1,4 @@
-name: Build images
+name: Build devcontainer
 
 permissions: {}
 

--- a/.github/workflows/devcontainer-build.yaml
+++ b/.github/workflows/devcontainer-build.yaml
@@ -1,0 +1,29 @@
+name: Build images
+
+permissions: {}
+
+on:
+  push:
+    branches:
+      - '*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  devcontainer-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Build devcontainer image
+        run: docker build .devcontainer   
+      - name: Trivy Scan Image
+        uses: aquasecurity/trivy-action@fbd16365eb88e12433951383f5e99bd901fc618f # v0.12.0
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
## Explanation

PRs that upgrade the dev container base image needs to be tested manually.

Example: PR https://github.com/kyverno/kyverno/pull/8667 will cause [issues in devcontainer](https://github.com/kyverno/kyverno/pull/8667#issuecomment-1766384940) but there is no way to detect that right now. This PR adds a workflow that builds .devcontainer docker file from the current branch