### PR TITLE
fix: evaluate namespaceObject for VAPs in the CLI

### DIFF
--- a/test/cli/test-validating-admission-policy/with-namespaceObject-1/kyverno-test.yaml
+++ b/test/cli/test-validating-admission-policy/with-namespaceObject-1/kyverno-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kyverno-test.yaml
+policies:
+- policy.yaml
+resources:
+- resources.yaml
+results:
+- isValidatingAdmissionPolicy: true
+  kind: Deployment
+  policy: check-deployment-namespace
+  resources:
+  - bad-deployment
+  result: fail
+- isValidatingAdmissionPolicy: true
+  kind: Deployment
+  policy: check-deployment-namespace
+  resources:
+  - good-deployment
+  result: pass
+variables: values.yaml

--- a/test/cli/test-validating-admission-policy/with-namespaceObject-1/policy.yaml
+++ b/test/cli/test-validating-admission-policy/with-namespaceObject-1/policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "check-deployment-namespace"
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+  validations:
+  - expression: "namespaceObject.metadata.name != 'default'"
+    message: "Using 'default' namespace is not allowed for pod controllers."

--- a/test/cli/test-validating-admission-policy/with-namespaceObject-1/resources.yaml
+++ b/test/cli/test-validating-admission-policy/with-namespaceObject-1/resources.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bad-deployment
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: busybox
+        image: busybox:latest
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: good-deployment
+  namespace: staging
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: busybox
+        image: busybox:latest

--- a/test/cli/test-validating-admission-policy/with-namespaceObject-1/values.yaml
+++ b/test/cli/test-validating-admission-policy/with-namespaceObject-1/values.yaml
@@ -1,0 +1,11 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Value
+metadata:
+  name: values
+namespaceSelector:
+- labels:
+    environment: staging
+  name: staging
+- labels:
+    environment: default
+  name: default

--- a/test/cli/test-validating-admission-policy/with-namespaceObject-2/kyverno-test.yaml
+++ b/test/cli/test-validating-admission-policy/with-namespaceObject-2/kyverno-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kyverno-test.yaml
+policies:
+- policy.yaml
+resources:
+- resources.yaml
+results:
+- isValidatingAdmissionPolicy: true
+  kind: Deployment
+  policy: check-deployment-namespace
+  resources:
+  - bad-deployment
+  result: fail
+- isValidatingAdmissionPolicy: true
+  kind: Deployment
+  policy: check-deployment-namespace
+  resources:
+  - good-deployment
+  result: pass
+- isValidatingAdmissionPolicy: true
+  kind: Deployment
+  policy: check-deployment-namespace
+  resources:
+  - skipped-deployment-1
+  - skipped-deployment-2
+  result: skip
+variables: values.yaml

--- a/test/cli/test-validating-admission-policy/with-namespaceObject-2/policy.yaml
+++ b/test/cli/test-validating-admission-policy/with-namespaceObject-2/policy.yaml
@@ -1,0 +1,31 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "check-deployment-namespace"
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+  validations:
+  - expression: "namespaceObject.metadata.name != 'default'"
+    message: "Using 'default' namespace is not allowed for pod controllers."
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "check-deployment-namespace-binding"
+spec:
+  policyName: "check-deployment-namespace"
+  validationActions: [Deny]
+  matchResources:
+    objectSelector:
+      matchLabels:
+        app: nginx

--- a/test/cli/test-validating-admission-policy/with-namespaceObject-2/resources.yaml
+++ b/test/cli/test-validating-admission-policy/with-namespaceObject-2/resources.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skipped-deployment-1
+  namespace: default
+  labels: 
+    app: busybox
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: busybox
+        image: busybox:latest
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skipped-deployment-2
+  namespace: staging
+  labels: 
+    app: busybox
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: busybox
+        image: busybox:latest
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bad-deployment
+  namespace: default
+  labels: 
+    app: nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: good-deployment
+  namespace: staging
+  labels: 
+    app: nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest

--- a/test/cli/test-validating-admission-policy/with-namespaceObject-2/values.yaml
+++ b/test/cli/test-validating-admission-policy/with-namespaceObject-2/values.yaml
@@ -1,0 +1,11 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Value
+metadata:
+  name: values
+namespaceSelector:
+- labels:
+    environment: staging
+  name: staging
+- labels:
+    environment: default
+  name: default


### PR DESCRIPTION
## Explanation
This PR evaluates the `namespaceObject` for Kubernetes ValidatingAdmissionPolicies in the CLI.
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
N/A
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.12.1
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
1. policy.yaml:
```
apiVersion: admissionregistration.k8s.io/v1beta1
kind: ValidatingAdmissionPolicy
metadata:
  name: "check-deployment-namespace"
spec:
  matchConstraints:
    resourceRules:
    - apiGroups:
      - apps
      apiVersions:
      - v1
      operations:
      - CREATE
      - UPDATE
      resources:
      - deployments
  validations:
  - expression: "namespaceObject.metadata.name != 'default'"
    message: "Using 'default' namespace is not allowed for pod controllers."
```
2. resources.yaml:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: bad-deployment
  namespace: default
spec:
  replicas: 2
  selector:
    matchLabels:
      app: busybox
  template:
    metadata:
      labels:
        app: busybox
    spec:
      containers:
      - name: busybox
        image: busybox:latest
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: good-deployment
  namespace: staging
spec:
  replicas: 2
  selector:
    matchLabels:
      app: busybox
  template:
    metadata:
      labels:
        app: busybox
    spec:
      containers:
      - name: busybox
        image: busybox:latest
```
3. Apply the VAP to the resource using the CLI:
```
kubectl-kyverno apply policy.yaml --resource resources.yaml -p

apiVersion: wgpolicyk8s.io/v1alpha2
kind: ClusterPolicyReport
metadata:
  creationTimestamp: null
  name: merged
results:
- message: Using 'default' namespace is not allowed for pod controllers.
  policy: check-deployment-namespace
  resources:
  - apiVersion: apps/v1
    kind: Deployment
    name: bad-deployment
    namespace: default
  result: fail
  rule: check-deployment-namespace
  scored: true
  source: ValidatingAdmissionPolicy
  timestamp:
    nanos: 0
    seconds: 1711984127
- policy: check-deployment-namespace
  resources:
  - apiVersion: apps/v1
    kind: Deployment
    name: good-deployment
    namespace: staging
  result: pass
  rule: check-deployment-namespace
  scored: true
  source: ValidatingAdmissionPolicy
  timestamp:
    nanos: 0
    seconds: 1711984127
summary:
  error: 0
  fail: 1
  pass: 1
  skip: 0
  warn: 0
```
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
