### PR TITLE
Default exclusions in webhooks

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -293,8 +293,8 @@ The chart values are organised per component.
 | config.excludeClusterRoles | list | `[]` | Exclude roles |
 | config.generateSuccessEvents | bool | `false` | Generate success events. |
 | config.resourceFilters | list | See [values.yaml](values.yaml) | Resource types to be skipped by the Kyverno policy engine. Make sure to surround each entry in quotes so that it doesn't get parsed as a nested YAML list. These are joined together without spaces, run through `tpl`, and the result is set in the config map. |
-| config.webhooks | list | `[]` | Defines the `namespaceSelector` in the webhook configurations. Note that it takes a list of `namespaceSelector` and/or `objectSelector` in the JSON format, and only the first element will be forwarded to the webhook configurations. The Kyverno namespace is excluded if `excludeKyvernoNamespace` is `true` (default) |
-| config.webhookAnnotations | object | `{}` | Defines annotations to set on webhook configurations. |
+| config.webhooks | list | `[{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kube-system"]}]}}]` | Defines the `namespaceSelector` in the webhook configurations. Note that it takes a list of `namespaceSelector` and/or `objectSelector` in the JSON format, and only the first element will be forwarded to the webhook configurations. The Kyverno namespace is excluded if `excludeKyvernoNamespace` is `true` (default) |
+| config.webhookAnnotations | object | `{"admissions.enforcer/disabled":"true"}` | Defines annotations to set on webhook configurations. |
 | config.webhookLabels | object | `{}` | Defines labels to set on webhook configurations. |
 | config.matchConditions | list | `[]` | Defines match conditions to set on webhook configurations (requires Kubernetes 1.27+). |
 | config.excludeKyvernoNamespace | bool | `true` | Exclude Kyverno namespace Determines if default Kyverno namespace exclusion is enabled for webhooks and resourceFilters |

--- a/charts/kyverno/templates/NOTES.txt
+++ b/charts/kyverno/templates/NOTES.txt
@@ -43,6 +43,4 @@ The following components have been installed in your cluster:
 ⚠️  WARNING: Generating reports from ValidatingAdmissionPolicies requires a Kubernetes 1.27+ cluster with `ValidatingAdmissionPolicy` feature gate and `admissionregistration.k8s.io` API group enabled.
 {{- end }}
 
-💡 Note: If Kyverno has been installed on AKS, it is likely you will need to disable the Admission Enforcer. Please see the Kyverno documentation at https://kyverno.io/docs/installation/platform-notes/#notes-for-aks-users for more details.
-
 💡 Note: There is a trade-off when deciding which approach to take regarding Namespace exclusions. Please see the documentation at https://kyverno.io/docs/installation/#security-vs-operability to understand the risks.

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -320,15 +320,14 @@ config:
   # Note that it takes a list of `namespaceSelector` and/or `objectSelector` in the JSON format, and only the first element
   # will be forwarded to the webhook configurations.
   # The Kyverno namespace is excluded if `excludeKyvernoNamespace` is `true` (default)
-  webhooks: []
+  webhooks:
     # Exclude namespaces
-    # - namespaceSelector:
-    #     matchExpressions:
-    #     - key: kubernetes.io/metadata.name
-    #       operator: NotIn
-    #       values:
-    #         - kube-system
-    #         - kyverno
+    - namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
     # Exclude objects
     # - objectSelector:
     #     matchExpressions:
@@ -336,9 +335,9 @@ config:
     #       operator: DoesNotExist
 
   # -- Defines annotations to set on webhook configurations.
-  webhookAnnotations: {}
+  webhookAnnotations:
     # Example to disable admission enforcer on AKS:
-    # 'admissions.enforcer/disabled': 'true'
+    'admissions.enforcer/disabled': 'true'
 
   # -- Defines labels to set on webhook configurations.
   webhookLabels: {}

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -188,7 +188,8 @@ data:
     [ServiceMonitor,kyverno,kyverno-reports-controller]
     [Secret,kyverno,kyverno-svc.kyverno.svc.*]
     [Secret,kyverno,kyverno-cleanup-controller.kyverno.svc.*]
-  webhooks: '[{"namespaceSelector": {"matchExpressions": [{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kyverno"]}]}}]'
+  webhooks: "[{\"namespaceSelector\":{\"matchExpressions\":[{\"key\":\"kubernetes.io/metadata.name\",\"operator\":\"NotIn\",\"values\":[\"kube-system\"]},{\"key\":\"kubernetes.io/metadata.name\",\"operator\":\"NotIn\",\"values\":[\"kyverno\"]}],\"matchLabels\":null}}]"
+  webhookAnnotations: "{\"admissions.enforcer/disabled\":\"true\"}"
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## Explanation

This PR excludes by default the `kube-system` Namespace in webhooks and adds the `'admissions.enforcer/disabled': 'true'` annotation to webhooks in order to provide safer defaults for many groups of users, specifically EKS and AKS.

Users who wish to revert to the previous behavior may opt out of these defaults by adding the following to their values override file.

```yaml
config:
  webhooks: null
  webhookAnnotations: null
```

Note that this could be a **breaking change** for some users who specifically wish to act on admission events for resource in `kube-system`. It will need to be clearly called out in the release notes.

## Related issue

Closes #9947
Closes #8872

## Milestone of this PR

1.12.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [x] I have created an issue to add or update [the documentation](https://github.com/kyverno/website) and the link is:

https://github.com/kyverno/website/issues/1200

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind helm

## Proposed Changes

This PR excludes by default the `kube-system` Namespace in webhooks and adds the `'admissions.enforcer/disabled': 'true'` annotation to webhooks in order to provide safer defaults for many groups of users, specifically EKS and AKS.

Users who wish to revert to the previous behavior may opt out of these defaults by adding the following to their values override file.

```yaml
config:
  webhooks: null
  webhookAnnotations: null
```


Note that this could be a **breaking change** for some users who specifically wish to act on admission events for resource in `kube-system`. It will need to be clearly called out in the release notes.

### Proof Manifests

With these changes, a default installation of this chart will see the following changed in the ConfigMap's `webhooks` key:

```sh
$ helm template kyverno -n kyverno . -s templates/config/configmap.yaml | yq .data.webhooks
[{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kube-system"]},{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kyverno"]}],"matchLabels":null}}]
```

and in the `webhookAnnotations` key:

```sh
$ helm template kyverno -n kyverno . -s templates/config/configmap.yaml | yq .data.webhookAnnotations
{"admissions.enforcer/disabled":"true"}
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is release-1.12.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

See [this request on Slack](https://kubernetes.slack.com/archives/CLGR9BJU9/p1711465343916409) for commentary. Based on the results, this seems safe to do.
