### PR TITLE
fix: remove dropped flag for goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -256,7 +256,7 @@ jobs:
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           version: latest
-          args: release --clean --timeout 90m --debug --release-notes=release/release-notes.out
+          args: release --clean --timeout 90m --release-notes=release/release-notes.out
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This is to fix the release failure https://github.com/kyverno/kyverno/actions/runs/9463689586/job/26081158003#step:9:16.