### PR TITLE
fix: add nodeSelector to the reports cleanup helm hook

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -737,6 +737,7 @@ The chart values are organised per component.
 | policyReportsCleanup.image.tag | string | `"1.28.4"` | Image tag Defaults to `latest` if omitted |
 | policyReportsCleanup.image.pullPolicy | string | `nil` | Image pull policy Defaults to image.pullPolicy if omitted |
 | policyReportsCleanup.podSecurityContext | object | `{}` | Security context for the pod |
+| policyReportsCleanup.nodeSelector | object | `{}` | Node labels for pod assignment |
 | policyReportsCleanup.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the hook containers |
 
 ## TLS Configuration

--- a/charts/kyverno/templates/hooks/post-upgrade.yaml
+++ b/charts/kyverno/templates/hooks/post-upgrade.yaml
@@ -54,5 +54,9 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- with .Values.policyReportsCleanup.nodeSelector }}
+      nodeSelector:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
   {{- end -}}
 {{- end -}}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -411,6 +411,9 @@ policyReportsCleanup:
   # -- Security context for the pod
   podSecurityContext: {}
 
+  # -- Node labels for pod assignment
+  nodeSelector: {}
+
   # -- Security context for the hook containers
   securityContext:
     runAsUser: 65534


### PR DESCRIPTION
## Explanation
This PR adds nodeSelector to the reports cleanup helm hook.
Closes #9055 