### PR TITLE
fix: failed to delete resource

### DIFF
--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -278,62 +278,8 @@ func (c *controller) cleanup(ctx context.Context, logger logr.Logger, policy kyv
 						errs = append(errs, err)
 						continue
 					}
-					if spec.ExcludeResources != nil {
-						excluded := match.CheckMatchesResources(
-							resource,
-							*spec.ExcludeResources,
-							nsLabels,
-							// TODO(eddycharly): we don't have user info here, we should check that
-							// we don't have user conditions in the policy rule
-							kyvernov2.RequestInfo{},
-							resource.GroupVersionKind(),
-							"",
-						)
-						if excluded == nil {
-							debug.Info("resource/exclude matched")
-							continue
-						} else {
-							debug.Info("resource/exclude didn't match", "result", excluded)
-						}
-					}
-					// check conditions
-					if spec.Conditions != nil {
-						enginectx.Reset()
-						if err := enginectx.SetTargetResource(resource.Object); err != nil {
-							debug.Error(err, "failed to add resource in context")
-							errs = append(errs, err)
-							continue
-						}
-						if err := enginectx.AddNamespace(resource.GetNamespace()); err != nil {
-							debug.Error(err, "failed to add namespace in context")
-							errs = append(errs, err)
-							continue
-						}
-						if err := enginectx.AddImageInfos(&resource, c.configuration); err != nil {
-							debug.Error(err, "failed to add image infos in context")
-							errs = append(errs, err)
-							continue
-						}
-						passed, err := conditions.CheckAnyAllConditions(logger, enginectx, *spec.Conditions)
-						if err != nil {
-							debug.Error(err, "failed to check condition")
-							errs = append(errs, err)
-							continue
-						}
-						if !passed {
-							debug.Info("conditions did not pass")
-							continue
-						}
-					}
-					var labels []attribute.KeyValue
-					labels = append(labels, commonLabels...)
-					labels = append(labels, attribute.String("resource_namespace", namespace))
-					logger.WithValues("name", name, "namespace", namespace).Info("resource matched, it will be deleted...")
-					if err := c.client.DeleteResource(ctx, resource.GetAPIVersion(), resource.GetKind(), namespace, name, false); err != nil {
-						if c.metrics.cleanupFailuresTotal != nil {
-							c.metrics.cleanupFailuresTotal.Add(ctx, 1, metric.WithAttributes(labels...))
-						}
-						debug.Error(err, "failed to delete resource")
+					if err := enginectx.AddNamespace(resource.GetNamespace()); err != nil {
+						debug.Error(err, "failed to add namespace in context")
 						errs = append(errs, err)
 						continue
 					}


### PR DESCRIPTION
## Explanation
This PR fixes a bug related to deleting a resource by the cleanup controller.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #10418 

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/kind bug
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/milestone 1.12.5
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Apply the CRD of access tokens: https://github.com/crossplane-contrib/provider-gitlab/blob/6dd6214a54867b97d7c7d10c08f06aa24e9c7717/package/crds/projects.gitlab.crossplane.io_accesstokens.yaml
2. Create the cluster role for cleanup controller:
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  labels:
    app.kubernetes.io/component: cleanup-controller
    app.kubernetes.io/instance: kyverno
    app.kubernetes.io/part-of: kyverno
  name: kyverno:cleanup-access-tokens
rules:
- apiGroups:
  - 'projects.gitlab.crossplane.io'
  resources:
  - accesstokens
  verbs:
  - delete
  - list
  - get
```
3. Create cluster cleanup policy:
```
apiVersion: kyverno.io/v2
kind: ClusterCleanupPolicy
metadata:
  name: crossplane-gitlab-rotate-token-delete-mrs
spec:
  conditions:
    any:
    - key: '{{ time_diff(''{{ time_now_utc() }}'', ''{{ target.spec.forProvider.expiresAt
        || time_now_utc() }}'') }}'
      operator: LessThanOrEquals
      value: 720h
    - key: '{{ time_diff(''{{ time_now_utc() }}'', ''{{ target.spec.forProvider.expiresAt
        || time_now_utc() }}'') }}'
      operator: GreaterThanOrEquals
      value: 2160h
  match:
    any:
    - resources:
        kinds:
        - projects.gitlab.crossplane.io/v1alpha1/AccessToken
  schedule: '*/1 * * * *'
```
4. Create the access token:
```
apiVersion: projects.gitlab.crossplane.io/v1alpha1
kind: AccessToken
metadata:
  name: pat-02-sjnjf-nvjb7
spec:
  deletionPolicy: Delete
  forProvider:
    expiresAt: "2024-06-25T08:02:02Z"
    name: eu1lab-eks001-rotated-tokens-pat-02
    projectId: "45536746"
    scopes:
    - write_repository
  managementPolicies:
  - '*'
  providerConfigRef:
    name: enterprise-messaging
  writeConnectionSecretToRef:
    name: pat-02-sjnjf-d4d02b2e-4bcb-4489-acf7-3dbd32fe4ca5
    namespace: crossplane-system
```
5. Get the access tokens:
```
$ kubectl get accesstokens.projects.gitlab.crossplane.io
No resources found
```
As expected, the resource is successfully deleted.
6. Check the generated events:
```
kubectl get events
LAST SEEN   TYPE      REASON          OBJECT                                                           MESSAGE
72s         Normal    PolicyApplied   clustercleanuppolicy/crossplane-gitlab-rotate-token-delete-mrs   successfully cleaned up the target resource AccessToken//pat-02-sjnjf-nvjb7
```
7. Re-create the access token.
8. Check the events after 1 minute:
```
kubectl get events
LAST SEEN   TYPE      REASON          OBJECT                                                           MESSAGE
3m1s        Normal    PolicyApplied   clustercleanuppolicy/crossplane-gitlab-rotate-token-delete-mrs   successfully cleaned up the target resource AccessToken//pat-02-sjnjf-nvjb7
1s          Normal    PolicyApplied   clustercleanuppolicy/crossplane-gitlab-rotate-token-delete-mrs   successfully cleaned up the target resource AccessToken//pat-02-sjnjf-nvjb7
```
9. Controller logs:
```
2024-07-02T15:58:00+03:00	LEVEL(-3)	cleanup-controller.worker	cleanup/controller.go:305	resource matched, it will be deleted...	{"id": 1, "key": "crossplane-gitlab-rotate-token-delete-mrs", "namespace": "", "name": "crossplane-gitlab-rotate-token-delete-mrs", "name": "pat-02-sjnjf-nvjb7", "namespace": ""}
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
