### PR TITLE
fix: deepcopy patched resource in foreach mutate

### DIFF
--- a/pkg/engine/handlers/mutation/common.go
+++ b/pkg/engine/handlers/mutation/common.go
@@ -77,7 +77,7 @@ func (f *forEachMutator) mutateElements(ctx context.Context, foreach kyvernov1.F
 		reverse = *foreach.Order == kyvernov1.Descending
 	}
 	if reverse {
-		engineutils.InvertedElement(elements)
+		elements = engineutils.InvertedElement(elements)
 	}
 
 	for index, element := range elements {

--- a/pkg/engine/handlers/mutation/common.go
+++ b/pkg/engine/handlers/mutation/common.go
@@ -66,6 +66,7 @@ func (f *forEachMutator) mutateElements(ctx context.Context, foreach kyvernov1.F
 	defer f.policyContext.JSONContext().Restore()
 
 	patchedResource := f.resource
+	patchedResource.unstructured = *f.resource.unstructured.DeepCopy()
 
 	reverse := false
 	// if it's a patch strategic merge, reverse by default

--- a/pkg/engine/handlers/mutation/common.go
+++ b/pkg/engine/handlers/mutation/common.go
@@ -77,7 +77,7 @@ func (f *forEachMutator) mutateElements(ctx context.Context, foreach kyvernov1.F
 		reverse = *foreach.Order == kyvernov1.Descending
 	}
 	if reverse {
-		elements = engineutils.InvertedElement(elements)
+		elements = engineutils.InvertElements(elements)
 	}
 
 	for index, element := range elements {

--- a/pkg/engine/mutate/mutation.go
+++ b/pkg/engine/mutate/mutation.go
@@ -82,8 +82,7 @@ func ForEach(name string, foreach kyvernov1.ForEachMutation, policyContext engin
 		return NewErrorResponse("empty mutate rule", nil)
 	}
 
-	patchedResource := resource.DeepCopy()
-	resourceBytes, err := patchedResource.MarshalJSON()
+	resourceBytes, err := resource.MarshalJSON()
 	if err != nil {
 		return NewErrorResponse("failed to marshal resource", err)
 	}
@@ -94,11 +93,11 @@ func ForEach(name string, foreach kyvernov1.ForEachMutation, policyContext engin
 	if strings.TrimSpace(string(resourceBytes)) == strings.TrimSpace(string(patchedBytes)) {
 		return NewResponse(engineapi.RuleStatusSkip, resource, "no patches applied")
 	}
-	if err := patchedResource.UnmarshalJSON(patchedBytes); err != nil {
+	if err := resource.UnmarshalJSON(patchedBytes); err != nil {
 		return NewErrorResponse("failed to unmarshal patched resource", err)
 	}
 
-	return NewResponse(engineapi.RuleStatusPass, *patchedResource, "resource patched")
+	return NewResponse(engineapi.RuleStatusPass, resource, "resource patched")
 }
 
 func substituteAllInForEach(fe kyvernov1.ForEachMutation, ctx context.Interface, logger logr.Logger) (*kyvernov1.ForEachMutation, error) {

--- a/pkg/engine/mutate/mutation.go
+++ b/pkg/engine/mutate/mutation.go
@@ -82,7 +82,8 @@ func ForEach(name string, foreach kyvernov1.ForEachMutation, policyContext engin
 		return NewErrorResponse("empty mutate rule", nil)
 	}
 
-	resourceBytes, err := resource.MarshalJSON()
+	patchedResource := resource.DeepCopy()
+	resourceBytes, err := patchedResource.MarshalJSON()
 	if err != nil {
 		return NewErrorResponse("failed to marshal resource", err)
 	}
@@ -93,11 +94,11 @@ func ForEach(name string, foreach kyvernov1.ForEachMutation, policyContext engin
 	if strings.TrimSpace(string(resourceBytes)) == strings.TrimSpace(string(patchedBytes)) {
 		return NewResponse(engineapi.RuleStatusSkip, resource, "no patches applied")
 	}
-	if err := resource.UnmarshalJSON(patchedBytes); err != nil {
+	if err := patchedResource.UnmarshalJSON(patchedBytes); err != nil {
 		return NewErrorResponse("failed to unmarshal patched resource", err)
 	}
 
-	return NewResponse(engineapi.RuleStatusPass, resource, "resource patched")
+	return NewResponse(engineapi.RuleStatusPass, *patchedResource, "resource patched")
 }
 
 func substituteAllInForEach(fe kyvernov1.ForEachMutation, ctx context.Interface, logger logr.Logger) (*kyvernov1.ForEachMutation, error) {

--- a/pkg/engine/utils/foreach.go
+++ b/pkg/engine/utils/foreach.go
@@ -24,10 +24,12 @@ func EvaluateList(jmesPath string, ctx enginecontext.EvalInterface) ([]interface
 }
 
 // InvertedElement inverted the order of element for patchStrategicMerge  policies as kustomize patch revering the order of patch resources.
-func InvertedElement(elements []interface{}) {
-	for i, j := 0, len(elements)-1; i < j; i, j = i+1, j-1 {
-		elements[i], elements[j] = elements[j], elements[i]
+func InvertedElement(elements []interface{}) []interface{} {
+	elementsCopy := make([]interface{}, len(elements))
+	for i := range elements {
+		elementsCopy[i] = elements[len(elements)-i-1]
 	}
+	return elementsCopy
 }
 
 func AddElementToContext(ctx engineapi.PolicyContext, element interface{}, index, nesting int, elementScope *bool) error {

--- a/pkg/engine/utils/foreach.go
+++ b/pkg/engine/utils/foreach.go
@@ -23,8 +23,9 @@ func EvaluateList(jmesPath string, ctx enginecontext.EvalInterface) ([]interface
 	return l, nil
 }
 
-// InvertedElement inverted the order of element for patchStrategicMerge  policies as kustomize patch revering the order of patch resources.
-func InvertedElement(elements []interface{}) []interface{} {
+// InvertElements inverts the order of elements for patchStrategicMerge policies
+// as kustomize patch reverses the order of patch resources.
+func InvertElements(elements []interface{}) []interface{} {
 	elementsCopy := make([]interface{}, len(elements))
 	for i := range elements {
 		elementsCopy[i] = elements[len(elements)-i-1]

--- a/pkg/engine/utils/foreach_test.go
+++ b/pkg/engine/utils/foreach_test.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_InvertElements(t *testing.T) {
+	elems := []interface{}{"a", "b", "c"}
+	elemsInverted := InvertElements(elems)
+
+	assert.Equal(t, "a", elemsInverted[2])
+	assert.Equal(t, "b", elemsInverted[1])
+	assert.Equal(t, "c", elemsInverted[0])
+}

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/README.md
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/README.md
@@ -1,0 +1,6 @@
+## Description
+
+This test creates two `Pod`s: trigger and target. The policy updates the image of the third container in the target pod whemn the trigger pod is created.
+## Expected Behavior
+
+When the trigger pod is applied the, image in container3 of target pod changes

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/chainsaw-test.yaml
@@ -1,0 +1,35 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: descending-patchjson
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: policy.yaml
+  - name: step-01-assert
+    try:
+    - assert:
+        file: policy-assert.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: target-pod.yaml
+  - name: step-02-assert
+    try:
+    - assert:
+        file: target-pod-assert.yaml
+  - name: step-03
+    try:
+    - apply:
+        file: trigger-pod.yaml
+  - name: step-03-assert
+    try:
+    - assert:
+        file: trigger-pod-assert.yaml
+  - name: step-04
+    try:
+    - assert:
+        file: target-pod-updated.yaml

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/policy-assert.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/policy-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: descending-jsonpatch
+

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/policy.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/policy.yaml
@@ -1,0 +1,34 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: descending-jsonpatch
+spec:
+  background: false
+  schemaValidation: false
+  rules:
+  - name: remove-elements
+    match:
+      all:
+      - resources:
+          kinds:
+            - Pod
+          names:
+            - trigger-pod
+    mutate:
+      targets:
+      - apiVersion: v1
+        kind: Pod
+        name: target-pod
+        namespace: default
+      foreach:
+      - list: "target.spec.containers"
+        order: Descending 
+        preconditions:
+          all:
+          - key: "{{ element.name }}"
+            operator: Equals
+            value: container3
+        patchesJson6902: |-
+          - op: replace
+            path: /spec/containers/{{elementIndex}}/image
+            value: ghcr.io/kyverno/test-verify-images:signed

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/target-pod-assert.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/target-pod-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: target-pod
+  namespace: default
+

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/target-pod-updated.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/target-pod-updated.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: target-pod
+  namespace: default
+spec:
+  containers:
+  - name: container1
+    image: busybox:latest
+  - name: container2
+    image: busybox:latest
+  - name: container3
+    image: ghcr.io/kyverno/test-verify-images:signed

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/target-pod.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/target-pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: target-pod
+  namespace: default
+spec:
+  containers:
+  - name: container1
+    image: busybox:latest
+  - name: container2
+    image: busybox:latest
+  - name: container3
+    image: busybox:latest
+

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/trigger-pod-assert.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/trigger-pod-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: trigger-pod
+  namespace: default
+

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/trigger-pod.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/descending-patchJson6902/trigger-pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: trigger-pod
+  namespace: default
+spec:
+  containers:
+  - name: container1
+    image: busybox:latest
+


### PR DESCRIPTION
## Explanation

After commit https://github.com/kyverno/kyverno/commit/46f02a8ba7c9c3bf00854f4e8904712c52a19839, when the order is set to `Descending` in foreach mutate, the order of items in the trigger resource also gets reverted, causing the wrong item to get patched.

This PR:
1. copies and reverses elements instead of swapping.
2. deepcopies the resource at the start of foreach

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue

Closes #10224
Closes #10199
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
