### PR TITLE
chore: use generateExisting under generate rule in chainsaw tests

### DIFF
--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-delete-ownerreferences-across-namespaces/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-delete-ownerreferences-across-namespaces/policy.yaml
@@ -24,9 +24,9 @@ kind: ClusterPolicy
 metadata:
   name: cpol-clone-delete-ownerreferences-across-namespaces
 spec:
-  generateExisting: true
   rules:
   - generate:
+      generateExisting: true
       apiVersion: v1
       clone:
         name: cpol-clone-delete-ownerreferences-across-namespaces

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-sync-reinstall-policy/chainsaw-step-06-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-sync-reinstall-policy/chainsaw-step-06-apply-1-1.yaml
@@ -3,9 +3,9 @@ kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-reinstall-policy
 spec:
-  generateExisting: true
   rules:
   - generate:
+      generateExisting: true
       apiVersion: v1
       clone:
         name: regcred

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-sync-single-source-multiple-triggers-targets/chainsaw-step-01-apply-1-3.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-sync-single-source-multiple-triggers-targets/chainsaw-step-01-apply-1-3.yaml
@@ -3,9 +3,9 @@ kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-single-source-multiple-targets
 spec:
-  generateExisting: false
   rules:
   - generate:
+      generateExisting: false
       apiVersion: v1
       clone:
         name: foosource

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-data-sync-to-nosync-delete-rule/chainsaw-step-04-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-data-sync-to-nosync-delete-rule/chainsaw-step-04-apply-1-1.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-sync-to-nosync-delete-rule
 spec:
-  generateExisting: false
   rules:
   - exclude:
       any:
@@ -14,6 +13,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-data-sync-to-nosync-delete-rule/delete-rule.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-data-sync-to-nosync-delete-rule/delete-rule.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: multiple-gens
 spec:
-  generateExisting: false
   rules:
   - name: super-secret
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: Secret

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-data-sync-to-nosync-delete-rule/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-data-sync-to-nosync-delete-rule/policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-sync-to-nosync-delete-rule
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/pod-restart-on-cm-update/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/pod-restart-on-cm-update/policy.yaml
@@ -6,7 +6,6 @@ metadata:
     policies.kyverno.io/description: >-
       This policy generates and synchronizes a configmap for custom resource kube-state-metrics.
 spec:
-  generateExisting: true
   mutateExistingOnPolicyUpdate: false
   schemaValidation: false
   rules:
@@ -24,6 +23,7 @@ spec:
                 matchLabels:
                   kubestatemetrics.platform.example: source
       generate:
+        generateExisting: true
         synchronize: true
         apiVersion: v1
         kind: Secret

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-list-sync-create/cluster-policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-list-sync-create/cluster-policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: sync-with-multi-clone
 spec:
-  generateExisting: false
   rules:
   - name: sync-secret
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       namespace: "{{request.object.metadata.name}}"
       synchronize : true
       cloneList:

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-list-sync-update/cluster-policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-list-sync-update/cluster-policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: sync-with-multi-clone-update
 spec:
-  generateExisting: false
   rules:
   - name: sync-secret
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       namespace: "{{request.object.metadata.name}}"
       synchronize : true
       cloneList:

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-existing-update-trigger-no-precondition/chainsaw-step-02-apply-1-2.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-existing-update-trigger-no-precondition/chainsaw-step-02-apply-1-2.yaml
@@ -3,9 +3,9 @@ kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-existing-update-trigger-no-precondition
 spec:
-  generateExisting: true
   rules:
   - generate:
+      generateExisting: true
       apiVersion: v1
       clone:
         name: source-secret

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-delete-downstream/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-delete-downstream/chainsaw-step-01-apply-1-1.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: zk-kafka-address
 spec:
-  generateExisting: true
   rules:
   - exclude:
       any:
@@ -14,6 +13,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: true
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-delete-policy/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-delete-policy/policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-nosync-delete-policy-policy
 spec:
-  generateExisting: false
   rules:
   - name: cpol-data-nosync-delete-policy-rule
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-delete-rule/policy-with-rule-removed.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-delete-rule/policy-with-rule-removed.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-nosync-delete-rule-policy
 spec:
-  generateExisting: false
   rules:
   - name: cpol-data-nosync-delete-rule-ruletwo
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: Secret

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-delete-rule/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-delete-rule/policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-nosync-delete-rule-policy
 spec:
-  generateExisting: false
   rules:
   - name: cpol-data-nosync-delete-rule-ruleone
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-modify-downstream/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-modify-downstream/policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-nosync-modify-downstream-policy
 spec:
-  generateExisting: false
   rules:
   - name: cpol-data-nosync-modify-downstream-rule
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-modify-rule/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-modify-rule/policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-nosync-modify-rule-policy
 spec:
-  generateExisting: false
   rules:
   - name: cpol-data-nosync-modify-rule-rule
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-modify-rule/rule-modified.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/cpol-data-nosync-modify-rule/rule-modified.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-nosync-modify-rule-policy
 spec:
-  generateExisting: false
   rules:
   - name: cpol-data-nosync-modify-rule-rule
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/generate-on-subresource-trigger/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/generate-on-subresource-trigger/policy.yaml
@@ -3,8 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: zk-kafka-address
 spec:
-  # generateExisting does not work for sub-resources
-  generateExisting: false
   rules:
     - name: k-kafka-address
       match:
@@ -13,6 +11,8 @@ spec:
               kinds:
                 - "Pod/exec"
       generate:
+        # generateExisting does not work for sub-resources
+        generateExisting: false
         # synchronization does not work for sub-resources
         synchronize: false
         apiVersion: v1

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-create/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-create/chainsaw-step-01-apply-1-1.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: zk-kafka-address
 spec:
-  generateExisting: false
   rules:
   - exclude:
       any:
@@ -14,6 +13,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-delete-downstream/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-delete-downstream/chainsaw-step-01-apply-1-1.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-sync-delete-downstream-policy
 spec:
-  generateExisting: false
   rules:
   - exclude:
       any:
@@ -14,6 +13,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-delete-policy/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-delete-policy/chainsaw-step-01-apply-1-1.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-sync-delete-policy
 spec:
-  generateExisting: false
   rules:
   - exclude:
       any:
@@ -14,6 +13,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-delete-rule/delete-rule.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-delete-rule/delete-rule.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: multiple-gens
 spec:
-  generateExisting: false
   rules:
   - name: super-secret
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: Secret

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-delete-rule/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-delete-rule/policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: multiple-gens
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-existing-update-trigger-no-precondition/chainsaw-step-02-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-existing-update-trigger-no-precondition/chainsaw-step-02-apply-1-1.yaml
@@ -3,9 +3,9 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-sync-existing-update-trigger-no-precondition
 spec:
-  generateExisting: true
   rules:
   - generate:
+      generateExisting: true
       apiVersion: policy/v1
       data:
         spec:

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-modify-downstream/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-modify-downstream/chainsaw-step-01-apply-1-1.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-sync-modify-downstream-policy
 spec:
-  generateExisting: false
   rules:
   - exclude:
       any:
@@ -14,6 +13,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-modify-rule/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-modify-rule/chainsaw-step-01-apply-1-1.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: zk-kafka-address
 spec:
-  generateExisting: true
   rules:
   - exclude:
       any:
@@ -14,6 +13,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: true
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-modify-rule/chainsaw-step-03-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-modify-rule/chainsaw-step-03-apply-1-1.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: zk-kafka-address
 spec:
-  generateExisting: true
   rules:
   - exclude:
       any:
@@ -14,6 +13,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: true
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-orphan-downstream-delete-policy/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/sync/cpol-data-sync-orphan-downstream-delete-policy/chainsaw-step-01-apply-1-1.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-sync-orphan-downstream-delete-policy
 spec:
-  generateExisting: false
   rules:
   - exclude:
       any:
@@ -14,6 +13,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/existing-basic-add-rule-data/add-rule.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/existing-basic-add-rule-data/add-rule.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: existing-basic-add-rule-data
 spec:
-  generateExisting: true
   rules:
   - name: existing-basic-create-rule
     match:
@@ -15,6 +14,7 @@ spec:
             matchLabels:
               color: blue
     generate:
+      generateExisting: true
       kind: NetworkPolicy
       apiVersion: networking.k8s.io/v1
       name: default-deny

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/existing-basic-add-rule-data/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/existing-basic-add-rule-data/policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: existing-basic-add-rule-data
 spec:
-  generateExisting: true
   rules:
   - name: existing-basic-create-rule
     match:
@@ -15,6 +14,7 @@ spec:
             matchLabels:
               color: blue
     generate:
+      generateExisting: true
       kind: NetworkPolicy
       apiVersion: networking.k8s.io/v1
       name: default-deny

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/existing-basic-create-policy-data/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/existing-basic-create-policy-data/policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: existing-basic-create-policy-data
 spec:
-  generateExisting: true
   rules:
   - name: existing-basic-create-rule
     match:
@@ -15,6 +14,7 @@ spec:
             matchLabels:
               color: red
     generate:
+      generateExisting: true
       kind: NetworkPolicy
       apiVersion: networking.k8s.io/v1
       name: default-deny

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/existing-basic-create-policy-preconditions-data/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/existing-basic-create-policy-preconditions-data/policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: existing-basic-create-policy-preconditions-data
 spec:
-  generateExisting: true
   rules:
   - name: existing-basic-create-data-preconditions-rule
     match:
@@ -17,6 +16,7 @@ spec:
         operator: Equals
         value: LoadBalancer
     generate:
+      generateExisting: true
       kind: ConfigMap
       apiVersion: v1
       name: mylb-cm

--- a/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule/policy-with-rule-removed.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule/policy-with-rule-removed.yaml
@@ -9,7 +9,6 @@ metadata:
   name: pol-data-nosync-delete-rule-policy
   namespace: otter
 spec:
-  generateExisting: false
   rules:
   - name: pol-data-nosync-delete-rule-policy-ruleone
     match:
@@ -18,6 +17,7 @@ spec:
           kinds:
           - Secret
     generate:
+      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule/policy.yaml
@@ -9,7 +9,6 @@ metadata:
   name: pol-data-nosync-delete-rule-policy
   namespace: otter
 spec:
-  generateExisting: false
   rules:
   - name: pol-data-nosync-delete-rule-policy-ruleone
     match:
@@ -18,6 +17,7 @@ spec:
           kinds:
           - Secret
     generate:
+      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule/chainsaw-step-01-apply-1-2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule/chainsaw-step-01-apply-1-2.yaml
@@ -4,9 +4,9 @@ metadata:
   name: multiple-gens
   namespace: pol-data-sync-delete-rule
 spec:
-  generateExisting: false
   rules:
   - generate:
+      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule/chainsaw-step-04-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule/chainsaw-step-04-apply-1-1.yaml
@@ -4,9 +4,9 @@ metadata:
   name: multiple-gens
   namespace: pol-data-sync-delete-rule
 spec:
-  generateExisting: false
   rules:
   - generate:
+      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/chainsaw-step-01-apply-1-2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/chainsaw-step-01-apply-1-2.yaml
@@ -4,9 +4,9 @@ metadata:
   name: zk-kafka-address
   namespace: pol-data-sync-modify-rule
 spec:
-  generateExisting: true
   rules:
   - generate:
+      generateExisting: true
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/chainsaw-step-03-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/chainsaw-step-03-apply-1-1.yaml
@@ -4,9 +4,9 @@ metadata:
   name: zk-kafka-address
   namespace: pol-data-sync-modify-rule
 spec:
-  generateExisting: true
   rules:
   - generate:
+      generateExisting: true
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace/chainsaw-step-01-apply-1-3.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace/chainsaw-step-01-apply-1-3.yaml
@@ -4,9 +4,9 @@ metadata:
   name: match-trigger-namespace
   namespace: match-trigger-namespace-ns
 spec:
-  generateExisting: true
   rules:
   - generate:
+      generateExisting: true
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace/chainsaw-step-01-apply-1-4.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace/chainsaw-step-01-apply-1-4.yaml
@@ -4,9 +4,9 @@ metadata:
   name: non-match-trigger-namespace
   namespace: non-match-trigger-namespace-ns
 spec:
-  generateExisting: true
   rules:
   - generate:
+      generateExisting: true
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/cloneList/policy-pass.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/cloneList/policy-pass.yaml
@@ -49,7 +49,6 @@ kind: ClusterPolicy
 metadata:
   name: target-scope-validation-pass-3
 spec:
-  generateExisting: false
   rules:
   - name: sync-secret
     match:
@@ -66,6 +65,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       namespace: "{{request.object.metadata.name}}"
       synchronize : true
       cloneList:

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-clonelist/cluster-policy.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-clonelist/cluster-policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-clonelist
 spec:
-  generateExisting: false
   rules:
   - name: sync-secret
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       namespace: "{{request.object.metadata.name}}"
       synchronize : true
       cloneList:

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-clonelist/update-kinds.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-clonelist/update-kinds.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-clonelist
 spec:
-  generateExisting: false
   rules:
   - name: sync-secret
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       namespace: "{{request.object.metadata.name}}"
       synchronize : true
       cloneList:

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-clonelist/update-ns.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-clonelist/update-ns.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-clonelist
 spec:
-  generateExisting: false
   rules:
   - name: sync-secret
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       namespace: "{{request.object.metadata.name}}"
       synchronize : true
       cloneList:

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-clonelist/update-selector.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-clonelist/update-selector.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-clonelist
 spec:
-  generateExisting: false
   rules:
   - name: sync-secret
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       namespace: "{{request.object.metadata.name}}"
       synchronize : true
       cloneList:

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-downstream/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-downstream/chainsaw-step-01-apply-1-1.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-downstream-rule
 spec:
-  generateExisting: false
   rules:
   - exclude:
       any:
@@ -14,6 +13,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-downstream/update-apiversion.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-downstream/update-apiversion.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-downstream-rule
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v2beta1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-downstream/update-kind.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-downstream/update-kind.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-downstream-rule
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: Secret

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-downstream/update-name.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-downstream/update-name.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-downstream-rule
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-downstream/update-namespace.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-downstream/update-namespace.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-downstream-rule
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-rule-spec/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-rule-spec/chainsaw-step-01-apply-1-1.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-rule-spec
 spec:
-  generateExisting: false
   rules:
   - exclude:
       any:
@@ -14,6 +13,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-rule-spec/update-rule-exclude.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-rule-spec/update-rule-exclude.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-rule-spec
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -18,6 +17,7 @@ spec:
           - kube-system
           - default
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-rule-spec/update-rule-generate-synchronize.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-rule-spec/update-rule-generate-synchronize.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-rule-spec
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-rule-spec/update-rule-match.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-rule-spec/update-rule-match.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-rule-spec
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -21,6 +20,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-rule-spec/update-rule-name.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/immutable-rule-spec/update-rule-name.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-update-rule-spec
 spec:
-  generateExisting: false
   rules:
   - name: i-changed-this
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/target-namespace-scope/policy-fail-1-no-ns-namespaced-target.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/target-namespace-scope/policy-fail-1-no-ns-namespaced-target.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-data-nosync-modify-rule-policy
 spec:
-  generateExisting: false
   rules:
   - name: cpol-data-nosync-modify-rule-rule
     match:
@@ -20,6 +19,7 @@ spec:
           - kube-public
           - kyverno
     generate:
+      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/policy/cloneList/policy-pass.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/cloneList/policy-pass.yaml
@@ -52,7 +52,6 @@ metadata:
   name: target-scope-validation-pass-3
   namespace: target-scope-validation-fail-ns
 spec:
-  generateExisting: false
   rules:
   - name: sync-secret
     match:
@@ -61,6 +60,7 @@ spec:
           kinds:
           - ConfigMap
     generate:
+      generateExisting: false
       namespace: target-scope-validation-fail-ns
       synchronize : true
       cloneList:

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-clonelist/policy.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-clonelist/policy.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-update-clonelist
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - name: sync-secret
     match:
@@ -13,6 +12,7 @@ spec:
           kinds:
           - ConfigMap
     generate:
+      generateExisting: false
       namespace: default
       synchronize : true
       cloneList:

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-clonelist/update-kinds.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-clonelist/update-kinds.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-update-clonelist
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - name: sync-secret
     match:
@@ -13,6 +12,7 @@ spec:
           kinds:
           - ConfigMap
     generate:
+      generateExisting: false
       namespace: default
       synchronize : true
       cloneList:

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-clonelist/update-ns.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-clonelist/update-ns.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-update-clonelist
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - name: sync-secret
     match:
@@ -13,6 +12,7 @@ spec:
           kinds:
           - ConfigMap
     generate:
+      generateExisting: false
       namespace: default
       synchronize : true
       cloneList:

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-clonelist/update-selector.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-clonelist/update-selector.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-update-clonelist
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - name: sync-secret
     match:
@@ -13,6 +12,7 @@ spec:
           kinds:
           - 
     generate:
+      generateExisting: false
       namespace: default
       synchronize : true
       cloneList:

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-downstream/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-downstream/chainsaw-step-01-apply-1-1.yaml
@@ -4,9 +4,9 @@ metadata:
   name: generate-update-downstream-rule
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - generate:
+      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-downstream/update-apiversion.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-downstream/update-apiversion.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-update-downstream-rule
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -13,6 +12,7 @@ spec:
           kinds:
           - ConfigMap
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v2beta1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-downstream/update-kind.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-downstream/update-kind.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-update-downstream-rule
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -13,6 +12,7 @@ spec:
           kinds:
           - ConfigMap
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: Secret

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-downstream/update-name.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-downstream/update-name.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-update-downstream-rule
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -13,6 +12,7 @@ spec:
           kinds:
           - ConfigMap
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-downstream/update-namespace.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-downstream/update-namespace.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-update-downstream-rule
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -13,6 +12,7 @@ spec:
           kinds:
           - ConfigMap
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-rule-spec/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-rule-spec/chainsaw-step-01-apply-1-1.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-update-rule-spec
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - exclude:
       any:
@@ -12,6 +11,7 @@ spec:
           kinds:
           - NetworkPolicy
     generate:
+      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-rule-spec/update-rule-exclude.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-rule-spec/update-rule-exclude.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-update-rule-spec
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -20,6 +19,7 @@ spec:
           names:
           - test
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-rule-spec/update-rule-generate-synchronize.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-rule-spec/update-rule-generate-synchronize.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-update-rule-spec
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -18,6 +17,7 @@ spec:
           kinds:
           - NetworkPolicy
     generate:
+      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-rule-spec/update-rule-match.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-rule-spec/update-rule-match.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-update-rule-spec
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - name: k-kafka-address
     match:
@@ -19,6 +18,7 @@ spec:
           kinds:
           - NetworkPolicy
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/policy/immutable-rule-spec/update-rule-name.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/immutable-rule-spec/update-rule-name.yaml
@@ -4,7 +4,6 @@ metadata:
   name: generate-update-rule-spec
   namespace: default
 spec:
-  generateExisting: false
   rules:
   - name: i-changed-this
     match:
@@ -18,6 +17,7 @@ spec:
           kinds:
           - NetworkPolicy
     generate:
+      generateExisting: false
       synchronize: true
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/validation/policy/target-namespace-scope/policy-fail-0.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/target-namespace-scope/policy-fail-0.yaml
@@ -3,7 +3,6 @@ kind: Policy
 metadata:
   name: pol-cluster-target
 spec:
-  generateExisting: false
   rules:
   - name: pol-cluster-target
     match:
@@ -12,6 +11,7 @@ spec:
           kinds:
           - ConfigMap
     generate:
+      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: Secret


### PR DESCRIPTION
## Explanation
This PR modifies the chainsaw tests to use the `generateExisting` field which was introduced under the `generate` rule.