### PR TITLE
feat: support generating VAPs in case of matching resources in specific namespaces

### DIFF
--- a/pkg/validatingadmissionpolicy/builder.go
+++ b/pkg/validatingadmissionpolicy/builder.go
@@ -115,7 +115,20 @@ func translateResource(discoveryClient dclient.IDiscovery, matchResources *admis
 	}
 
 	matchResources.ResourceRules = *rules
-	matchResources.NamespaceSelector = res.NamespaceSelector
+	if len(res.Namespaces) > 0 {
+		namespaceSelector := &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "kubernetes.io/metadata.name",
+					Operator: "In",
+					Values:   res.Namespaces,
+				},
+			},
+		}
+		matchResources.NamespaceSelector = namespaceSelector
+	} else {
+		matchResources.NamespaceSelector = res.NamespaceSelector
+	}
 	matchResources.ObjectSelector = res.Selector
 	return nil
 }

--- a/pkg/validatingadmissionpolicy/kyvernopolicy_checker.go
+++ b/pkg/validatingadmissionpolicy/kyvernopolicy_checker.go
@@ -90,8 +90,8 @@ func CanGenerateVAP(spec *kyvernov1.Spec) (bool, string) {
 
 func checkResources(resource kyvernov1.ResourceDescription) (bool, string) {
 	var msg string
-	if len(resource.Namespaces) != 0 || len(resource.Annotations) != 0 {
-		msg = "skip generating ValidatingAdmissionPolicy: Namespaces / Annotations in resource description is not applicable."
+	if len(resource.Annotations) != 0 {
+		msg = "skip generating ValidatingAdmissionPolicy: Annotations in resource description is not applicable."
 		return false, msg
 	}
 	if resource.Name != "" && wildcard.ContainsWildcard(resource.Name) {

--- a/pkg/validatingadmissionpolicy/kyvernopolicy_checker_test.go
+++ b/pkg/validatingadmissionpolicy/kyvernopolicy_checker_test.go
@@ -30,7 +30,7 @@ func Test_Check_Resources(t *testing.T) {
   ]
 }
 `),
-			expected: false,
+			expected: true,
 		},
 		{
 			name: "resource-with-annotations",

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
         file: policy-assert.yaml
   - name: step-02
     try:
-    - error:
+    - assert:
         file: validatingadmissionpolicy.yaml
-    - error:
+    - assert:
         file: validatingadmissionpolicybinding.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/policy-assert.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/policy-assert.yaml
@@ -8,5 +8,5 @@ status:
     status: "True"
     type: Ready
   validatingadmissionpolicy:
-    generated: false
+    generated: true
   

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/policy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/policy.yaml
@@ -10,12 +10,13 @@ spec:
         any:
         - resources:
             kinds:
-              - Deployment
+            - Deployment
             operations:
             - CREATE
             - UPDATE
             namespaces:
-            - prod
+            - production
+            - staging
       validate:
         cel:
           expressions:

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/validatingadmissionpolicy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/validatingadmissionpolicy.yaml
@@ -1,0 +1,35 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kyverno
+  name: disallow-host-path-t4
+  ownerReferences:
+  - apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    name: disallow-host-path-t4
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+        - production
+        - staging
+    resourceRules:
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+  validations:
+  - expression: '!has(object.spec.template.spec.volumes) || object.spec.template.spec.volumes.all(volume,
+      !has(volume.hostPath))'
+    message: HostPath volumes are forbidden. The field spec.template.spec.volumes[*].hostPath
+      must be unset.

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/validatingadmissionpolicybinding.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/validatingadmissionpolicybinding.yaml
@@ -4,4 +4,10 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kyverno
   name: disallow-host-path-t4-binding
-spec: {}
+  ownerReferences:
+  - apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    name: disallow-host-path-t4
+spec:
+  policyName: disallow-host-path-t4
+  validationActions: [Audit, Warn]

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/skip-generate/cpol-match-resource-in-specific-namespace/validatingadmissionpolicy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/skip-generate/cpol-match-resource-in-specific-namespace/validatingadmissionpolicy.yaml
@@ -1,7 +1,0 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
-kind: ValidatingAdmissionPolicy
-metadata:
-  labels:
-    app.kubernetes.io/managed-by: kyverno
-  name: disallow-host-path-t4
-spec: {}


### PR DESCRIPTION
## Explanation
In Kyverno policies, users can match resources in specific namespaces as follows:
```
match:
  any:
  - resources:
      kinds:
      - Deployment
      operations:
      - CREATE
      - UPDATE
      namespaces:
      - production
      - staging
```
However, in ValidatingAdmissionPolicies, there is no way to specify a namespace by its name. Instead, this PR uses the `namespaceSelector` to achieve the same behavior:
```
matchConstraints:
  namespaceSelector:
    matchExpressions:
    - key: kubernetes.io/metadata.name
      operator: In
      values:
      - production
      - staging
  resourceRules:
  - apiGroups:
    - apps
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    resources:
    - deployments
```
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
N/A
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.13
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. policy.yaml:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-host-path-t4
spec:
  validationFailureAction: Audit
  rules:
    - name: host-path
      match:
        any:
        - resources:
            kinds:
            - Deployment
            operations:
            - CREATE
            - UPDATE
            namespaces:
            - production
            - staging
      validate:
        cel:
          expressions:
            - expression: "!has(object.spec.template.spec.volumes) || object.spec.template.spec.volumes.all(volume, !has(volume.hostPath))"
              message: "HostPath volumes are forbidden. The field spec.template.spec.volumes[*].hostPath must be unset."
```
2. The generated VAP and its binding:
```
apiVersion: admissionregistration.k8s.io/v1alpha1
kind: ValidatingAdmissionPolicy
metadata:
  labels:
    app.kubernetes.io/managed-by: kyverno
  name: disallow-host-path-t4
  ownerReferences:
  - apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    name: disallow-host-path-t4
spec:
  failurePolicy: Fail
  matchConstraints:
    namespaceSelector:
      matchExpressions:
      - key: kubernetes.io/metadata.name
        operator: In
        values:
        - production
        - staging
    resourceRules:
    - apiGroups:
      - apps
      apiVersions:
      - v1
      operations:
      - CREATE
      - UPDATE
      resources:
      - deployments
  validations:
  - expression: '!has(object.spec.template.spec.volumes) || object.spec.template.spec.volumes.all(volume,
      !has(volume.hostPath))'
    message: HostPath volumes are forbidden. The field spec.template.spec.volumes[*].hostPath
      must be unset.
---
apiVersion: admissionregistration.k8s.io/v1alpha1
kind: ValidatingAdmissionPolicyBinding
metadata:
  labels:
    app.kubernetes.io/managed-by: kyverno
  name: disallow-host-path-t4-binding
  ownerReferences:
  - apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    name: disallow-host-path-t4
spec:
  policyName: disallow-host-path-t4
  validationActions: [Audit, Warn]
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
