### PR TITLE
fix: use correct k8s version in custom sigstore tuf kuttl test

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -550,13 +550,13 @@ jobs:
               - custom-sigstore
         k8s-version:
           - name: v1.25
-            version: v1.25.11
+            version: v1.25.x
           - name: v1.26
-            version: v1.26.6
+            version: v1.26.x
           - name: v1.27
-            version: v1.27.3
+            version: v1.27.x
           - name: v1.28
-            version: v1.28.0
+            version: v1.28.x
         tests:
           - custom-sigstore
     needs: prepare-images
@@ -575,6 +575,10 @@ jobs:
         timeout-minutes: 10
       - name: Create kind cluster and setup Sigstore Scaffolding
         uses: sigstore/scaffolding/actions/setup@d120ad89e1f5c9d4a0bbd92959c6874be2a2131d
+        with:
+          version: 'v0.6.8'
+          k8s-version: ${{ matrix.k8s-version.version }}
+          knative-version: '1.10.0'
       - name: Create TUF values config map
         run: |
           kubectl create namespace kyverno


### PR DESCRIPTION
## Explanation

 I was not passing the k8s version in TUF scaffolding step and it as defaulting to v1.24.x. This PR fixes that