### PR TITLE
fix: skip rules without operation in resource webhook creation

### DIFF
--- a/pkg/controllers/webhook/utils.go
+++ b/pkg/controllers/webhook/utils.go
@@ -80,6 +80,12 @@ func (wh *webhook) buildRulesWithOperations(final map[string][]admissionregistra
 		if (gv.Group == "" || gv.Group == "*") && (gv.Version == "v1" || gv.Version == "*") && (resources.Has("pods") || resources.Has("*")) {
 			resources.Insert("pods/ephemeralcontainers")
 		}
+		
+		operations := findKeyContainingSubstring(final, firstResource, defaultOpn)
+		if len(operations) == 0 {
+			continue
+		}
+
 		rules = append(rules, admissionregistrationv1.RuleWithOperations{
 			Rule: admissionregistrationv1.Rule{
 				APIGroups:   []string{gv.Group},
@@ -87,7 +93,7 @@ func (wh *webhook) buildRulesWithOperations(final map[string][]admissionregistra
 				Resources:   sets.List(resources),
 				Scope:       ptr.To(gv.scopeType),
 			},
-			Operations: findKeyContainingSubstring(final, firstResource, defaultOpn),
+			Operations: operations,
 		})
 	}
 	less := func(a []string, b []string) (int, bool) {

--- a/pkg/controllers/webhook/utils.go
+++ b/pkg/controllers/webhook/utils.go
@@ -80,7 +80,7 @@ func (wh *webhook) buildRulesWithOperations(final map[string][]admissionregistra
 		if (gv.Group == "" || gv.Group == "*") && (gv.Version == "v1" || gv.Version == "*") && (resources.Has("pods") || resources.Has("*")) {
 			resources.Insert("pods/ephemeralcontainers")
 		}
-		
+
 		operations := findKeyContainingSubstring(final, firstResource, defaultOpn)
 		if len(operations) == 0 {
 			continue


### PR DESCRIPTION
## Explanation
The error `MutatingWebhookConfiguration: webhooks[0].rules[0].operations: Required value` occurs when using mutating and generating rules in the same policy.

## Related issue
Fixes #10143 .
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR

/milestone 1.12.1

## What type of PR is this

/kind bug

## Proposed Changes
Add a check in order to skip rules without any mapped operation.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
 - [ ] CLI support should be added and my PR doesn't contain that functionality.
