### PR TITLE
feat: add arm64 support in devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04@sha256:965fbcae990b0467ed5657caceaec165018ef44a4d2d46c7cdea80a9dff0d1ea
+FROM ubuntu:22.04@sha256:2b7412e6465c3c7fc5bb21d3e6f1917c167358449fecac8176c6e496e5c1f05f
 
 RUN apt-get update && apt-get install -y sudo git curl apt-transport-https ca-certificates gnupg-agent software-properties-common
 ARG USERNAME=root
@@ -6,24 +6,26 @@ RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
 # Install Golang
-RUN curl -LO https://dl.google.com/go/go1.21.3.linux-amd64.tar.gz \
-    && tar -C /usr/local -xzf go1.21.3.linux-amd64.tar.gz \
-    && rm go1.21.3.linux-amd64.tar.gz \
+RUN ARCH="$(dpkg --print-architecture)"; \
+    curl -LO https://dl.google.com/go/go1.21.3.linux-$ARCH.tar.gz \
+    && tar -C /usr/local -xzf go1.21.3.linux-$ARCH.tar.gz \
+    && rm go1.21.3.linux-$ARCH.tar.gz \
     && echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile
 
 # Install Docker
 # Install Docker
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 RUN echo \
-    "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
     $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 RUN apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io
 
 # Install kubectl and Minikube
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+RUN ARCH="$(dpkg --print-architecture)"; \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/$ARCH/kubectl \
     && chmod +x kubectl && mv kubectl /usr/local/bin/ \
-    && curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 \
-    && install minikube-linux-amd64 /usr/local/bin/minikube \
+    && curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-$ARCH \
+    && install minikube-linux-$ARCH /usr/local/bin/minikube \
     && minikube config set driver docker
 
 # Expose ports for Minikube and Docker


### PR DESCRIPTION
## Explanation

Using devcontainer in `arm64` can sometimes cause the following error:

```bash
 => ERROR [7/8] RUN apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io                                                                                                                   4.4s 
------                                                                                                                                                                                                                
 > [7/8] RUN apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io:                                                                                                                              
1.982 Hit:1 http://ports.ubuntu.com/ubuntu-ports jammy InRelease
2.132 Hit:2 http://ports.ubuntu.com/ubuntu-ports jammy-updates InRelease
2.296 Hit:3 http://ports.ubuntu.com/ubuntu-ports jammy-backports InRelease
2.459 Hit:4 http://ports.ubuntu.com/ubuntu-ports jammy-security InRelease
2.869 Get:5 https://download.docker.com/linux/ubuntu jammy InRelease [48.9 kB]
3.199 Get:6 https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages [25.4 kB]
3.235 Fetched 74.3 kB in 3s (25.4 kB/s)
3.235 Reading package lists...
3.747 Reading package lists...
4.205 Building dependency tree...
4.326 Reading state information...
4.378 Package docker-ce is not available, but is referred to by another package.
4.378 This may mean that the package is missing, has been obsoleted, or
4.378 is only available from another source
4.378 However the following packages replace it:
4.378   docker-ce-cli:amd64
4.378 
```

This PR updates the devcontainer docker file to be platform independent