### PR TITLE
fix: remove policy informer from vap controller

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -191,7 +191,6 @@ func createrLeaderControllers(
 			kubeClient,
 			kyvernoClient,
 			dynamicClient.Discovery(),
-			kyvernoInformer.Kyverno().V1().Policies(),
 			kyvernoInformer.Kyverno().V1().ClusterPolicies(),
 			kubeInformer.Admissionregistration().V1alpha1().ValidatingAdmissionPolicies(),
 			kubeInformer.Admissionregistration().V1alpha1().ValidatingAdmissionPolicyBindings(),

--- a/pkg/controllers/validatingadmissionpolicy-generate/controller.go
+++ b/pkg/controllers/validatingadmissionpolicy-generate/controller.go
@@ -57,7 +57,6 @@ func NewController(
 	client kubernetes.Interface,
 	kyvernoClient versioned.Interface,
 	discoveryClient dclient.IDiscovery,
-	polInformer kyvernov1informers.PolicyInformer,
 	cpolInformer kyvernov1informers.ClusterPolicyInformer,
 	vapInformer admissionregistrationv1alpha1informers.ValidatingAdmissionPolicyInformer,
 	vapbindingInformer admissionregistrationv1alpha1informers.ValidatingAdmissionPolicyBindingInformer,


### PR DESCRIPTION
## Explanation
This PR removes unnecessary parameter `polInformer` passed to the VAP controller.
Currently, VAPs can only be generated from clusterpolicies.