### PR TITLE
enable validate generic resources with --genericresource

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -47,23 +47,25 @@ type SkippedInvalidPolicies struct {
 }
 
 type ApplyCommandConfig struct {
-	KubeConfig     string
-	Context        string
-	Namespace      string
-	MutateLogPath  string
-	Variables      []string
-	ValuesFile     string
-	UserInfoPath   string
-	Cluster        bool
-	PolicyReport   bool
-	Stdin          bool
-	RegistryAccess bool
-	AuditWarn      bool
-	ResourcePaths  []string
-	PolicyPaths    []string
-	GitBranch      string
-	warnExitCode   int
-	warnNoPassed   bool
+	KubeConfig      string
+	Context         string
+	Namespace       string
+	MutateLogPath   string
+	Variables       []string
+	ValuesFile      string
+	UserInfoPath    string
+	Cluster         bool
+	PolicyReport    bool
+	Stdin           bool
+	RegistryAccess  bool
+	AuditWarn       bool
+	ResourcePaths   []string
+	PolicyPaths     []string
+	GitBranch       string
+	warnExitCode    int
+	warnNoPassed    bool
+    // To validate generic resources
+	genericResource bool
 }
 
 func Command() *cobra.Command {
@@ -96,6 +98,7 @@ func Command() *cobra.Command {
 	}
 	cmd.Flags().StringSliceVarP(&applyCommandConfig.ResourcePaths, "resource", "r", []string{}, "Path to resource files")
 	cmd.Flags().BoolVarP(&applyCommandConfig.Cluster, "cluster", "c", false, "Checks if policies should be applied to cluster in the current context")
+	cmd.Flags().BoolVar(&applyCommandConfig.genericResource, "genericresource", false, "Apply policy to a file that is not a kubernetes resource. for eg, does not contain `apiVersion` and `kind`")
 	cmd.Flags().StringVarP(&applyCommandConfig.MutateLogPath, "output", "o", "", "Prints the mutated resources in provided file/directory")
 	// currently `set` flag supports variable for single policy applied on single resource
 	cmd.Flags().StringVarP(&applyCommandConfig.UserInfoPath, "userinfo", "u", "", "Admission Info including Roles, Cluster Roles and Subjects")
@@ -284,7 +287,7 @@ func (c *ApplyCommandConfig) applyPolicytoResource(
 }
 
 func (c *ApplyCommandConfig) loadResources(out io.Writer, policies []kyvernov1.PolicyInterface, validatingAdmissionPolicies []v1alpha1.ValidatingAdmissionPolicy, dClient dclient.Interface) ([]*unstructured.Unstructured, error) {
-	resources, err := common.GetResourceAccordingToResourcePath(out, nil, c.ResourcePaths, c.Cluster, policies, validatingAdmissionPolicies, dClient, c.Namespace, c.PolicyReport, "")
+	resources, err := common.GetResourceAccordingToResourcePath(out, nil, c.ResourcePaths, c.Cluster, policies, validatingAdmissionPolicies, dClient, c.Namespace, c.PolicyReport, "", c.genericResource)
 	if err != nil {
 		return resources, fmt.Errorf("failed to load resources (%w)", err)
 	}

--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -64,7 +64,7 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool, auditWa
 	// resources
 	fmt.Fprintln(out, "  Loading resources", "...")
 	resourceFullPath := path.GetFullPaths(testCase.Test.Resources, testDir, isGit)
-	resources, err := common.GetResourceAccordingToResourcePath(out, testCase.Fs, resourceFullPath, false, policies, validatingAdmissionPolicies, dClient, "", false, testDir)
+	resources, err := common.GetResourceAccordingToResourcePath(out, testCase.Fs, resourceFullPath, false, policies, validatingAdmissionPolicies, dClient, "", false, testDir, false)
 	if err != nil {
 		return nil, fmt.Errorf("Error: failed to load resources (%s)", err)
 	}

--- a/cmd/cli/kubectl-kyverno/utils/common/common.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common.go
@@ -35,13 +35,17 @@ func GetResourceAccordingToResourcePath(
 	namespace string,
 	policyReport bool,
 	policyResourcePath string,
+	isGenericResource bool,
 ) (resources []*unstructured.Unstructured, err error) {
 	if fs != nil {
+		//TODO: add logic here too for generic JSON
 		resources, err = GetResourcesWithTest(out, fs, policies, resourcePaths, policyResourcePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract the resources (%w)", err)
 		}
 	} else {
+		//TODO: add logic here too for generic JSON
+
 		if len(resourcePaths) > 0 && resourcePaths[0] == "-" {
 			if source.IsStdin(resourcePaths[0]) {
 				resourceStr := ""
@@ -57,6 +61,7 @@ func GetResourceAccordingToResourcePath(
 				}
 			}
 		} else {
+
 			if len(resourcePaths) > 0 {
 				fileDesc, err := os.Stat(resourcePaths[0])
 				if err != nil {
@@ -78,7 +83,7 @@ func GetResourceAccordingToResourcePath(
 				}
 			}
 
-			resources, err = GetResources(out, policies, validatingAdmissionPolicies, resourcePaths, dClient, cluster, namespace, policyReport)
+			resources, err = GetResources(out, policies, validatingAdmissionPolicies, resourcePaths, dClient, cluster, namespace, policyReport, isGenericResource)
 			if err != nil {
 				return resources, err
 			}

--- a/cmd/cli/kubectl-kyverno/utils/common/fetch.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/fetch.go
@@ -35,6 +35,7 @@ func GetResources(
 	cluster bool,
 	namespace string,
 	policyReport bool,
+	isGenericResource bool,
 ) ([]*unstructured.Unstructured, error) {
 	resources := make([]*unstructured.Unstructured, 0)
 	var err error
@@ -62,7 +63,7 @@ func GetResources(
 			}
 		}
 	} else if len(resourcePaths) > 0 {
-		resources, err = whenClusterIsFalse(out, resourcePaths, policyReport)
+		resources, err = whenClusterIsFalse(out, resourcePaths, policyReport, isGenericResource)
 		if err != nil {
 			return resources, err
 		}
@@ -102,7 +103,7 @@ func whenClusterIsTrue(out io.Writer, resourceTypes []schema.GroupVersionKind, s
 	return resources, nil
 }
 
-func whenClusterIsFalse(out io.Writer, resourcePaths []string, policyReport bool) ([]*unstructured.Unstructured, error) {
+func whenClusterIsFalse(out io.Writer, resourcePaths []string, policyReport bool, isGenericResource bool) ([]*unstructured.Unstructured, error) {
 	resources := make([]*unstructured.Unstructured, 0)
 	for _, resourcePath := range resourcePaths {
 		resourceBytes, err := resource.GetFileBytes(resourcePath)
@@ -115,9 +116,19 @@ func whenClusterIsFalse(out io.Writer, resourcePaths []string, policyReport bool
 			continue
 		}
 
-		getResources, err := resource.GetUnstructuredResources(resourceBytes)
-		if err != nil {
-			return nil, err
+		var getResources []*unstructured.Unstructured
+		if !isGenericResource {
+			getResources, err = resource.GetUnstructuredResources(resourceBytes)
+			if err != nil {
+				fmt.Print("error in getUnstructuredResources\n")
+				return nil, err
+			}
+		} else {
+			getResources, err = resource.GetUnstructuredGenericResources(resourceBytes)
+			if err != nil {
+				fmt.Print("error in getUnstructuredGenericResources\n")
+				return nil, err
+			}
 		}
 
 		resources = append(resources, getResources...)

--- a/pkg/engine/utils/match.go
+++ b/pkg/engine/utils/match.go
@@ -68,6 +68,7 @@ func doesResourceMatchConditionBlock(
 	}
 
 	var errs []error
+	//CHANGE KIND MATCH CONDITION HEREEEEE
 	if len(conditionBlock.Kinds) > 0 {
 		// Matching on ephemeralcontainers even when they are not explicitly specified for backward compatibility.
 		if !matchutils.CheckKind(conditionBlock.Kinds, gvk, subresource, true) {

--- a/pkg/utils/match/kind.go
+++ b/pkg/utils/match/kind.go
@@ -1,6 +1,7 @@
 package match
 
 import (
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/resource"
 	"github.com/kyverno/kyverno/ext/wildcard"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -14,7 +15,8 @@ var podGVK = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 func CheckKind(kinds []string, gvk schema.GroupVersionKind, subresource string, allowEphemeralContainers bool) bool {
 	for _, k := range kinds {
 		group, version, kind, sub := kubeutils.ParseKindSelector(k)
-		if wildcard.Match(group, gvk.Group) && wildcard.Match(version, gvk.Version) && wildcard.Match(kind, gvk.Kind) {
+		matchKind := wildcard.Match(kind, gvk.Kind) || gvk.Kind == resource.GenericResourceKind
+		if wildcard.Match(group, gvk.Group) && wildcard.Match(version, gvk.Version) && matchKind {
 			if wildcard.Match(sub, subresource) {
 				return true
 			} else if allowEphemeralContainers && gvk == podGVK && subresource == "ephemeralcontainers" {


### PR DESCRIPTION
## Explanation

Earlier the cli could not apply policies on non-k8s yaml files. i.e files that do not have `apiVersion`, `kind` fields. This PR adds a command line flag `--genericjson` which is a bool value using which the user can validate such generic resources. Or, the user can specify `kind: GenericResource` to achieve this same result.

## Related issue

Closes #7788 


## Documentation (optional)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
 
## What type of PR is this


> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature


## Proposed Changes
The changes will be in 2 steps:
1. How we load GenericResources
2. How we process the resources

For the first part, I propose adding a bool value `isGenericResource` to the `apply` command. If it is set to true, we shall automatically add fields `kind: GenericResource`  and `apiVersion: V1` while loading the resource from the file. The user need not specify these fields in their resource file. 

Secondly, while processing the policy on the resource we add an additional operator which checks for the `kind` of the resource. If the kind is `GenericResource` it will apply the policy on the resource regardless of the matching `kind` on the policy. This might bring about behaviour that is not expected. For example, if the template the policy expects is different from that of the resource. I hope to discuss that further.

### Proof Manifests


# Kyverno Policy

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-ns-purpose-label
spec:
  validationFailureAction: Audit
  rules:
  - name: require-ns-purpose-label
    match:
      any:
      - resources:
          kinds:
          - Deployment
    validate:
      message: "You must have label `purpose` with value `production` set on all new Deployments"
      pattern:
        metadata:
          labels:
            purpose: production
```
# Generic Resource 

```yaml
metadata:
  generation: 2
  labels:
    app: crow
    purpose: production
  name: crow
  namespace: black
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: crow
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: crow
    spec:
      containers:
        image: polinux/stress
        imagePullPolicy: Always
        name: crow
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      terminationGracePeriodSeconds: 30
```
# Kubectl-Kyverno cli Manifest

```
mviswanathsai@pop-os:~$ kubectl-kyverno apply /home/mviswanathsai/customPolicy.yaml --resource=/home/mviswanathsai/pod.yaml --genericresource=true

Applying 1 policy rule(s) to 1 resource(s)...

pass: 1, fail: 0, warn: 0, error: 0, skip: 0 

```


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

