### PR TITLE
[WIP] [Feature] Add customer headers for service calls

### DIFF
--- a/api/kyverno/v1/common_types.go
+++ b/api/kyverno/v1/common_types.go
@@ -163,6 +163,9 @@ type APICall struct {
 	// +kubebuilder:validation:Optional
 	Data []RequestData `json:"data,omitempty" yaml:"data,omitempty"`
 
+	// Headers specifies the header values to send to the server
+	Headers []HeaderData `json:"headers,omitempty" yaml:"headers:omitempty"`
+
 	// Service is an API call to a JSON web service
 	// +kubebuilder:validation:Optional
 	Service *ServiceCall `json:"service,omitempty" yaml:"service,omitempty"`
@@ -215,6 +218,15 @@ type RequestData struct {
 
 	// Value is the data value
 	Value *apiextv1.JSON `json:"value" yaml:"value"`
+}
+
+// HeaderData contains the HTTP header fields
+type HeaderData struct {
+	// Key is the header value
+	Key string `json:"key" yaml:"key"`
+
+	// Value is the header value
+	Value string `json:"value" yaml:"value"`
 }
 
 // Condition defines variable-based conditional criteria for rule execution.

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
@@ -208,6 +208,25 @@ spec:
                                   - value
                                   type: object
                                 type: array
+                              headers:
+                                description: Data specifies the POST data sent to
+                                  the server.
+                                items:
+                                  description: RequestData contains the HTTP POST
+                                    data
+                                  properties:
+                                    key:
+                                      description: Key is a unique identifier for
+                                        the data value
+                                      type: string
+                                    value:
+                                      description: Value is the data value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  required:
+                                    - key
+                                    - value
+                                  type: object
+                                type: array
                               jmesPath:
                                 description: JMESPath is an optional JSON Match Expression
                                   that can be used to transform the JSON response

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
@@ -208,25 +208,6 @@ spec:
                                   - value
                                   type: object
                                 type: array
-                              headers:
-                                description: Data specifies the POST data sent to
-                                  the server.
-                                items:
-                                  description: RequestData contains the HTTP POST
-                                    data
-                                  properties:
-                                    key:
-                                      description: Key is a unique identifier for
-                                        the data value
-                                      type: string
-                                    value:
-                                      description: Value is the data value
-                                      x-kubernetes-preserve-unknown-fields: true
-                                  required:
-                                    - key
-                                    - value
-                                  type: object
-                                type: array
                               jmesPath:
                                 description: JMESPath is an optional JSON Match Expression
                                   that can be used to transform the JSON response

--- a/pkg/engine/apicall/apiCall.go
+++ b/pkg/engine/apicall/apiCall.go
@@ -162,6 +162,17 @@ func (a *apiCall) buildHTTPRequest(ctx context.Context, apiCall *kyvernov1.Conte
 		if token != "" && req != nil {
 			req.Header.Add("Authorization", "Bearer "+token)
 		}
+
+		if apiCall.Headers != nil && req != nil {
+			for _, header := range apiCall.Headers {
+				if header.Key == "Authorization" {
+					req.Header.Set(header.Key, header.Value)
+				} else {
+					// TODO: Pull values if they are secrets
+					req.Header.Add(header.Key, header.Value)
+				}
+			}
+		}
 	}()
 
 	if apiCall.Method == "GET" {


### PR DESCRIPTION
***************
**This is a WIP and the remaining parts of the PR will be filled out**

TODO:

- [ ]  Add support to pull values from Secrets
- [ ] Add Chainsaw tests
***************

## Explanation

This PR enables custom headers to be defined for api calls. Use cases for custom headers could be as follows:

* Inject Authorization headers for a given request
* Add `User-Agent` headers to easily identify requests coming from Kyverno

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue

Closes https://github.com/kyverno/kyverno/issues/6833

## Milestone of this PR

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind feature

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
