### PR TITLE
fix: add pods/ephemeralcontainers to the generated VAPs

### DIFF
--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/README.md
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/README.md
@@ -1,0 +1,7 @@
+## Description
+
+This is a corner case test to ensure that "pods/ephemeralcontainers" are added in the match block of the ValidatingAdmissionPolicy.
+
+## Expected Behavior
+
+The test should pass if the "pods/ephemeralcontainers" are added in the match block of the ValidatingAdmissionPolicy. If not, the test fails. Moreover, a Pod is created and the policy should block the use of ephemeral containers.

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/chainsaw-test.yaml
@@ -1,0 +1,27 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: block-ephemeral-containers
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
+  - name: step-02
+    try:
+    - assert:
+        file: validatingadmissionpolicy.yaml
+    - assert:
+        file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - apply:
+        file: pod.yaml
+  - name: step-04
+    try:
+    - script:
+        content: if kubectl debug -it test-pod --image=busybox:1.35 --target=busybox; then exit 1; else exit 0; fi;

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/pod.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: busybox
+    image: busybox:1.35
+    command: ["sleep", "300"]

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/policy-assert.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/policy-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: block-ephemeral-containers
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready
+  

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/policy-assert.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/policy-assert.yaml
@@ -7,4 +7,3 @@ status:
   - reason: Succeeded
     status: "True"
     type: Ready
-  

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/policy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: block-ephemeral-containers
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+  - name: block-ephemeral-containers
+    match:
+      any:
+      - resources:
+          kinds:
+            - Pod
+    validate:
+      cel:
+        expressions:
+          - expression: "!has(object.spec.ephemeralContainers)"
+            message: "Ephemeral (debug) containers are not permitted."

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/validatingadmissionpolicy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/validatingadmissionpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kyverno
+  name: block-ephemeral-containers
+  ownerReferences:
+  - apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    name: block-ephemeral-containers
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - pods
+      - pods/ephemeralcontainers
+  validations:
+  - expression: '!has(object.spec.ephemeralContainers)'
+    message: Ephemeral (debug) containers are not permitted.

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/validatingadmissionpolicybinding.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/block-ephemeral-containers/validatingadmissionpolicybinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kyverno
+  name: block-ephemeral-containers-binding
+  ownerReferences:
+  - apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    name: block-ephemeral-containers
+spec:
+  policyName: block-ephemeral-containers
+  validationActions:
+  - Deny


### PR DESCRIPTION
## Explanation
This PR is to add "pods/ephemeralcontainers" in the match block of the generated ValidatingAdmissionPolicies in case the Kyverno policy matches pods. This is because it is added by default in the validatingwebhookconfiguration.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
N/A
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.12.2
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Create a Kyverno policy that blocks the use of ephemeral containers:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: block-ephemeral-containers
spec:
  validationFailureAction: Enforce
  background: true
  rules:
  - name: block-ephemeral-containers
    match:
      any:
      - resources:
          kinds:
            - Pod
    validate:
      cel:
        expressions:
          - expression: "!has(object.spec.ephemeralContainers)"
            message: "Ephemeral (debug) containers are not permitted."
```
2. Check the generated VAP:
```
apiVersion: admissionregistration.k8s.io/v1alpha1
kind: ValidatingAdmissionPolicy
metadata:
  labels:
    app.kubernetes.io/managed-by: kyverno
  name: block-ephemeral-containers
  ownerReferences:
  - apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    name: block-ephemeral-containers
spec:
  failurePolicy: Fail
  matchConstraints:
    resourceRules:
    - apiGroups:
      - ""
      apiVersions:
      - v1
      operations:
      - CREATE
      - UPDATE
      resources:
      - pods
      - pods/ephemeralcontainers
  validations:
  - expression: '!has(object.spec.ephemeralContainers)'
    message: Ephemeral (debug) containers are not permitted.
```
3. Create a pod:
```
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
spec:
  containers:
  - name: busybox
    image: busybox:1.35
    command: ["sleep", "300"]
```
4. Use `kubectl debug` command:
```
$ kubectl debug -it pod01 --image=busybox:1.35 --target=busybox

Targeting container "busybox". If you don't see processes from this container it may be because the container runtime doesn't support this feature.
Defaulting debug container name to debugger-45ght.
The pods "pod01" is invalid: : ValidatingAdmissionPolicy 'block-ephemeral-containers' with binding 'block-ephemeral-containers-binding' denied request: Ephemeral (debug) containers are not permitted.
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
