### PR TITLE
chore: default logging format to rfc3339

### DIFF
--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -79,7 +79,7 @@ func Setup(logFormat string, loggingTimestampFormat string, level int) error {
 	case RFC3339NANO:
 		zc.EncoderConfig.EncodeTime = zapcore.RFC3339NanoTimeEncoder
 	case "default":
-		zc.EncoderConfig.EncodeTime = zapcore.EpochNanosTimeEncoder
+		zc.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
 	default:
 		return errors.New("timestamp format not recognized, pass `iso8601` for ISO8601, `rfc3339` for RFC3339, `rfc3339nano` for RFC3339NANO, `millis` for Epoch Millis, `nanos` for Epoch Nanos, or omit the flag for the Unix Epoch timestamp format")
 	}


### PR DESCRIPTION
## Explanation

With https://github.com/kyverno/kyverno/pull/9276 the default logging format was set to Epoch Nanos which is not easy to ready. This PR switches the default logging format to RFC3339.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/1.12.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Logging timestamp after this PR:
```
k logs -n kyverno -f deploy/kyverno-admission-controller
Defaulted container "kyverno" out of: kyverno, kyverno-pre (init)
2024-02-23T09:22:14Z	INFO	setup.version	version/version.go:49	version	{"version": "(devel)", "hash": "cd023846a726d3b8b4bccb3ce83c901e562b2930", "time": "2024-02-23T08:54:46Z"}
2024-02-23T09:22:14Z	LEVEL(-2)	setup.flag	internal/flag.go:260		{"add_dir_header": "false"}
2024-02-23T09:22:14Z	LEVEL(-2)	setup.flag	internal/flag.go:260		{"admissionReports": "true"}
2024-02-23T09:22:14Z	LEVEL(-2)	setup.flag	internal/flag.go:260		{"allowInsecureRegistry": "false"}
2024-02-23T09:22:14Z	LEVEL(-2)	setup.flag	internal/flag.go:260		{"alsologtostderr": "false"}
2024-02-23T09:22:14Z	LEVEL(-2)	setup.flag	internal/flag.go:260		{"autoUpdateWebhooks": "true"}
2024-02-23T09:22:14Z	LEVEL(-2)	setup.flag	internal/flag.go:260		{"backgroundServiceAccountName": "system:serviceaccount:kyverno:kyverno-background-controller"}
```
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
