### PR TITLE
chore (deps): bump a couple of deps

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -667,7 +667,7 @@ jobs:
         uses: ./.github/actions/setup-build-env
         timeout-minutes: 10
       - name: Create kind cluster and setup Sigstore Scaffolding
-        uses: sigstore/scaffolding/actions/setup@838c26c783a08cf497dfff29d95ca90c6eeba3df
+        uses: sigstore/scaffolding/actions/setup@46eb35c1c415d976c7f9d3ee4c936e65c35e8e3e
         with:
           version: 'v0.6.8'
           k8s-version: ${{ matrix.k8s-version.version }}

--- a/.github/workflows/devcontainer-build.yaml
+++ b/.github/workflows/devcontainer-build.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Build devcontainer image
         run: docker build .devcontainer   
       - name: Trivy Scan Image
-        uses: aquasecurity/trivy-action@f78e9ecf42a1271402d4f484518b9313235990e1 # v0.13.1
+        uses: aquasecurity/trivy-action@2b6a709cf9c4025c5438138008beaddbb02086f0 # v0.14.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true

--- a/.github/workflows/images-build.yaml
+++ b/.github/workflows/images-build.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: ko build
         run: VERSION=${{ github.ref_name }} make ko-build-all
       - name: Trivy Scan Image
-        uses: aquasecurity/trivy-action@f78e9ecf42a1271402d4f484518b9313235990e1 # v0.13.1
+        uses: aquasecurity/trivy-action@2b6a709cf9c4025c5438138008beaddbb02086f0 # v0.14.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true

--- a/.github/workflows/images-publish.yaml
+++ b/.github/workflows/images-publish.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/setup-build-env
         timeout-minutes: 30
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@f78e9ecf42a1271402d4f484518b9313235990e1 # v0.13.1
+        uses: aquasecurity/trivy-action@2b6a709cf9c4025c5438138008beaddbb02086f0 # v0.14.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/actions/setup-build-env
         timeout-minutes: 30
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@f78e9ecf42a1271402d4f484518b9313235990e1 # v0.13.1
+        uses: aquasecurity/trivy-action@2b6a709cf9c4025c5438138008beaddbb02086f0 # v0.14.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cyphar/filepath-securejoin v0.2.4
 	github.com/dgraph-io/ristretto v0.1.1
-	github.com/distribution/distribution v2.8.2+incompatible
+	github.com/distribution/reference v0.5.0
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/fatih/color v1.15.0
 	github.com/fluxcd/pkg/oci v0.32.0

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	k8s.io/pod-security-admission v0.28.3
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.16.2
-	sigs.k8s.io/kubectl-validate v0.0.1
+	sigs.k8s.io/kubectl-validate v0.0.2
 	sigs.k8s.io/kustomize/api v0.15.0
 	sigs.k8s.io/kustomize/kyaml v0.15.0
 	sigs.k8s.io/release-utils v0.7.6

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/digitorus/timestamp v0.0.0-20230902153158-687734543647 h1:WOk5Aclr/+s
 github.com/digitorus/timestamp v0.0.0-20230902153158-687734543647/go.mod h1:GvWntX9qiTlOud0WkQ6ewFm0LPy5JUR1Xo0Ngbd1w6Y=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
-github.com/distribution/distribution v2.8.2+incompatible h1:k9+4DKdOG+quPFZXT/mUsiQrGu9vYCp+dXpuPkuqhk8=
-github.com/distribution/distribution v2.8.2+incompatible/go.mod h1:EgLm2NgWtdKgzF9NpMzUKgzmR7AMmb0VQi2B+ZzDRjc=
+github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
+github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=

--- a/go.sum
+++ b/go.sum
@@ -2444,8 +2444,8 @@ sigs.k8s.io/controller-runtime v0.16.2 h1:mwXAVuEk3EQf478PQwQ48zGOXvW27UJc8NHktQ
 sigs.k8s.io/controller-runtime v0.16.2/go.mod h1:vpMu3LpI5sYWtujJOa2uPK61nB5rbwlN7BAB8aSLvGU=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/kubectl-validate v0.0.1 h1:wKIpCBQwJI559/prMMe0j1cIQSf5IkAQF4IjljNz5jw=
-sigs.k8s.io/kubectl-validate v0.0.1/go.mod h1:iEeHEOp73Wpn2QIDFNJcfDqebHyF7Qjilf+88WoKcWw=
+sigs.k8s.io/kubectl-validate v0.0.2 h1:P11D8/9ooXYlZYgJfPY3jeQqY246o96hQ/jqNXCNWCc=
+sigs.k8s.io/kubectl-validate v0.0.2/go.mod h1:iEeHEOp73Wpn2QIDFNJcfDqebHyF7Qjilf+88WoKcWw=
 sigs.k8s.io/kustomize/api v0.15.0 h1:6Ca88kEOBVotHDw+y2IsIMYtg9Pvv7MKpW9JMyF/OH4=
 sigs.k8s.io/kustomize/api v0.15.0/go.mod h1:p19kb+E14gN7zcIBR/nhByJDAfUa7N8mp6ZdH/mMXbg=
 sigs.k8s.io/kustomize/kyaml v0.15.0 h1:ynlLMAxDhrY9otSg5GYE2TcIz31XkGZ2Pkj7SdolD84=

--- a/pkg/utils/image/infos.go
+++ b/pkg/utils/image/infos.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/distribution/distribution/reference"
+	"github.com/distribution/reference"
 	"github.com/kyverno/kyverno/pkg/config"
 )
 

--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/distribution/distribution/reference"
+	"github.com/distribution/reference"
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/jmoiron/jsonq"
 	"github.com/kyverno/go-jmespath"


### PR DESCRIPTION
This PR:
- bump sigstore/scaffolding from 838c26c783a08cf497dfff29d95ca90c6eeba3df to 46eb35c1c415d976c7f9d3ee4c936e65c35e8e3e
- bump aquasecurity/trivy-action from 0.13.1 to 0.14.0
- bump github.com/distribution/distribution from 2.8.2+incompatible to 2.8.3+incompatible
- bump sigs.k8s.io/kubectl-validate from 0.0.1 to 0.0.2

Closes https://github.com/kyverno/kyverno/pull/8851.
Closes https://github.com/kyverno/kyverno/pull/8843.
Closes https://github.com/kyverno/kyverno/pull/8616.
Closes https://github.com/kyverno/kyverno/pull/8854.