### PR TITLE
Policyexception with cli

### DIFF
--- a/cmd/cli/kubectl-kyverno/apis/v1alpha1/test.go
+++ b/cmd/cli/kubectl-kyverno/apis/v1alpha1/test.go
@@ -34,4 +34,7 @@ type Test struct {
 
 	// Values are the values to be used in the test
 	Values *ValuesSpec `json:"values,omitempty"`
+
+	// Policy Exceptions are the policy exceptions to be used in the test
+	PolicyExceptions []string `json:"policyExceptions,omitempty"`
 }

--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -6,7 +6,9 @@ import (
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/api/kyverno/v1beta1"
+	kyvernov2beta1 "github.com/kyverno/kyverno/api/kyverno/v2beta1"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/deprecations"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/exception"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/log"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/path"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/policy"
@@ -74,6 +76,17 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool, auditWa
 			fmt.Fprintln(out, "  Warning: found duplicated resource", dup.Kind, dup.Name, dup.Namespace)
 		}
 	}
+	// policy exceptions
+	var policyExceptions []*kyvernov2beta1.PolicyException
+	if len(testCase.Test.PolicyExceptions) > 0 {
+		fmt.Fprintln(out, "  Loading policy exceptions", "...")
+		policyexceptionFullPath := path.GetFullPaths(testCase.Test.PolicyExceptions, testDir, isGit)
+		policyExceptions, err = exception.Loader(testCase.Fs, testDir, policyexceptionFullPath...)
+		if err != nil {
+			return nil, fmt.Errorf("Error: failed to load policy exceptions (%s)", err)
+		}
+	}
+	fmt.Print(policyExceptions)
 	// init store
 	var store store.Store
 	store.SetLocal(true)

--- a/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
@@ -40,6 +40,12 @@ spec:
             items:
               type: string
             type: array
+          policyExceptions:
+            description: Policy Exceptions are the policy exceptions to be used in
+              the test
+            items:
+              type: string
+            type: array
           resources:
             description: Resources are the resource to be used in the test
             items:

--- a/cmd/cli/kubectl-kyverno/exception/load.go
+++ b/cmd/cli/kubectl-kyverno/exception/load.go
@@ -2,7 +2,10 @@ package exception
 
 import (
 	"fmt"
+	"io"
+	"os"
 
+	"github.com/go-git/go-billy/v5"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
 	kyvernov2beta1 "github.com/kyverno/kyverno/api/kyverno/v2beta1"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/data"
@@ -41,5 +44,43 @@ func Load(content []byte) ([]*kyvernov2beta1.PolicyException, error) {
 			return nil, fmt.Errorf("policy exception type not supported %s", gvk)
 		}
 	}
+	return exceptions, nil
+}
+
+func Loader(fs billy.Filesystem, resoucepath string, paths ...string) ([]*kyvernov2beta1.PolicyException, error) {
+	var exceptions []*kyvernov2beta1.PolicyException
+	for _, path := range paths {
+		var content []byte
+		var err error
+
+		if fs != nil {
+			// If a filesystem is provided, use it to read the file
+			f, err := fs.Open(path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to open file: %s, error: %v", path, err)
+			}
+			defer f.Close()
+
+			content, err = io.ReadAll(f)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read file: %s, error: %v", path, err)
+			}
+		} else {
+			// Otherwise, read the file from the local filesystem
+			content, err = os.ReadFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read file: %s, error: %v", path, err)
+			}
+		}
+		fmt.Printf("loading policy exception from file: %s\n", path)
+		// Load the policy exceptions from the content
+		excs, err := Load(content)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load policy exceptions from file: %s, error: %v", path, err)
+		}
+
+		exceptions = append(exceptions, excs...)
+	}
+
 	return exceptions, nil
 }


### PR DESCRIPTION
## Explanation
This is Draft PR to elaborate I am currently working on this issue and take guidance form maintainer @eddycharly @MariamFahmy98 Please guide me if my approach is right or wrong 
Currently i am focusing on only Test command as @eddycharly mention in issue [conversation](https://github.com/kyverno/kyverno/issues/6746#issuecomment-1722316154) after completing Test command then i will contribute to apply command 
Till now i have added PolicyExceptions in Test struct then generated crds and successfully loaded policy exception file in runTest function and then i also tested policyexception is loaded or not by building cli binary then applying kyverno-test.yaml that is mentioned below in cli test 
Now i am finding how kyverno apply policyexception on policies in backend engine but it is little tough to understand 
If this approach is right till now then please guide me how to proceed further how to use these loaded policy exception in processor and how to execute policyexception in engine  
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Focus #6746 @eddycharly @MariamFahmy98 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (optional)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->


# Kyverno CLI test manifest 

```yaml
apiVersion: cli.kyverno.io/v1alpha1
kind: Test
metadata:
  name: disallow-host-namespaces-test-exception
policies:
- ../disallow-host-namespace.yaml
resources:
- dp-with-delta.yaml
- dp-without-delta.yaml
policyexceptions: 
- policy-exception1.yaml
- policy-exception2.yaml
results:
  - kind: Deployment
    policy: disallow-host-namespaces
    resources: 
    - important-tool
    rule: host-namespaces
    result: fail
  - kind: Deployment
    policy: disallow-host-namespaces
    resources: 
    - notimportant-tool
    rule: host-namespaces
    result: fail
```
I added some printf to check the output
```
sanskar@sanskar-HP-Laptop-15s-du1xxx:~/policies/exceptiontestcli$ kubectl-kyverno test . 
Loading test  ( .kyverno-test/kyverno-test.yaml ) ...
  Loading values/variables ...
  Loading policies ...
  Loading resources ...
  Loading policy exceptions ...
loading policy exception from file: .kyverno-test/policy-exception1.yaml
loading policy exception from file: .kyverno-test/policy-exception2.yaml
[0xc000607a20 0xc0008366e0]  Applying 1 policy to 2 resources ...
  Checking results ...

│────│──────────────────────────│─────────────────│──────────────────────────────│────────│────────│
│ ID │ POLICY                   │ RULE            │ RESOURCE                     │ RESULT │ REASON │
│────│──────────────────────────│─────────────────│──────────────────────────────│────────│────────│
│ 1  │ disallow-host-namespaces │ host-namespaces │ Deployment/important-tool    │ Pass   │ Ok     │
│ 2  │ disallow-host-namespaces │ host-namespaces │ Deployment/notimportant-tool │ Pass   │ Ok     │
│────│──────────────────────────│─────────────────│──────────────────────────────│────────│────────│


Test Summary: 2 tests passed and 0 tests failed
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
