### PR TITLE
chore: use mutateExistingOnPolicyUpdate under mutate rule in chainsaw tests

### DIFF
--- a/pkg/engine/mutation_test.go
+++ b/pkg/engine/mutation_test.go
@@ -1625,7 +1625,6 @@ func Test_mutate_existing_resources(t *testing.T) {
 				            "name": "sync-cms"
 				        },
 				        "spec": {
-				            "mutateExistingOnPolicyUpdate": false,
 				            "rules": [
 				                {
 				                    "name": "concat-cm",
@@ -1647,6 +1646,7 @@ func Test_mutate_existing_resources(t *testing.T) {
 				                        ]
 				                    },
 				                    "mutate": {
+                                "mutateExistingOnPolicyUpdate": false,
 				                        "targets": [
 				                            {
 				                                "apiVersion": "v1",
@@ -1717,7 +1717,6 @@ func Test_mutate_existing_resources(t *testing.T) {
 		            "name": "sync-cms"
 		        },
 		        "spec": {
-		            "mutateExistingOnPolicyUpdate": false,
 		            "rules": [
 		                {
 		                    "name": "concat-cm",
@@ -1739,6 +1738,7 @@ func Test_mutate_existing_resources(t *testing.T) {
 		                        ]
 		                    },
 		                    "mutate": {
+                            "mutateExistingOnPolicyUpdate": false,
 		                        "targets": [
 		                            {
 		                                "apiVersion": "v1",

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/pod-restart-on-cm-update/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/pod-restart-on-cm-update/policy.yaml
@@ -7,7 +7,6 @@ metadata:
       This policy generates and synchronizes a configmap for custom resource kube-state-metrics.
 spec:
   generateExisting: true
-  mutateExistingOnPolicyUpdate: false
   schemaValidation: false
   rules:
     - name: generate-cm-for-kube-state-metrics-crds
@@ -55,6 +54,7 @@ spec:
             operator: Equals
             value: UPDATE
       mutate:
+        mutateExistingOnPolicyUpdate: false
         targets:
           - apiVersion: apps/v1
             kind: Deployment

--- a/test/conformance/chainsaw/mutate/clusterpolicy/cornercases/variables-mutate-existing/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/cornercases/variables-mutate-existing/chainsaw-step-01-apply-1-1.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: reload
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
   - match:
       any:
@@ -14,6 +13,7 @@ spec:
             matchLabels:
               kyverno.io/watch: "true"
     mutate:
+      mutateExistingOnPolicyUpdate: false
       patchStrategicMerge:
         metadata:
           annotations:

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/background-false/chainsaw-step-01-apply-1-2.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/background-false/chainsaw-step-01-apply-1-2.yaml
@@ -18,7 +18,6 @@ metadata:
   name: add-privileged-existing-namespaces
 spec:
   background: false
-  mutateExistingOnPolicyUpdate: true
   rules:
   - match:
       any:
@@ -28,6 +27,7 @@ spec:
           names:
           - background-false-ns
     mutate:
+      mutateExistingOnPolicyUpdate: true
       patchStrategicMerge:
         metadata:
           labels:

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/basic-create-patchesJson6902/chainsaw-step-01-apply-1-3.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/basic-create-patchesJson6902/chainsaw-step-01-apply-1-3.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: test-post-mutation
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
   - match:
       any:
@@ -15,6 +14,7 @@ spec:
           namespaces:
           - staging-4
     mutate:
+      mutateExistingOnPolicyUpdate: false
       patchesJson6902: "- op: add\n  path: \"/metadata/labels/env\"\n  value: \"{{
         request.object.metadata.namespace }}\"  "
       targets:

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/basic-create/chainsaw-step-01-apply-1-3.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/basic-create/chainsaw-step-01-apply-1-3.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: mutate-existing-secret
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
   - match:
       any:
@@ -15,6 +14,7 @@ spec:
           namespaces:
           - staging
     mutate:
+      mutateExistingOnPolicyUpdate: false
       patchStrategicMerge:
         metadata:
           labels:

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/basic-delete/chainsaw-step-01-apply-1-4.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/basic-delete/chainsaw-step-01-apply-1-4.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: test-post-mutation-delete-trigger
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
   - match:
       any:
@@ -17,6 +16,7 @@ spec:
           operations:
           - DELETE
     mutate:
+      mutateExistingOnPolicyUpdate: false
       patchStrategicMerge:
         metadata:
           labels:

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/basic-update/chainsaw-step-01-apply-1-4.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/basic-update/chainsaw-step-01-apply-1-4.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: mutate-existing-secret
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
   - match:
       any:
@@ -15,6 +14,7 @@ spec:
           namespaces:
           - staging
     mutate:
+      mutateExistingOnPolicyUpdate: false
       patchStrategicMerge:
         metadata:
           labels:

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/delete-trigger-namespace/policy.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/delete-trigger-namespace/policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: mutate-existing-secret
 spec:
-  mutateExistingOnPolicyUpdate: true
   rules:
     - name: mutate-secret-on-configmap-event
       match:
@@ -16,6 +15,7 @@ spec:
             namespaces:
             - staging
       mutate:
+        mutateExistingOnPolicyUpdate: true
         targets:
         - apiVersion: v1
           kind: Secret

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/multiple-rules-match-exclude/chainsaw-step-01-apply-1-5.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/multiple-rules-match-exclude/chainsaw-step-01-apply-1-5.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-multiple-rules-match-exclude
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
   - match:
       any:
@@ -14,6 +13,7 @@ spec:
             matchLabels:
               policy.lan/flag: "true"
     mutate:
+      mutateExistingOnPolicyUpdate: false
       patchStrategicMerge:
         metadata:
           labels:

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/multiple-trigger-resources/policy.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/multiple-trigger-resources/policy.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:  
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  mutateExistingOnPolicyUpdate: true
   validationFailureAction: Enforce
   rules:
   - name: propagate org label from namespace
@@ -24,6 +23,7 @@ spec:
         urlPath: /api/v1/namespaces/{{ request.object.metadata.namespace }}
         jmesPath: metadata.labels.org
     mutate:
+      mutateExistingOnPolicyUpdate: true
       targets:
       - apiVersion: v1
         kind: Pod

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/namespaceselector/policy.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/namespaceselector/policy.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:  
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  mutateExistingOnPolicyUpdate: false
   validationFailureAction: Enforce
   rules:
   - name: propagate org label from namespace
@@ -24,6 +23,7 @@ spec:
         urlPath: /api/v1/namespaces/{{ request.object.metadata.namespace }}
         jmesPath: metadata.labels.org
     mutate:
+      mutateExistingOnPolicyUpdate: false
       targets:
       - apiVersion: v1
         kind: Pod

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/onpolicyupdate/basic-create-policy/chainsaw-step-02-apply-1-1.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/onpolicyupdate/basic-create-policy/chainsaw-step-02-apply-1-1.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: test-post-mutation-create-policy
 spec:
-  mutateExistingOnPolicyUpdate: true
   rules:
   - match:
       any:
@@ -15,6 +14,7 @@ spec:
           namespaces:
           - staging-3
     mutate:
+      mutateExistingOnPolicyUpdate: true
       patchStrategicMerge:
         metadata:
           labels:

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/onpolicyupdate/namespaceselector/policy.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/onpolicyupdate/namespaceselector/policy.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:  
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  mutateExistingOnPolicyUpdate: true
   validationFailureAction: Enforce
   rules:
   - name: propagate org label from namespace
@@ -24,6 +23,7 @@ spec:
         urlPath: /api/v1/namespaces/{{ request.object.metadata.namespace }}
         jmesPath: metadata.labels.org
     mutate:
+      mutateExistingOnPolicyUpdate: true
       targets:
       - apiVersion: v1
         kind: Pod

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/preconditions/policy.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/preconditions/policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: test
 spec:
-  mutateExistingOnPolicyUpdate: true
   rules:
     - name: test
       match:
@@ -14,6 +13,7 @@ spec:
               names:
                 - default
       mutate:
+        mutateExistingOnPolicyUpdate: true
         targets:
           - kind: Pod
             apiVersion: '*'

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/validation/auth-check/cpol-namespace-variable/policy.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/validation/auth-check/cpol-namespace-variable/policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-namespace-variable
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
     - name: apply-flag
       match:
@@ -15,6 +14,7 @@ spec:
                 matchLabels:
                   policy.lan/flag: 'true'
       mutate:
+        mutateExistingOnPolicyUpdate: false
         targets:
           - kind: PersistentVolumeClaim
             apiVersion: v1

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/validation/auth-check/cpol-standard-auth-check/policy.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/validation/auth-check/cpol-standard-auth-check/policy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: cpol-mutate-existing-auth-check
 spec:
-  mutateExistingOnPolicyUpdate: true
   background: false
   rules:
   - name: label-privileged-namespaces
@@ -13,6 +12,7 @@ spec:
           kinds:
           - Namespace
     mutate:
+      mutateExistingOnPolicyUpdate: true
       targets:
         - apiVersion: v1
           kind: ServiceAccount

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/validation/mutate-existing-require-targets/policy-no-targets.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/validation/mutate-existing-require-targets/policy-no-targets.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: mutate-existing-require-targets-policy-no-targets
 spec:
-  mutateExistingOnPolicyUpdate: true
   rules:
     - name: mutate-secret-on-configmap-create
       match:
@@ -16,6 +15,7 @@ spec:
             namespaces:
             - staging
       mutate:
+        mutateExistingOnPolicyUpdate: true
         patchStrategicMerge:
           metadata:
             labels:

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/validation/mutate-existing-require-targets/policy-targets.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/validation/mutate-existing-require-targets/policy-targets.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: mutate-existing-require-targets-policy-targets
 spec:
-  mutateExistingOnPolicyUpdate: true
   rules:
     - name: mutate-secret-on-configmap-create
       match:
@@ -16,6 +15,7 @@ spec:
             namespaces:
             - staging
       mutate:
+        mutateExistingOnPolicyUpdate: true
         targets:
         - apiVersion: v1
           kind: Secret

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/validation/target-variable-validation/policy-bad.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/validation/target-variable-validation/policy-bad.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: target-variable-validation-cpol
 spec:
-  mutateExistingOnPolicyUpdate: true
   schemaValidation: false
   background: true
   rules:
@@ -14,6 +13,7 @@ spec:
               kinds:
                 - Secret
       mutate:
+        mutateExistingOnPolicyUpdate: true
         targets:
           - apiVersion: v1
             kind: ConfigMap

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/validation/target-variable-validation/policy-good.yaml
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/validation/target-variable-validation/policy-good.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: target-variable-validation-cpol
 spec:
-  mutateExistingOnPolicyUpdate: true
   schemaValidation: false
   background: true
   rules:
@@ -14,6 +13,7 @@ spec:
               kinds:
                 - Secret
       mutate:
+        mutateExistingOnPolicyUpdate: true
         targets:
           - apiVersion: v1
             kind: ConfigMap

--- a/test/conformance/chainsaw/mutate/policy/standard/existing/validation/auth-check/policy.yaml
+++ b/test/conformance/chainsaw/mutate/policy/standard/existing/validation/auth-check/policy.yaml
@@ -4,7 +4,6 @@ metadata:
   name: pol-mutate-existing-auth-check
   namespace: pol-mutate-existing-auth-check-ns
 spec:
-  mutateExistingOnPolicyUpdate: true
   background: false
   rules:
   - name: label-privileged-namespaces
@@ -14,6 +13,7 @@ spec:
           kinds:
           - ConfigMap
     mutate:
+      mutateExistingOnPolicyUpdate: true
       targets:
         - apiVersion: v1
           kind: ServiceAccount

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/schema-validation-for-mutateExisting/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/schema-validation-for-mutateExisting/policy.yaml
@@ -7,7 +7,6 @@ metadata:
       This policy generates and synchronizes a configmap for custom resource kube-state-metrics.
 spec:
   generateExisting: true
-  mutateExistingOnPolicyUpdate: true
   rules:
     - name: restart-kube-state-metrics-on-cm-change
       match:
@@ -25,6 +24,7 @@ spec:
             operator: NotEquals
             value: source
       mutate:
+        mutateExistingOnPolicyUpdate: true
         targets:
           - apiVersion: apps/v1
             kind: Deployment


### PR DESCRIPTION
## Explanation
This PR modifies the chainsaw tests to use the `mutateExistingOnPolicyUpdate` field which was introduced under the `mutate` rule.