### PR TITLE
fix: use the default namespace in case --namespace isn't set in kyverno create exception (cherry-pick #9014)

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/create/exception/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/create/exception/command_test.go
@@ -44,7 +44,7 @@ apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
 metadata:
   name: test
-  namespace: 
+  namespace: default
 spec:
   background: true
   match:
@@ -77,7 +77,7 @@ apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
 metadata:
   name: test
-  namespace: 
+  namespace: default
 spec:
   background: true
   match:

--- a/cmd/cli/kubectl-kyverno/commands/create/templates/exception.yaml
+++ b/cmd/cli/kubectl-kyverno/commands/create/templates/exception.yaml
@@ -2,7 +2,7 @@ apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
 metadata:
   name: {{ .Name }}
-  namespace: {{ .Namespace }}
+  namespace: {{ or .Namespace "default" }}
 spec:
   background: {{ .Background }}
   match:


### PR DESCRIPTION
cherrypicked fix: use the default namespace in case --namespace isn't set in kyverno create exception (#9014)