### PR TITLE
fix: set all operations by default in the generated VAP

### DIFF
--- a/pkg/validatingadmissionpolicy/builder.go
+++ b/pkg/validatingadmissionpolicy/builder.go
@@ -295,6 +295,8 @@ func translateOperations(operations []string) []admissionregistrationv1.Operatio
 	if len(vapOperations) == 0 {
 		vapOperations = append(vapOperations, admissionregistrationv1.Create)
 		vapOperations = append(vapOperations, admissionregistrationv1.Update)
+		vapOperations = append(vapOperations, admissionregistrationv1.Connect)
+		vapOperations = append(vapOperations, admissionregistrationv1.Delete)
 	}
 	return vapOperations
 }

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/policy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/policy.yaml
@@ -12,6 +12,9 @@ spec:
       - resources:
           kinds:
             - Pod
+          operations:
+            - CREATE
+            - UPDATE
     validate:
       cel:
         expressions:

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/validatingadmissionpolicy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/validatingadmissionpolicy.yaml
@@ -19,8 +19,6 @@ spec:
       operations:
       - CREATE
       - UPDATE
-      - CONNECT
-      - DELETE
       resources:
       - pods
       - pods/ephemeralcontainers

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/validatingadmissionpolicy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/validatingadmissionpolicy.yaml
@@ -19,6 +19,8 @@ spec:
       operations:
       - CREATE
       - UPDATE
+      - CONNECT
+      - DELETE
       resources:
       - pods
       - pods/ephemeralcontainers

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/chainsaw-test.yaml
@@ -36,5 +36,5 @@ spec:
         check:  
           ($error != null): true
           # This check ensures the contents of stderr are exactly as shown.  
-          ($stderr): |-
+          (trim_space($stderr)): |-
             The pods "my-pod" is invalid: : ValidatingAdmissionPolicy 'deny-exec-by-namespace-name' with binding 'deny-exec-by-namespace-name-binding' denied request: Pods in this namespace may not be exec'd into.

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/chainsaw-test.yaml
@@ -1,0 +1,40 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: block-exec-in-pods
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ns.yaml
+  - name: step-02
+    try:
+    - script:
+        content: kubectl run my-pod --image nginx -n pci
+  - name: step-03
+    try:
+    - apply:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
+  - name: step-04
+    try:
+    - assert:
+        file: validatingadmissionpolicy.yaml
+    - assert:
+        file: validatingadmissionpolicybinding.yaml
+  - name: step-05
+    try:
+    - sleep:
+        duration: 3s
+  - name: step-06
+    try:
+    - script:
+        content: kubectl exec my-pod -n pci -- ls
+        check:  
+          ($error != null): true
+          # This check ensures the contents of stderr are exactly as shown.  
+          ($stderr): |-
+            The pods "my-pod" is invalid: : ValidatingAdmissionPolicy 'deny-exec-by-namespace-name' with binding 'deny-exec-by-namespace-name-binding' denied request: Pods in this namespace may not be exec'd into.

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/ns.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pci

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/policy-assert.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/policy-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-exec-by-namespace-name
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready
+  

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/policy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-exec-by-namespace-name
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+  - name: deny-exec-ns-pci
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod/exec
+    celPreconditions:
+      - name: "operation-should-be-connect"
+        expression: "request.operation == 'CONNECT'"
+    validate:
+      cel:
+        expressions:
+          - expression: "request.namespace != 'pci'"
+            message: Pods in this namespace may not be exec'd into.

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/validatingadmissionpolicy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/validatingadmissionpolicy.yaml
@@ -1,0 +1,32 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kyverno
+  name: deny-exec-by-namespace-name
+  ownerReferences:
+  - apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    name: deny-exec-by-namespace-name
+spec:
+  failurePolicy: Fail
+  matchConditions:
+  - expression: request.operation == 'CONNECT'
+    name: operation-should-be-connect
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      - CONNECT
+      - DELETE
+      resources:
+      - pods/exec
+      scope: '*'
+  validations:
+  - expression: request.namespace != 'pci'
+    message: Pods in this namespace may not be exec'd into.

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/validatingadmissionpolicybinding.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/validatingadmissionpolicybinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kyverno
+  name: deny-exec-by-namespace-name-binding
+  ownerReferences:
+  - apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    name: deny-exec-by-namespace-name
+spec:
+  policyName: deny-exec-by-namespace-name
+  validationActions:
+  - Deny

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/validatingadmissionpolicybinding.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-exec-in-pods/validatingadmissionpolicybinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   labels:

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-namespace-match-resource/policy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-namespace-match-resource/policy.yaml
@@ -21,6 +21,9 @@ spec:
             namespaces:
             - testing-ns
             - staging-ns
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-resources-by-names/policy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-resources-by-names/policy.yaml
@@ -14,6 +14,9 @@ spec:
             - Deployment
             names: 
             - "staging"
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-all-exclude-one/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-all-exclude-one/chainsaw-test.yaml
@@ -2,7 +2,7 @@ apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
   creationTimestamp: null
-  name: cpol-match-kind-with-wildcard
+  name: cpol-match-all-exclude-one
 spec:
   steps:
   - name: step-01

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/validatingadmissionpolicy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/validatingadmissionpolicy.yaml
@@ -26,6 +26,8 @@ spec:
       operations:
       - CREATE
       - UPDATE
+      - CONNECT
+      - DELETE
       resources:
       - '*'
   validations:


### PR DESCRIPTION
## Explanation
The generated VAPs set `operations` to only `CREATE` and `UPDATE`  in case users don't specify them in the Kyverno policies. This raises an issue when a Kyverno policy matches `pod/exec` in which the operation is of type `CONNECT` but isn't set in the policy definition itself. But, it is configured in the corresponding `validatingwebhookconfiguration`. Since the operations in the Kyverno policy aren't set, the generated VAP sets operations to `CREATE` and `UPDATE`. 
This PR adds all operations in the generated VAP by default.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
N/A
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.12.1
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Set the flag `--generateValidatingAdmissionPolicy` to `true` in the admission controller.
2. Create the following policy that blocks exec commands in pods.
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: deny-exec-by-namespace-name
spec:
  validationFailureAction: Enforce
  background: false
  rules:
  - name: deny-exec-ns-pci
    match:
      any:
      - resources:
          kinds:
          - Pod/exec
    celPreconditions:
      - name: "operation-should-be-connect"
        expression: "request.operation == 'CONNECT'"
    validate:
      cel:
        expressions:
          - expression: "request.namespace != 'pci'"
            message: Pods in this namespace may not be exec'd into.
```
3. Create the namespace `pci`.
4. Create a pod: `kubectl run my-pod --image nginx -n pci`.
5. Check that a corresponding VAP is generated:
```
apiVersion: admissionregistration.k8s.io/v1alpha1
kind: ValidatingAdmissionPolicy
metadata:
  labels:
    app.kubernetes.io/managed-by: kyverno
  name: deny-exec-by-namespace-name
  ownerReferences:
  - apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    name: deny-exec-by-namespace-name
spec:
  failurePolicy: Fail
  matchConditions:
  - expression: request.operation == 'CONNECT'
    name: operation-should-be-connect
  matchConstraints:
    resourceRules:
    - apiGroups:
      - ""
      apiVersions:
      - v1
      operations:
      - CREATE
      - UPDATE
      - CONNECT
      - DELETE
      resources:
      - pods/exec
      scope: '*'
  validations:
  - expression: request.namespace != 'pci'
    message: Pods in this namespace may not be exec'd into.
```
6. Try to run the `exec` command:
```
kubectl exec my-pod -n pci -- ls

The pods "my-pod" is invalid: : ValidatingAdmissionPolicy 'deny-exec-by-namespace-name' with binding 'deny-exec-by-namespace-name-binding' denied request: Pods in this namespace may not be exec'd into.
```

The generated VAP blocks the exec command.

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
