### PR TITLE
fix: Adjust chart templates to handle hostNetwork set to true

### DIFF
--- a/charts/kyverno/templates/admission-controller/deployment.yaml
+++ b/charts/kyverno/templates/admission-controller/deployment.yaml
@@ -189,10 +189,10 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-          - containerPort: 9443
+          - containerPort: {{ .Values.admissionController.webhookServer.port }}
             name: https
             protocol: TCP
-          - containerPort: 8000
+          - containerPort: {{ .Values.admissionController.metering.port }}
             name: metrics-port
             protocol: TCP
           {{ if .Values.admissionController.profiling.enabled }}

--- a/charts/kyverno/templates/admission-controller/service.yaml
+++ b/charts/kyverno/templates/admission-controller/service.yaml
@@ -36,7 +36,7 @@ metadata:
 spec:
   ports:
   - port: {{ .Values.admissionController.metricsService.port }}
-    targetPort: 8000
+    targetPort: {{ .Values.admissionController.metering.port }}
     protocol: TCP
     name: metrics-port
     {{- if and (eq .Values.admissionController.metricsService.type "NodePort") (not (empty .Values.admissionController.metricsService.nodePort)) }}

--- a/charts/kyverno/templates/cleanup-controller/deployment.yaml
+++ b/charts/kyverno/templates/cleanup-controller/deployment.yaml
@@ -80,10 +80,10 @@ spec:
           image: {{ include "kyverno.cleanup-controller.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.cleanupController.image "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.cleanupController.image.pullPolicy }}
           ports:
-          - containerPort: 9443
+          - containerPort: {{ .Values.cleanupController.webhookServer.port }}
             name: https
             protocol: TCP
-          - containerPort: 8000
+          - containerPort: {{ .Values.cleanupController.metering.port }}
             name: metrics
             protocol: TCP
           {{ if .Values.cleanupController.profiling.enabled }}

--- a/charts/kyverno/templates/cleanup-controller/deployment.yaml
+++ b/charts/kyverno/templates/cleanup-controller/deployment.yaml
@@ -80,7 +80,7 @@ spec:
           image: {{ include "kyverno.cleanup-controller.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.cleanupController.image "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.cleanupController.image.pullPolicy }}
           ports:
-          - containerPort: {{ .Values.cleanupController.webhookServer.port }}
+          - containerPort: {{ .Values.cleanupController.server.port }}
             name: https
             protocol: TCP
           - containerPort: {{ .Values.cleanupController.metering.port }}

--- a/charts/kyverno/templates/cleanup-controller/service.yaml
+++ b/charts/kyverno/templates/cleanup-controller/service.yaml
@@ -39,7 +39,7 @@ metadata:
 spec:
   ports:
   - port: {{ .Values.cleanupController.metricsService.port }}
-    targetPort: 8000
+    targetPort: {{ .Values.cleanupController.metering.port }}
     protocol: TCP
     name: metrics-port
     {{- if and (eq .Values.cleanupController.metricsService.type "NodePort") (not (empty .Values.cleanupController.metricsService.nodePort)) }}


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->
When deploying the charts on an EKS cluster with custom CNI (Calico), the `hostNetwork` option must be enabled. However, due to the hardcoded ports 9443 and 8000 for each controller, only one pod can run per node.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->
Closed #8898


## What type of PR is this

/kind bug

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:
-->
#### values.yaml

```yaml
admissionController:
  replicas: 3
  hostNetwork: true
  webhookServer:
    port: 10254
  startupProbe:
    httpGet:
      port: 10254
  livenessProbe:
    httpGet:
      port: 10254
  readinessProbe:
    httpGet:
      port: 10254
  metering:
    port: 10255
cleanupController:
  hostNetwork: true
  server:
    port: 10257
  startupProbe:
    httpGet:
      port: 10257
  livenessProbe:
    httpGet:
      port: 10257
  readinessProbe:
    httpGet:
      port: 10257
  metering:
    port: 10258

```

<details><summary>Test results</summary>

```sh
$ helm install -f override-values.yaml kyverno -n kyverno --create-namespace ./
NAME: kyverno
LAST DEPLOYED: Mon Mar 11 09:28:35 2024
NAMESPACE: kyverno
STATUS: deployed
REVISION: 1
NOTES:
Chart version: v0.0.0
Kyverno version: latest

Thank you for installing kyverno! Your release is named kyverno.

The following components have been installed in your cluster:
- CRDs
- Admission controller
- Reports controller
- Cleanup controller
- Background controller



💡 Note: If Kyverno has been installed on AKS, it is likely you will need to disable the Admission Enforcer. Please see the Kyverno documentation at https://kyverno.io/docs/installation/platform-notes/#notes-for-aks-users for more details.

💡 Note: There is a trade-off when deciding which approach to take regarding Namespace exclusions. Please see the documentation at https://kyverno.io/docs/installation/#security-vs-operability to understand the risks.

$ kubectl get po -n kyverno                           
NAME                                             READY   STATUS    RESTARTS   AGE
kyverno-admission-controller-58bcf47bf7-27n89    1/1     Running   0          53s
kyverno-admission-controller-58bcf47bf7-h6fkz    1/1     Running   0          53s
kyverno-admission-controller-58bcf47bf7-k6fzv    1/1     Running   0          54s
kyverno-background-controller-84bc79c84b-85l54   1/1     Running   0          54s
kyverno-cleanup-controller-595485469d-tmgw8      1/1     Running   0          54s
kyverno-reports-controller-7995f8f659-2lpnw      1/1     Running   0          54s

$ kubectl get clusterpolicies.kyverno.io | grep Enforce
require-ns-purpose-label         true        true         Enforce           True    111s   Ready

$ cat ns.yaml                                          
apiVersion: v1
kind: Namespace
metadata:
  name: prod-bus-app1
  labels:
    purpose: development

$ kubectl apply -f ns.yaml                             
Error from server: error when creating "ns.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 

resource Namespace//prod-bus-app1 was blocked due to the following policies 

require-ns-purpose-label:
  require-ns-purpose-label: 'validation error: You must have label `purpose` with
    value `production` set on all new namespaces. rule require-ns-purpose-label failed
    at path /metadata/labels/purpose/'

$ cat cleanup-policy.yaml
apiVersion: kyverno.io/v2beta1
kind: ClusterCleanupPolicy
metadata:
  name: cleandeploy
spec:
  match:
    any:
    - resources:
        kinds:
          - Pod
        selector:
          matchLabels:
            canremove: "true"
  schedule: "*/5 * * * *"

$ kubectl apply -f cleanup-policy.yaml       
clustercleanuppolicy.kyverno.io/cleandeploy created

$ cat pod-to-cleanup.yaml
apiVersion: v1
kind: Pod
metadata:
  name: pod-to-be-clean
  labels:
    canremove: "true"
spec:
  containers:
  - name: busybox
    image: busybox:latest
    command: ["sleep", "1500"]
  restartPolicy: Always

$ kubectl apply -f pod-to-cleanup.yaml
pod/pod-to-be-clean created

Pod successfully deleted.
```

</details>

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
