### PR TITLE
variable substitution errors reported

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -89,7 +89,7 @@ func Command() *cobra.Command {
 			} else if table {
 				printTable(out, detailedResults, applyCommandConfig.AuditWarn, responses...)
 			} else {
-				printViolations(out, rc)
+				printViolations(out, rc, skipInvalidPolicies)
 			}
 			return exit(rc, applyCommandConfig.warnExitCode, applyCommandConfig.warnNoPassed)
 		},
@@ -438,8 +438,16 @@ func printReport(out io.Writer, engineResponses []engineapi.EngineResponse, audi
 	}
 }
 
-func printViolations(out io.Writer, rc *processor.ResultCounts) {
-	fmt.Fprintf(out, "\npass: %d, fail: %d, warn: %d, error: %d, skip: %d \n", rc.Pass(), rc.Fail(), rc.Warn(), rc.Error(), rc.Skip())
+func printViolations(out io.Writer, rc *processor.ResultCounts, skipInvalidPolicies SkippedInvalidPolicies) {
+	if len(skipInvalidPolicies.invalid) > 0 || len(skipInvalidPolicies.skipped) > 0 {
+		if len(skipInvalidPolicies.invalid) > 0 {
+			fmt.Fprintf(out, "\npass: %d, fail: %d, warn: %d, error: %d, skip: %d \n", rc.Pass(), rc.Fail(), rc.Warn(), len(skipInvalidPolicies.invalid), rc.Skip())
+		} else {
+			fmt.Fprintf(out, "\npass: %d, fail: %d, warn: %d, error: %d, skip: %d \n", rc.Pass(), rc.Fail(), rc.Warn(), len(skipInvalidPolicies.skipped), rc.Skip())
+		}
+	} else {
+		fmt.Fprintf(out, "\npass: %d, fail: %d, warn: %d, error: %d, skip: %d \n", rc.Pass(), rc.Fail(), rc.Warn(), rc.Error(), rc.Skip())
+	}
 }
 
 func exit(rc *processor.ResultCounts, warnExitCode int, warnNoPassed bool) error {


### PR DESCRIPTION
## Explanation
variable substitution are now getting reported in summarised results 
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
fixes #9228
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (optional)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Previously:
```kubectl-kyverno apply /tmp/policy.yaml -r /tmp/resource.yaml -v 5

Applying 1 policy rule(s) to 1 resource(s)...
E1219 23:36:51.851415   82051 command.go:239] kubectl-kyverno "msg"="policy validation error" "error"="policy contains invalid variables: variable substitution failed for rule check-token-exp: variable spec.volumes[].projected.sources[].serviceAccountToken.expirationSeconds must match regex \"request\\.|element|elementIndex|@|images|images\\.|image\\.|([a-z_0-9]+\\()[^{}]\" or patterns []"
----------------------------------------------------------------------
Policies Skipped (as required variables are not provided by the user):
1. check-sa-tokens
----------------------------------------------------------------------

pass: 0, fail: 0, warn: 0, error: 0, skip: 0
```
After:
```

Applying 1 policy rule(s) to 1 resource(s)...
E0107 12:58:47.664244   55292 command.go:245] "policy validation error" err="policy contains invalid variables: variable substitution failed for rule check-token-exp: variable spec.volumes[].projected.sources[].serviceAccountToken.expirationSeconds must match regex \"request\\.|element|elementIndex|@|images|images\\.|image\\.|([a-z_0-9]+\\()[^{}]\" or patterns []" logger="kubectl-kyverno"
----------------------------------------------------------------------
Policies Skipped (as required variables are not provided by the user):
1. check-sa-tokens
----------------------------------------------------------------------

pass: 0, fail: 0, warn: 0, error: 1, skip: 0 
```
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
