### PR TITLE
fix: allow cleanup controller to update the policy status

### DIFF
--- a/charts/kyverno/templates/cleanup-controller/clusterrole.yaml
+++ b/charts/kyverno/templates/cleanup-controller/clusterrole.yaml
@@ -46,6 +46,13 @@ rules:
       - list
       - watch
   - apiGroups:
+      - kyverno.io
+    resources:
+      - clustercleanuppolicies/status
+      - cleanuppolicies/status
+    verbs:
+      - update
+  - apiGroups:
       - ''
     resources:
       - configmaps

--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -340,7 +340,10 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 		if err != nil {
 			return err
 		}
-		c.updateCleanupPolicyStatus(ctx, policy, namespace, *executionTime)
+		if err := c.updateCleanupPolicyStatus(ctx, policy, namespace, *executionTime); err != nil {
+			logger.Error(err, "failed to update the cleanup policy status")
+			return err
+		}
 		nextExecutionTime, err = policy.GetNextExecutionTime(*executionTime)
 		if err != nil {
 			logger.Error(err, "failed to get the policy next execution time")
@@ -357,19 +360,26 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 	return nil
 }
 
-func (c *controller) updateCleanupPolicyStatus(ctx context.Context, policy kyvernov2alpha1.CleanupPolicyInterface, namespace string, time time.Time) {
+func (c *controller) updateCleanupPolicyStatus(ctx context.Context, policy kyvernov2alpha1.CleanupPolicyInterface, namespace string, time time.Time) error {
 	switch obj := policy.(type) {
 	case *kyvernov2beta1.ClusterCleanupPolicy:
 		latest := obj.DeepCopy()
-		latest.Status.LastExecutionTime.Time = time
+		latest.Status.LastExecutionTime = metav1.NewTime(time)
 
-		new, _ := c.kyvernoClient.KyvernoV2beta1().ClusterCleanupPolicies().UpdateStatus(ctx, latest, metav1.UpdateOptions{})
+		new, err := c.kyvernoClient.KyvernoV2beta1().ClusterCleanupPolicies().UpdateStatus(ctx, latest, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
 		logging.V(3).Info("updated cluster cleanup policy status", "name", policy.GetName(), "status", new.Status)
 	case *kyvernov2beta1.CleanupPolicy:
 		latest := obj.DeepCopy()
-		latest.Status.LastExecutionTime.Time = time
+		latest.Status.LastExecutionTime = metav1.NewTime(time)
 
-		new, _ := c.kyvernoClient.KyvernoV2beta1().CleanupPolicies(namespace).UpdateStatus(ctx, latest, metav1.UpdateOptions{})
+		new, err := c.kyvernoClient.KyvernoV2beta1().CleanupPolicies(namespace).UpdateStatus(ctx, latest, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
 		logging.V(3).Info("updated cleanup policy status", "name", policy.GetName(), "namespace", policy.GetNamespace(), "status", new.Status)
 	}
+	return nil
 }


### PR DESCRIPTION
## Explanation
This PR gives the cleanup controller the permissions to update the cleanup policy status. 
Without this fix, a thousands of logged messages were displayed continuously due to the fact that the `status.lastExecutionTime` has a value of `null` and it is never updated so the cleanup policy is continuously fired.

Here are the logs that indicate the sucessful update of `status.lastExecutionTime`:
```
I1018 11:36:00.161080       1 controller.go:376]  "msg"="updated cluster cleanup policy status" "name"="clean-bare-pods" "status"={"lastExecutionTime":"2023-10-18T11:36:00Z"}
I1018 11:21:00.159747       1 controller.go:93] cleanup-controller "msg"="updated" "kind"="ClusterCleanupPolicy" "name"="clean-bare-pods" "operation"="updated"
```
From the policy itself:
```
status:
  lastExecutionTime: "2023-10-18T11:36:00Z"
```
Related issue: #8593