### PR TITLE
fix a chainsaw test

### DIFF
--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/skip-generate/cpol-exclude/validatingadmissionpolicybinding.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/skip-generate/cpol-exclude/validatingadmissionpolicybinding.yaml
@@ -3,5 +3,5 @@ kind: ValidatingAdmissionPolicyBinding
 metadata:
   labels:
     app.kubernetes.io/managed-by: kyverno
-  name: disallow-host-path-t10
+  name: disallow-host-path-t10-binding
 spec: {}


### PR DESCRIPTION
## Explanation
This PR adds a missing `-binding` in a chainsaw test related to VAPs.