### PR TITLE
fix: add the support of v2alpha1 exceptions in the CLI

### DIFF
--- a/cmd/cli/kubectl-kyverno/exception/load.go
+++ b/cmd/cli/kubectl-kyverno/exception/load.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	kyvernov2alpha1 "github.com/kyverno/kyverno/api/kyverno/v2alpha1"
 	kyvernov2beta1 "github.com/kyverno/kyverno/api/kyverno/v2beta1"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/data"
 	"github.com/kyverno/kyverno/ext/resource/convert"
@@ -16,9 +17,10 @@ import (
 )
 
 var (
-	factory, _       = resourceloader.New(openapiclient.NewComposite(openapiclient.NewLocalCRDFiles(data.Crds(), data.CrdsFolder)))
-	exceptionV2beta1 = schema.GroupVersion(kyvernov2beta1.GroupVersion).WithKind("PolicyException")
-	exceptionV2      = schema.GroupVersion(kyvernov2.GroupVersion).WithKind("PolicyException")
+	factory, _        = resourceloader.New(openapiclient.NewComposite(openapiclient.NewLocalCRDFiles(data.Crds(), data.CrdsFolder)))
+	exceptionV2alpha1 = schema.GroupVersion(kyvernov2alpha1.GroupVersion).WithKind("PolicyException")
+	exceptionV2beta1  = schema.GroupVersion(kyvernov2beta1.GroupVersion).WithKind("PolicyException")
+	exceptionV2       = schema.GroupVersion(kyvernov2.GroupVersion).WithKind("PolicyException")
 )
 
 func Load(paths ...string) ([]*kyvernov2beta1.PolicyException, error) {
@@ -49,7 +51,7 @@ func load(content []byte) ([]*kyvernov2beta1.PolicyException, error) {
 			return nil, err
 		}
 		switch gvk {
-		case exceptionV2beta1, exceptionV2:
+		case exceptionV2alpha1, exceptionV2beta1, exceptionV2:
 			exception, err := convert.To[kyvernov2beta1.PolicyException](untyped)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Explanation
This PR adds the support for applying/testing v2alpha1 exceptions using Kyverno CLI.
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
N/A
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.12.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Using Kyverno apply command:
      1. policy.yaml:
      ```
      apiVersion: kyverno.io/v1
      kind: ClusterPolicy
      metadata:
        name: max-containers
      spec:
        validationFailureAction: Enforce
        background: false
        rules:
        - name: max-two-containers
          match:
            any:
            - resources:
                kinds:
                - Pod
          validate:
            message: "A maximum of 2 containers are allowed inside a Pod."
            deny:
              conditions:
                any:
                - key: "{{request.object.spec.containers[] | length(@)}}"
                  operator: GreaterThan
                  value: 2
      ```
      2. exception.yaml:
      ```
      apiVersion: kyverno.io/v2alpha1
      kind: PolicyException
      metadata:
        name: container-exception
      spec:
        exceptions:
        - policyName: max-containers
          ruleNames:
          - max-two-containers
          - autogen-max-two-containers
        match:
          any:
          - resources:
              kinds:
              - Pod
              - Deployment
        conditions:
          any:
          - key: "{{ request.object.metadata.labels.color || '' }}"
            operator: Equals
            value: blue
      ```
      3. resource.yaml:
      ```
      apiVersion: apps/v1
      kind: Deployment
      metadata:
        name: three-containers-deployment
        labels:
          app: my-app
          color: blue
      spec:
        replicas: 3
        selector:
          matchLabels:
            app: my-app
        template:
          metadata:
            labels:
              app: my-app
              color: blue
          spec:
            containers:
              - name: nginx-container
                image: nginx:latest
                ports:
                  - containerPort: 80
              - name: redis-container
                image: redis:latest
                ports:
                  - containerPort: 6379
              - name: busybox-container
                image: busybox:latest
                command: ["/bin/sh", "-c", "while true; do echo 'Hello from BusyBox'; sleep 10; done"]
      ```
      
      The result of applying the policy to the resource given an exception:
      ```
      cmd/cli/kubectl-kyverno/kubectl-kyverno apply policy.yaml --resource resource.yaml --exception exception.yaml
      
      Applying 3 policy rule(s) to 1 resource(s) with 1 exception(s)...
      
      pass: 0, fail: 0, warn: 0, error: 0, skip: 1 
      ```
2. Using Kyverno test command:
      1. policy.yaml:
      ```
      apiVersion: kyverno.io/v2beta1
      kind: ClusterPolicy
      metadata:
        name: disallow-host-namespaces
      spec:
        validationFailureAction: Enforce
        background: false
        rules:
          - name: host-namespaces
            match:
              any:
              - resources:
                  kinds:
                    - Pod
            validate:
              message: >-
                Sharing the host namespaces is disallowed. The fields spec.hostNetwork,
                spec.hostIPC, and spec.hostPID must be unset or set to `false`.          
              pattern:
                spec:
                  =(hostPID): "false"
                  =(hostIPC): "false"
                  =(hostNetwork): "false"
      ```
      2. resource.yaml:
      ```
      apiVersion: apps/v1
      kind: Deployment
      metadata:
        name: important-tool
        namespace: delta
        labels:
          app: busybox
      spec:
        replicas: 1
        selector:
          matchLabels:
            app: busybox
        template:
          metadata:
            labels:
              app: busybox
          spec:
            hostIPC: true
            containers:
            - image: busybox:1.35
              name: busybox
              command: ["sleep", "1d"]
      ---
      apiVersion: apps/v1
      kind: Deployment
      metadata:
        name: not-important
        namespace: gamma
        labels:
          app: busybox
      spec:
        replicas: 1
        selector:
          matchLabels:
            app: busybox
        template:
          metadata:
            labels:
              app: busybox
          spec:
            hostIPC: true
            containers:
            - image: busybox:1.35
              name: busybox
              command: ["sleep", "1d"]   
      ```
      3. exception.yaml:
      ```
      apiVersion: kyverno.io/v2alpha1
      kind: PolicyException
      metadata:
        name: delta-exception
        namespace: delta
      spec:
        exceptions:
        - policyName: disallow-host-namespaces
          ruleNames:
          - host-namespaces
          - autogen-host-namespaces
        match:
          any:
          - resources:
              kinds:
              - Pod
              - Deployment
              namespaces:
              - delta
              names:
              - important-tool*
      ```
      4. kyverno-test.yaml:
      ```
      apiVersion: cli.kyverno.io/v1alpha1
      kind: Test
      metadata:
        name: disallow-host-namespaces-test-exception
      policies:
      - policy.yaml
      resources:
      - resource.yaml
      exceptions: 
      - exception.yaml
      results:
        - kind: Deployment
          policy: disallow-host-namespaces
          resources: 
          - important-tool
          rule: host-namespaces
          result: skip
        - kind: Deployment
          policy: disallow-host-namespaces
          resources:
          - not-important
          rule: host-namespaces
          result: fail
      ```
      
      The result of applying a policy to resources given an exception:
      ```
      cmd/cli/kubectl-kyverno/kubectl-kyverno test ../manifests/exceptions/cli/test 
      Loading test  ( ../manifests/exceptions/cli/test/kyverno-test.yaml ) ...
        Loading values/variables ...
        Loading policies ...
        Loading resources ...
        Loading exceptions ...
        Applying 1 policy to 2 resources with 1 exception ...
        Checking results ...
      
      │────│──────────────────────────│─────────────────│───────────────────────────│────────│────────│
      │ ID │ POLICY                   │ RULE            │ RESOURCE                  │ RESULT │ REASON │
      │────│──────────────────────────│─────────────────│───────────────────────────│────────│────────│
      │ 1  │ disallow-host-namespaces │ host-namespaces │ Deployment/important-tool │ Pass   │ Ok     │
      │ 2  │ disallow-host-namespaces │ host-namespaces │ Deployment/not-important  │ Pass   │ Ok     │
      │────│──────────────────────────│─────────────────│───────────────────────────│────────│────────│
      
      
      Test Summary: 2 tests passed and 0 tests failed
      ```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
