### PR TITLE
Add support for overriding autogenControllers per policy

### DIFF
--- a/charts/kyverno-policies/README.md
+++ b/charts/kyverno-policies/README.md
@@ -87,6 +87,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | policyExclude | object | `{}` | Exclude resources from individual policies. Policies with multiple rules can have individual rules excluded by using the name of the rule as the key in the `policyExclude` map. |
 | policyPreconditions | object | `{}` | Add preconditions to individual policies. Policies with multiple rules can have individual rules excluded by using the name of the rule as the key in the `policyPreconditions` map. |
 | autogenControllers | string | `""` | Customize the target Pod controllers for the auto-generated rules. (Eg. `none`, `Deployment`, `DaemonSet,Deployment,StatefulSet`) For more info https://kyverno.io/docs/writing-policies/autogen/. |
+| autogenControllersOverride | object | `{}` | Override autogenControllers for individual policies |
 | nameOverride | string | `nil` | Name override. |
 | customLabels | object | `{}` | Additional labels. |
 | background | bool | `true` | Policies background mode |

--- a/charts/kyverno-policies/templates/baseline/disallow-capabilities.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-capabilities.yaml
@@ -6,8 +6,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Disallow Capabilities
     policies.kyverno.io/category: Pod Security Standards (Baseline)

--- a/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Disallow Host Namespaces
     policies.kyverno.io/category: Pod Security Standards (Baseline)

--- a/charts/kyverno-policies/templates/baseline/disallow-host-path.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-path.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Disallow hostPath
     policies.kyverno.io/category: Pod Security Standards (Baseline)

--- a/charts/kyverno-policies/templates/baseline/disallow-host-ports.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-ports.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Disallow hostPorts
     policies.kyverno.io/category: Pod Security Standards (Baseline)

--- a/charts/kyverno-policies/templates/baseline/disallow-host-process.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-process.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Disallow hostProcess
     policies.kyverno.io/category: Pod Security Standards (Baseline)

--- a/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Disallow Privileged Containers
     policies.kyverno.io/category: Pod Security Standards (Baseline)

--- a/charts/kyverno-policies/templates/baseline/disallow-proc-mount.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-proc-mount.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Disallow procMount
     policies.kyverno.io/category: Pod Security Standards (Baseline)

--- a/charts/kyverno-policies/templates/baseline/disallow-selinux.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-selinux.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Disallow SELinux
     policies.kyverno.io/category: Pod Security Standards (Baseline)

--- a/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Restrict AppArmor
     policies.kyverno.io/category: Pod Security Standards (Baseline)

--- a/charts/kyverno-policies/templates/baseline/restrict-seccomp.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-seccomp.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Restrict Seccomp
     policies.kyverno.io/category: Pod Security Standards (Baseline)

--- a/charts/kyverno-policies/templates/baseline/restrict-sysctls.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-sysctls.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Restrict sysctls
     policies.kyverno.io/category: Pod Security Standards (Baseline)

--- a/charts/kyverno-policies/templates/other/require-non-root-groups.yaml
+++ b/charts/kyverno-policies/templates/other/require-non-root-groups.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/category: Sample
     {{- if .Values.podSecuritySeverity }}

--- a/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.yaml
@@ -6,8 +6,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Disallow Capabilities (Strict)
     policies.kyverno.io/category: Pod Security Standards (Restricted)

--- a/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Disallow Privilege Escalation
     policies.kyverno.io/category: Pod Security Standards (Restricted)

--- a/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Require Run As Non-Root User
     policies.kyverno.io/category: Pod Security Standards (Restricted)

--- a/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Require runAsNonRoot
     policies.kyverno.io/category: Pod Security Standards (Restricted)

--- a/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.yaml
@@ -5,8 +5,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Restrict Seccomp (Strict)
     policies.kyverno.io/category: Pod Security Standards (Restricted)

--- a/charts/kyverno-policies/templates/restricted/restrict-volume-types.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-volume-types.yaml
@@ -6,8 +6,12 @@ kind: {{ .Values.policyKind }}
 metadata:
   name: {{ $name }}
   annotations:
+    {{- if hasKey .Values.autogenControllersOverride $name }}
+    pod-policies.kyverno.io/autogen-controllers: {{ get .Values.autogenControllersOverride $name }}
+    {{- else }}
     {{- with .Values.autogenControllers }}
     pod-policies.kyverno.io/autogen-controllers: {{ . }}
+    {{- end }}
     {{- end }}
     policies.kyverno.io/title: Restrict Volume Types
     policies.kyverno.io/category: Pod Security Standards (Restricted)

--- a/charts/kyverno-policies/values.yaml
+++ b/charts/kyverno-policies/values.yaml
@@ -99,6 +99,10 @@ policyPreconditions: {}
 # For more info https://kyverno.io/docs/writing-policies/autogen/.
 autogenControllers: ""
 
+# -- Override autogenControllers for individual policies
+autogenControllersOverride: {}
+  # disallow-capabilities: Deployment,DaemonSet,StatefulSet
+
 # -- Name override.
 nameOverride:
 


### PR DESCRIPTION
## Explanation

`autogenControllers` is currently a global setting. For some policies (e.g pod-probes) you might want to change this setting per policy.

## Related issue


## Milestone of this PR

## Documentation (required for features)



## What type of PR is this

/kind feature

## Proposed Changes

Users can override `autogenControllers` per policy. If the policy is not overriden then the existing default `autogenControllers` setting is used.

### Proof Manifests

# Kubernetes resource


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments


