### PR TITLE
skip invalid policy files

### DIFF
--- a/cmd/cli/kubectl-kyverno/_testdata/policies-invalid/artifacthub-pkg.yml
+++ b/cmd/cli/kubectl-kyverno/_testdata/policies-invalid/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: add-network-policy
+version: 1.0.0
+displayName: Add Network Policy
+createdAt: "2023-04-10T19:47:15.000Z"
+description: >-
+  By default, Kubernetes allows communications across all Pods within a cluster. The NetworkPolicy resource and a CNI plug-in that supports NetworkPolicy must be used to restrict communications. A default NetworkPolicy should be configured for each Namespace to default deny all ingress and egress traffic to the Pods in the Namespace. Application teams can then configure additional NetworkPolicy resources to allow desired traffic to application Pods from select sources. This policy will create a new NetworkPolicy resource named `default-deny` which will deny all traffic anytime a new Namespace is created.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/best-practices/add-network-policy/add-network-policy.yaml
+  ```
+keywords:
+  - kyverno
+  - Multi-Tenancy
+  - EKS Best Practices
+readme: |
+  By default, Kubernetes allows communications across all Pods within a cluster. The NetworkPolicy resource and a CNI plug-in that supports NetworkPolicy must be used to restrict communications. A default NetworkPolicy should be configured for each Namespace to default deny all ingress and egress traffic to the Pods in the Namespace. Application teams can then configure additional NetworkPolicy resources to allow desired traffic to application Pods from select sources. This policy will create a new NetworkPolicy resource named `default-deny` which will deny all traffic anytime a new Namespace is created.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Multi-Tenancy, EKS Best Practices"
+  kyverno/subject: "NetworkPolicy"
+digest: d01c7f24cf053549534bba5b98cc479ee0e5a4a01f810b8a45d11c86b26d846e

--- a/cmd/cli/kubectl-kyverno/_testdata/policies-invalid/chainsaw-test.yaml
+++ b/cmd/cli/kubectl-kyverno/_testdata/policies-invalid/chainsaw-test.yaml
@@ -1,0 +1,27 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: add-network-policy
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: old-resource.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: ../add-network-policy.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-03
+    try:
+    - apply:
+        file: ../.kyverno-test/resource.yaml
+  - name: step-04
+    try:
+    - assert:
+        file: ../.kyverno-test/generatedResource.yaml
+    - error:
+        file: notGeneratedResource.yaml

--- a/cmd/cli/kubectl-kyverno/_testdata/policies-invalid/policy-ready.yaml
+++ b/cmd/cli/kubectl-kyverno/_testdata/policies-invalid/policy-ready.yaml
@@ -1,0 +1,6 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-networkpolicy
+status:
+  ready: true

--- a/cmd/cli/kubectl-kyverno/_testdata/policies-mixed/artifacthub-pkg.yml
+++ b/cmd/cli/kubectl-kyverno/_testdata/policies-mixed/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: add-network-policy
+version: 1.0.0
+displayName: Add Network Policy
+createdAt: "2023-04-10T19:47:15.000Z"
+description: >-
+  By default, Kubernetes allows communications across all Pods within a cluster. The NetworkPolicy resource and a CNI plug-in that supports NetworkPolicy must be used to restrict communications. A default NetworkPolicy should be configured for each Namespace to default deny all ingress and egress traffic to the Pods in the Namespace. Application teams can then configure additional NetworkPolicy resources to allow desired traffic to application Pods from select sources. This policy will create a new NetworkPolicy resource named `default-deny` which will deny all traffic anytime a new Namespace is created.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/best-practices/add-network-policy/add-network-policy.yaml
+  ```
+keywords:
+  - kyverno
+  - Multi-Tenancy
+  - EKS Best Practices
+readme: |
+  By default, Kubernetes allows communications across all Pods within a cluster. The NetworkPolicy resource and a CNI plug-in that supports NetworkPolicy must be used to restrict communications. A default NetworkPolicy should be configured for each Namespace to default deny all ingress and egress traffic to the Pods in the Namespace. Application teams can then configure additional NetworkPolicy resources to allow desired traffic to application Pods from select sources. This policy will create a new NetworkPolicy resource named `default-deny` which will deny all traffic anytime a new Namespace is created.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Multi-Tenancy, EKS Best Practices"
+  kyverno/subject: "NetworkPolicy"
+digest: d01c7f24cf053549534bba5b98cc479ee0e5a4a01f810b8a45d11c86b26d846e

--- a/cmd/cli/kubectl-kyverno/_testdata/policies-mixed/cpol-pod-requirements.yaml
+++ b/cmd/cli/kubectl-kyverno/_testdata/policies-mixed/cpol-pod-requirements.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+  name: pod-requirements
+spec:
+  admission: true
+  background: false
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: pods-require-account
+    validate:
+      message: User pods must include an account for charging
+      pattern:
+        metadata:
+          labels:
+            account: '*?'
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: pods-require-limits
+    validate:
+      message: CPU and memory resource requests and limits are required for user pods
+      pattern:
+        spec:
+          containers:
+          - resources:
+              limits:
+                cpu: ?*
+                memory: ?*
+              requests:
+                cpu: ?*
+                memory: ?*
+  validationFailureAction: Audit

--- a/cmd/cli/kubectl-kyverno/_testdata/policies-mixed/nested/artifacthub-pkg.yml
+++ b/cmd/cli/kubectl-kyverno/_testdata/policies-mixed/nested/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: add-network-policy
+version: 1.0.0
+displayName: Add Network Policy
+createdAt: "2023-04-10T19:47:15.000Z"
+description: >-
+  By default, Kubernetes allows communications across all Pods within a cluster. The NetworkPolicy resource and a CNI plug-in that supports NetworkPolicy must be used to restrict communications. A default NetworkPolicy should be configured for each Namespace to default deny all ingress and egress traffic to the Pods in the Namespace. Application teams can then configure additional NetworkPolicy resources to allow desired traffic to application Pods from select sources. This policy will create a new NetworkPolicy resource named `default-deny` which will deny all traffic anytime a new Namespace is created.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/best-practices/add-network-policy/add-network-policy.yaml
+  ```
+keywords:
+  - kyverno
+  - Multi-Tenancy
+  - EKS Best Practices
+readme: |
+  By default, Kubernetes allows communications across all Pods within a cluster. The NetworkPolicy resource and a CNI plug-in that supports NetworkPolicy must be used to restrict communications. A default NetworkPolicy should be configured for each Namespace to default deny all ingress and egress traffic to the Pods in the Namespace. Application teams can then configure additional NetworkPolicy resources to allow desired traffic to application Pods from select sources. This policy will create a new NetworkPolicy resource named `default-deny` which will deny all traffic anytime a new Namespace is created.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Multi-Tenancy, EKS Best Practices"
+  kyverno/subject: "NetworkPolicy"
+digest: d01c7f24cf053549534bba5b98cc479ee0e5a4a01f810b8a45d11c86b26d846e

--- a/cmd/cli/kubectl-kyverno/_testdata/policies-mixed/nested/cpol-pod-requirements.yaml
+++ b/cmd/cli/kubectl-kyverno/_testdata/policies-mixed/nested/cpol-pod-requirements.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+  name: pod-requirements
+spec:
+  admission: true
+  background: false
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: pods-require-account
+    validate:
+      message: User pods must include an account for charging
+      pattern:
+        metadata:
+          labels:
+            account: '*?'
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: pods-require-limits
+    validate:
+      message: CPU and memory resource requests and limits are required for user pods
+      pattern:
+        spec:
+          containers:
+          - resources:
+              limits:
+                cpu: ?*
+                memory: ?*
+              requests:
+                cpu: ?*
+                memory: ?*
+  validationFailureAction: Audit

--- a/cmd/cli/kubectl-kyverno/policy/load_test.go
+++ b/cmd/cli/kubectl-kyverno/policy/load_test.go
@@ -40,6 +40,41 @@ func TestLoad(t *testing.T) {
 	}
 }
 
+func TestLoadInvalid(t *testing.T) {
+	tests := []struct {
+		name         string
+		fs           billy.Filesystem
+		resourcePath string
+		paths        []string
+		wantErr      bool
+		count        int
+	}{{
+		name:         "invalid policy resources",
+		fs:           nil,
+		resourcePath: "",
+		paths:        []string{"../_testdata/policies-invalid/"},
+		wantErr:      false,
+		count:        0,
+	}, {
+		name:         "mixed policy resources",
+		fs:           nil,
+		resourcePath: "",
+		paths:        []string{"../_testdata/policies-mixed/"},
+		count:        2,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policies, _, _, err := Load(tt.fs, tt.resourcePath, tt.paths...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Load() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			assert.Equal(t, tt.count, len(policies))
+		})
+	}
+}
+
 func TestLoadWithKubectlValidate(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Explanation

Skip invalid policy YAMLs when loading from local filesystem

## Related issue

Fixes https://github.com/kyverno/kyverno/issues/10171

## Milestone of this PR

1.12.2

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind bug

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

Skip invalid policy YAMLs when loading from local filesystem

### Proof Manifests

See unit tests.

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
