### PR TITLE
fix: display a message when the controller has no permissions for VAPs

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -222,17 +222,16 @@ func main() {
 	var (
 		// TODO: this has been added to backward support command line arguments
 		// will be removed in future and the configuration will be set only via configmaps
-		serverIP                          string
-		webhookTimeout                    int
-		maxQueuedEvents                   int
-		omitEvents                        string
-		autoUpdateWebhooks                bool
-		webhookRegistrationTimeout        time.Duration
-		admissionReports                  bool
-		dumpPayload                       bool
-		servicePort                       int
-		backgroundServiceAccountName      string
-		generateValidatingAdmissionPolicy bool
+		serverIP                     string
+		webhookTimeout               int
+		maxQueuedEvents              int
+		omitEvents                   string
+		autoUpdateWebhooks           bool
+		webhookRegistrationTimeout   time.Duration
+		admissionReports             bool
+		dumpPayload                  bool
+		servicePort                  int
+		backgroundServiceAccountName string
 	)
 	flagset := flag.NewFlagSet("kyverno", flag.ExitOnError)
 	flagset.BoolVar(&dumpPayload, "dumpPayload", false, "Set this flag to activate/deactivate debug mode.")
@@ -244,8 +243,8 @@ func main() {
 	flagset.DurationVar(&webhookRegistrationTimeout, "webhookRegistrationTimeout", 120*time.Second, "Timeout for webhook registration, e.g., 30s, 1m, 5m.")
 	flagset.Func(toggle.ProtectManagedResourcesFlagName, toggle.ProtectManagedResourcesDescription, toggle.ProtectManagedResources.Parse)
 	flagset.Func(toggle.ForceFailurePolicyIgnoreFlagName, toggle.ForceFailurePolicyIgnoreDescription, toggle.ForceFailurePolicyIgnore.Parse)
+	flagset.Func(toggle.GenerateValidatingAdmissionPolicyFlagName, toggle.GenerateValidatingAdmissionPolicyDescription, toggle.GenerateValidatingAdmissionPolicy.Parse)
 	flagset.BoolVar(&admissionReports, "admissionReports", true, "Enable or disable admission reports.")
-	flagset.BoolVar(&generateValidatingAdmissionPolicy, "generateValidatingAdmissionPolicy", false, "Set this flag 'true' to generate validating admission policies.")
 	flagset.IntVar(&servicePort, "servicePort", 443, "Port used by the Kyverno Service resource and for webhook configurations.")
 	flagset.StringVar(&backgroundServiceAccountName, "backgroundServiceAccountName", "", "Background service account name.")
 	flagset.StringVar(&caSecretName, "caSecretName", "", "Name of the secret containing CA.")
@@ -283,6 +282,7 @@ func main() {
 		os.Exit(1)
 	}
 	// check if validating admission policies are registered in the API server
+	generateValidatingAdmissionPolicy := toggle.FromContext(context.TODO()).GenerateValidatingAdmissionPolicy()
 	if generateValidatingAdmissionPolicy {
 		groupVersion := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1alpha1"}
 		if _, err := setup.KyvernoDynamicClient.GetKubeClient().Discovery().ServerResourcesForGroupVersion(groupVersion.String()); err != nil {

--- a/pkg/controllers/validatingadmissionpolicy-generate/controller.go
+++ b/pkg/controllers/validatingadmissionpolicy-generate/controller.go
@@ -314,13 +314,13 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 	}
 
 	if !c.vapPermissions {
-		logger.Info("doesn't have required permissions for generating validating admission policies")
-		c.updateClusterPolicyStatus(ctx, *policy, false, "doesn't have required permissions for generating validating admission policies")
+		logger.Info("doesn't have required permissions for generating ValidatingAdmissionPolicies")
+		c.updateClusterPolicyStatus(ctx, *policy, false, "doesn't have required permissions for generating ValidatingAdmissionPolicies")
 		return nil
 	}
 	if !c.vapbindingPermissions {
-		logger.Info("doesn't have required permissions for generating validating admission policy bindings")
-		c.updateClusterPolicyStatus(ctx, *policy, false, "doesn't have required permissions for generating validating admission policy bindings")
+		logger.Info("doesn't have required permissions for generating ValidatingAdmissionPolicyBindings")
+		c.updateClusterPolicyStatus(ctx, *policy, false, "doesn't have required permissions for generating ValidatingAdmissionPolicyBindings")
 		return nil
 	}
 

--- a/pkg/toggle/context.go
+++ b/pkg/toggle/context.go
@@ -10,6 +10,7 @@ type Toggles interface {
 	ProtectManagedResources() bool
 	ForceFailurePolicyIgnore() bool
 	EnableDeferredLoading() bool
+	GenerateValidatingAdmissionPolicy() bool
 }
 
 type defaultToggles struct{}
@@ -24,6 +25,10 @@ func (defaultToggles) ForceFailurePolicyIgnore() bool {
 
 func (defaultToggles) EnableDeferredLoading() bool {
 	return EnableDeferredLoading.enabled()
+}
+
+func (defaultToggles) GenerateValidatingAdmissionPolicy() bool {
+	return GenerateValidatingAdmissionPolicy.enabled()
 }
 
 type contextKey struct{}

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -21,12 +21,18 @@ const (
 	EnableDeferredLoadingDescription = "enable deferred loading of context variables"
 	enableDeferredLoadingEnvVar      = "FLAG_ENABLE_DEFERRED_LOADING"
 	defaultEnableDeferredLoading     = true
+	// generate validating admission policies
+	GenerateValidatingAdmissionPolicyFlagName    = "generateValidatingAdmissionPolicy"
+	GenerateValidatingAdmissionPolicyDescription = "Set the flag to 'true', to generate validating admission policies."
+	generateValidatingAdmissionPolicyEnvVar      = "FLAG_GENERATE_VALIDATING_ADMISSION_POLICY"
+	defaultGenerateValidatingAdmissionPolicy     = false
 )
 
 var (
-	ProtectManagedResources  = newToggle(defaultProtectManagedResources, protectManagedResourcesEnvVar)
-	ForceFailurePolicyIgnore = newToggle(defaultForceFailurePolicyIgnore, forceFailurePolicyIgnoreEnvVar)
-	EnableDeferredLoading    = newToggle(defaultEnableDeferredLoading, enableDeferredLoadingEnvVar)
+	ProtectManagedResources           = newToggle(defaultProtectManagedResources, protectManagedResourcesEnvVar)
+	ForceFailurePolicyIgnore          = newToggle(defaultForceFailurePolicyIgnore, forceFailurePolicyIgnoreEnvVar)
+	EnableDeferredLoading             = newToggle(defaultEnableDeferredLoading, enableDeferredLoadingEnvVar)
+	GenerateValidatingAdmissionPolicy = newToggle(defaultGenerateValidatingAdmissionPolicy, generateValidatingAdmissionPolicyEnvVar)
 )
 
 type ToggleFlag interface {

--- a/pkg/utils/validatingadmissionpolicy/permissions.go
+++ b/pkg/utils/validatingadmissionpolicy/permissions.go
@@ -7,12 +7,24 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// HasRequiredPermissions check if the admission controller has the required permissions to generate both
-// validating admission policies and their bindings.
-func HasRequiredPermissions(resource schema.GroupVersionResource, s checker.AuthChecker) bool {
+func hasPermissions(resource schema.GroupVersionResource, s checker.AuthChecker) bool {
 	can, err := checker.Check(context.TODO(), s, resource.Group, resource.Version, resource.Resource, "", "", "create", "update", "list", "delete")
 	if err != nil {
 		return false
 	}
 	return can
+}
+
+// HasValidatingAdmissionPolicyPermission check if the admission controller has the required permissions to generate
+// Kubernetes ValidatingAdmissionPolicy
+func HasValidatingAdmissionPolicyPermission(s checker.AuthChecker) bool {
+	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "validatingadmissionpolicies"}
+	return hasPermissions(gvr, s)
+}
+
+// HasValidatingAdmissionPolicyBindingPermission check if the admission controller has the required permissions to generate
+// Kubernetes ValidatingAdmissionPolicyBinding
+func HasValidatingAdmissionPolicyBindingPermission(s checker.AuthChecker) bool {
+	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "validatingadmissionpolicybindings"}
+	return hasPermissions(gvr, s)
 }

--- a/pkg/utils/validatingadmissionpolicy/permissions.go
+++ b/pkg/utils/validatingadmissionpolicy/permissions.go
@@ -1,0 +1,18 @@
+package validatingadmissionpolicy
+
+import (
+	"context"
+
+	"github.com/kyverno/kyverno/pkg/auth/checker"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// HasRequiredPermissions check if the admission controller has the required permissions to generate both
+// validating admission policies and their bindings.
+func HasRequiredPermissions(resource schema.GroupVersionResource, s checker.AuthChecker) bool {
+	can, err := checker.Check(context.TODO(), s, resource.Group, resource.Version, resource.Resource, "", "", "create", "update", "list", "delete")
+	if err != nil {
+		return false
+	}
+	return can
+}

--- a/pkg/validation/policy/actions.go
+++ b/pkg/validation/policy/actions.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/policy/validate"
 	"github.com/kyverno/kyverno/pkg/toggle"
 	"github.com/kyverno/kyverno/pkg/utils/validatingadmissionpolicy"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // Validation provides methods to validate a rule
@@ -51,16 +50,12 @@ func validateActions(idx int, rule *kyvernov1.Rule, client dclient.Interface, mo
 		if toggle.FromContext(context.TODO()).GenerateValidatingAdmissionPolicy() {
 			authCheck := authChecker.NewSelfChecker(client.GetKubeClient().AuthorizationV1().SelfSubjectAccessReviews())
 			// check if the controller has the required permissions to generate validating admission policies.
-			gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "validatingadmissionpolicies"}
-			vapPermissions := validatingadmissionpolicy.HasRequiredPermissions(gvr, authCheck)
-			if !vapPermissions {
+			if !validatingadmissionpolicy.HasValidatingAdmissionPolicyPermission(authCheck) {
 				return "doesn't have required permissions for generating ValidatingAdmissionPolicies", nil
 			}
 
 			// check if the controller has the required permissions to generate validating admission policy bindings.
-			gvr = schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "validatingadmissionpolicybindings"}
-			vapbindingPermissions := validatingadmissionpolicy.HasRequiredPermissions(gvr, authCheck)
-			if !vapbindingPermissions {
+			if !validatingadmissionpolicy.HasValidatingAdmissionPolicyBindingPermission(authCheck) {
 				return "doesn't have required permissions for generating ValidatingAdmissionPolicyBindings", nil
 			}
 		}

--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -299,8 +299,13 @@ func Validate(policy, oldPolicy kyvernov1.PolicyInterface, client dclient.Interf
 			}
 		}
 
-		if err := validateActions(i, &rules[i], client, mock, username); err != nil {
+		msg, err := validateActions(i, &rules[i], client, mock, username)
+		if err != nil {
 			return warnings, err
+		} else {
+			if len(msg) != 0 {
+				warnings = append(warnings, msg)
+			}
 		}
 
 		if rule.HasVerifyImages() {


### PR DESCRIPTION
## Explanation
This PR displays a message when the admission controller has no permissions to generate validating admission policies and their bindings.

In case the user enabled the flag `--generateValidatingAdmissionPolicy=true` and created the following policy:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-host-path
spec:
  validationFailureAction: Enforce
  background: false
  rules:
    - name: host-path
      match:
        any:
        - resources:
            kinds:
              - Pod
      validate:
        cel:
          expressions:
            - expression: "!has(object.spec.volumes) || object.spec.volumes.all(volume, !has(volume.hostPath))"
              message: "HostPath volumes are forbidden. The field spec.template.spec.volumes[*].hostPath must be unset."
```
The output:
```
Warning: doesn't have required permissions for generating ValidatingAdmissionPolicies
clusterpolicy.kyverno.io/disallow-host-path created
```
From the controller logs:
```
I1030 10:42:14.291446       1 controller.go:317] validatingadmissionpolicy-generate-controller/worker "msg"="doesn't have required permissions for generating validating admission policies" "id"=1 "key"="disallow-host-path" "name"="disallow-host-path" "namespace"=""
```

The status of the policy:
```
validatingadmissionpolicy:
    generated: false
    message: doesn't have required permissions for generating ValidatingAdmissionPolicies
      policies
```