### PR TITLE
Readable timestamps in logs

### DIFF
--- a/cmd/cli/kubectl-kyverno/log/log.go
+++ b/cmd/cli/kubectl-kyverno/log/log.go
@@ -18,7 +18,7 @@ func Configure() error {
 func configure(args ...string) error {
 	logging.InitFlags(nil)
 	if isVerbose(args...) {
-		return logging.Setup(logging.TextFormat, 0)
+		return logging.Setup(logging.TextFormat, logging.DefaultTime, 0)
 	}
 	return nil
 }

--- a/cmd/internal/flag.go
+++ b/cmd/internal/flag.go
@@ -13,7 +13,8 @@ import (
 
 var (
 	// logging
-	loggingFormat string
+	loggingFormat   string
+	loggingTsFormat string
 	// profiling
 	profilingEnabled bool
 	profilingAddress string
@@ -59,6 +60,7 @@ var (
 func initLoggingFlags() {
 	logging.InitFlags(nil)
 	flag.StringVar(&loggingFormat, "loggingFormat", logging.TextFormat, "This determines the output format of the logger.")
+	flag.StringVar(&loggingTsFormat, "loggingtsFormat", logging.DefaultTime, "This determines the timestamp format of the logger.")
 	checkErr(flag.Set("v", "2"), "failed to init flags")
 }
 

--- a/cmd/internal/logging.go
+++ b/cmd/internal/logging.go
@@ -11,6 +11,6 @@ import (
 func setupLogger() logr.Logger {
 	logLevel, err := strconv.Atoi(flag.Lookup("v").Value.String())
 	checkErr(err, "failed to setup logger")
-	checkErr(logging.Setup(loggingFormat, logLevel), "failed to setup logger")
+	checkErr(logging.Setup(loggingFormat, loggingTsFormat, logLevel), "failed to setup logger")
 	return logging.WithName("setup")
 }

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	stdlog "log"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/textlogger"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -28,13 +28,22 @@ const (
 	LogLevelController = 1
 	// LogLevelClient is the log level to use for clients.
 	LogLevelClient = 1
+	// time formats
+	DefaultTime = "default"
+	ISO8601     = "iso8601"
+	RFC3339     = "rfc3339"
+	MILLIS      = "millis"
+	NANOS       = "nanos"
+	EPOCH       = "epoch"
+	RFC3339NANO = "rfc3339nano"
 )
 
 // Initially, globalLog comes from controller-runtime/log with logger created earlier by controller-runtime.
 // When logging.Setup is called, globalLog is switched to the real logger.
 // Call depth of all loggers created before logging.Setup will not work, including package level loggers as they are created before main.
 // All loggers created after logging.Setup won't be subject to the call depth limitation and will work if the underlying sink supports it.
-var globalLog = log.Log
+
+var globalLog = log.Log //returns a Null log sink if SetLogger is not called.
 
 func InitFlags(flags *flag.FlagSet) {
 	// clear flags initialized in static dependencies
@@ -46,28 +55,53 @@ func InitFlags(flags *flag.FlagSet) {
 
 // Setup configures the logger with the supplied log format.
 // It returns an error if the JSON logger could not be initialized or passed logFormat is not recognized.
-func Setup(logFormat string, level int) error {
+func Setup(logFormat string, loggingTimestampFormat string, level int) error {
+
+	fmt.Print("We are setting the logging up..\n")
+
+	var zc zap.Config
+
 	switch logFormat {
 	case TextFormat:
-		config := textlogger.NewConfig(
-			textlogger.Verbosity(level),
-			textlogger.Output(os.Stdout),
-		)
-		globalLog = textlogger.NewLogger(config)
+		zc = zap.NewDevelopmentConfig()
+
 	case JSONFormat:
-		zc := zap.NewProductionConfig()
-		// Zap's levels get more and less verbose as the number gets smaller and higher respectively (DebugLevel is -1, InfoLevel is 0, WarnLevel is 1, and so on).
-		zc.Level = zap.NewAtomicLevelAt(zapcore.Level(-1 * level))
-		zapLog, err := zc.Build()
-		if err != nil {
-			return err
-		}
-		globalLog = zapr.NewLogger(zapLog)
-		// in json mode we configure klog and global logger to use zapr
-		klog.SetLogger(globalLog.WithName("klog"))
+		zc = zap.NewProductionConfig()
+
 	default:
 		return errors.New("log format not recognized, pass `text` for text mode or `json` to enable JSON logging")
 	}
+
+	switch loggingTimestampFormat {
+	case ISO8601:
+		zc.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	case RFC3339:
+		zc.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
+	case MILLIS:
+		zc.EncoderConfig.EncodeTime = zapcore.EpochMillisTimeEncoder
+	case NANOS:
+		zc.EncoderConfig.EncodeTime = zapcore.EpochNanosTimeEncoder
+	case EPOCH:
+		zc.EncoderConfig.EncodeTime = zapcore.EpochTimeEncoder
+	case RFC3339NANO:
+		zc.EncoderConfig.EncodeTime = zapcore.RFC3339NanoTimeEncoder
+	case "default":
+		zc.EncoderConfig.EncodeTime = zapcore.EpochNanosTimeEncoder
+
+	default:
+		return errors.New("timestamp format not recognized, pass `iso8601` for ISO8601, `rfc3339` for RFC3339, `rfc3339nano` for RFC3339NANO, `millis` for Epoch Millis, `nanos` for Epoch Nanos, or omit the flag for the Unix Epoch timestamp format")
+	}
+
+	// Zap's levels get more and less verbose as the number gets smaller and higher respectively (DebugLevel is -1, InfoLevel is 0, WarnLevel is 1, and so on).
+	zc.Level = zap.NewAtomicLevelAt(zapcore.Level(-1 * level))
+	zapLog, err := zc.Build()
+	if err != nil {
+		return err
+	}
+	globalLog = zapr.NewLogger(zapLog)
+	// in json mode we configure klog and global logger to use zapr
+	klog.SetLogger(globalLog.WithName("klog"))
+
 	log.SetLogger(globalLog)
 	return nil
 }

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"fmt"
 	"io"
 	stdlog "log"
 	"os"
@@ -56,8 +55,6 @@ func InitFlags(flags *flag.FlagSet) {
 // Setup configures the logger with the supplied log format.
 // It returns an error if the JSON logger could not be initialized or passed logFormat is not recognized.
 func Setup(logFormat string, loggingTimestampFormat string, level int) error {
-
-	fmt.Print("We are setting the logging up..\n")
 
 	var zc zap.Config
 

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -69,6 +69,7 @@ func Setup(logFormat string, loggingTimestampFormat string, level int) error {
 		return errors.New("log format not recognized, pass `text` for text mode or `json` to enable JSON logging")
 	}
 
+	//Configure the timestamp format
 	switch loggingTimestampFormat {
 	case ISO8601:
 		zc.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder


### PR DESCRIPTION
## Explanation

Logging earlier did not provide human-readable timestamps. This PR provides a command line flag with which the user can choose the timestamp that they prefer for their logs.

## Related issue

Closes #8749 

## What type of PR is this

 /kind feature

## Proposed Changes
Adding a flag called `loggingtsFormat` which lets the user decide between Epoch, Epoch Nanos, Epoch Millis, RFC3339, RFC3339NANO, ISO8601 timestamps. If the user omits the flag, it defaults to Epoch Nanos. 
Textlogger has been removed and replaced with zap throughout for both console and JSON logging, for simplicity.

### Proof Manifests
![image](https://github.com/kyverno/kyverno/assets/110663831/badd548c-364d-409d-8217-22bafda55380)
![image](https://github.com/kyverno/kyverno/assets/110663831/81f4b208-8dc7-4e3d-8092-6c632d91df85)
![image](https://github.com/kyverno/kyverno/assets/110663831/110d3c28-7338-4d2d-a2e8-a09f30febfa1)
And by omitting the flag, the timestamp format defaults to Epoch Nanos
![image](https://github.com/kyverno/kyverno/assets/110663831/f4968d7c-89b3-47e9-8082-bafbd6d08749)



## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [X] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

Moved to #9276