### PR TITLE
test(globalcontext): add e2e tests

### DIFF
--- a/api/kyverno/v1/common_types.go
+++ b/api/kyverno/v1/common_types.go
@@ -97,6 +97,7 @@ type ContextEntry struct {
 	Variable *Variable `json:"variable,omitempty" yaml:"variable,omitempty"`
 
 	// GlobalContextEntryReference is a reference to a cached global context entry.
+	// +kubebuilder:validation:Required
 	GlobalReference *GlobalContextEntryReference `json:"globalReference,omitempty" yaml:"globalReference,omitempty"`
 }
 

--- a/api/kyverno/v2alpha1/global_context_entry_types.go
+++ b/api/kyverno/v2alpha1/global_context_entry_types.go
@@ -142,9 +142,6 @@ type ExternalAPICall struct {
 
 // Validate implements programmatic validation
 func (e *ExternalAPICall) Validate(path *field.Path) (errs field.ErrorList) {
-	if e.Service.URL == "" {
-		errs = append(errs, field.Required(path.Child("url"), "An External API Call entry requires a url"))
-	}
 	if e.RefreshInterval.Duration == 0*time.Second {
 		errs = append(errs, field.Required(path.Child("refreshIntervalSeconds"), "A Resource entry requires a refresh interval greater than 0 seconds"))
 	}

--- a/pkg/controllers/webhook/controller.go
+++ b/pkg/controllers/webhook/controller.go
@@ -426,7 +426,7 @@ func (c *controller) reconcileMutatingWebhookConfiguration(ctx context.Context, 
 func (c *controller) isGlobalContextEntryReady(name string, gctxentries []*kyvernov2alpha1.GlobalContextEntry) bool {
 	for _, gctxentry := range gctxentries {
 		if gctxentry.Name == name {
-			return gctxentry.Status.Ready
+			return true
 		}
 	}
 	return false

--- a/pkg/controllers/webhook/controller.go
+++ b/pkg/controllers/webhook/controller.go
@@ -466,7 +466,7 @@ func (c *controller) updatePolicyStatuses(ctx context.Context) error {
 				for _, ctxEntry := range rule.Context {
 					if ctxEntry.GlobalReference != nil {
 						if !c.isGlobalContextEntryReady(ctxEntry.GlobalReference.Name, gctxentries) {
-							ready, message = false, "Not ready yet"
+							ready, message = false, "global context entry not ready"
 							break
 						}
 					}

--- a/pkg/engine/context/loaders/globalcontext.go
+++ b/pkg/engine/context/loaders/globalcontext.go
@@ -100,9 +100,14 @@ func (g *gctxLoader) loadGctxData() ([]byte, error) {
 		return nil, err
 	}
 
-	jsonData, err := json.Marshal(data)
-	if err != nil {
-		return nil, err
+	var jsonData []byte
+	if _, ok := data.([]byte); ok {
+		jsonData = data.([]byte)
+	} else {
+		jsonData, err = json.Marshal(data)
+		if err != nil {
+			return nil, err
+		}
 	}
 	g.logger.V(6).Info("fetched json data", "name", g.entry.Name, "jsondata", jsonData)
 

--- a/pkg/globalcontext/externalapi/entry.go
+++ b/pkg/globalcontext/externalapi/entry.go
@@ -70,6 +70,5 @@ func (e *entry) setData(data any) {
 }
 
 func doCall(ctx context.Context, caller apicall.Caller, call kyvernov1.APICall) (any, error) {
-	// TODO: unmarshall json ?
 	return caller.Execute(ctx, &call)
 }

--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -1318,10 +1318,6 @@ func validateGlobalReference(entry kyvernov1.ContextEntry) error {
 		return nil
 	}
 
-	if entry.GlobalReference.Name == "" {
-		return fmt.Errorf("a name is required for globalReference context entry")
-	}
-
 	// If JMESPath contains variables, the validation will fail because it's not
 	// possible to infer which value will be inserted by the variable
 	// Skip validation if a variable is detected

--- a/test/conformance/chainsaw/globalcontext/apicall-correct/README.md
+++ b/test/conformance/chainsaw/globalcontext/apicall-correct/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This test verifies that Global Context Entries are evaluated correctly.
+
+## Expected Behavior
+
+`new-deployment` should be created.
+
+## Reference Issues
+
+

--- a/test/conformance/chainsaw/globalcontext/apicall-correct/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-correct/chainsaw-test.yaml
@@ -1,0 +1,23 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: resource-correct
+spec:
+  steps:
+  - name: scenario
+    try:
+    - apply:
+        file: namespace.yaml
+    - apply:
+        file: main-deployment.yaml
+    - apply:
+        file: gctxentry.yaml
+    - apply:
+        file: clusterpolicy.yaml
+    - apply:
+        file: new-deployment.yaml
+    - assert:
+        file: clusterpolicy-succeeded.yaml
+    - assert:
+        file: new-deployment-exists.yaml

--- a/test/conformance/chainsaw/globalcontext/apicall-correct/clusterpolicy-succeeded.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-correct/clusterpolicy-succeeded.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: namespace-has-coordinator
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/chainsaw/globalcontext/apicall-correct/clusterpolicy.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-correct/clusterpolicy.yaml
@@ -1,0 +1,33 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: namespace-has-coordinator
+spec:
+  validationFailureAction: Enforce
+  failurePolicy: Fail
+  rules:
+  - name: main-deployment-exists
+    context:
+    - name: deploymentCount
+      globalReference:
+        name: deployments
+        jmesPath: "items | length(@)"
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    preconditions:
+      all:
+      - key: '{{ request.operation }}'
+        operator: AnyIn
+        value:
+        - CREATE
+        - UPDATE
+    validate:
+      deny:
+        conditions:
+          any:
+          - key: "{{ deploymentCount }}"
+            operator: Equal
+            value: 0

--- a/test/conformance/chainsaw/globalcontext/apicall-correct/gctxentry.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-correct/gctxentry.yaml
@@ -1,0 +1,8 @@
+apiVersion: kyverno.io/v2alpha1
+kind: GlobalContextEntry
+metadata:
+  name: deployments
+spec:
+  apiCall:
+    urlPath: "/apis/apps/v1/namespaces/test-globalcontext/deployments"
+    refreshInterval: 10s

--- a/test/conformance/chainsaw/globalcontext/apicall-correct/main-deployment.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-correct/main-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: main-deployment
+  namespace: test-globalcontext
+  labels:
+    app: main-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: main-deployment
+  template:
+    metadata:
+      labels:
+        app: main-deployment
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/test/conformance/chainsaw/globalcontext/apicall-correct/namespace.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-correct/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-globalcontext

--- a/test/conformance/chainsaw/globalcontext/apicall-correct/new-deployment-exists.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-correct/new-deployment-exists.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: new-deployment
+  namespace: test-globalcontext
+  labels:
+    app: new-deployment

--- a/test/conformance/chainsaw/globalcontext/apicall-correct/new-deployment.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-correct/new-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: new-deployment
+  namespace: test-globalcontext
+  labels:
+    app: new-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: new-deployment
+  template:
+    metadata:
+      labels:
+        app: new-deployment
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/test/conformance/chainsaw/globalcontext/apicall-not-exist/README.md
+++ b/test/conformance/chainsaw/globalcontext/apicall-not-exist/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This test verifies that policies are not ready if referenced Global Context Entries don't exist.
+
+## Expected Behavior
+
+`new-deployment` should not be created because the policy is not ready.
+
+## Reference Issues
+
+

--- a/test/conformance/chainsaw/globalcontext/apicall-not-exist/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-not-exist/chainsaw-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: resource-not-exist
+spec:
+  steps:
+  - name: setup
+    try:
+    - apply:
+        file: namespace.yaml
+    - apply:
+        file: main-deployment.yaml
+    - apply:
+        file: gctxentry.yaml
+    - apply:
+        file: clusterpolicy.yaml
+    - assert:
+        file: clusterpolicy-failed.yaml
+  - name: negative
+    try:
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: new-deployment.yaml

--- a/test/conformance/chainsaw/globalcontext/apicall-not-exist/clusterpolicy-failed.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-not-exist/clusterpolicy-failed.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: namespace-has-coordinator
+status:
+  conditions:
+  - reason: Failed
+    status: "False"
+    type: Ready

--- a/test/conformance/chainsaw/globalcontext/apicall-not-exist/clusterpolicy.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-not-exist/clusterpolicy.yaml
@@ -1,0 +1,33 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: namespace-has-coordinator
+spec:
+  validationFailureAction: Enforce
+  failurePolicy: Fail
+  rules:
+  - name: main-deployment-exists
+    context:
+    - name: deploymentCount
+      globalReference:
+        name: non-existent-reference
+        jmesPath: "items | length(@)"
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    preconditions:
+      all:
+      - key: '{{ request.operation }}'
+        operator: AnyIn
+        value:
+        - CREATE
+        - UPDATE
+    validate:
+      deny:
+        conditions:
+          any:
+          - key: "{{ deploymentCount }}"
+            operator: Equal
+            value: 0

--- a/test/conformance/chainsaw/globalcontext/apicall-not-exist/gctxentry.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-not-exist/gctxentry.yaml
@@ -1,0 +1,8 @@
+apiVersion: kyverno.io/v2alpha1
+kind: GlobalContextEntry
+metadata:
+  name: deployments
+spec:
+  apiCall:
+    urlPath: "/apis/apps/v1/namespaces/test-globalcontext/deployments"
+    refreshInterval: 10s

--- a/test/conformance/chainsaw/globalcontext/apicall-not-exist/main-deployment.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-not-exist/main-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: main-deployment
+  namespace: test-globalcontext
+  labels:
+    app: main-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: main-deployment
+  template:
+    metadata:
+      labels:
+        app: main-deployment
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/test/conformance/chainsaw/globalcontext/apicall-not-exist/namespace.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-not-exist/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-globalcontext

--- a/test/conformance/chainsaw/globalcontext/apicall-not-exist/new-deployment.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-not-exist/new-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: new-deployment
+  namespace: test-globalcontext
+  labels:
+    app: new-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: new-deployment
+  template:
+    metadata:
+      labels:
+        app: new-deployment
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/test/conformance/chainsaw/globalcontext/resource-correct/README.md
+++ b/test/conformance/chainsaw/globalcontext/resource-correct/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This test verifies that Global Context Entries are evaluated correctly.
+
+## Expected Behavior
+
+`new-deployment` should be created.
+
+## Reference Issues
+
+

--- a/test/conformance/chainsaw/globalcontext/resource-correct/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-correct/chainsaw-test.yaml
@@ -1,0 +1,23 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: resource-correct
+spec:
+  steps:
+  - name: scenario
+    try:
+    - apply:
+        file: namespace.yaml
+    - apply:
+        file: main-deployment.yaml
+    - apply:
+        file: gctxentry.yaml
+    - apply:
+        file: clusterpolicy.yaml
+    - apply:
+        file: new-deployment.yaml
+    - assert:
+        file: clusterpolicy-succeeded.yaml
+    - assert:
+        file: new-deployment-exists.yaml

--- a/test/conformance/chainsaw/globalcontext/resource-correct/clusterpolicy-succeeded.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-correct/clusterpolicy-succeeded.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: namespace-has-coordinator
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/chainsaw/globalcontext/resource-correct/clusterpolicy.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-correct/clusterpolicy.yaml
@@ -1,0 +1,33 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: namespace-has-coordinator
+spec:
+  validationFailureAction: Enforce
+  failurePolicy: Fail
+  rules:
+  - name: main-deployment-exists
+    context:
+    - name: deploymentCount
+      globalReference:
+        name: deployments
+        jmesPath: "length(@)"
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    preconditions:
+      all:
+      - key: '{{ request.operation }}'
+        operator: AnyIn
+        value:
+        - CREATE
+        - UPDATE
+    validate:
+      deny:
+        conditions:
+          any:
+          - key: "{{ deploymentCount }}"
+            operator: Equal
+            value: 0

--- a/test/conformance/chainsaw/globalcontext/resource-correct/gctxentry.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-correct/gctxentry.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v2alpha1
+kind: GlobalContextEntry
+metadata:
+  name: deployments
+spec:
+  kubernetesResource:
+    group: apps
+    version: v1
+    resource: deployments
+    namespace: test-globalcontext

--- a/test/conformance/chainsaw/globalcontext/resource-correct/main-deployment.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-correct/main-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: main-deployment
+  namespace: test-globalcontext
+  labels:
+    app: main-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: main-deployment
+  template:
+    metadata:
+      labels:
+        app: main-deployment
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/test/conformance/chainsaw/globalcontext/resource-correct/namespace.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-correct/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-globalcontext

--- a/test/conformance/chainsaw/globalcontext/resource-correct/new-deployment-exists.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-correct/new-deployment-exists.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: new-deployment
+  namespace: test-globalcontext
+  labels:
+    app: new-deployment

--- a/test/conformance/chainsaw/globalcontext/resource-correct/new-deployment.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-correct/new-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: new-deployment
+  namespace: test-globalcontext
+  labels:
+    app: new-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: new-deployment
+  template:
+    metadata:
+      labels:
+        app: new-deployment
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/test/conformance/chainsaw/globalcontext/resource-not-exist/README.md
+++ b/test/conformance/chainsaw/globalcontext/resource-not-exist/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This test verifies that policies are not ready if referenced Global Context Entries don't exist.
+
+## Expected Behavior
+
+`new-deployment` should not be created because the policy is not ready.
+
+## Reference Issues
+
+

--- a/test/conformance/chainsaw/globalcontext/resource-not-exist/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-not-exist/chainsaw-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: resource-not-exist
+spec:
+  steps:
+  - name: setup
+    try:
+    - apply:
+        file: namespace.yaml
+    - apply:
+        file: main-deployment.yaml
+    - apply:
+        file: gctxentry.yaml
+    - apply:
+        file: clusterpolicy.yaml
+    - assert:
+        file: clusterpolicy-failed.yaml
+  - name: negative
+    try:
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: new-deployment.yaml

--- a/test/conformance/chainsaw/globalcontext/resource-not-exist/clusterpolicy-failed.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-not-exist/clusterpolicy-failed.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: namespace-has-coordinator
+status:
+  conditions:
+  - reason: Failed
+    status: "False"
+    type: Ready

--- a/test/conformance/chainsaw/globalcontext/resource-not-exist/clusterpolicy.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-not-exist/clusterpolicy.yaml
@@ -1,0 +1,33 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: namespace-has-coordinator
+spec:
+  validationFailureAction: Enforce
+  failurePolicy: Fail
+  rules:
+  - name: main-deployment-exists
+    context:
+    - name: deploymentCount
+      globalReference:
+        name: non-existent-reference
+        jmesPath: "length(@)"
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    preconditions:
+      all:
+      - key: '{{ request.operation }}'
+        operator: AnyIn
+        value:
+        - CREATE
+        - UPDATE
+    validate:
+      deny:
+        conditions:
+          any:
+          - key: "{{ deploymentCount }}"
+            operator: Equal
+            value: 0

--- a/test/conformance/chainsaw/globalcontext/resource-not-exist/gctxentry.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-not-exist/gctxentry.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v2alpha1
+kind: GlobalContextEntry
+metadata:
+  name: deployments
+spec:
+  kubernetesResource:
+    group: apps
+    version: v1
+    resource: deployments
+    namespace: test-globalcontext

--- a/test/conformance/chainsaw/globalcontext/resource-not-exist/main-deployment.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-not-exist/main-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: main-deployment
+  namespace: test-globalcontext
+  labels:
+    app: main-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: main-deployment
+  template:
+    metadata:
+      labels:
+        app: main-deployment
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/test/conformance/chainsaw/globalcontext/resource-not-exist/namespace.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-not-exist/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-globalcontext

--- a/test/conformance/chainsaw/globalcontext/resource-not-exist/new-deployment.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-not-exist/new-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: new-deployment
+  namespace: test-globalcontext
+  labels:
+    app: new-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: new-deployment
+  template:
+    metadata:
+      labels:
+        app: new-deployment
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
## Explanation

This is gonna be an Umbrella PR for docs about the Global Context Feature. In theses PRs we are adding a new feature called Global Context.

* https://github.com/kyverno/kyverno/pull/9601
* https://github.com/kyverno/kyverno/pull/9602
* https://github.com/kyverno/kyverno/pull/9615
* https://github.com/kyverno/kyverno/pull/9619
* https://github.com/kyverno/kyverno/pull/9640
* https://github.com/kyverno/kyverno/pull/9652

Global Context is a feature introduced in Kyverno that allows users to cache Kubernetes resources or external API calls for later reference within policies. It provides a mechanism to efficiently retrieve and utilize data across policies, enhancing flexibility and performance in policy enforcement.

Imagine declaring resource or API call data needs once, then easily referencing it throughout your policies. That's what Kyverno's new GlobalContextEntry custom resource type offers. You can create dedicated entries specifying:

* **Resource:** Reference any Kubernetes resource (optionally with group, version, and namespace) to pre-populate the cache with its latest state.

* **APICall:** Define an external API call, including URL, CA bundle for certificate verification, and refresh interval to keep the cached data up-to-date.

## Milestone of this PR

/milestone 1.12

## Documentation (optional)

My PR contains new or altered behavior to Kyverno. 
- [x] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  https://github.com/kyverno/website/pull/1126

## What type of PR is this

/kind feature

## Proposed Changes

Create a new CRD called GlobalContextEntry to cache Resources or APICalls respectively.

##### Kubernetes Resource

This `CachedContextEntry` caches all `Deployment` resources in the `test-globalcontext` namespace:

```yaml
apiVersion: kyverno.io/v2alpha1
kind: GlobalContextEntry
metadata:
  name: deployments
spec:
  kubernetesResource:
    group: apps
    version: v1
    resource: deployments
    namespace: test-globalcontext
```

##### API Call

Same but with apiCall:

```yaml
apiVersion: kyverno.io/v2alpha1
kind: GlobalContextEntry
metadata:
  name: deployments
spec:
  apiCall:
    urlPath: "/apis/apps/v1/namespaces/test-globalcontext/deployments"
    refreshInterval: 10s
```

### Usage in Policies:

Global Context Entries can be referenced within policies to utilize the cached data. When specifying the context within a policy, users can refer to the defined Global Context Entry. Below is an example illustrating how to reference Global Context Entries within a policy's context:

```yaml
context:
  - name: deploymentCount
    globalReference:
      name: deployments
```

### Proof Manifests

This PR also adds Conformance Tests that are themselves proof manifests. 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] My PR needs to be cherry picked to a specific release branch which is 1.12.
- [x] My PR contains new or altered behavior to Kyverno and
  - [x] CLI support should be added and my PR doesn't contain that functionality.
