### PR TITLE
fix: update CLI to use store for fetching regclient 

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -146,7 +146,7 @@ func runTest(out io.Writer, testCase test.TestCase, auditWarn bool) ([]engineapi
 			Client:                    dClient,
 			Subresources:              vars.Subresources(),
 			Out:                       out,
-			RegistryClient:            store.GetRegistryClient(),
+			RegistryClient:            rclient,
 		}
 		ers, err := processor.ApplyPoliciesOnResource()
 		if err != nil {

--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
-	"github.com/kyverno/kyverno/pkg/registryclient"
 	policyvalidation "github.com/kyverno/kyverno/pkg/validation/policy"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -142,7 +141,7 @@ func runTest(out io.Writer, testCase test.TestCase, auditWarn bool) ([]engineapi
 			Client:                    dClient,
 			Subresources:              vars.Subresources(),
 			Out:                       out,
-			RegistryClient:            registryclient.NewOrDie(),
+			RegistryClient:            store.GetRegistryClient(),
 		}
 		ers, err := processor.ApplyPoliciesOnResource()
 		if err != nil {

--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/kyverno/kyverno/pkg/registryclient"
 	policyvalidation "github.com/kyverno/kyverno/pkg/validation/policy"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -123,6 +124,10 @@ func runTest(out io.Writer, testCase test.TestCase, auditWarn bool) ([]engineapi
 			continue
 		}
 		validPolicies = append(validPolicies, pol)
+	}
+	rclient := store.GetRegistryClient()
+	if rclient == nil {
+		rclient = registryclient.NewOrDie()
 	}
 	// execute engine
 	var engineResponses []engineapi.EngineResponse


### PR DESCRIPTION
## Explanation

Added the change in test command from 9315.

That PR cannot directly be cherry picked as  `processor.PolicyProcessor` expects different fields.

### Proof Manifests

```bash
❯ docker logout ghcr.io
❯ ./kubectl-kyverno test test-reg --registry=true --v=4
Loading test  ( test-reg/kyverno-test.yaml ) ...
  Loading values/variables ...
  Loading policies ...
  Loading resources ...
  Applying 1 policy to 1 resource ...
I0105 13:31:15.541919   53505 imageverifier.go:498] "image attestors verification failed" logger="engine.verify" policy.name="check-image" policy.namespace="" policy.apply="All" new.kind="Pod" new.namespace="default" new.name="signed" rule.name="verify-signature" verifiedCount=0 requiredCount=1 errors=".attestors[0].entries[0]: failed to parse image reference: ghcr.io/kyverno/test-verify-image-private:signed: GET https://ghcr.io/token?scope=repository%3Akyverno%2Ftest-verify-image-private%3Apull&service=ghcr.io: UNAUTHORIZED: authentication required"
E0105 13:31:15.542400   53505 imageverifier.go:360] "failed to verify image" err=".attestors[0].entries[0]: failed to parse image reference: ghcr.io/kyverno/test-verify-image-private:signed: GET https://ghcr.io/token?scope=repository%3Akyverno%2Ftest-verify-image-private%3Apull&service=ghcr.io: UNAUTHORIZED: authentication required" logger="engine.verify" policy.name="check-image" policy.namespace="" policy.apply="All" new.kind="Pod" new.namespace="default" new.name="signed" rule.name="verify-signature"
  Checking results ...

│────│─────────────│──────────────────│────────────│────────│─────────────────────│
│ ID │ POLICY      │ RULE             │ RESOURCE   │ RESULT │ REASON              │
│────│─────────────│──────────────────│────────────│────────│─────────────────────│
│ 1  │ check-image │ verify-signature │ Pod/signed │ Fail   │ Want pass, got fail │
│────│─────────────│──────────────────│────────────│────────│─────────────────────│


Test Summary: 0 tests passed and 1 tests failed

Aggregated Failed Test Cases : 
│────│─────────────│──────────────────│────────────│────────│─────────────────────│
│ ID │ POLICY      │ RULE             │ RESOURCE   │ RESULT │ REASON              │
│────│─────────────│──────────────────│────────────│────────│─────────────────────│
│ 1  │ check-image │ verify-signature │ Pod/signed │ Fail   │ Want pass, got fail │
│────│─────────────│──────────────────│────────────│────────│─────────────────────│
Error: 1 tests failed
❯ export CR_PAT=xxxxx
❯ echo $CR_PAT | docker login ghcr.io -u xxxxx --password-stdin
Login Succeeded
❯ ./kubectl-kyverno test test-reg --registry=true --v=4
Loading test  ( test-reg/kyverno-test.yaml ) ...
  Loading values/variables ...
  Loading policies ...
  Loading resources ...
  Applying 1 policy to 1 resource ...
  Checking results ...

│────│─────────────│──────────────────│────────────│────────│────────│
│ ID │ POLICY      │ RULE             │ RESOURCE   │ RESULT │ REASON │
│────│─────────────│──────────────────│────────────│────────│────────│
│ 1  │ check-image │ verify-signature │ Pod/signed │ Pass   │ Ok     │
│────│─────────────│──────────────────│────────────│────────│────────│


Test Summary: 1 tests passed and 0 tests failed

~/kyverno registry-auth-cli-fix* ❯   
```