### PR TITLE
fix: CEL policies aren't applied to deleted resources

### DIFF
--- a/pkg/engine/handlers/validation/validate_cel.go
+++ b/pkg/engine/handlers/validation/validate_cel.go
@@ -47,11 +47,6 @@ func (h validateCELHandler) Process(
 	_ engineapi.EngineContextLoader,
 	exceptions []*kyvernov2.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
-	if engineutils.IsDeleteRequest(policyContext) {
-		logger.V(3).Info("skipping CEL validation on deleted resource")
-		return resource, nil
-	}
-
 	// check if there is a policy exception matches the incoming resource
 	exception := engineutils.MatchesException(exceptions, policyContext, logger)
 	if exception != nil {
@@ -76,21 +71,29 @@ func (h validateCELHandler) Process(
 
 	// get resource's name, namespace, GroupVersionResource, and GroupVersionKind
 	gvr := schema.GroupVersionResource(policyContext.RequestResource())
-	gvk := resource.GroupVersionKind()
-	namespaceName := resource.GetNamespace()
-	resourceName := resource.GetName()
-	resourceKind, _ := policyContext.ResourceKind()
+	gvk, _ := policyContext.ResourceKind()
 	policyKind := policyContext.Policy().GetKind()
 	policyName := policyContext.Policy().GetName()
 
-	object := resource.DeepCopyObject()
-	// in case of update request, set the oldObject to the current resource before it gets updated
-	var oldObject runtime.Object
+	// in case of UPDATE requests, set the oldObject to the current resource before it gets updated
+	var object, oldObject runtime.Object
 	oldResource := policyContext.OldResource()
 	if oldResource.Object == nil {
 		oldObject = nil
 	} else {
 		oldObject = oldResource.DeepCopyObject()
+	}
+
+	var ns, name string
+	// in case of DELETE request, get the name and the namespace from the old object
+	if resource.Object == nil {
+		ns = oldResource.GetNamespace()
+		name = oldResource.GetName()
+		object = nil
+	} else {
+		ns = resource.GetNamespace()
+		name = resource.GetName()
+		object = resource.DeepCopyObject()
 	}
 
 	// check if the rule uses parameter resources
@@ -129,11 +132,11 @@ func (h validateCELHandler) Process(
 	// Special case, the namespace object has the namespace of itself.
 	// unset it if the incoming object is a namespace
 	if gvk.Kind == "Namespace" && gvk.Version == "v1" && gvk.Group == "" {
-		namespaceName = ""
+		ns = ""
 	}
-	if namespaceName != "" {
+	if ns != "" {
 		if h.client != nil {
-			namespace, err = h.client.GetNamespace(ctx, namespaceName, metav1.GetOptions{})
+			namespace, err = h.client.GetNamespace(ctx, ns, metav1.GetOptions{})
 			if err != nil {
 				return resource, handlers.WithResponses(
 					engineapi.RuleError(rule.Name, engineapi.Validation, "Error getting the resource's namespace", err),
@@ -142,7 +145,7 @@ func (h validateCELHandler) Process(
 		} else {
 			namespace = &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: namespaceName,
+					Name: ns,
 				},
 			}
 		}
@@ -150,16 +153,20 @@ func (h validateCELHandler) Process(
 
 	requestInfo := policyContext.AdmissionInfo()
 	userInfo := internal.NewUser(requestInfo.AdmissionUserInfo.Username, requestInfo.AdmissionUserInfo.UID, requestInfo.AdmissionUserInfo.Groups)
-	admissionAttributes := admission.NewAttributesRecord(object, oldObject, gvk, namespaceName, resourceName, gvr, "", admission.Operation(policyContext.Operation()), nil, false, &userInfo)
-	versionedAttr, _ := admission.NewVersionedAttributes(admissionAttributes, admissionAttributes.GetKind(), nil)
-	authorizer := internal.NewAuthorizer(h.client, resourceKind)
+	attr := admission.NewAttributesRecord(object, oldObject, gvk, ns, name, gvr, "", admission.Operation(policyContext.Operation()), nil, false, &userInfo)
+	o := admission.NewObjectInterfacesFromScheme(runtime.NewScheme())
+	versionedAttr, err := admission.NewVersionedAttributes(attr, attr.GetKind(), o)
+	if err != nil {
+		return resource, handlers.WithError(rule, engineapi.Validation, "error while creating versioned attributes", err)
+	}
+	authorizer := internal.NewAuthorizer(h.client, gvk)
 	// validate the incoming object against the rule
 	var validationResults []validating.ValidateResult
 	if hasParam {
 		paramKind := rule.Validation.CEL.ParamKind
 		paramRef := rule.Validation.CEL.ParamRef
 
-		params, err := collectParams(ctx, h.client, paramKind, paramRef, namespaceName)
+		params, err := collectParams(ctx, h.client, paramKind, paramRef, ns)
 		if err != nil {
 			return resource, handlers.WithResponses(
 				engineapi.RuleError(rule.Name, engineapi.Validation, "error in parameterized resource", err),

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/cel-messages-upon-resource-failure(deprecated)/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/cel-messages-upon-resource-failure(deprecated)/policy.yaml
@@ -14,6 +14,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         message: "hostPort must either be unset or set to 0"
         cel:

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/cel-messages-upon-resource-failure/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/cel-messages-upon-resource-failure/policy.yaml
@@ -13,6 +13,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         validationFailureAction: Enforce
         message: "hostPort must either be unset or set to 0"

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/authorizor-checks/with-permissions/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/authorizor-checks/with-permissions/policy.yaml
@@ -12,6 +12,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         cel:
           expressions:

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/authorizor-checks/without-permissions/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/authorizor-checks/without-permissions/policy.yaml
@@ -12,6 +12,9 @@ spec:
         - resources:
             kinds:
               - Deployment
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         cel:
           expressions:

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/cel-preconditions/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/cel-preconditions/policy.yaml
@@ -12,6 +12,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+              - CREATE
+              - UPDATE
       celPreconditions:
           - name: "first match condition in CEL"
             expression: "object.metadata.name.matches('nginx-pod')"

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/cel-variables/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/cel-variables/policy.yaml
@@ -12,6 +12,9 @@ spec:
         - resources:
             kinds:
               - Deployment
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         cel:
           variables:

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/check-statefulset-namespace/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/check-statefulset-namespace/policy.yaml
@@ -12,6 +12,9 @@ spec:
         - resources:
             kinds:
               - StatefulSet
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         cel:
           expressions:

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/disallow-host-port/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/disallow-host-port/policy.yaml
@@ -14,6 +14,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         cel:
           expressions:

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/parameter-resources/clusterscoped/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/parameter-resources/clusterscoped/policy.yaml
@@ -12,6 +12,9 @@ spec:
         - resources:
             kinds:
               - Namespace
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         cel:
           paramKind: 

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/parameter-resources/namespaced/match-clusterscoped-resource/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/parameter-resources/namespaced/match-clusterscoped-resource/policy.yaml
@@ -12,6 +12,9 @@ spec:
         - resources:
             kinds:
               - Namespace
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         cel:
           paramKind: 

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/parameter-resources/namespaced/set-paramref-namespace/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/parameter-resources/namespaced/set-paramref-namespace/policy.yaml
@@ -12,6 +12,9 @@ spec:
         - resources:
             kinds:
               - Deployment
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         cel:
           paramKind: 

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/parameter-resources/namespaced/unset-paramref-namespace/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel(deprecated)/parameter-resources/namespaced/unset-paramref-namespace/policy.yaml
@@ -12,6 +12,9 @@ spec:
         - resources:
             kinds:
               - StatefulSet
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         cel:
           paramKind: 

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/authorizor-checks/with-permissions/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/authorizor-checks/with-permissions/policy.yaml
@@ -11,6 +11,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         validationFailureAction: Enforce
         cel:

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/authorizor-checks/without-permissions/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/authorizor-checks/without-permissions/policy.yaml
@@ -11,6 +11,9 @@ spec:
         - resources:
             kinds:
               - Deployment
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         validationFailureAction: Enforce
         cel:

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/cel-preconditions/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/cel-preconditions/policy.yaml
@@ -11,6 +11,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+              - CREATE
+              - UPDATE
       celPreconditions:
           - name: "first match condition in CEL"
             expression: "object.metadata.name.matches('nginx-pod')"

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/cel-variables/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/cel-variables/policy.yaml
@@ -11,6 +11,9 @@ spec:
         - resources:
             kinds:
               - Deployment
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         validationFailureAction: Enforce
         cel:

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/check-statefulset-namespace/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/check-statefulset-namespace/policy.yaml
@@ -11,6 +11,9 @@ spec:
         - resources:
             kinds:
               - StatefulSet
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         validationFailureAction: Enforce
         cel:

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/deny/README.md
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/deny/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This test creates a policy that uses CEL expressions to deny the creation/deletion/update of any pod.
+
+## Expected Behavior
+
+Any pod creation/deletion/update is blocked.
+
+## Reference Issue(s)
+
+10576

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/deny/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/deny/chainsaw-test.yaml
@@ -1,0 +1,32 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: deny
+spec:
+  steps:
+  - name: step-01
+    try:
+    - script:
+        content: kubectl run nginx --image=nginx
+  - name: step-02
+    try:
+    - apply:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
+  - name: step-03
+    try:
+    - script:
+        content: "if kubectl run --image=busybox foo\nthen \n  exit 1\nelse \n  exit
+          0\nfi\n"
+  - name: step-04
+    try:
+    - script:
+        content: "if kubectl label pod nginx app=nginx\nthen \n  exit 1\nelse \n  exit
+          0\nfi\n"
+  - name: step-05
+    try:
+    - script:
+        content: "if kubectl delete pod nginx\nthen \n  exit 1\nelse \n  exit
+          0\nfi\n"

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/deny/policy-assert.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/deny/policy-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-operations-on-pod
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/deny/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/deny/policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-operations-on-pod
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+  - name: rule-1
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      cel:
+        expressions:
+          - expression: "false"
+            message: Create, update and delete on pods is not allowed

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/disallow-host-port/pod-fail.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/disallow-host-port/pod-fail.yaml
@@ -1,10 +1,11 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: webserver
+  name: webserver-2
 spec:
   containers:
   - name: webserver
     image: nginx:latest
     ports:
     - hostPort: 80
+      containerPort: 80

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/disallow-host-port/pod-pass.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/disallow-host-port/pod-pass.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: webserver
+  name: webserver-1
 spec:
   containers:
   - name: webserver

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/disallow-host-port/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/disallow-host-port/policy.yaml
@@ -13,6 +13,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         validationFailureAction: Enforce
         cel:

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/parameter-resources/clusterscoped/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/parameter-resources/clusterscoped/policy.yaml
@@ -11,6 +11,9 @@ spec:
         - resources:
             kinds:
               - Namespace
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         validationFailureAction: Enforce
         cel:

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/parameter-resources/namespaced/match-clusterscoped-resource/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/parameter-resources/namespaced/match-clusterscoped-resource/policy.yaml
@@ -11,6 +11,9 @@ spec:
         - resources:
             kinds:
               - Namespace
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         validationFailureAction: Enforce
         cel:

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/parameter-resources/namespaced/set-paramref-namespace/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/parameter-resources/namespaced/set-paramref-namespace/policy.yaml
@@ -11,6 +11,9 @@ spec:
         - resources:
             kinds:
               - Deployment
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         validationFailureAction: Enforce
         cel:

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/parameter-resources/namespaced/unset-paramref-namespace/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/parameter-resources/namespaced/unset-paramref-namespace/policy.yaml
@@ -11,6 +11,9 @@ spec:
         - resources:
             kinds:
               - StatefulSet
+            operations:
+              - CREATE
+              - UPDATE
       validate:
         validationFailureAction: Enforce
         cel:


### PR DESCRIPTION
## Explanation
Policies that make use of `validate.cel` subrules aren't applied on resources in case the admission request is of type `DELETE`. This PR allows the application of policies on resources in case the `match` block matches the `DELETE` requests.
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #10576 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.12.5
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Create an nginx pod: `kubectl run nginx --image=nginx`
2. Create a policy that denies the creation/deletion/update of pods:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: restrict-operations-on-pod
spec:
  validationFailureAction: Enforce
  background: true
  rules:
  - name: rule-1
    match:
      any:
      - resources:
          kinds:
          - Pod
    validate:
      cel:
        expressions:
          - expression: "false"
            message: Create, update and delete on pods is not allowed
```
3. Delete the existing pod:
```
$ kubectl delete pod nginx
Error from server: admission webhook "validate.kyverno.svc-fail" denied the request: 

resource Pod/default/nginx was blocked due to the following policies 

restrict-operations-on-pod:
  rule-1: Create, update and delete on pods is not allowed
```
As expected, the deletion of the `nginx` pod is blocked.
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
