### PR TITLE
fix: generate VAPs that match all resources when kinds is set to *

### DIFF
--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/chainsaw-test.yaml
@@ -1,0 +1,19 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: cpol-match-kind-with-wildcard
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
+  - name: step-02
+    try:
+    - assert:
+        file: validatingadmissionpolicy.yaml
+    - assert:
+        file: validatingadmissionpolicybinding.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/policy-assert.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/policy-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: disallow-host-path-t4
+  name: check-label-app4
 status:
   conditions:
   - reason: Succeeded

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/policy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: check-label-app4
+spec:
+  validationFailureAction: Audit
+  background: false
+  rules:
+    - name: check-label-app
+      match:
+        all:
+        - resources:
+            kinds:
+            - '*'
+            namespaces:
+            - production
+            - staging
+      validate:
+        cel:
+          expressions:
+            - expression: "'app' in object.metadata.labels"

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/validatingadmissionpolicy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/validatingadmissionpolicy.yaml
@@ -1,0 +1,32 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kyverno
+  name: check-label-app4
+  ownerReferences:
+  - apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    name: check-label-app4
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+        - production
+        - staging
+    resourceRules:
+    - apiGroups:
+      - '*'
+      apiVersions:
+      - '*'
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - '*'
+  validations:
+  - expression: '''app'' in object.metadata.labels'

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/validatingadmissionpolicybinding.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/validatingadmissionpolicybinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kyverno
+  name: check-label-app4-binding
+  ownerReferences:
+  - apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    name: check-label-app4
+spec:
+  policyName: check-label-app4
+  validationActions: [Audit, Warn]


### PR DESCRIPTION
## Explanation
This PR generates VAPs that match all resources when the `kinds` is set to `*` in the Kyverno policy.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #10207 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.12.2
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Create the following policy:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: check-label-app4
spec:
  validationFailureAction: Audit
  background: false
  rules:
    - name: check-label-app
      match:
        all:
        - resources:
            kinds:
            - '*'
            namespaces:
            - production
            - staging
      validate:
        cel:
          expressions:
            - expression: "'app' in object.metadata.labels"
```
The policy is successfully created and the corresponding VAP is generated as follows:
```
apiVersion: admissionregistration.k8s.io/v1alpha1
kind: ValidatingAdmissionPolicy
metadata:
  labels:
    app.kubernetes.io/managed-by: kyverno
  name: check-label-app4
  ownerReferences:
  - apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    name: check-label-app4
spec:
  failurePolicy: Fail
  matchConstraints:
    namespaceSelector:
      matchExpressions:
      - key: kubernetes.io/metadata.name
        operator: In
        values:
        - production
        - staging
    resourceRules:
    - apiGroups:
      - '*'
      apiVersions:
      - '*'
      operations:
      - CREATE
      - UPDATE
      resources:
      - '*'
  validations:
  - expression: '''app'' in object.metadata.labels'
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
