### PR TITLE
feat: support list of policyexception namespaces

### DIFF
--- a/cmd/internal/engine.go
+++ b/cmd/internal/engine.go
@@ -60,7 +60,8 @@ func NewExceptionSelector(
 	logger logr.Logger,
 	kyvernoInformer kyvernoinformer.SharedInformerFactory,
 ) (engineapi.PolicyExceptionSelector, Controller) {
-	logger = logger.WithName("exception-selector").WithValues("enablePolicyException", enablePolicyException, "exceptionNamespace", exceptionNamespace)
+	polexNamespaces := ExceptionNamespaces()
+	logger = logger.WithName("exception-selector").WithValues("enablePolicyException", enablePolicyException, "exceptionNamespaces", polexNamespaces)
 	logger.Info("setup exception selector...")
 	if !enablePolicyException {
 		return nil, nil
@@ -69,7 +70,7 @@ func NewExceptionSelector(
 		kyvernoInformer.Kyverno().V1().ClusterPolicies(),
 		kyvernoInformer.Kyverno().V1().Policies(),
 		kyvernoInformer.Kyverno().V2beta1().PolicyExceptions(),
-		exceptionNamespace,
+		polexNamespaces,
 	)
 	polexController := NewController(
 		exceptioncontroller.ControllerName,

--- a/cmd/internal/flag.go
+++ b/cmd/internal/flag.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"flag"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -97,7 +98,7 @@ func initKubeconfigFlags(qps float64, burst int, eventsQPS float64, eventsBurst 
 }
 
 func initPolicyExceptionsFlags() {
-	flag.StringVar(&exceptionNamespace, "exceptionNamespace", "", "Configure the namespace to accept PolicyExceptions.")
+	flag.StringVar(&exceptionNamespace, "exceptionNamespace", "", "Configure a comma sperated list of namespaces to accept PolicyExceptions.")
 	flag.BoolVar(&enablePolicyException, "enablePolicyException", true, "Enable PolicyException feature.")
 }
 
@@ -234,8 +235,8 @@ func ParseFlags(config Configuration, opts ...Option) {
 	flag.Parse()
 }
 
-func ExceptionNamespace() string {
-	return exceptionNamespace
+func ExceptionNamespaces() []string {
+	return strings.Split(exceptionNamespace, ",")
 }
 
 func PolicyExceptionEnabled() bool {

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -534,8 +534,8 @@ func main() {
 		setup.Jp,
 	)
 	exceptionHandlers := webhooksexception.NewHandlers(exception.ValidationOptions{
-		Enabled:   internal.PolicyExceptionEnabled(),
-		Namespace: internal.ExceptionNamespace(),
+		Enabled:    internal.PolicyExceptionEnabled(),
+		Namespaces: internal.ExceptionNamespaces(),
 	})
 	globalContextHandlers := webhooksglobalcontext.NewHandlers(globalcontext.ValidationOptions{
 		Enabled: internal.PolicyExceptionEnabled(),

--- a/pkg/validation/exception/validate.go
+++ b/pkg/validation/exception/validate.go
@@ -8,13 +8,13 @@ import (
 )
 
 const (
-	namespacesDontMatch = "PolicyException resource namespace must match the defined namespace."
+	namespacesDontMatch = "PolicyException resource namespace must match one of the defined namespaces."
 	disabledPolex       = "PolicyException resources would not be processed until it is enabled."
 )
 
 type ValidationOptions struct {
-	Enabled   bool
-	Namespace string
+	Enabled    bool
+	Namespaces []string
 }
 
 // Validate checks policy exception is valid
@@ -22,8 +22,17 @@ func Validate(ctx context.Context, logger logr.Logger, polex *kyvernov2beta1.Pol
 	var warnings []string
 	if !opts.Enabled {
 		warnings = append(warnings, disabledPolex)
-	} else if opts.Namespace != "" && opts.Namespace != polex.Namespace {
-		warnings = append(warnings, namespacesDontMatch)
+	} else if len(opts.Namespaces) > 0 {
+		found := false
+		for _, ns := range opts.Namespaces {
+			if ns == polex.Namespace {
+				found = true
+				break
+			}
+		}
+		if !found {
+			warnings = append(warnings, namespacesDontMatch)
+		}
 	}
 	errs := polex.Validate()
 	return warnings, errs.ToAggregate()


### PR DESCRIPTION
## Explanation
This PR modifies the flag `--exceptionNamespace` to accept a list of a comma-separated namespaces for policy exceptions.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #6980
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.13.0
<!-

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
The flag `--exceptionNamespace` accepts a list of comma-separated namespaces.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Create multiple namespaces:
```
kubectl create ns-1
kubectl create ns-2
kubectl create ns-3
```
2. Set the flag `--exceptionNamespace` to `ns-1,ns-2`.
3. Create a PolicyException in `ns-3`:
```
apiVersion: kyverno.io/v2beta1
kind: PolicyException                   
metadata:     
  name: delta-exception
  namespace: ns-3            
spec:   
  exceptions:
  - policyName: disallow-host-namespaces
    ruleNames:
    - host-namespaces
    - autogen-host-namespaces
  match:           
    any:       
    - resources:
        kinds:           
        - Pod
        - Deployment
        names:
        - important-tool*
```
The output:
```
Warning: PolicyException resource namespace must match one of the defined namespaces.
policyexception.kyverno.io/delta-exception created
```

Moreover, the exceptions cache will only list exceptions from the defined namespaces.

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
