### PR TITLE
Handle HTTP chunked encoding with maxAPICallResponseLength 

### DIFF
--- a/pkg/engine/apicall/apiCall_test.go
+++ b/pkg/engine/apicall/apiCall_test.go
@@ -23,11 +23,20 @@ var (
 	}
 )
 
-func buildTestServer(responseData []byte) *httptest.Server {
+func buildTestServer(responseData []byte, useChunked bool) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/resource", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" {
 			w.Write(responseData)
+
+			if useChunked {
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					panic("expected http.ResponseWriter to be an http.Flusher")
+				}
+				flusher.Flush()
+			}
+
 			return
 		}
 
@@ -42,47 +51,55 @@ func buildTestServer(responseData []byte) *httptest.Server {
 }
 
 func Test_serviceGetRequest(t *testing.T) {
-	serverResponse := []byte(`{ "day": "Sunday" }`)
-	s := buildTestServer(serverResponse)
-	defer s.Close()
 
-	entry := kyvernov1.ContextEntry{}
-	ctx := enginecontext.NewContext(jp)
+	testfn := func(t *testing.T, useChunked bool) {
 
-	_, err := New(logr.Discard(), jp, entry, ctx, nil, apiConfig)
-	assert.ErrorContains(t, err, "missing APICall")
+		serverResponse := []byte(`{ "day": "Sunday" }`)
+		s := buildTestServer(serverResponse, useChunked)
+		defer s.Close()
 
-	entry.Name = "test"
-	entry.APICall = &kyvernov1.APICall{
-		Service: &kyvernov1.ServiceCall{
-			URL: s.URL,
-		},
+		entry := kyvernov1.ContextEntry{}
+		ctx := enginecontext.NewContext(jp)
+
+		_, err := New(logr.Discard(), jp, entry, ctx, nil, apiConfig)
+		assert.ErrorContains(t, err, "missing APICall")
+
+		entry.Name = "test"
+		entry.APICall = &kyvernov1.APICall{
+			Service: &kyvernov1.ServiceCall{
+				URL: s.URL,
+			},
+		}
+
+		call, err := New(logr.Discard(), jp, entry, ctx, nil, apiConfig)
+		assert.NilError(t, err)
+		_, err = call.FetchAndLoad(context.TODO())
+		assert.ErrorContains(t, err, "invalid request type")
+
+		entry.APICall.Method = "GET"
+		call, err = New(logr.Discard(), jp, entry, ctx, nil, apiConfig)
+		assert.NilError(t, err)
+		_, err = call.FetchAndLoad(context.TODO())
+		assert.ErrorContains(t, err, "HTTP 404")
+
+		entry.APICall.Service.URL = s.URL + "/resource"
+		call, err = New(logr.Discard(), jp, entry, ctx, nil, apiConfig)
+		assert.NilError(t, err)
+
+		data, err := call.FetchAndLoad(context.TODO())
+		assert.NilError(t, err)
+		assert.Assert(t, data != nil, "nil data")
+		assert.Equal(t, string(serverResponse), string(data))
 	}
 
-	call, err := New(logr.Discard(), jp, entry, ctx, nil, apiConfig)
-	assert.NilError(t, err)
-	_, err = call.FetchAndLoad(context.TODO())
-	assert.ErrorContains(t, err, "invalid request type")
+	t.Run("Content-Length", func(t *testing.T) { testfn(t, false) })
+	t.Run("Chunked", func(t *testing.T) { testfn(t, true) })
 
-	entry.APICall.Method = "GET"
-	call, err = New(logr.Discard(), jp, entry, ctx, nil, apiConfig)
-	assert.NilError(t, err)
-	_, err = call.FetchAndLoad(context.TODO())
-	assert.ErrorContains(t, err, "HTTP 404")
-
-	entry.APICall.Service.URL = s.URL + "/resource"
-	call, err = New(logr.Discard(), jp, entry, ctx, nil, apiConfig)
-	assert.NilError(t, err)
-
-	data, err := call.FetchAndLoad(context.TODO())
-	assert.NilError(t, err)
-	assert.Assert(t, data != nil, "nil data")
-	assert.Equal(t, string(serverResponse), string(data))
 }
 
 func Test_servicePostRequest(t *testing.T) {
 	serverResponse := []byte(`{ "day": "Monday" }`)
-	s := buildTestServer(serverResponse)
+	s := buildTestServer(serverResponse, false)
 	defer s.Close()
 
 	entry := kyvernov1.ContextEntry{


### PR DESCRIPTION
## Explanation

This PR fixes the handling of the `Content-Length` header. 

## Related issue

Discussion see #9214. @vishal-chdhry 

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->


## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

There should be no changes in documented behavior.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.


