### PR TITLE
fix: remove undefined flag in the helm chart

### DIFF
--- a/charts/kyverno/templates/cleanup-controller/deployment.yaml
+++ b/charts/kyverno/templates/cleanup-controller/deployment.yaml
@@ -80,7 +80,7 @@ spec:
           image: {{ include "kyverno.cleanup-controller.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.cleanupController.image "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.cleanupController.image.pullPolicy }}
           ports:
-          - containerPort: {{ .Values.cleanupController.server.port }}
+          - containerPort: {{ .Values.cleanupController.webhookServer.port }}
             name: https
             protocol: TCP
           - containerPort: {{ .Values.cleanupController.metering.port }}
@@ -95,7 +95,6 @@ spec:
             - --caSecretName={{ template "kyverno.cleanup-controller.name" . }}.{{ template "kyverno.namespace" . }}.svc.kyverno-tls-ca
             - --tlsSecretName={{ template "kyverno.cleanup-controller.name" . }}.{{ template "kyverno.namespace" . }}.svc.kyverno-tls-pair
             - --servicePort={{ .Values.cleanupController.service.port }}
-            - --cleanupServerPort={{ .Values.cleanupController.server.port }}
             - --webhookServerPort={{ .Values.cleanupController.webhookServer.port }}
             {{- if .Values.cleanupController.tracing.enabled }}
             - --enableTracing

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -1635,10 +1635,6 @@ cleanupController:
   # Update the `dnsPolicy` accordingly as well to suit the host network mode.
   hostNetwork: false
 
-  # -- cleanupController server port
-  # in case you are using hostNetwork: true, you might want to change the port the cleanupController is listening to
-  server:
-    port: 9443
   # -- cleanupController webhook server port
   # in case you are using hostNetwork: true, you might want to change the port the webhookServer is listening to
   webhookServer:


### PR DESCRIPTION
## Explanation
In the helm chart, the cleanup controller deployment specifies the flag `--cleanupServerPort` which doesn't exist in the 1st place. In addition to that, `values.yaml` defines two variables for the cleanup controller port; `cleanupController.server.port` and `cleanupController.webhookServer.port`.

This PR removes the undefined flag and it also removes the duplicated `cleanupController.server.port`.