### PR TITLE
fix: deep copy resource in cli when operation is update

### DIFF
--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -234,7 +234,8 @@ func (p *PolicyProcessor) makePolicyContext(
 		return nil, fmt.Errorf("failed to create policy context (%w)", err)
 	}
 	if operation == kyvernov1.Update {
-		policyContext = policyContext.WithOldResource(resource)
+		resource := resource.DeepCopy()
+		policyContext = policyContext.WithOldResource(*resource)
 		if err := policyContext.JSONContext().AddOldResource(resource.Object); err != nil {
 			return nil, fmt.Errorf("failed to update old resource in json context (%w)", err)
 		}


### PR DESCRIPTION
## Explanation

Fix we need to deep copy the resource in the cli when operation is update.

## Related issue

Fixes #9188 