### PR TITLE
Use nancy on actually included dependencies

### DIFF
--- a/.github/workflows/nancy.yaml
+++ b/.github/workflows/nancy.yaml
@@ -30,6 +30,6 @@ jobs:
         uses: ./.github/actions/setup-build-env
         timeout-minutes: 10
       - name: WriteGoList
-        run: go list -json -m all > go.list
+        run: go list -json -deps ./... > go.list
       - name: Nancy SAST Scan
         uses: sonatype-nexus-community/nancy-github-action@726e338312e68ecdd4b4195765f174d3b3ce1533 # v1.0.3


### PR DESCRIPTION
## Explanation

After the comment made here: https://github.com/kyverno/kyverno/pull/8816#issuecomment-1818012716
I did some research and found that yes, we actually currently include dependencies which do not end up in our binaries. I am uncertain why this was implemented initially.

It might be that this was part of the security scorecard but this implementation does not make sense to me in hindsight.

## Related issue

https://github.com/kyverno/kyverno/issues/7594

## What type of PR is this

/kind bug


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

My change is taken directly from the nancy best practices: https://github.com/sonatype-nexus-community/nancy#what-is-the-best-usage-of-nancy
