### PR TITLE
fix: large table row ID number format in CLI

### DIFF
--- a/cmd/cli/kubectl-kyverno/output/table/row_compact.go
+++ b/cmd/cli/kubectl-kyverno/output/table/row_compact.go
@@ -2,7 +2,7 @@ package table
 
 type RowCompact struct {
 	IsFailure bool
-	ID        int    `header:"id"`
+	ID        int    `header:"id,text"`
 	Policy    string `header:"policy"`
 	Rule      string `header:"rule"`
 	Resource  string `header:"resource"`


### PR DESCRIPTION
## Explanation

This fixes the `apply` CLI command format issue with `--table` option.
After applying this commit the row count over 1000 will be `1234` instead of `1.2K`.

## Related issue

Closes #9280 

## What type of PR is this
/kind bug

### Proof Manifests

Same as noted in #9280. After applying this the output will be the following:
```
...
│ 1495       │ dummy  │ autogen-dummy │ default/Deployment/deploy-1494 │ Pass   │        │
│ 1496       │ dummy  │ autogen-dummy │ default/Deployment/deploy-1495 │ Pass   │        │
│ 1497       │ dummy  │ autogen-dummy │ default/Deployment/deploy-1496 │ Pass   │        │
│ 1498       │ dummy  │ autogen-dummy │ default/Deployment/deploy-1497 │ Pass   │        │
...
```

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
