### PR TITLE
truncate event messages to 1024 chars

### DIFF
--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -59,7 +59,12 @@ func buildPolicyEventMessage(resp engineapi.RuleResponse, resource engineapi.Res
 		fmt.Fprintf(&b, "; %s", resp.Message())
 	}
 
-	return b.String()
+	msg := b.String()
+	if len(msg) > 1024 {
+		msg = msg[0:1021] + "..."
+	}
+
+	return msg
 }
 
 func NewPolicyAppliedEvent(source Source, engineResponse engineapi.EngineResponse) Info {

--- a/pkg/event/events_test.go
+++ b/pkg/event/events_test.go
@@ -1,0 +1,25 @@
+package event
+
+import (
+	"testing"
+
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"gotest.tools/assert"
+)
+
+func TestMessageLength(t *testing.T) {
+	msg := "policy psa/baseline fail: Validation rule 'baseline' failed. It violates PodSecurity \"restricted:latest\": (Forbidden reason: allowPrivilegeEscalation != false, field error list: [spec.containers[0].securityContext.allowPrivilegeEscalation is forbidden, forbidden values found: nil])(Forbidden reason: unrestricted capabilities, field error list: [spec.containers[0].securityContext.capabilities.drop: Required value])(Forbidden reason: host namespaces, field error list: [spec.hostNetwork is forbidden, forbidden values found: true])(Forbidden reason: hostPath volumes, field error list: [spec.volumes[1].hostPath is forbidden, forbidden values found: /run/xtables.lock, spec.volumes[2].hostPath is forbidden, forbidden values found: /lib/modules])(Forbidden reason: privileged, field error list: [spec.containers[0].securityContext.privileged is forbidden, forbidden values found: true])(Forbidden reason: restricted volume types, field error list: [spec.volumes[1].hostPath: Forbidden, spec.volumes[2].hostPath: Forbidden])(Forbidden reason: runAsNonRoot != true, field error list: [spec.containers[0].securityContext.runAsNonRoot: Required value])(Forbidden reason: seccompProfile, field error list: [spec.containers[0].securityContext.seccompProfile.type: Required value])"
+	assert.Assert(t, len(msg) > 1024)
+
+	resp := engineapi.NewRuleResponse("podSecurity", engineapi.Validation, msg, engineapi.RuleStatusFail)
+
+	resource := &engineapi.ResourceSpec{
+		Kind:       "Pod",
+		APIVersion: "v1",
+		Namespace:  "default",
+		UID:        "9005aec3-f779-4d19-985b-3ff51a695cca",
+	}
+
+	eventMsg := buildPolicyEventMessage(*resp, *resource, true)
+	assert.Equal(t, 1024, len(eventMsg))
+}


### PR DESCRIPTION
## Explanation

Truncate event message lengths to 1024 characters

## Related issue

Fixes https://github.com/kyverno/kyverno/issues/10210

## Milestone of this PR

1.12.2

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

 /kind bug

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

Truncate event message lengths to 1024 characters


### Proof Manifests

See unit tests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
