### PR TITLE
feat: apply VAP bindings in CLI apply command in offline mode

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -193,7 +193,7 @@ func (c *ApplyCommandConfig) applyCommandHelper(out io.Writer) (*processor.Resul
 	if err != nil {
 		return rc, resources1, skipInvalidPolicies, responses1, err
 	}
-	responses2, err := c.applyValidatingAdmissionPolicytoResource(vaps, vapBindings, resources1, rc, dClient)
+	responses2, err := c.applyValidatingAdmissionPolicytoResource(vaps, vapBindings, resources1, variables.NamespaceSelectors(), rc, dClient)
 	if err != nil {
 		return rc, resources1, skipInvalidPolicies, responses1, err
 	}
@@ -215,18 +215,20 @@ func (c *ApplyCommandConfig) applyValidatingAdmissionPolicytoResource(
 	vaps []v1alpha1.ValidatingAdmissionPolicy,
 	vapBindings []v1alpha1.ValidatingAdmissionPolicyBinding,
 	resources []*unstructured.Unstructured,
+	namespaceSelectorMap map[string]map[string]string,
 	rc *processor.ResultCounts,
 	dClient dclient.Interface,
 ) ([]engineapi.EngineResponse, error) {
 	var responses []engineapi.EngineResponse
 	for _, resource := range resources {
 		processor := processor.ValidatingAdmissionPolicyProcessor{
-			Policies:     vaps,
-			Bindings:     vapBindings,
-			Resource:     resource,
-			PolicyReport: c.PolicyReport,
-			Rc:           rc,
-			Client:       dClient,
+			Policies:             vaps,
+			Bindings:             vapBindings,
+			Resource:             resource,
+			NamespaceSelectorMap: namespaceSelectorMap,
+			PolicyReport:         c.PolicyReport,
+			Rc:                   rc,
+			Client:               dClient,
 		}
 		ers, err := processor.ApplyPolicyOnResource()
 		if err != nil {

--- a/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
@@ -277,6 +277,84 @@ func Test_Apply(t *testing.T) {
 		},
 		{
 			config: ApplyCommandConfig{
+				PolicyPaths: []string{"../../../../../test/cli/test-validating-admission-policy/with-bindings-1/policy.yaml"},
+				ResourcePaths: []string{
+					"../../../../../test/cli/test-validating-admission-policy/with-bindings-1/deployment1.yaml",
+					"../../../../../test/cli/test-validating-admission-policy/with-bindings-1/deployment2.yaml",
+				},
+				PolicyReport: true,
+			},
+			expectedPolicyReports: []policyreportv1alpha2.PolicyReport{{
+				Summary: policyreportv1alpha2.PolicyReportSummary{
+					Pass:  0,
+					Fail:  1,
+					Skip:  0,
+					Error: 0,
+					Warn:  0,
+				},
+			}},
+		},
+		{
+			config: ApplyCommandConfig{
+				PolicyPaths: []string{"../../../../../test/cli/test-validating-admission-policy/with-bindings-2/policy.yaml"},
+				ResourcePaths: []string{
+					"../../../../../test/cli/test-validating-admission-policy/with-bindings-2/deployment1.yaml",
+					"../../../../../test/cli/test-validating-admission-policy/with-bindings-2/deployment2.yaml",
+				},
+				PolicyReport: true,
+			},
+			expectedPolicyReports: []policyreportv1alpha2.PolicyReport{{
+				Summary: policyreportv1alpha2.PolicyReportSummary{
+					Pass:  0,
+					Fail:  1,
+					Skip:  0,
+					Error: 0,
+					Warn:  0,
+				},
+			}},
+		},
+		{
+			config: ApplyCommandConfig{
+				PolicyPaths: []string{"../../../../../test/cli/test-validating-admission-policy/with-bindings-3/policy.yaml"},
+				ResourcePaths: []string{
+					"../../../../../test/cli/test-validating-admission-policy/with-bindings-3/deployment1.yaml",
+					"../../../../../test/cli/test-validating-admission-policy/with-bindings-3/deployment2.yaml",
+					"../../../../../test/cli/test-validating-admission-policy/with-bindings-3/deployment3.yaml",
+				},
+				ValuesFile:   "../../../../../test/cli/test-validating-admission-policy/with-bindings-3/values.yaml",
+				PolicyReport: true,
+			},
+			expectedPolicyReports: []policyreportv1alpha2.PolicyReport{{
+				Summary: policyreportv1alpha2.PolicyReportSummary{
+					Pass:  0,
+					Fail:  2,
+					Skip:  0,
+					Error: 0,
+					Warn:  0,
+				},
+			}},
+		},
+		{
+			config: ApplyCommandConfig{
+				PolicyPaths: []string{"../../../../../test/cli/test-validating-admission-policy/with-bindings-4/policy.yaml"},
+				ResourcePaths: []string{
+					"../../../../../test/cli/test-validating-admission-policy/with-bindings-4/deployment1.yaml",
+					"../../../../../test/cli/test-validating-admission-policy/with-bindings-4/deployment2.yaml",
+				},
+				PolicyReport: true,
+			},
+			expectedPolicyReports: []policyreportv1alpha2.PolicyReport{{
+				Summary: policyreportv1alpha2.PolicyReportSummary{
+					Pass:  0,
+					Fail:  1,
+					Skip:  0,
+					Error: 0,
+					Warn:  0,
+				},
+			}},
+		},
+		{
+			config: ApplyCommandConfig{
 				PolicyPaths:   []string{"https://github.com/kyverno/policies/best-practices/require-labels/", "../../../../../test/best_practices/disallow_latest_tag.yaml"},
 				ResourcePaths: []string{"../../../../../test/resources/pod_with_version_tag.yaml"},
 				GitBranch:     "main",

--- a/cmd/cli/kubectl-kyverno/processor/vap_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/vap_processor.go
@@ -9,12 +9,13 @@ import (
 )
 
 type ValidatingAdmissionPolicyProcessor struct {
-	Policies     []v1alpha1.ValidatingAdmissionPolicy
-	Bindings     []v1alpha1.ValidatingAdmissionPolicyBinding
-	Resource     *unstructured.Unstructured
-	PolicyReport bool
-	Rc           *ResultCounts
-	Client       dclient.Interface
+	Policies             []v1alpha1.ValidatingAdmissionPolicy
+	Bindings             []v1alpha1.ValidatingAdmissionPolicyBinding
+	Resource             *unstructured.Unstructured
+	NamespaceSelectorMap map[string]map[string]string
+	PolicyReport         bool
+	Rc                   *ResultCounts
+	Client               dclient.Interface
 }
 
 func (p *ValidatingAdmissionPolicyProcessor) ApplyPolicyOnResource() ([]engineapi.EngineResponse, error) {
@@ -26,7 +27,7 @@ func (p *ValidatingAdmissionPolicyProcessor) ApplyPolicyOnResource() ([]engineap
 				policyData.AddBinding(binding)
 			}
 		}
-		response, _ := validatingadmissionpolicy.Validate(policyData, *p.Resource, p.Client)
+		response, _ := validatingadmissionpolicy.Validate(policyData, *p.Resource, p.NamespaceSelectorMap, p.Client)
 		responses = append(responses, response)
 		p.Rc.addValidatingAdmissionResponse(policy, response)
 	}

--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -85,7 +85,7 @@ func (s *scanner) ScanResource(ctx context.Context, resource unstructured.Unstru
 					policyData.AddBinding(binding)
 				}
 			}
-			res, err := validatingadmissionpolicy.Validate(policyData, resource, s.client)
+			res, err := validatingadmissionpolicy.Validate(policyData, resource, map[string]map[string]string{}, s.client)
 			if err != nil {
 				errors = append(errors, err)
 			}

--- a/pkg/validatingadmissionpolicy/matcher.go
+++ b/pkg/validatingadmissionpolicy/matcher.go
@@ -1,0 +1,89 @@
+package validatingadmissionpolicy
+
+import (
+	v1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/api/admissionregistration/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/rules"
+)
+
+// matches checks the following:
+// - if the namespace selector matches the resource namespace
+// - if the object selector matches the resource
+// - if the resource is excluded by the policy/binding
+// - if the resource matches the policy/binding rules
+func matches(attr admission.Attributes, namespaceSelectorMap map[string]map[string]string, matchCriteria v1alpha1.MatchResources) (bool, error) {
+	// check if the namespace selector matches the resource namespace
+	if matchCriteria.NamespaceSelector != nil {
+		selector, err := metav1.LabelSelectorAsSelector(matchCriteria.NamespaceSelector)
+		if err != nil {
+			return false, err
+		}
+		if nsLabels, ok := namespaceSelectorMap[attr.GetNamespace()]; ok {
+			if !selector.Matches(labels.Set(nsLabels)) {
+				return false, nil
+			}
+		} else {
+			return false, nil
+		}
+	}
+
+	// check if the object selector matches the resource
+	if matchCriteria.ObjectSelector != nil {
+		selector, err := metav1.LabelSelectorAsSelector(matchCriteria.ObjectSelector)
+		if err != nil {
+			return false, err
+		}
+		accessor, err := meta.Accessor(attr.GetObject())
+		if err != nil {
+			return false, err
+		}
+		if len(accessor.GetLabels()) != 0 {
+			if !selector.Matches(labels.Set(accessor.GetLabels())) {
+				return false, nil
+			}
+		}
+	}
+
+	// check if the resource is excluded by the policy/binding
+	if len(matchCriteria.ExcludeResourceRules) != 0 {
+		if matchesResourceRules(matchCriteria.ExcludeResourceRules, attr) {
+			return false, nil
+		}
+	}
+
+	// check if the resource is matched by the policy/binding
+	if len(matchCriteria.ResourceRules) != 0 {
+		return matchesResourceRules(matchCriteria.ResourceRules, attr), nil
+	}
+
+	return true, nil
+}
+
+func matchesResourceRules(resourceRules []v1alpha1.NamedRuleWithOperations, attr admission.Attributes) bool {
+	for _, r := range resourceRules {
+		rule := v1.RuleWithOperations(r.RuleWithOperations)
+		ruleMatcher := rules.Matcher{
+			Rule: rule,
+			Attr: attr,
+		}
+		if !ruleMatcher.Matches() {
+			continue
+		}
+		// an empty name list always matches
+		if len(r.ResourceNames) == 0 {
+			return true
+		}
+
+		name := attr.GetName()
+		for _, matchedName := range r.ResourceNames {
+			if name == matchedName {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/validatingadmissionpolicy/matcher.go
+++ b/pkg/validatingadmissionpolicy/matcher.go
@@ -1,8 +1,7 @@
 package validatingadmissionpolicy
 
 import (
-	v1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/api/admissionregistration/v1alpha1"
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -15,7 +14,7 @@ import (
 // - if the object selector matches the resource
 // - if the resource is excluded by the policy/binding
 // - if the resource matches the policy/binding rules
-func matches(attr admission.Attributes, namespaceSelectorMap map[string]map[string]string, matchCriteria v1alpha1.MatchResources) (bool, error) {
+func matches(attr admission.Attributes, namespaceSelectorMap map[string]map[string]string, matchCriteria admissionregistrationv1alpha1.MatchResources) (bool, error) {
 	// check if the namespace selector matches the resource namespace
 	if matchCriteria.NamespaceSelector != nil {
 		selector, err := metav1.LabelSelectorAsSelector(matchCriteria.NamespaceSelector)
@@ -63,11 +62,10 @@ func matches(attr admission.Attributes, namespaceSelectorMap map[string]map[stri
 	return true, nil
 }
 
-func matchesResourceRules(resourceRules []v1alpha1.NamedRuleWithOperations, attr admission.Attributes) bool {
+func matchesResourceRules(resourceRules []admissionregistrationv1alpha1.NamedRuleWithOperations, attr admission.Attributes) bool {
 	for _, r := range resourceRules {
-		rule := v1.RuleWithOperations(r.RuleWithOperations)
 		ruleMatcher := rules.Matcher{
-			Rule: rule,
+			Rule: r.RuleWithOperations,
 			Attr: attr,
 		}
 		if !ruleMatcher.Matches() {

--- a/test/cli/test-validating-admission-policy/with-bindings-1/deployment1.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-1/deployment1.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: busybox-deployment
+  labels:
+    app: busybox
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: busybox
+        image: busybox:latest

--- a/test/cli/test-validating-admission-policy/with-bindings-1/deployment2.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-1/deployment2.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest

--- a/test/cli/test-validating-admission-policy/with-bindings-1/policy.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-1/policy.yaml
@@ -1,0 +1,30 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "check-deployment-replicas"
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+  validations:
+  - expression: object.spec.replicas <= 2
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "check-deployment-replicas-binding"
+spec:
+  policyName: "check-deployment-replicas"
+  validationActions: [Deny]
+  matchResources:
+    objectSelector:
+      matchLabels:
+        app: nginx

--- a/test/cli/test-validating-admission-policy/with-bindings-2/deployment1.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-2/deployment1.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: busybox-deployment
+  labels:
+    app: busybox
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: busybox
+        image: busybox:latest

--- a/test/cli/test-validating-admission-policy/with-bindings-2/deployment2.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-2/deployment2.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest

--- a/test/cli/test-validating-admission-policy/with-bindings-2/policy.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-2/policy.yaml
@@ -1,0 +1,39 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "check-deployment-replicas"
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+  validations:
+  - expression: object.spec.replicas <= 2
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "check-deployment-replicas-binding"
+spec:
+  policyName: "check-deployment-replicas"
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+      - apiGroups:
+        - apps
+        apiVersions:
+        - v1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - deployments
+        resourceNames:
+        - nginx-deployment

--- a/test/cli/test-validating-admission-policy/with-bindings-3/deployment1.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-3/deployment1.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: busybox-deployment
+  namespace: testing
+  labels:
+    app: busybox
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: busybox
+        image: busybox:latest

--- a/test/cli/test-validating-admission-policy/with-bindings-3/deployment2.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-3/deployment2.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: staging
+  labels:
+    app: nginx
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest

--- a/test/cli/test-validating-admission-policy/with-bindings-3/deployment3.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-3/deployment3.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: production
+  labels:
+    app: nginx
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest

--- a/test/cli/test-validating-admission-policy/with-bindings-3/policy.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-3/policy.yaml
@@ -1,0 +1,34 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "check-deployment-replicas"
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+  validations:
+  - expression: object.spec.replicas <= 2
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "check-deployment-replicas-binding"
+spec:
+  policyName: "check-deployment-replicas"
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchExpressions:
+      - key: environment
+        operator: In
+        values:
+        - staging
+        - production

--- a/test/cli/test-validating-admission-policy/with-bindings-3/values.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-3/values.yaml
@@ -1,0 +1,14 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Value
+metadata:
+  name: values
+namespaceSelector:
+  - name: staging
+    labels:
+      environment: staging
+  - name: production
+    labels:
+      environment: production
+  - name: testing
+    labels:
+      environment: testing

--- a/test/cli/test-validating-admission-policy/with-bindings-4/deployment1.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-4/deployment1.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: busybox-deployment
+  labels:
+    app: busybox
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: busybox
+        image: busybox:latest

--- a/test/cli/test-validating-admission-policy/with-bindings-4/deployment2.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-4/deployment2.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest

--- a/test/cli/test-validating-admission-policy/with-bindings-4/policy.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-4/policy.yaml
@@ -1,0 +1,39 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "check-deployment-replicas"
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+  validations:
+  - expression: object.spec.replicas <= 2
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "check-deployment-replicas-binding"
+spec:
+  policyName: "check-deployment-replicas"
+  validationActions: [Deny]
+  matchResources:
+    excludeResourceRules:
+      - apiGroups:
+        - apps
+        apiVersions:
+        - v1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - deployments
+        resourceNames:
+        - nginx-deployment


### PR DESCRIPTION
## Explanation
This PR supports applying bindings along with VAPs using Kyverno CLI `apply` command in offline mode. i.e. without communicating to the cluster.
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
N/A
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.12.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. `policy.yaml`:
```
apiVersion: admissionregistration.k8s.io/v1beta1
kind: ValidatingAdmissionPolicy
metadata:
  name: "check-deployment-replicas"
spec:
  matchConstraints:
    resourceRules:
    - apiGroups:
      - apps
      apiVersions:
      - v1
      operations:
      - CREATE
      - UPDATE
      resources:
      - deployments
  validations:
  - expression: object.spec.replicas <= 2
---
apiVersion: admissionregistration.k8s.io/v1beta1
kind: ValidatingAdmissionPolicyBinding
metadata:
  name: "check-deployment-replicas-binding"
spec:
  policyName: "check-deployment-replicas"
  validationActions: [Deny]
  matchResources:
    namespaceSelector:
      matchExpressions:
      - key: environment
        operator: In
        values:
        - staging
        - production
```
2. `deployments.yaml`:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: busybox-deployment
  namespace: testing
  labels:
    app: busybox
spec:
  replicas: 4
  selector:
    matchLabels:
      app: busybox
  template:
    metadata:
      labels:
        app: busybox
    spec:
      containers:
      - name: busybox
        image: busybox:latest
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment-1
  namespace: staging
  labels:
    app: nginx
spec:
  replicas: 4
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:latest
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment-2
  namespace: production
  labels:
    app: nginx
spec:
  replicas: 4
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:latest
```
The above resource manifest has the following:
  - deployment `busybox-deployment` that exists in the `testing` namespace.
  - deployment `nginx-deployment-1` that exists in the `staging` namespace.
  - deployment `nginx-deployment-2` exists in the `production` namespace.
 
All of them have replicas of four.

3. `values.yaml`:
```
apiVersion: cli.kyverno.io/v1alpha1
kind: Value
metadata:
  name: values
namespaceSelector:
  - name: staging
    labels:
      environment: staging
  - name: production
    labels:
      environment: production
  - name: testing
    labels:
      environment: testing
```

Apply the policy to the resources:
```
./cmd/cli/kubectl-kyverno/kubectl-kyverno apply policy.yaml -r deployments.yaml -f values.yaml -p

Applying 1 policy rule(s) to 3 resource(s)...
----------------------------------------------------------------------
POLICY REPORT:
----------------------------------------------------------------------
apiVersion: wgpolicyk8s.io/v1alpha2
kind: ClusterPolicyReport
metadata:
  creationTimestamp: null
  name: merged
results:
- message: 'failed expression: object.spec.replicas <= 2'
  policy: check-deployment-replicas
  resources:
  - apiVersion: apps/v1
    kind: Deployment
    name: nginx-deployment-1
    namespace: staging
  result: fail
  scored: true
  source: kyverno
  timestamp:
    nanos: 0
    seconds: 1708357960
- message: 'failed expression: object.spec.replicas <= 2'
  policy: check-deployment-replicas
  resources:
  - apiVersion: apps/v1
    kind: Deployment
    name: nginx-deployment-2
    namespace: production
  result: fail
  scored: true
  source: kyverno
  timestamp:
    nanos: 0
    seconds: 1708357960
summary:
  error: 0
  fail: 2
  pass: 0
  skip: 0
  warn: 0
```
Since both `nginx-deployemnt-1` and `nginx-deployment-2` matches both policy definition and binding,  they are validated against the policy. Hence, they got a result of `fail` since they violate the CEL expression.
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
