### PR TITLE
fix: add the retry annotation in case of failures and errors

### DIFF
--- a/pkg/background/mutate/mutate.go
+++ b/pkg/background/mutate/mutate.go
@@ -166,6 +166,9 @@ func (c *mutateExistingController) ProcessUR(ur *kyvernov1beta1.UpdateRequest) e
 				err := fmt.Errorf("failed to mutate existing resource, rule %s, response %v: %s", r.Name(), r.Status(), r.Message())
 				logger.Error(err, "")
 				errs = append(errs, err)
+				if err := common.UpdateRetryAnnotation(c.kyvernoClient, ur); err != nil {
+					errs = append(errs, err)
+				}
 				c.report(err, policy, rule.Name, patched)
 
 			case engineapi.RuleStatusSkip:


### PR DESCRIPTION
## Explanation
I figured out that the URs aren't only stuck in case of the deletion of the trigger namespace, but they are also stuck in case there are any errors/failures as a result of applying the rule to the resource.

Consider the following case:
1. Create a namespace:
```
apiVersion: v1
kind: Namespace
metadata:
  labels:
    org: kyverno-test
  name: org-label-inheritance-existing-ns
```
2. Create a configmap:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-org
  namespace: org-label-inheritance-existing-ns
```
3. Create a pod:
```
apiVersion: v1
kind: Pod
metadata:
  name: test-org
  namespace: org-label-inheritance-existing-ns
spec:
  containers:
  - image: nginx:latest
    name: test-org
```
4. Create a policy that sets `mutateExistingOnPolicyUpdate` to true:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: org-label-inheritance-existing
  annotations:  
    pod-policies.kyverno.io/autogen-controllers: none
spec:
  mutateExistingOnPolicyUpdate: true
  validationFailureAction: Enforce
  rules:
  - name: propagate org label from namespace
    match:
      any:
      - resources:
          kinds:
          - ConfigMap
          namespaceSelector:
            matchExpressions:
              - key: org
                operator: Exists
    context:
    - name: org
      apiCall:
        urlPath: /api/v1/namespaces/{{ request.object.metadata.namespace }}
        jmesPath: metadata.labels.org
    mutate:
      targets:
      - apiVersion: v1
        kind: Pod
        namespace: "{{ request.object.metadata.namespace }}"
        name: "{{ request.object.metadata.name }}"
      patchStrategicMerge:
        metadata:
          annotations:
            org: "{{ org }}"
```
5. The background controller continuously logs the following messages:
```
E1216 12:52:41.802220   30228 mutate.go:167] "" err="failed to mutate existing resource, rule propagate org label from namespace, response error: : pods \"kube-root-ca.crt\" not found" logger="background" name="ur-6bt6g" policy="org-label-inheritance-existing" resource="v1/ConfigMap/org-label-inheritance-existing-ns/kube-root-ca.crt"
I1216 12:52:41.802379   30228 mutate.go:234] "cannot generate events for empty target resource" logger="background.mutateExisting" policy="org-label-inheritance-existing" rule="propagate org label from namespace"
```
```
kubectl get ur -n kyverno 
NAME       POLICY                           RULETYPE   RESOURCEKIND   RESOURCENAME       RESOURCENAMESPACE                   STATUS   AGE
ur-6bt6g   org-label-inheritance-existing   mutate     ConfigMap      kube-root-ca.crt   org-label-inheritance-existing-ns   Failed   59s
```

The trigger resource is a configmap and there are two of them in the namespace `org-label-inheritance-existing-ns`:
```
kubectl get cm -n org-label-inheritance-existing-ns 
NAME               DATA   AGE
kube-root-ca.crt   1      70m
test-org           0      70m
```
Therefore, two `UpdateRequest` is created, one for `test-org`, and this is processed successfully, and the other is for `kube-root-ca.crt` and this is stuck in fail status because the policy fetches a pod with the same configmap name and there is no pod called `kube-root-ca.crt` so the engine response is of type error.

This PR adds the retry annotation in the UR when the engine response is of type fail or error.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Related to #9089 and #7882
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.11.2
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (optional)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Use the `UpdateRetryAnnotation` in case the engine response is of type fail or error.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
By using the provided test case, the UR is no longer stuck as it is processed three times, and at the fourth time, it is deleted.
Logs:
```
E1216 12:55:59.616260   31373 mutate.go:176] "" err="mutate existing rule skipped, rule propagate org label from namespace, response skip: no patches applied" logger="background" name="ur-f5vhj" policy="org-label-inheritance-existing" resource="v1/ConfigMap/org-label-inheritance-existing-ns/test-org"
I1216 12:55:59.616321   31373 mutate.go:237] "cannot generate events for empty target resource" logger="background.mutateExisting" policy="org-label-inheritance-existing" rule="propagate org label from namespace"
E1216 12:55:59.629190   31373 mutate.go:167] "" err="failed to mutate existing resource, rule propagate org label from namespace, response error: : pods \"kube-root-ca.crt\" not found" logger="background" name="ur-ct2sm" policy="org-label-inheritance-existing" resource="v1/ConfigMap/org-label-inheritance-existing-ns/kube-root-ca.crt"
I1216 12:55:59.642349   31373 mutate.go:237] "cannot generate events for empty target resource" logger="background.mutateExisting" policy="org-label-inheritance-existing" rule="propagate org label from namespace"
E1216 12:55:59.685678   31373 mutate.go:167] "" err="failed to mutate existing resource, rule propagate org label from namespace, response error: : pods \"kube-root-ca.crt\" not found" logger="background" name="ur-ct2sm" policy="org-label-inheritance-existing" resource="v1/ConfigMap/org-label-inheritance-existing-ns/kube-root-ca.crt"
I1216 12:55:59.692978   31373 mutate.go:237] "cannot generate events for empty target resource" logger="background.mutateExisting" policy="org-label-inheritance-existing" rule="propagate org label from namespace"
```
```
kubectl get ur -n kyverno 
No resources found in kyverno namespace.
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
