### PR TITLE
fix: skip processing the oldObject for audit policies

### DIFF
--- a/pkg/engine/handlers/validation/validate_assert.go
+++ b/pkg/engine/handlers/validation/validate_assert.go
@@ -125,13 +125,13 @@ func (h validateAssertHandler) Process(
 			if engineutils.IsUpdateRequest(policyContext) && allowExisitingViolations {
 				errs, err := validateOldObject(ctx, policyContext, rule, payload, bindings)
 				if err != nil {
-					logger.V(2).Info("warning: failed to validate old object", "rule", rule.Name, "error", err.Error())
+					logger.V(4).Info("warning: failed to validate old object", "rule", rule.Name, "error", err.Error())
 					return resource, handlers.WithSkip(rule, engineapi.Validation, "failed to validate old object")
 				}
 
 				logger.V(3).Info("old object verification", "errors", errs)
 				if len(errs) != 0 {
-					logger.V(3).Info("warning: skipping the rule evaluation as pre-existing violations are allowed", "rule", rule.Name)
+					logger.V(2).Info("warning: skipping the rule evaluation as pre-existing violations are allowed", "rule", rule.Name)
 					return resource, handlers.WithSkip(rule, engineapi.Validation, "skipping the rule evaluation as pre-existing violations are allowed")
 				}
 			}

--- a/pkg/engine/handlers/validation/validate_assert.go
+++ b/pkg/engine/handlers/validation/validate_assert.go
@@ -112,20 +112,31 @@ func (h validateAssertHandler) Process(
 	}
 	// compose a response
 	if len(errs) != 0 {
-		allowExisitingViolations := rule.HasValidateAllowExistingViolations()
-		if engineutils.IsUpdateRequest(policyContext) && allowExisitingViolations {
-			errs, err := validateOldObject(ctx, policyContext, rule, payload, bindings)
-			if err != nil {
-				logger.V(2).Info("warning: failed to validate old object, skipping the rule evaluation as pre-existing violations are allowed", "rule", rule.Name, "error", err.Error())
-				return resource, handlers.WithSkip(rule, engineapi.Validation, "failed to validate old object, skipping as preexisting violations are allowed")
-			}
+		var action kyvernov1.ValidationFailureAction
+		if rule.Validation.FailureAction != nil {
+			action = *rule.Validation.FailureAction
+		} else {
+			action = policyContext.Policy().GetSpec().ValidationFailureAction
+		}
 
-			logger.V(3).Info("old object verification", "errors", errs)
-			if len(errs) != 0 {
-				logger.V(3).Info("skipping modified resource as validation results have not changed")
-				return resource, handlers.WithSkip(rule, engineapi.Validation, "skipping modified resource as validation results have not changed")
+		// process the old object for UPDATE admission requests in case of enforce policies
+		if action == kyvernov1.Enforce {
+			allowExisitingViolations := rule.HasValidateAllowExistingViolations()
+			if engineutils.IsUpdateRequest(policyContext) && allowExisitingViolations {
+				errs, err := validateOldObject(ctx, policyContext, rule, payload, bindings)
+				if err != nil {
+					logger.V(2).Info("warning: failed to validate old object, skipping the rule evaluation as pre-existing violations are allowed", "rule", rule.Name, "error", err.Error())
+					return resource, handlers.WithSkip(rule, engineapi.Validation, "failed to validate old object, skipping as preexisting violations are allowed")
+				}
+
+				logger.V(3).Info("old object verification", "errors", errs)
+				if len(errs) != 0 {
+					logger.V(3).Info("skipping modified resource as validation results have not changed")
+					return resource, handlers.WithSkip(rule, engineapi.Validation, "skipping modified resource as validation results have not changed")
+				}
 			}
 		}
+
 		var responses []*engineapi.RuleResponse
 		for _, err := range errs {
 			responses = append(responses, engineapi.RuleFail(rule.Name, engineapi.Validation, err.Error(), rule.ReportProperties))

--- a/pkg/engine/handlers/validation/validate_assert.go
+++ b/pkg/engine/handlers/validation/validate_assert.go
@@ -125,14 +125,14 @@ func (h validateAssertHandler) Process(
 			if engineutils.IsUpdateRequest(policyContext) && allowExisitingViolations {
 				errs, err := validateOldObject(ctx, policyContext, rule, payload, bindings)
 				if err != nil {
-					logger.V(2).Info("warning: failed to validate old object, skipping the rule evaluation as pre-existing violations are allowed", "rule", rule.Name, "error", err.Error())
-					return resource, handlers.WithSkip(rule, engineapi.Validation, "failed to validate old object, skipping as preexisting violations are allowed")
+					logger.V(2).Info("warning: failed to validate old object", "rule", rule.Name, "error", err.Error())
+					return resource, handlers.WithSkip(rule, engineapi.Validation, "failed to validate old object")
 				}
 
 				logger.V(3).Info("old object verification", "errors", errs)
 				if len(errs) != 0 {
-					logger.V(3).Info("skipping modified resource as validation results have not changed")
-					return resource, handlers.WithSkip(rule, engineapi.Validation, "skipping modified resource as validation results have not changed")
+					logger.V(3).Info("warning: skipping the rule evaluation as pre-existing violations are allowed", "rule", rule.Name)
+					return resource, handlers.WithSkip(rule, engineapi.Validation, "skipping the rule evaluation as pre-existing violations are allowed")
 				}
 			}
 		}

--- a/pkg/engine/handlers/validation/validate_pss.go
+++ b/pkg/engine/handlers/validation/validate_pss.go
@@ -133,23 +133,33 @@ func (h validatePssHandler) validate(
 		}
 		msg := fmt.Sprintf(`Validation rule '%s' failed. It violates PodSecurity "%s:%s": %s`, rule.Name, podSecurity.Level, podSecurity.Version, pss.FormatChecksPrint(pssChecks))
 		ruleResponse := engineapi.RuleFail(rule.Name, engineapi.Validation, msg, rule.ReportProperties).WithPodSecurityChecks(podSecurityChecks)
-		allowExisitingViolations := rule.HasValidateAllowExistingViolations()
-		if engineutils.IsUpdateRequest(policyContext) && allowExisitingViolations {
-			logger.V(4).Info("is update request")
-			priorResp, err := h.validateOldObject(ctx, logger, policyContext, resource, rule, engineLoader, exceptions)
-			if err != nil {
-				logger.V(2).Info("warning: failed to validate old object, skipping the rule evaluation as pre-existing violations are allowed", "rule", rule.Name, "error", err.Error())
-				return resource, engineapi.RuleSkip(rule.Name, engineapi.Validation, "failed to validate old object, skipping as preexisting violations are allowed", rule.ReportProperties)
-			}
+		var action kyvernov1.ValidationFailureAction
+		if rule.Validation.FailureAction != nil {
+			action = *rule.Validation.FailureAction
+		} else {
+			action = policyContext.Policy().GetSpec().ValidationFailureAction
+		}
 
-			if ruleResponse.Status() == priorResp.Status() {
-				logger.V(3).Info("skipping modified resource as validation results have not changed", "oldResp", priorResp, "newResp", ruleResponse)
-				if ruleResponse.Status() == engineapi.RuleStatusPass {
-					return resource, ruleResponse
+		// process the old object for UPDATE admission requests in case of enforce policies
+		if action == kyvernov1.Enforce {
+			allowExisitingViolations := rule.HasValidateAllowExistingViolations()
+			if engineutils.IsUpdateRequest(policyContext) && allowExisitingViolations {
+				logger.V(4).Info("is update request")
+				priorResp, err := h.validateOldObject(ctx, logger, policyContext, resource, rule, engineLoader, exceptions)
+				if err != nil {
+					logger.V(2).Info("warning: failed to validate old object, skipping the rule evaluation as pre-existing violations are allowed", "rule", rule.Name, "error", err.Error())
+					return resource, engineapi.RuleSkip(rule.Name, engineapi.Validation, "failed to validate old object, skipping as preexisting violations are allowed", rule.ReportProperties)
 				}
-				return resource, engineapi.RuleSkip(rule.Name, engineapi.Validation, "skipping modified resource as validation results have not changed", rule.ReportProperties)
+
+				if ruleResponse.Status() == priorResp.Status() {
+					logger.V(3).Info("skipping modified resource as validation results have not changed", "oldResp", priorResp, "newResp", ruleResponse)
+					if ruleResponse.Status() == engineapi.RuleStatusPass {
+						return resource, ruleResponse
+					}
+					return resource, engineapi.RuleSkip(rule.Name, engineapi.Validation, "skipping modified resource as validation results have not changed", rule.ReportProperties)
+				}
+				logger.V(4).Info("old object response is different", "oldResp", priorResp, "newResp", ruleResponse)
 			}
-			logger.V(4).Info("old object response is different", "oldResp", priorResp, "newResp", ruleResponse)
 		}
 
 		return resource, ruleResponse

--- a/pkg/engine/handlers/validation/validate_pss.go
+++ b/pkg/engine/handlers/validation/validate_pss.go
@@ -147,16 +147,16 @@ func (h validatePssHandler) validate(
 				logger.V(4).Info("is update request")
 				priorResp, err := h.validateOldObject(ctx, logger, policyContext, resource, rule, engineLoader, exceptions)
 				if err != nil {
-					logger.V(2).Info("warning: failed to validate old object, skipping the rule evaluation as pre-existing violations are allowed", "rule", rule.Name, "error", err.Error())
-					return resource, engineapi.RuleSkip(rule.Name, engineapi.Validation, "failed to validate old object, skipping as preexisting violations are allowed", rule.ReportProperties)
+					logger.V(2).Info("warning: failed to validate old object", "rule", rule.Name, "error", err.Error())
+					return resource, engineapi.RuleSkip(rule.Name, engineapi.Validation, "failed to validate old object", rule.ReportProperties)
 				}
 
 				if ruleResponse.Status() == priorResp.Status() {
-					logger.V(3).Info("skipping modified resource as validation results have not changed", "oldResp", priorResp, "newResp", ruleResponse)
+					logger.V(3).Info("warning: skipping the rule evaluation as pre-existing violations are allowed", "oldResp", priorResp, "newResp", ruleResponse)
 					if ruleResponse.Status() == engineapi.RuleStatusPass {
 						return resource, ruleResponse
 					}
-					return resource, engineapi.RuleSkip(rule.Name, engineapi.Validation, "skipping modified resource as validation results have not changed", rule.ReportProperties)
+					return resource, engineapi.RuleSkip(rule.Name, engineapi.Validation, "skipping the rule evaluation as pre-existing violations are allowed", rule.ReportProperties)
 				}
 				logger.V(4).Info("old object response is different", "oldResp", priorResp, "newResp", ruleResponse)
 			}

--- a/pkg/engine/handlers/validation/validate_pss.go
+++ b/pkg/engine/handlers/validation/validate_pss.go
@@ -144,21 +144,19 @@ func (h validatePssHandler) validate(
 		if action == kyvernov1.Enforce {
 			allowExisitingViolations := rule.HasValidateAllowExistingViolations()
 			if engineutils.IsUpdateRequest(policyContext) && allowExisitingViolations {
-				logger.V(4).Info("is update request")
 				priorResp, err := h.validateOldObject(ctx, logger, policyContext, resource, rule, engineLoader, exceptions)
 				if err != nil {
-					logger.V(2).Info("warning: failed to validate old object", "rule", rule.Name, "error", err.Error())
+					logger.V(4).Info("warning: failed to validate old object", "rule", rule.Name, "error", err.Error())
 					return resource, engineapi.RuleSkip(rule.Name, engineapi.Validation, "failed to validate old object", rule.ReportProperties)
 				}
 
 				if ruleResponse.Status() == priorResp.Status() {
-					logger.V(3).Info("warning: skipping the rule evaluation as pre-existing violations are allowed", "oldResp", priorResp, "newResp", ruleResponse)
+					logger.V(2).Info("warning: skipping the rule evaluation as pre-existing violations are allowed", "oldResp", priorResp, "newResp", ruleResponse)
 					if ruleResponse.Status() == engineapi.RuleStatusPass {
 						return resource, ruleResponse
 					}
 					return resource, engineapi.RuleSkip(rule.Name, engineapi.Validation, "skipping the rule evaluation as pre-existing violations are allowed", rule.ReportProperties)
 				}
-				logger.V(4).Info("old object response is different", "oldResp", priorResp, "newResp", ruleResponse)
 			}
 		}
 

--- a/pkg/engine/handlers/validation/validate_resource.go
+++ b/pkg/engine/handlers/validation/validate_resource.go
@@ -146,20 +146,30 @@ func (v *validator) validate(ctx context.Context) *engineapi.RuleResponse {
 		v.log.V(2).Info("invalid validation rule: podSecurity, cel, patterns, or deny expected")
 	}
 
-	allowExisitingViolations := v.rule.HasValidateAllowExistingViolations()
-	if engineutils.IsUpdateRequest(v.policyContext) && allowExisitingViolations && v.nesting == 0 { // is update request and is the root level validate
-		priorResp, err := v.validateOldObject(ctx)
-		if err != nil {
-			v.log.V(2).Info("warning: failed to validate old object, skipping the rule evaluation as pre-existing violations are allowed", "rule", v.rule.Name, "error", err.Error())
-			return engineapi.RuleSkip(v.rule.Name, engineapi.Validation, "failed to validate old object, skipping as preexisting violations are allowed", ruleResponse.Properties())
-		}
+	var action kyvernov1.ValidationFailureAction
+	if v.rule.Validation.FailureAction != nil {
+		action = *v.rule.Validation.FailureAction
+	} else {
+		action = v.policyContext.Policy().GetSpec().ValidationFailureAction
+	}
 
-		if engineutils.IsSameRuleResponse(ruleResponse, priorResp) {
-			v.log.V(3).Info("skipping modified resource as validation results have not changed")
-			if ruleResponse.Status() == engineapi.RuleStatusPass {
-				return ruleResponse
+	// process the old object for UPDATE admission requests in case of enforce policies
+	if action == kyvernov1.Enforce {
+		allowExisitingViolations := v.rule.HasValidateAllowExistingViolations()
+		if engineutils.IsUpdateRequest(v.policyContext) && allowExisitingViolations && v.nesting == 0 { // is update request and is the root level validate
+			priorResp, err := v.validateOldObject(ctx)
+			if err != nil {
+				v.log.V(2).Info("warning: failed to validate old object, skipping the rule evaluation as pre-existing violations are allowed", "rule", v.rule.Name, "error", err.Error())
+				return engineapi.RuleSkip(v.rule.Name, engineapi.Validation, "failed to validate old object, skipping as preexisting violations are allowed", ruleResponse.Properties())
 			}
-			return engineapi.RuleSkip(v.rule.Name, engineapi.Validation, "skipping modified resource as validation results have not changed", v.rule.ReportProperties)
+
+			if engineutils.IsSameRuleResponse(ruleResponse, priorResp) {
+				v.log.V(3).Info("skipping modified resource as validation results have not changed")
+				if ruleResponse.Status() == engineapi.RuleStatusPass {
+					return ruleResponse
+				}
+				return engineapi.RuleSkip(v.rule.Name, engineapi.Validation, "skipping modified resource as validation results have not changed", v.rule.ReportProperties)
+			}
 		}
 	}
 

--- a/pkg/engine/handlers/validation/validate_resource.go
+++ b/pkg/engine/handlers/validation/validate_resource.go
@@ -159,16 +159,16 @@ func (v *validator) validate(ctx context.Context) *engineapi.RuleResponse {
 		if engineutils.IsUpdateRequest(v.policyContext) && allowExisitingViolations && v.nesting == 0 { // is update request and is the root level validate
 			priorResp, err := v.validateOldObject(ctx)
 			if err != nil {
-				v.log.V(2).Info("warning: failed to validate old object, skipping the rule evaluation as pre-existing violations are allowed", "rule", v.rule.Name, "error", err.Error())
-				return engineapi.RuleSkip(v.rule.Name, engineapi.Validation, "failed to validate old object, skipping as preexisting violations are allowed", ruleResponse.Properties())
+				v.log.V(2).Info("warning: failed to validate old object", "rule", v.rule.Name, "error", err.Error())
+				return engineapi.RuleSkip(v.rule.Name, engineapi.Validation, "failed to validate old object", ruleResponse.Properties())
 			}
 
 			if engineutils.IsSameRuleResponse(ruleResponse, priorResp) {
-				v.log.V(3).Info("skipping modified resource as validation results have not changed")
+				v.log.V(3).Info("warning: skipping the rule evaluation as pre-existing violations are allowed")
 				if ruleResponse.Status() == engineapi.RuleStatusPass {
 					return ruleResponse
 				}
-				return engineapi.RuleSkip(v.rule.Name, engineapi.Validation, "skipping modified resource as validation results have not changed", v.rule.ReportProperties)
+				return engineapi.RuleSkip(v.rule.Name, engineapi.Validation, "skipping the rule evaluation as pre-existing violations are allowed", v.rule.ReportProperties)
 			}
 		}
 	}

--- a/pkg/engine/handlers/validation/validate_resource.go
+++ b/pkg/engine/handlers/validation/validate_resource.go
@@ -159,12 +159,12 @@ func (v *validator) validate(ctx context.Context) *engineapi.RuleResponse {
 		if engineutils.IsUpdateRequest(v.policyContext) && allowExisitingViolations && v.nesting == 0 { // is update request and is the root level validate
 			priorResp, err := v.validateOldObject(ctx)
 			if err != nil {
-				v.log.V(2).Info("warning: failed to validate old object", "rule", v.rule.Name, "error", err.Error())
+				v.log.V(4).Info("warning: failed to validate old object", "rule", v.rule.Name, "error", err.Error())
 				return engineapi.RuleSkip(v.rule.Name, engineapi.Validation, "failed to validate old object", ruleResponse.Properties())
 			}
 
 			if engineutils.IsSameRuleResponse(ruleResponse, priorResp) {
-				v.log.V(3).Info("warning: skipping the rule evaluation as pre-existing violations are allowed")
+				v.log.V(2).Info("warning: skipping the rule evaluation as pre-existing violations are allowed")
 				if ruleResponse.Status() == engineapi.RuleStatusPass {
 					return ruleResponse
 				}

--- a/pkg/engine/handlers/validation/validate_resource_test.go
+++ b/pkg/engine/handlers/validation/validate_resource_test.go
@@ -150,9 +150,9 @@ var (
         },
         "name": "check-image",
         "validate": {
-    			"failureAction": "Audit",
-					"allowExistingViolations": true,
-          "foreach": [
+    	    "failureAction": "Enforce",
+		    "allowExistingViolations": true,
+            "foreach": [
             {
               "deny": {
                 "conditions": {

--- a/test/conformance/chainsaw/reports/admission/update-deployment/README.md
+++ b/test/conformance/chainsaw/reports/admission/update-deployment/README.md
@@ -1,0 +1,15 @@
+## Description
+
+This test verifies that policy report doesn't change when a resource is updated and the engine response is the same as before.
+
+A policy in Audit mode is created.
+A deployment is created, the deployment violates the policy and we assert the policy report contains a `warn` result.
+The deployment is then updated but it still violates the policy.
+
+## Expected result
+
+When the resource is updated and it still violates the policy, the policy report should not change.
+
+## Related issue(s)
+
+- https://github.com/kyverno/kyverno/issues/10169

--- a/test/conformance/chainsaw/reports/admission/update-deployment/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/reports/admission/update-deployment/chainsaw-test.yaml
@@ -1,0 +1,41 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: update-deployment
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: deployment.yaml
+    - assert:
+        file: deployment.yaml
+  - name: step-03
+    try:
+    - sleep:
+        duration: 5s
+  - name: step-04
+    try:
+    - assert:
+        file: report-assert.yaml
+  - name: step-05
+    try:
+    - apply:
+        file: update-deployment.yaml
+    - assert:
+        file: update-deployment.yaml
+  - name: step-06
+    try:
+    - sleep:
+        duration: 5s
+  - name: step-07
+    try:
+    - assert:
+        file: report-assert.yaml

--- a/test/conformance/chainsaw/reports/admission/update-deployment/deployment.yaml
+++ b/test/conformance/chainsaw/reports/admission/update-deployment/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest

--- a/test/conformance/chainsaw/reports/admission/update-deployment/policy-assert.yaml
+++ b/test/conformance/chainsaw/reports/admission/update-deployment/policy-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-multiple-replicas
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/chainsaw/reports/admission/update-deployment/policy.yaml
+++ b/test/conformance/chainsaw/reports/admission/update-deployment/policy.yaml
@@ -1,0 +1,29 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-multiple-replicas
+  annotations:
+    policies.kyverno.io/category: Best Practises
+    policies.kyverno.io/minversion: 1.9.2
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/subject: Deployment,StatefulSet
+    policies.kyverno.io/title: Require Multiple Replicas
+    policies.kyverno.io/scored: "false"
+spec:
+  background: false
+  rules:
+    - name: require-multiple-replicas
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+              operations:
+                - CREATE
+                - UPDATE
+      validate:
+        pattern:
+          spec:
+            replicas: ">1"
+  validationFailureAction: Audit

--- a/test/conformance/chainsaw/reports/admission/update-deployment/report-assert.yaml
+++ b/test/conformance/chainsaw/reports/admission/update-deployment/report-assert.yaml
@@ -1,0 +1,23 @@
+apiVersion: wgpolicyk8s.io/v1alpha2
+kind: PolicyReport
+metadata:
+  ownerReferences:
+  - apiVersion: apps/v1
+    kind: Deployment
+    name: nginx-test
+results:
+- message: 'validation error: rule require-multiple-replicas failed at path /spec/replicas/'
+  policy: require-multiple-replicas
+  result: warn
+  rule: require-multiple-replicas
+  source: kyverno
+scope:
+  apiVersion: apps/v1
+  kind: Deployment
+  name: nginx-test
+summary:
+  error: 0
+  fail: 0
+  pass: 0
+  skip: 0
+  warn: 1

--- a/test/conformance/chainsaw/reports/admission/update-deployment/update-deployment.yaml
+++ b/test/conformance/chainsaw/reports/admission/update-deployment/update-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx-1
+          image: nginx:latest


### PR DESCRIPTION
## Explanation
This PR skips processing the oldOject for the updated resource in case of audit policies.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #10169 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.13.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Create a policy:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-multiple-replicas
  annotations:
    policies.kyverno.io/category: Best Practises
    policies.kyverno.io/minversion: 1.9.2
    policies.kyverno.io/severity: low
    policies.kyverno.io/subject: Deployment,StatefulSet
    policies.kyverno.io/title: Require Multiple Replicas
    policies.kyverno.io/scored: "false"
spec:
  background: false
  rules:
    - name: require-multiple-replicas
      match:
        any:
          - resources:
              kinds:
                - Deployment
                - StatefulSet
              operations:
                - CREATE
                - UPDATE
      validate:
        pattern:
          spec:
            replicas: ">1"
  validationFailureAction: Audit
```
2. Create the following deployment that violates the policy:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: nginx
  name: nginx-test
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
        - name: nginx
          image: nginx:latest
```
3. Check the generated policy report:
```
$ kubectl get polr
NAME                                   KIND         NAME         PASS   FAIL   WARN   ERROR   SKIP   AGE
4fab9c5f-7b73-46c8-a6aa-4c4c4ad3eb5f   Deployment   nginx-test   0      0      1      0       0      9s
```
4. Update the deployment by using `kubectl edit`. (don't modify the replicas, you can update the container name for example)
5. Check the reports:
```
$ kubectl get polr
NAME                                   KIND         NAME         PASS   FAIL   WARN   ERROR   SKIP   AGE
4fab9c5f-7b73-46c8-a6aa-4c4c4ad3eb5f   Deployment   nginx-test   0      0      1      0       0      102s
```
As expected, the policy report result isn't changed since the resource still violates the policy.
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
