### PR TITLE
fix: add VAP and VAPB to reports controller ClusterRole

### DIFF
--- a/charts/kyverno/templates/reports-controller/clusterrole.yaml
+++ b/charts/kyverno/templates/reports-controller/clusterrole.yaml
@@ -58,6 +58,16 @@ rules:
       - update
       - watch
       - deletecollection
+{{- if .Values.features.validatingAdmissionPolicyReports.enabled }}
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+    verbs:
+      - get
+      - list
+{{- end }}
   - apiGroups:
       - ''
       - events.k8s.io


### PR DESCRIPTION
## Explanation
This PR adds permissions for the reports controller to get and list validating admission policies in case the user enabled the flag `--validatingAdmissionPolicyReports`.