### PR TITLE
fix: ttl cleanup not working with cluster wide resources

### DIFF
--- a/pkg/controllers/ttl/controller.go
+++ b/pkg/controllers/ttl/controller.go
@@ -122,7 +122,11 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, itemKey 
 	if err != nil {
 		return err
 	}
-	obj, err := c.lister.ByNamespace(namespace).Get(name)
+	getter := c.lister.Get
+	if namespace != "" {
+		getter = c.lister.ByNamespace(namespace).Get
+	}
+	obj, err := getter(name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// resource doesn't exist anymore, nothing much to do at this point


### PR DESCRIPTION
## Explanation

Fix ttl cleanup not working with cluster wide resources.

## Related issue

Fixes #9053
