### PR TITLE
remove duplicated log messages

### DIFF
--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -1665,7 +1665,7 @@ func Test_ImageNormalize(t *testing.T) {
 			assert.NilError(t, err)
 			result, err := jp.Search("")
 			if tc.wantErr {
-				assert.Error(t, err, "JMESPath function 'image_normalize': bad image: docker.io/: invalid reference format")
+				assert.Error(t, err, "JMESPath function 'image_normalize': bad image: docker.io/, defaultRegistry: docker.io, enableDefaultRegistryMutation: true: invalid reference format")
 			} else {
 				assert.NilError(t, err)
 				res, ok := result.(string)

--- a/pkg/utils/image/infos.go
+++ b/pkg/utils/image/infos.go
@@ -6,10 +6,7 @@ import (
 
 	"github.com/distribution/distribution/reference"
 	"github.com/kyverno/kyverno/pkg/config"
-	"github.com/kyverno/kyverno/pkg/logging"
 )
-
-var logger = logging.WithName("image")
 
 type ImageInfo struct {
 	// Registry is the URL address of the image registry e.g. `docker.io`
@@ -51,17 +48,11 @@ func (i *ImageInfo) ReferenceWithTag() string {
 }
 
 func GetImageInfo(image string, cfg config.Configuration) (*ImageInfo, error) {
-	logger.V(3).Info(
-		"getting the image info",
-		"image", image,
-		"defaultRegistry", config.Configuration.GetDefaultRegistry(cfg),
-		"enableDefaultRegistryMutation", config.Configuration.GetEnableDefaultRegistryMutation(cfg),
-	)
 	// adding the default domain in order to properly parse image info
 	fullImageName := addDefaultRegistry(image, cfg)
 	ref, err := reference.Parse(fullImageName)
 	if err != nil {
-		return nil, fmt.Errorf("bad image: %s: %w", fullImageName, err)
+		return nil, fmt.Errorf("bad image: %s, defaultRegistry: %s, enableDefaultRegistryMutation: %t: %w", fullImageName, config.Configuration.GetDefaultRegistry(cfg), config.Configuration.GetEnableDefaultRegistryMutation(cfg), err)
 	}
 
 	var registry, path, name, tag, digest string
@@ -85,16 +76,6 @@ func GetImageInfo(image string, cfg config.Configuration) (*ImageInfo, error) {
 	if fullImageName != image && !config.Configuration.GetEnableDefaultRegistryMutation(cfg) {
 		registry = ""
 	}
-
-	logger.V(3).Info(
-		"getting the image info",
-		"image", image,
-		"registry", registry,
-		"name", name,
-		"path", path,
-		"tag", tag,
-		"digest", digest,
-	)
 
 	return &ImageInfo{
 		Registry: registry,


### PR DESCRIPTION
## Explanation
This PR removes duplicated log messages in the `images` package.
Before removing them, we got the following:
```
I1017 16:33:00.060754  103178 infos.go:54] image "msg"="getting the image info" "defaultRegistry"="docker.io" "enableDefaultRegistryMutation"=true "image"="registry.k8s.io/coredns/coredns:v1.10.1"
I1017 16:33:00.060836  103178 infos.go:89] image "msg"="getting the image info" "digest"="" "image"="registry.k8s.io/coredns/coredns:v1.10.1" "name"="coredns" "path"="coredns/coredns" "registry"="registry.k8s.io" "tag"="v1.10.1"
I1017 16:33:00.060972  103178 context.go:299]  "msg"="updated image info" "images"={"containers":{"coredns":{"registry":"registry.k8s.io","name":"coredns","path":"coredns/coredns","tag":"v1.10.1","jsonPointer":"/spec/containers/0/image"}}}
```
After its removal, we will have only the following:
```
I1017 16:33:00.060972  103178 context.go:299]  "msg"="updated image info" "images"={"containers":{"coredns":{"registry":"registry.k8s.io","name":"coredns","path":"coredns/coredns","tag":"v1.10.1","jsonPointer":"/spec/containers/0/image"}}}
```
