### PR TITLE
fix: reduce logs in controllers when an item is not found

### DIFF
--- a/pkg/utils/controller/run.go
+++ b/pkg/utils/controller/run.go
@@ -109,7 +109,7 @@ func handleErr(ctx context.Context, logger logr.Logger, metric *controllerMetric
 	if err == nil {
 		queue.Forget(obj)
 	} else if errors.IsNotFound(err) {
-		logger.Info("Dropping request from the queue", "obj", obj, "error", err.Error())
+		logger.V(4).Info("Dropping request from the queue", "obj", obj, "error", err.Error())
 		queue.Forget(obj)
 	} else if queue.NumRequeues(obj) < maxRetries {
 		logger.Info("Retrying request", "obj", obj, "error", err.Error())


### PR DESCRIPTION
## Explanation

Reduce logs in controllers when an item is not found.
