### PR TITLE
fix: mutate existing force reconciliation

### DIFF
--- a/pkg/policy/mutate.go
+++ b/pkg/policy/mutate.go
@@ -12,10 +12,6 @@ import (
 
 func (pc *policyController) handleMutate(policyKey string, policy kyvernov1.PolicyInterface) error {
 	logger := pc.log.WithName("handleMutate").WithName(policyKey)
-	if !policy.GetSpec().MutateExistingOnPolicyUpdate {
-		logger.V(4).Info("skip policy application on policy event", "policyKey", policyKey, "mutateExiting", policy.GetSpec().MutateExistingOnPolicyUpdate)
-		return nil
-	}
 
 	logger.Info("update URs on policy event")
 	for _, rule := range policy.GetSpec().Rules {

--- a/pkg/policy/policy_controller.go
+++ b/pkg/policy/policy_controller.go
@@ -144,11 +144,9 @@ func NewPolicyController(
 
 func (pc *policyController) canBackgroundProcess(p kyvernov1.PolicyInterface) bool {
 	logger := pc.log.WithValues("policy", p.GetName())
-	if !p.BackgroundProcessingEnabled() {
-		if !p.GetSpec().HasGenerate() && !p.GetSpec().IsMutateExisting() {
-			logger.V(4).Info("background processing is disabled")
-			return false
-		}
+	if !p.GetSpec().HasGenerate() && !p.GetSpec().IsMutateExisting() {
+		logger.V(4).Info("policy does not have background rules for reconciliation")
+		return false
 	}
 
 	if err := policyvalidation.ValidateVariables(p, true); err != nil {

--- a/pkg/policy/policy_controller.go
+++ b/pkg/policy/policy_controller.go
@@ -159,8 +159,8 @@ func (pc *policyController) canBackgroundProcess(p kyvernov1.PolicyInterface) bo
 		val := os.Getenv("BACKGROUND_SCAN_INTERVAL")
 		interval, err := time.ParseDuration(val)
 		if err != nil {
-			logger.Error(err, "failed to parse BACKGROUND_SCAN_INTERVAL env variable, skip[ing the policy event")
-			return false
+			logger.V(4).Info("failed to parse BACKGROUND_SCAN_INTERVAL env variable, falling to default 1h", "msg", err.Error())
+			interval = time.Hour
 		}
 		if p.GetCreationTimestamp().Add(interval).After(time.Now()) {
 			return p.GetSpec().GetMutateExistingOnPolicyUpdate()

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/background-false/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/background-false/chainsaw-step-01-apply-1-1.yaml
@@ -1,36 +1,4 @@
-apiVersion: kyverno.io/v1
-kind: ClusterPolicy
+apiVersion: v1
+kind: Namespace
 metadata:
-  annotations:
-    kyverno.io/kubernetes-version: "1.24"
-    kyverno.io/kyverno-version: 1.8.0
-    policies.kyverno.io/category: Pod Security Admission
-    policies.kyverno.io/description: 'When Pod Security Admission is configured with
-      a cluster-wide AdmissionConfiguration file which sets either baseline or restricted,
-      for example in many PaaS CIS profiles, it may be necessary to relax this to
-      privileged on a per-Namespace basis so that more granular control can be provided.
-      This policy labels new and existing Namespaces, except that of kube-system,
-      with the `pod-security.kubernetes.io/enforce: privileged` label.      '
-    policies.kyverno.io/minversion: 1.7.0
-    policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Namespace
-    policies.kyverno.io/title: Add Privileged Label to Existing Namespaces
-  name: add-privileged-existing-namespaces
-spec:
-  background: false
-  mutateExistingOnPolicyUpdate: true
-  rules:
-  - match:
-      any:
-      - resources:
-          kinds:
-          - Namespace
-    mutate:
-      patchStrategicMerge:
-        metadata:
-          labels:
-            foo: bar
-      targets:
-      - apiVersion: v1
-        kind: Namespace
-    name: label-privileged-namespaces
+  name: background-false-ns

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/background-false/chainsaw-step-01-apply-1-2.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/background-false/chainsaw-step-01-apply-1-2.yaml
@@ -1,0 +1,39 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: "1.24"
+    kyverno.io/kyverno-version: 1.8.0
+    policies.kyverno.io/category: Pod Security Admission
+    policies.kyverno.io/description: 'When Pod Security Admission is configured with
+      a cluster-wide AdmissionConfiguration file which sets either baseline or restricted,
+      for example in many PaaS CIS profiles, it may be necessary to relax this to
+      privileged on a per-Namespace basis so that more granular control can be provided.
+      This policy labels new and existing Namespaces, except that of kube-system,
+      with the `pod-security.kubernetes.io/enforce: privileged` label.      '
+    policies.kyverno.io/minversion: 1.7.0
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Namespace
+    policies.kyverno.io/title: Add Privileged Label to Existing Namespaces
+  name: add-privileged-existing-namespaces
+spec:
+  background: false
+  mutateExistingOnPolicyUpdate: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          names:
+          - background-false-ns
+    mutate:
+      patchStrategicMerge:
+        metadata:
+          labels:
+            foo: bar
+      targets:
+      - apiVersion: v1
+        kind: Namespace
+        name: background-false-ns
+    name: label-privileged-namespaces

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/background-false/chainsaw-step-03-assert-1-1.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/background-false/chainsaw-step-03-assert-1-1.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: background-false-ns
   labels:
     foo: bar
-  name: default

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/background-false/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/background-false/chainsaw-test.yaml
@@ -9,9 +9,12 @@ spec:
     try:
     - apply:
         file: chainsaw-step-01-apply-1-1.yaml
+    - apply:
+        file: chainsaw-step-01-apply-1-2.yaml
     - assert:
         file: chainsaw-step-01-assert-1-1.yaml
   - name: step-03
     try:
     - assert:
         file: chainsaw-step-03-assert-1-1.yaml
+        timeout: 1m30s


### PR DESCRIPTION
## Explanation

This PR fixes force reconciliation for mutateExisting policies. This policy will be applied during the background scan (1h by default, can be customized through use of env var `BACKGROUND_SCAN_INTERVAL`, performed by the background controller) regardless of `mutateExistingOnPolicyUpdate` settings.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes https://github.com/kyverno/kyverno/issues/9174.
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.11.2
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (optional)

My PR contains new or altered behavior to Kyverno. 
- [x] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

https://github.com/kyverno/website/pull/1078

## What type of PR is this
/bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

No chainsaw test is added as it requires custom installation for the background controller. And checks for both scenarios are the same - to verify the annotation is added, just with different delays.

Update the background scan interval to `2m`, follow the reproduction steps in the issue, and:

1. apply the policy with `mutateExistingOnPolicyUpdate: false`, the annotation is added after 2m
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: debug-add-annotations
spec:
  background: false
  mutateExistingOnPolicyUpdate: false
  rules:
    - name: debug-add-bad-annotation
      match:
        any:
        - resources:
            kinds:
            - Deployment
            namespaces:
            - engineering
      mutate:
        targets:
        - apiVersion: apps/v1
          kind: Deployment
          name: foo
          namespace: engineering
        patchStrategicMerge:
          metadata:
            annotations:
              corp.io/random: "{{ random('[0-9a-z]{8}') }}"
```
2. apply the policy with `mutateExistingOnPolicyUpdate: true`, the annotation is added immediately when the policy is created.
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: debug-add-annotations
spec:
  background: false
  mutateExistingOnPolicyUpdate: true
  rules:
    - name: debug-add-bad-annotation
      match:
        any:
        - resources:
            kinds:
            - Deployment
            namespaces:
            - engineering
      mutate:
        targets:
        - apiVersion: apps/v1
          kind: Deployment
          name: foo
          namespace: engineering
        patchStrategicMerge:
          metadata:
            annotations:
              corp.io/random: "{{ random('[0-9a-z]{8}') }}"
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
