### PR TITLE
Revert "fix(chart): only create ServiceMonitor if cluster supports it (#7926)

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -35,8 +35,6 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: support for GrafanaDashboard custom resource
-    - kind: changed
-      description: only create ServiceMonitor if cluster supports it
     - kind: fixed
       description: rbac templating issues
     - kind: added

--- a/charts/kyverno/templates/admission-controller/servicemonitor.yaml
+++ b/charts/kyverno/templates/admission-controller/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.admissionController.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if .Values.admissionController.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/kyverno/templates/background-controller/servicemonitor.yaml
+++ b/charts/kyverno/templates/background-controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.backgroundController.enabled -}}
-{{- if and .Values.backgroundController.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+{{- if .Values.backgroundController.serviceMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/kyverno/templates/cleanup-controller/servicemonitor.yaml
+++ b/charts/kyverno/templates/cleanup-controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cleanupController.enabled -}}
-{{- if and .Values.cleanupController.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+{{- if .Values.cleanupController.serviceMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/kyverno/templates/reports-controller/servicemonitor.yaml
+++ b/charts/kyverno/templates/reports-controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.reportsController.enabled -}}
-{{- if and .Values.reportsController.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+{{- if .Values.reportsController.serviceMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
This reverts commit 590dce5830888ab592cb69e44ed57dd486403347.

This will ensure servicemonitor can be enabled with ArgoCD which doesn't support querying API capabilities

Fixes #8891

