### PR TITLE
give public access to PreProcessPattern

### DIFF
--- a/pkg/engine/mutate/patch/strategicMergePatch.go
+++ b/pkg/engine/mutate/patch/strategicMergePatch.go
@@ -57,7 +57,7 @@ func preProcessStrategicMergePatch(logger logr.Logger, pattern, resource string)
 	patternNode := yaml.MustParse(pattern)
 	resourceNode := yaml.MustParse(resource)
 
-	err := preProcessPattern(logger, patternNode, resourceNode)
+	err := PreProcessPattern(logger, patternNode, resourceNode)
 
 	return patternNode, err
 }

--- a/pkg/engine/mutate/patch/strategicPreprocessing.go
+++ b/pkg/engine/mutate/patch/strategicPreprocessing.go
@@ -44,7 +44,7 @@ func NewGlobalConditionError(err error) error {
 // A parent node having MappingNode keeps the data as <keyNode>, <ValueNode> inside it's Content field and Tag field as "!!map".
 // A parent node having Sequence keeps the data as array of Node inside Content field and a Tag field as "!!seq".
 // https://github.com/kubernetes-sigs/kustomize/blob/master/kyaml/yaml/rnode.go
-func preProcessPattern(logger logr.Logger, pattern, resource *yaml.RNode) error {
+func PreProcessPattern(logger logr.Logger, pattern, resource *yaml.RNode) error {
 	err := preProcessRecursive(logger, pattern, resource)
 	if err != nil {
 		return err

--- a/pkg/engine/mutate/patch/strategicPreprocessing_test.go
+++ b/pkg/engine/mutate/patch/strategicPreprocessing_test.go
@@ -1208,7 +1208,7 @@ func Test_ConditionCheck_SeveralElementsMatchExceptOne(t *testing.T) {
 	pattern := yaml.MustParse(string(patternRaw))
 	containers := yaml.MustParse(string(containersRaw))
 
-	err := preProcessPattern(logr.Discard(), pattern, containers)
+	err := PreProcessPattern(logr.Discard(), pattern, containers)
 	assert.NilError(t, err)
 
 	patternContainers := pattern.Field("containers")
@@ -1261,7 +1261,7 @@ func Test_NonExistingKeyMustFailPreprocessing(t *testing.T) {
 
 	pattern := yaml.MustParse(string(rawPattern))
 	resource := yaml.MustParse(string(rawResource))
-	err := preProcessPattern(logr.Discard(), pattern, resource)
+	err := PreProcessPattern(logr.Discard(), pattern, resource)
 	assert.Error(t, err, "condition failed: could not found \"key1\" key in the resource")
 }
 
@@ -1272,7 +1272,7 @@ func Test_NestedConditionals(t *testing.T) {
 
 	pattern := yaml.MustParse(rawPattern)
 	resource := yaml.MustParse(rawResource)
-	err := preProcessPattern(logr.Discard(), pattern, resource)
+	err := PreProcessPattern(logr.Discard(), pattern, resource)
 	assert.NilError(t, err)
 	resultPattern, _ := pattern.String()
 
@@ -1312,6 +1312,6 @@ func Test_GlobalCondition_Fail(t *testing.T) {
 
 	pattern := yaml.MustParse(string(rawPattern))
 	resource := yaml.MustParse(string(rawResource))
-	err := preProcessPattern(logr.Discard(), pattern, resource)
+	err := PreProcessPattern(logr.Discard(), pattern, resource)
 	assert.Error(t, err, "global condition failed: could not found \"emptyDir\" key in the resource")
 }


### PR DESCRIPTION
## Explanation

We are using your fantastic project as a library, especially using your anchor technique for applying patch strategic merge.
In order to easily integrate with your code, we need the `preProcessPattern` to be accessible from our code, hence changing its name to `PreProcessPattern`.

## Related issue

https://github.com/kyverno/kyverno/issues/9886

## Milestone of this PR

<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR does not alter the behavior of Kyverno. 

## What type of PR is this

/kind feature

## Proposed Changes

It's really a little change, with only local changes as the function was previously private, the change cannot impact other projects nor users.

### Proof Manifests

Not applicable

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable (none are applicable indeed).
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

Thanks a lot for your great project!
