### PR TITLE
feat: enable kubectl-validate by default in cli

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -42,7 +42,7 @@ jobs:
           fi
       - name: Test CLI
         run: |
-          VERSION=${{ github.ref_name }} make test-cli
+          KYVERNO_KUBECTL_VALIDATE=false VERSION=${{ github.ref_name }} make test-cli
       - name: Test CLI (failures)
         run: |
           CLI_PATH=$PWD/cmd/cli/kubectl-kyverno/kubectl-kyverno
@@ -75,7 +75,7 @@ jobs:
           fi
       - name: Test CLI
         run: |
-          KYVERNO_KUBECTL_VALIDATE=true VERSION=${{ github.ref_name }} make test-cli
+          VERSION=${{ github.ref_name }} make test-cli
       - name: Test CLI (failures)
         run: |
           CLI_PATH=$PWD/cmd/cli/kubectl-kyverno/kubectl-kyverno

--- a/cmd/cli/kubectl-kyverno/experimental/experimental.go
+++ b/cmd/cli/kubectl-kyverno/experimental/experimental.go
@@ -10,17 +10,17 @@ const (
 	KubectlValidateEnv = "KYVERNO_KUBECTL_VALIDATE" //nolint:gosec
 )
 
-func getBool(env string) bool {
+func getBool(env string, fallback bool) bool {
 	if b, err := strconv.ParseBool(os.Getenv(env)); err == nil {
 		return b
 	}
-	return false
+	return fallback
 }
 
 func IsEnabled() bool {
-	return getBool(ExperimentalEnv)
+	return getBool(ExperimentalEnv, false)
 }
 
 func UseKubectlValidate() bool {
-	return getBool(KubectlValidateEnv)
+	return getBool(KubectlValidateEnv, true)
 }


### PR DESCRIPTION
## Explanation

Enable kubectl-validate by default in the cli.
