### PR TITLE
fix(polex): multiple polexes with conditions

### DIFF
--- a/pkg/engine/background.go
+++ b/pkg/engine/background.go
@@ -68,7 +68,12 @@ func (e *engine) filterRule(
 		return nil
 	}
 	// check if there is a policy exception matches the incoming resource
-	exception := engineutils.MatchesException(exceptions, policyContext, logger)
+	exception, err := engineutils.MatchesException(exceptions, policyContext, logger)
+	if err != nil {
+		logger.Error(err, "failed to get matching exceptions")
+		return engineapi.RuleError(rule.Name, engineapi.Validation, "failed to get matching exceptions", err)
+	}
+
 	if exception != nil {
 		key, err := cache.MetaNamespaceKeyFunc(exception)
 		if err != nil {

--- a/pkg/engine/handlers/mutation/mutate_existing.go
+++ b/pkg/engine/handlers/mutation/mutate_existing.go
@@ -38,7 +38,12 @@ func (h mutateExistingHandler) Process(
 	exceptions []kyvernov2beta1.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there is a policy exception matches the incoming resource
-	exception := engineutils.MatchesException(exceptions, policyContext, logger)
+	exception, err := engineutils.MatchesException(exceptions, policyContext, logger)
+	if err != nil {
+		logger.Error(err, "failed to get matching exceptions")
+		return resource, handlers.WithError(rule, engineapi.Validation, "failed to get matching exceptions", err)
+	}
+
 	if exception != nil {
 		key, err := cache.MetaNamespaceKeyFunc(exception)
 		if err != nil {

--- a/pkg/engine/handlers/mutation/mutate_image.go
+++ b/pkg/engine/handlers/mutation/mutate_image.go
@@ -69,7 +69,12 @@ func (h mutateImageHandler) Process(
 	exceptions []kyvernov2beta1.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there is a policy exception matches the incoming resource
-	exception := engineutils.MatchesException(exceptions, policyContext, logger)
+	exception, err := engineutils.MatchesException(exceptions, policyContext, logger)
+	if err != nil {
+		logger.Error(err, "failed to get matching exceptions")
+		return resource, handlers.WithError(rule, engineapi.Validation, "failed to get matching exceptions", err)
+	}
+
 	if exception != nil {
 		key, err := cache.MetaNamespaceKeyFunc(exception)
 		if err != nil {

--- a/pkg/engine/handlers/mutation/mutate_resource.go
+++ b/pkg/engine/handlers/mutation/mutate_resource.go
@@ -31,7 +31,12 @@ func (h mutateResourceHandler) Process(
 	exceptions []kyvernov2beta1.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there is a policy exception matches the incoming resource
-	exception := engineutils.MatchesException(exceptions, policyContext, logger)
+	exception, err := engineutils.MatchesException(exceptions, policyContext, logger)
+	if err != nil {
+		logger.Error(err, "failed to get matching exceptions")
+		return resource, handlers.WithError(rule, engineapi.Validation, "failed to get matching exceptions", err)
+	}
+
 	if exception != nil {
 		key, err := cache.MetaNamespaceKeyFunc(exception)
 		if err != nil {

--- a/pkg/engine/handlers/validation/validate_cel.go
+++ b/pkg/engine/handlers/validation/validate_cel.go
@@ -52,7 +52,12 @@ func (h validateCELHandler) Process(
 	}
 
 	// check if there is a policy exception matches the incoming resource
-	exception := engineutils.MatchesException(exceptions, policyContext, logger)
+	exception, err := engineutils.MatchesException(exceptions, policyContext, logger)
+	if err != nil {
+		logger.Error(err, "failed to get matching exceptions")
+		return resource, handlers.WithError(rule, engineapi.Validation, "failed to get matching exceptions", err)
+	}
+
 	if exception != nil {
 		key, err := cache.MetaNamespaceKeyFunc(exception)
 		if err != nil {

--- a/pkg/engine/handlers/validation/validate_image.go
+++ b/pkg/engine/handlers/validation/validate_image.go
@@ -48,7 +48,12 @@ func (h validateImageHandler) Process(
 	exceptions []kyvernov2beta1.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there is a policy exception matches the incoming resource
-	exception := engineutils.MatchesException(exceptions, policyContext, logger)
+	exception, err := engineutils.MatchesException(exceptions, policyContext, logger)
+	if err != nil {
+		logger.Error(err, "failed to get matching exceptions")
+		return resource, handlers.WithError(rule, engineapi.Validation, "failed to get matching exceptions", err)
+	}
+
 	if exception != nil {
 		key, err := cache.MetaNamespaceKeyFunc(exception)
 		if err != nil {

--- a/pkg/engine/handlers/validation/validate_manifest.go
+++ b/pkg/engine/handlers/validation/validate_manifest.go
@@ -60,7 +60,12 @@ func (h validateManifestHandler) Process(
 	exceptions []kyvernov2beta1.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there is a policy exception matches the incoming resource
-	exception := engineutils.MatchesException(exceptions, policyContext, logger)
+	exception, err := engineutils.MatchesException(exceptions, policyContext, logger)
+	if err != nil {
+		logger.Error(err, "failed to get matching exceptions")
+		return resource, handlers.WithError(rule, engineapi.Validation, "failed to get matching exceptions", err)
+	}
+
 	if exception != nil {
 		key, err := cache.MetaNamespaceKeyFunc(exception)
 		if err != nil {

--- a/pkg/engine/handlers/validation/validate_pss.go
+++ b/pkg/engine/handlers/validation/validate_pss.go
@@ -43,7 +43,12 @@ func (h validatePssHandler) Process(
 	}
 
 	// check if there is a policy exception matches the incoming resource
-	exception := engineutils.MatchesException(exceptions, policyContext, logger)
+	exception, err := engineutils.MatchesException(exceptions, policyContext, logger)
+	if err != nil {
+		logger.Error(err, "failed to get matching exceptions")
+		return resource, handlers.WithError(rule, engineapi.Validation, "failed to get matching exceptions", err)
+	}
+
 	if exception != nil && !exception.HasPodSecurity() {
 		key, err := cache.MetaNamespaceKeyFunc(exception)
 		if err != nil {

--- a/pkg/engine/handlers/validation/validate_resource.go
+++ b/pkg/engine/handlers/validation/validate_resource.go
@@ -41,7 +41,12 @@ func (h validateResourceHandler) Process(
 	exceptions []kyvernov2beta1.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there is a policy exception matches the incoming resource
-	exception := engineutils.MatchesException(exceptions, policyContext, logger)
+	exception, err := engineutils.MatchesException(exceptions, policyContext, logger)
+	if err != nil {
+		logger.Error(err, "failed to get matching exceptions")
+		return resource, handlers.WithError(rule, engineapi.Validation, "failed to get matching exceptions", err)
+	}
+
 	if exception != nil {
 		key, err := cache.MetaNamespaceKeyFunc(exception)
 		if err != nil {

--- a/pkg/engine/utils/exceptions.go
+++ b/pkg/engine/utils/exceptions.go
@@ -37,7 +37,7 @@ func MatchesException(
 					return nil
 				}
 				if !passed {
-					return nil
+					continue
 				}
 			}
 			return &polex

--- a/pkg/engine/utils/exceptions.go
+++ b/pkg/engine/utils/exceptions.go
@@ -14,7 +14,7 @@ func MatchesException(
 	polexs []kyvernov2beta1.PolicyException,
 	policyContext engineapi.PolicyContext,
 	logger logr.Logger,
-) *kyvernov2beta1.PolicyException {
+) (*kyvernov2beta1.PolicyException, error) {
 	gvk, subresource := policyContext.ResourceKind()
 	resource := policyContext.NewResource()
 	if resource.Object == nil {
@@ -34,14 +34,14 @@ func MatchesException(
 			if polex.Spec.Conditions != nil {
 				passed, err := conditions.CheckAnyAllConditions(logger, policyContext.JSONContext(), *polex.Spec.Conditions)
 				if err != nil {
-					return nil
+					return nil, err
 				}
 				if !passed {
 					continue
 				}
 			}
-			return &polex
+			return &polex, nil
 		}
 	}
-	return nil
+	return nil, nil
 }

--- a/test/conformance/chainsaw/exceptions/good-bad-conditions/README.md
+++ b/test/conformance/chainsaw/exceptions/good-bad-conditions/README.md
@@ -1,0 +1,8 @@
+## Description
+
+This test creates a policy that only allows a maximum of 3 containers inside a pod. It then creates an exception with `conditions` field defined which tests out the functionality for the conditions support in `PolicyException`. Two `PolicyExceptions` are created one without matching conditions and one with to test the behavior of multiple exceptions with conditions.
+
+
+## Expected Behavior
+
+The first `PolicyException` should fail the condition but the second `PolicyException` should pass it and the deployment should be created.

--- a/test/conformance/chainsaw/exceptions/good-bad-conditions/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/exceptions/good-bad-conditions/chainsaw-test.yaml
@@ -1,0 +1,24 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: conditions
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: policy.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: failing-exception.yaml
+    - apply:
+        file: passing-exception.yaml
+  - finally:
+    - sleep:
+        duration: 5s
+    name: step-03
+    try:
+    - apply:
+        file: good-deployment.yaml

--- a/test/conformance/chainsaw/exceptions/good-bad-conditions/failing-exception.yaml
+++ b/test/conformance/chainsaw/exceptions/good-bad-conditions/failing-exception.yaml
@@ -1,0 +1,21 @@
+apiVersion: kyverno.io/v2beta1
+kind: PolicyException
+metadata:
+  name: failing-container-exception
+spec:
+  exceptions:
+  - policyName: max-containers
+    ruleNames:
+    - max-two-containers
+    - autogen-max-two-containers
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod
+        - Deployment
+  conditions:
+    any:
+    - key: "{{ request.object.metadata.labels.color || '' }}"
+      operator: Equals
+      value: red

--- a/test/conformance/chainsaw/exceptions/good-bad-conditions/good-deployment.yaml
+++ b/test/conformance/chainsaw/exceptions/good-bad-conditions/good-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: good-deployment
+  labels:
+    app: my-app
+    color: blue
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+        color: blue
+    spec:
+      containers:
+        - name: nginx-container
+          image: nginx:latest
+          ports:
+            - containerPort: 80
+          resources:
+            limits:
+              cpu: "1"
+              memory: "256Mi"
+            requests:
+              cpu: "0.5"
+              memory: "128Mi"
+        - name: redis-container
+          image: redis:latest
+          ports:
+            - containerPort: 6379
+          resources:
+            limits:
+              cpu: "0.5"
+              memory: "512Mi"
+            requests:
+              cpu: "0.25"
+              memory: "256Mi"
+        - name: busybox-container
+          image: busybox:latest
+          command: ["/bin/sh", "-c", "while true; do echo 'Hello from BusyBox'; sleep 10; done"]
+          resources:
+            limits:
+              cpu: "0.5"
+              memory: "128Mi"
+            requests:
+              cpu: "0.25"
+              memory: "64Mi"

--- a/test/conformance/chainsaw/exceptions/good-bad-conditions/passing-exception.yaml
+++ b/test/conformance/chainsaw/exceptions/good-bad-conditions/passing-exception.yaml
@@ -1,0 +1,21 @@
+apiVersion: kyverno.io/v2beta1
+kind: PolicyException
+metadata:
+  name: passing-container-exception
+spec:
+  exceptions:
+  - policyName: max-containers
+    ruleNames:
+    - max-two-containers
+    - autogen-max-two-containers
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod
+        - Deployment
+  conditions:
+    any:
+    - key: "{{ request.object.metadata.labels.color || '' }}"
+      operator: Equals
+      value: blue

--- a/test/conformance/chainsaw/exceptions/good-bad-conditions/policy.yaml
+++ b/test/conformance/chainsaw/exceptions/good-bad-conditions/policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: max-containers
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+  - name: max-two-containers
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: "A maximum of 2 containers are allowed inside a Pod."
+      deny:
+        conditions:
+          any:
+          - key: "{{request.object.spec.containers[] | length(@)}}"
+            operator: GreaterThan
+            value: "2"


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

This PR fixes an issue where multiple Polexes wouldn't evaluate if the first one doesn't pass the condition test.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
