### PR TITLE
Fix: metrics exposure inconsistencies and unwanted side-effects

### DIFF
--- a/pkg/config/metricsconfig.go
+++ b/pkg/config/metricsconfig.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"maps"
 	"slices"
 	"sync"
 	"time"
@@ -77,30 +78,44 @@ func (mcd *metricsConfig) GetBucketBoundaries() []float64 {
 func (mcd *metricsConfig) BuildMeterProviderViews() []sdkmetric.View {
 	mcd.mux.RLock()
 	defer mcd.mux.RUnlock()
-	var views []sdkmetric.View
-	for key, value := range mcd.metricsExposure {
-		if *value.Enabled {
-			views = append(views, sdkmetric.NewView(
-				sdkmetric.Instrument{Name: key},
-				sdkmetric.Stream{
-					AttributeFilter: func(kv attribute.KeyValue) bool {
-						return !slices.Contains(value.DisabledLabelDimensions, string(kv.Key))
-					},
-					Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-						Boundaries: value.BucketBoundaries,
-						NoMinMax:   false,
-					},
-				},
-			))
-		} else if !*value.Enabled {
-			views = append(views, sdkmetric.NewView(
-				sdkmetric.Instrument{Name: key},
-				sdkmetric.Stream{
-					Aggregation: sdkmetric.AggregationDrop{},
-				},
-			))
-		}
+
+	views := []sdkmetric.View{}
+
+	if len(mcd.metricsExposure) > 0 {
+		var metricsExposure = maps.Clone(mcd.metricsExposure)
+		views = append(views, func(i sdkmetric.Instrument) (sdkmetric.Stream, bool) {
+			s := sdkmetric.Stream{Name: i.Name, Description: i.Description, Unit: i.Unit}
+
+			config, exists := metricsExposure[i.Name]
+			if !exists {
+				return s, false
+			}
+
+			if config.Enabled != nil && !*config.Enabled {
+				s.Aggregation = sdkmetric.AggregationDrop{}
+				return s, true
+			}
+
+			if len(config.DisabledLabelDimensions) > 0 {
+				s.AttributeFilter = func(kv attribute.KeyValue) bool {
+					return !slices.Contains(config.DisabledLabelDimensions, string(kv.Key))
+				}
+			}
+
+			if len(config.BucketBoundaries) > 0 {
+				aggregation := sdkmetric.DefaultAggregationSelector(i.Kind)
+				switch a := aggregation.(type) {
+				case sdkmetric.AggregationExplicitBucketHistogram:
+					a.Boundaries = config.BucketBoundaries
+					a.NoMinMax = false
+					s.Aggregation = a
+				}
+			}
+
+			return s, true
+		})
 	}
+
 	return views
 }
 

--- a/pkg/config/metricsconfig.go
+++ b/pkg/config/metricsconfig.go
@@ -82,7 +82,7 @@ func (mcd *metricsConfig) BuildMeterProviderViews() []sdkmetric.View {
 	views := []sdkmetric.View{}
 
 	if len(mcd.metricsExposure) > 0 {
-		var metricsExposure = maps.Clone(mcd.metricsExposure)
+		metricsExposure := maps.Clone(mcd.metricsExposure)
 		views = append(views, func(i sdkmetric.Instrument) (sdkmetric.Stream, bool) {
 			s := sdkmetric.Stream{Name: i.Name, Description: i.Description, Unit: i.Unit}
 

--- a/pkg/config/metricsconfig_test.go
+++ b/pkg/config/metricsconfig_test.go
@@ -109,7 +109,7 @@ func Test_metricsConfig_BuildMeterProviderViews(t *testing.T) {
 			metricsExposure: map[string]metricExposureConfig{
 				"metric1": {Enabled: boolPtr(true), DisabledLabelDimensions: []string{"dim1"}, BucketBoundaries: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 25, 30}},
 			},
-			expectedSize: 0,
+			expectedSize: 1,
 			validateFunc: func(views []sdkmetric.View) bool {
 				stream, _ := views[0](sdkmetric.Instrument{Name: "metric2"})
 				assert := stream.AttributeFilter == nil

--- a/pkg/config/metricsconfig_test.go
+++ b/pkg/config/metricsconfig_test.go
@@ -105,13 +105,26 @@ func Test_metricsConfig_BuildMeterProviderViews(t *testing.T) {
 			expectedSize:    0,
 		},
 		{
-			name: "Case 2: metrics enabled",
+			name: "Case 2: metrics enabled, no transformation configured",
+			metricsExposure: map[string]metricExposureConfig{
+				"metric1": {Enabled: boolPtr(true)},
+			},
+			expectedSize: 1,
+			validateFunc: func(views []sdkmetric.View) bool {
+				stream, _ := views[0](sdkmetric.Instrument{Name: "metric1"})
+				assert := stream.AttributeFilter == nil
+				assert = assert && stream.Aggregation == nil
+				return assert
+			},
+		},
+		{
+			name: "Case 3: metrics enabled, histogram metric",
 			metricsExposure: map[string]metricExposureConfig{
 				"metric1": {Enabled: boolPtr(true), DisabledLabelDimensions: []string{"dim1"}, BucketBoundaries: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 25, 30}},
 			},
 			expectedSize: 1,
 			validateFunc: func(views []sdkmetric.View) bool {
-				stream, _ := views[0](sdkmetric.Instrument{Name: "metric1"})
+				stream, _ := views[0](sdkmetric.Instrument{Name: "metric1", Kind: sdkmetric.InstrumentKindHistogram})
 				assert := stream.AttributeFilter(attribute.String("policy_validation_mode", ""))
 				assert = assert && !stream.AttributeFilter(attribute.String("dim1", ""))
 				assert = assert && reflect.DeepEqual(stream.Aggregation, sdkmetric.AggregationExplicitBucketHistogram{
@@ -122,7 +135,21 @@ func Test_metricsConfig_BuildMeterProviderViews(t *testing.T) {
 			},
 		},
 		{
-			name: "Case 3: metrics disabled",
+			name: "Case 4: metrics enabled, non histogram metric",
+			metricsExposure: map[string]metricExposureConfig{
+				"metric1": {Enabled: boolPtr(true), DisabledLabelDimensions: []string{"dim1"}, BucketBoundaries: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 25, 30}},
+			},
+			expectedSize: 1,
+			validateFunc: func(views []sdkmetric.View) bool {
+				stream, _ := views[0](sdkmetric.Instrument{Name: "metric1", Kind: sdkmetric.InstrumentKindCounter})
+				assert := stream.AttributeFilter(attribute.String("policy_validation_mode", ""))
+				assert = assert && !stream.AttributeFilter(attribute.String("dim1", ""))
+				assert = assert && stream.Aggregation == nil
+				return assert
+			},
+		},
+		{
+			name: "Case 5: metrics disabled",
 			metricsExposure: map[string]metricExposureConfig{
 				"metric1": {Enabled: boolPtr(false)},
 			},

--- a/pkg/config/metricsconfig_test.go
+++ b/pkg/config/metricsconfig_test.go
@@ -105,7 +105,20 @@ func Test_metricsConfig_BuildMeterProviderViews(t *testing.T) {
 			expectedSize:    0,
 		},
 		{
-			name: "Case 2: metrics enabled, no transformation configured",
+			name: "Case 2: there is no matching entry on the exposure config",
+			metricsExposure: map[string]metricExposureConfig{
+				"metric1": {Enabled: boolPtr(true), DisabledLabelDimensions: []string{"dim1"}, BucketBoundaries: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 25, 30}},
+			},
+			expectedSize: 0,
+			validateFunc: func(views []sdkmetric.View) bool {
+				stream, _ := views[0](sdkmetric.Instrument{Name: "metric2"})
+				assert := stream.AttributeFilter == nil
+				assert = assert && stream.Aggregation == nil
+				return assert
+			},
+		},
+		{
+			name: "Case 3: metrics enabled, no transformation configured",
 			metricsExposure: map[string]metricExposureConfig{
 				"metric1": {Enabled: boolPtr(true)},
 			},
@@ -118,7 +131,7 @@ func Test_metricsConfig_BuildMeterProviderViews(t *testing.T) {
 			},
 		},
 		{
-			name: "Case 3: metrics enabled, histogram metric",
+			name: "Case 4: metrics enabled, histogram metric",
 			metricsExposure: map[string]metricExposureConfig{
 				"metric1": {Enabled: boolPtr(true), DisabledLabelDimensions: []string{"dim1"}, BucketBoundaries: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 25, 30}},
 			},
@@ -135,7 +148,7 @@ func Test_metricsConfig_BuildMeterProviderViews(t *testing.T) {
 			},
 		},
 		{
-			name: "Case 4: metrics enabled, non histogram metric",
+			name: "Case 5: metrics enabled, non histogram metric",
 			metricsExposure: map[string]metricExposureConfig{
 				"metric1": {Enabled: boolPtr(true), DisabledLabelDimensions: []string{"dim1"}, BucketBoundaries: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 25, 30}},
 			},
@@ -149,7 +162,7 @@ func Test_metricsConfig_BuildMeterProviderViews(t *testing.T) {
 			},
 		},
 		{
-			name: "Case 5: metrics disabled",
+			name: "Case 6: metrics disabled",
 			metricsExposure: map[string]metricExposureConfig{
 				"metric1": {Enabled: boolPtr(false)},
 			},


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->
This change translates the metric exposure config to a open-telemetry view function that selectively applies the a configured dimension filters and bucket aggregations driven by the underlying metrics runtime details.
The improvement completes and extends the metric dimension filter feature to other non histogram kind of metrics. It also fixes a side-effect where counters are accidentally getting transformed into histograms when the metric exposure config prescribes custom bucket boundaries.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->
Closes #9998 

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: kyverno-metrics
  namespace: kyverno
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

Deploy a metric exposure config by populating the corresponding keys of the values.yaml e.g.:
```yaml
metricsConfig:
  create: true
  metricsExposure:
    kyverno_policy_results:
      enabled: false
    kyverno_policy_execution_duration_seconds:
      disabledLabelDimensions:
        [
          "rule_execution_cause",
          "rule_name",
          "rule_result",
          "rule_type",
        ]
      bucketBoundaries: [0.005, 0.01, 0.025]
      enabled: true
    kyverno_admission_requests:
      disabledLabelDimensions:
        ["resource_namespace", "resource_kind", "resource_request_operation"]
      enabled: true

admissionController:
  metricsService:
    create: true
```

The undlying config map itself:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: kyverno-metrics
  namespace: kyverno
data:
  metricsExposure: '{"kyverno_admission_requests":{"disabledLabelDimensions":["resource_namespace", "resource_kind", "resource_request_operation"],"enabled":true},"kyverno_policy_execution_duration_seconds":{"disabledLabelDimensions":["rule_execution_cause","rule_name","rule_result","rule_type"],"bucketBoundaries":[0.005, 0.01, 0.025],"enabled":true}, "kyverno_policy_results":{"enabled":false}}'
```

Inspect the metrics emitted, e.g.:
```
$ k port-forward svc/kyverno-svc-metrics -n kyverno 8000:8000
$ curl localhost:8000/metrics
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
