### PR TITLE
fix: use v2beta1 version of exceptions in kyverno create CLI (cherry-pick #8908)

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/create/exception/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/create/exception/command.go
@@ -7,7 +7,6 @@ import (
 	"text/template"
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
-	"github.com/kyverno/kyverno/api/kyverno/v2alpha1"
 	"github.com/kyverno/kyverno/api/kyverno/v2beta1"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/command"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/create/templates"
@@ -18,7 +17,7 @@ type options struct {
 	Name       string
 	Namespace  string
 	Background bool
-	Exceptions []v2alpha1.Exception
+	Exceptions []v2beta1.Exception
 	Match      v2beta1.MatchResources
 }
 
@@ -81,12 +80,12 @@ func Command() *cobra.Command {
 	return cmd
 }
 
-func parseRule(in string) *v2alpha1.Exception {
+func parseRule(in string) *v2beta1.Exception {
 	parts := strings.Split(in, ",")
 	if len(parts) < 2 {
 		return nil
 	}
-	return &v2alpha1.Exception{
+	return &v2beta1.Exception{
 		PolicyName: parts[0],
 		RuleNames:  parts[1:],
 	}

--- a/cmd/cli/kubectl-kyverno/commands/create/exception/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/create/exception/command_test.go
@@ -40,7 +40,7 @@ func TestCommandWithAny(t *testing.T) {
 	out, err := io.ReadAll(b)
 	assert.NoError(t, err)
 	expected := `
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: test
@@ -73,7 +73,7 @@ func TestCommandWithAll(t *testing.T) {
 	out, err := io.ReadAll(b)
 	assert.NoError(t, err)
 	expected := `
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: test

--- a/cmd/cli/kubectl-kyverno/commands/create/templates/exception.yaml
+++ b/cmd/cli/kubectl-kyverno/commands/create/templates/exception.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ .Name }}


### PR DESCRIPTION
Cherry-picked fix: use v2beta1 version of exceptions in kyverno create CLI (https://github.com/kyverno/kyverno/pull/8908)