### PR TITLE
fix: filter policies based on the validationFailureAction of the rule if exists

### DIFF
--- a/api/kyverno/v1/common_types.go
+++ b/api/kyverno/v1/common_types.go
@@ -467,6 +467,18 @@ type Validation struct {
 	CEL *CEL `json:"cel,omitempty" yaml:"cel,omitempty"`
 }
 
+func (v *Validation) HasEnforce() bool {
+	if v.ValidationFailureAction != nil && v.ValidationFailureAction.Enforce() {
+		return true
+	}
+	for _, action := range v.ValidationFailureActionOverrides {
+		if action.Action.Enforce() {
+			return true
+		}
+	}
+	return false
+}
+
 // PodSecurity applies exemptions for Kubernetes Pod Security admission
 // by specifying exclusions for Pod Security Standards controls.
 type PodSecurity struct {

--- a/api/kyverno/v1/spec_types.go
+++ b/api/kyverno/v1/spec_types.go
@@ -171,6 +171,21 @@ func (s *Spec) HasValidate() bool {
 	return false
 }
 
+// HasValidateEnforce checks if the policy has any validate rules with enforce action
+func (s *Spec) HasValidateEnforce() bool {
+	for _, rule := range s.Rules {
+		if rule.HasValidate() && rule.Validation.HasEnforce() {
+			return true
+		}
+	}
+	for _, override := range s.ValidationFailureActionOverrides {
+		if override.Action.Enforce() {
+			return true
+		}
+	}
+	return s.ValidationFailureAction.Enforce()
+}
+
 // HasGenerate checks for generate rule types
 func (s *Spec) HasGenerate() bool {
 	for _, rule := range s.Rules {
@@ -226,32 +241,6 @@ func (s *Spec) BackgroundProcessingEnabled() bool {
 		return true
 	}
 	return *s.Background
-}
-
-// GetValidationFailureAction returns the value of the validationFailureAction
-func (s *Spec) GetValidationFailureAction() ValidationFailureAction {
-	for _, rule := range s.Rules {
-		if rule.HasValidate() {
-			validationFailureAction := rule.Validation.ValidationFailureAction
-			if validationFailureAction != nil {
-				return *validationFailureAction
-			}
-		}
-	}
-	return s.ValidationFailureAction
-}
-
-// GetValidationFailureActionOverrides returns the value of the validationFailureActionOverrides
-func (s *Spec) GetValidationFailureActionOverrides() []ValidationFailureActionOverride {
-	for _, rule := range s.Rules {
-		if rule.HasValidate() {
-			validationFailureActionOverrides := rule.Validation.ValidationFailureActionOverrides
-			if len(validationFailureActionOverrides) != 0 {
-				return validationFailureActionOverrides
-			}
-		}
-	}
-	return s.ValidationFailureActionOverrides
 }
 
 // GetMutateExistingOnPolicyUpdate return MutateExistingOnPolicyUpdate set value

--- a/api/kyverno/v2beta1/common_types.go
+++ b/api/kyverno/v2beta1/common_types.go
@@ -57,6 +57,18 @@ type Validation struct {
 	CEL *kyvernov1.CEL `json:"cel,omitempty" yaml:"cel,omitempty"`
 }
 
+func (v *Validation) HasEnforce() bool {
+	if v.ValidationFailureAction != nil && v.ValidationFailureAction.Enforce() {
+		return true
+	}
+	for _, action := range v.ValidationFailureActionOverrides {
+		if action.Action.Enforce() {
+			return true
+		}
+	}
+	return false
+}
+
 // ConditionOperator is the operation performed on condition key and value.
 // +kubebuilder:validation:Enum=Equals;NotEquals;AnyIn;AllIn;AnyNotIn;AllNotIn;GreaterThanOrEquals;GreaterThan;LessThanOrEquals;LessThan;DurationGreaterThanOrEquals;DurationGreaterThan;DurationLessThanOrEquals;DurationLessThan
 type ConditionOperator string

--- a/api/kyverno/v2beta1/spec_types.go
+++ b/api/kyverno/v2beta1/spec_types.go
@@ -135,6 +135,21 @@ func (s *Spec) HasValidate() bool {
 	return false
 }
 
+// HasValidateEnforce checks if the policy has any validate rules with enforce action
+func (s *Spec) HasValidateEnforce() bool {
+	for _, rule := range s.Rules {
+		if rule.HasValidate() && rule.Validation.HasEnforce() {
+			return true
+		}
+	}
+	for _, override := range s.ValidationFailureActionOverrides {
+		if override.Action.Enforce() {
+			return true
+		}
+	}
+	return s.ValidationFailureAction.Enforce()
+}
+
 // HasGenerate checks for generate rule types
 func (s *Spec) HasGenerate() bool {
 	for _, rule := range s.Rules {
@@ -195,32 +210,6 @@ func (s *Spec) BackgroundProcessingEnabled() bool {
 	}
 
 	return *s.Background
-}
-
-// GetValidationFailureAction returns the value of the validationFailureAction
-func (s *Spec) GetValidationFailureAction() kyvernov1.ValidationFailureAction {
-	for _, rule := range s.Rules {
-		if rule.HasValidate() {
-			validationFailureAction := rule.Validation.ValidationFailureAction
-			if validationFailureAction != nil {
-				return *validationFailureAction
-			}
-		}
-	}
-	return s.ValidationFailureAction
-}
-
-// GetValidationFailureActionOverrides returns the value of the validationFailureActionOverrides
-func (s *Spec) GetValidationFailureActionOverrides() []kyvernov1.ValidationFailureActionOverride {
-	for _, rule := range s.Rules {
-		if rule.HasValidate() {
-			validationFailureActionOverrides := rule.Validation.ValidationFailureActionOverrides
-			if len(validationFailureActionOverrides) != 0 {
-				return validationFailureActionOverrides
-			}
-		}
-	}
-	return s.ValidationFailureActionOverrides
 }
 
 // GetMutateExistingOnPolicyUpdate return MutateExistingOnPolicyUpdate set value

--- a/cmd/cli/kubectl-kyverno/policy/load_test.go
+++ b/cmd/cli/kubectl-kyverno/policy/load_test.go
@@ -110,7 +110,7 @@ func TestLoadWithKubectlValidate(t *testing.T) {
 			assert.NotNil(t, policy)
 			spec := policy.GetSpec()
 			assert.NotNil(t, spec)
-			assert.True(t, spec.GetValidationFailureAction().Audit())
+			assert.True(t, spec.ValidationFailureAction.Audit())
 			assert.NotNil(t, spec.Background)
 			assert.True(t, *spec.Background)
 			assert.NotNil(t, spec.Admission)

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -172,7 +172,7 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 		if err != nil {
 			return responses, err
 		}
-		validateResponse := eng.Validate(context.TODO(), policyContext)
+		validateResponse := eng.Validate(context.TODO(), policyContext, policy.GetSpec().HasValidateEnforce())
 		responses = append(responses, validateResponse)
 		resource = validateResponse.PatchedResource
 	}

--- a/pkg/controllers/metrics/policy/metrics.go
+++ b/pkg/controllers/metrics/policy/metrics.go
@@ -27,7 +27,7 @@ func (pc *controller) registerPolicyChangesMetricUpdatePolicy(ctx context.Contex
 		logger.Error(err, "error occurred while registering kyverno_policy_changes_total metrics for the above policy's updation", "name", oldP.GetName())
 	}
 	// curP will require a new kyverno_policy_changes_total metric if the above update involved change in the following fields:
-	if curSpec.BackgroundProcessingEnabled() != oldSpec.BackgroundProcessingEnabled() || curSpec.GetValidationFailureAction().Enforce() != oldSpec.GetValidationFailureAction().Enforce() {
+	if curSpec.BackgroundProcessingEnabled() != oldSpec.BackgroundProcessingEnabled() || curSpec.ValidationFailureAction.Enforce() != oldSpec.ValidationFailureAction.Enforce() {
 		err = policyChangesMetric.RegisterPolicy(ctx, pc.metricsConfig, curP, policyChangesMetric.PolicyUpdated)
 		if err != nil {
 			logger.Error(err, "error occurred while registering kyverno_policy_changes_total metrics for the above policy's updation", "name", curP.GetName())

--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -116,7 +116,7 @@ func (s *scanner) validateResource(ctx context.Context, resource unstructured.Un
 		WithNewResource(resource).
 		WithPolicy(policy).
 		WithNamespaceLabels(nsLabels)
-	response := s.engine.Validate(ctx, policyCtx)
+	response := s.engine.Validate(ctx, policyCtx, policy.GetSpec().HasValidateEnforce())
 	if len(response.PolicyResponse.Rules) > 0 {
 		s.logger.V(6).Info("validateResource", "policy", policy, "response", response)
 	}

--- a/pkg/engine/api/engine.go
+++ b/pkg/engine/api/engine.go
@@ -19,6 +19,7 @@ type Engine interface {
 	Validate(
 		ctx context.Context,
 		policyContext PolicyContext,
+		enforce bool,
 	) EngineResponse
 
 	// Mutate performs mutation. Overlay first and then mutation patches

--- a/pkg/engine/api/engineresponse.go
+++ b/pkg/engine/api/engineresponse.go
@@ -199,7 +199,36 @@ func (er EngineResponse) GetValidationFailureAction() kyvernov1.ValidationFailur
 		return ""
 	}
 	spec := pol.AsKyvernoPolicy().GetSpec()
-	for _, v := range spec.GetValidationFailureActionOverrides() {
+	for _, r := range spec.Rules {
+		for _, v := range r.Validation.ValidationFailureActionOverrides {
+			if !v.Action.IsValid() {
+				continue
+			}
+			if v.Namespaces == nil {
+				hasPass, err := utils.CheckSelector(v.NamespaceSelector, er.namespaceLabels)
+				if err == nil && hasPass {
+					return v.Action
+				}
+			}
+			for _, ns := range v.Namespaces {
+				if wildcard.Match(ns, er.PatchedResource.GetNamespace()) {
+					if v.NamespaceSelector == nil {
+						return v.Action
+					}
+					hasPass, err := utils.CheckSelector(v.NamespaceSelector, er.namespaceLabels)
+					if err == nil && hasPass {
+						return v.Action
+					}
+				}
+			}
+		}
+
+		if r.Validation.ValidationFailureAction != nil {
+			return *r.Validation.ValidationFailureAction
+		}
+	}
+
+	for _, v := range spec.ValidationFailureActionOverrides {
 		if !v.Action.IsValid() {
 			continue
 		}
@@ -221,5 +250,6 @@ func (er EngineResponse) GetValidationFailureAction() kyvernov1.ValidationFailur
 			}
 		}
 	}
-	return spec.GetValidationFailureAction()
+	fmt.Println("spec.ValidationFailureAction:", spec.ValidationFailureAction)
+	return spec.ValidationFailureAction
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -84,12 +84,13 @@ func NewEngine(
 func (e *engine) Validate(
 	ctx context.Context,
 	policyContext engineapi.PolicyContext,
+	enforce bool,
 ) engineapi.EngineResponse {
 	startTime := time.Now()
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext)
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.validate"), policyContext)
 	if internal.MatchPolicyContext(logger, e.client, policyContext, e.configuration) {
-		policyResponse := e.validate(ctx, logger, policyContext)
+		policyResponse := e.validate(ctx, logger, policyContext, enforce)
 		response = response.WithPolicyResponse(policyResponse)
 	}
 	response = response.WithStats(engineapi.NewExecutionStats(startTime, time.Now()))

--- a/pkg/engine/fuzz_test.go
+++ b/pkg/engine/fuzz_test.go
@@ -162,6 +162,7 @@ func FuzzEngineValidateTest(f *testing.F) {
 		validateEngine.Validate(
 			validateContext,
 			pc.WithPolicy(policy),
+			false,
 		)
 	})
 }
@@ -212,6 +213,7 @@ func FuzzPodBypass(f *testing.F) {
 		er := validateEngine.Validate(
 			validateContext,
 			pc.WithPolicy(testPolicy.ClusterPolicy),
+			false,
 		)
 		blocked := blockRequest([]engineapi.EngineResponse{er})
 		if blocked != shouldBlock {

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -17,6 +17,7 @@ func (e *engine) validate(
 	ctx context.Context,
 	logger logr.Logger,
 	policyContext engineapi.PolicyContext,
+	enforce bool,
 ) engineapi.PolicyResponse {
 	resp := engineapi.NewPolicyResponse()
 	policy := policyContext.Policy()
@@ -26,55 +27,84 @@ func (e *engine) validate(
 	policyContext.JSONContext().Checkpoint()
 	defer policyContext.JSONContext().Restore()
 
+	hasEnforce := func(actions []kyvernov1.ValidationFailureActionOverride) bool {
+		for _, action := range actions {
+			if enforce && action.Action.Enforce() {
+				return true
+			}
+		}
+		return false
+	}
 	gvk, _ := policyContext.ResourceKind()
 	for _, rule := range autogen.ComputeRules(policy, gvk.Kind) {
-		startTime := time.Now()
-		logger := internal.LoggerWithRule(logger, rule)
-		handlerFactory := func() (handlers.Handler, error) {
-			hasValidate := rule.HasValidate()
-			hasVerifyImageChecks := rule.HasVerifyImageChecks()
-			if !hasValidate && !hasVerifyImageChecks {
+		isEnforce := false
+		// check the validation failure action
+		validationFailureAction := rule.Validation.ValidationFailureAction
+		if validationFailureAction == nil {
+			validationFailureAction = &policy.GetSpec().ValidationFailureAction
+		}
+		if enforce && validationFailureAction.Enforce() {
+			isEnforce = true
+		}
+		// check the validation failure action overrides
+		if len(rule.Validation.ValidationFailureActionOverrides) != 0 {
+			if hasEnforce(rule.Validation.ValidationFailureActionOverrides) {
+				isEnforce = true
+			}
+		} else if len(policy.GetSpec().ValidationFailureActionOverrides) != 0 {
+			if hasEnforce(policy.GetSpec().ValidationFailureActionOverrides) {
+				isEnforce = true
+			}
+		}
+		if isEnforce == enforce {
+			startTime := time.Now()
+			logger := internal.LoggerWithRule(logger, rule)
+			handlerFactory := func() (handlers.Handler, error) {
+				hasValidate := rule.HasValidate()
+				hasVerifyImageChecks := rule.HasVerifyImageChecks()
+				if !hasValidate && !hasVerifyImageChecks {
+					return nil, nil
+				}
+				if hasValidate {
+					hasVerifyManifest := rule.HasVerifyManifests()
+					hasValidatePss := rule.HasValidatePodSecurity()
+					hasValidateCEL := rule.HasValidateCEL()
+					if hasVerifyManifest {
+						return validation.NewValidateManifestHandler(
+							policyContext,
+							e.client,
+						)
+					} else if hasValidatePss {
+						return validation.NewValidatePssHandler()
+					} else if hasValidateCEL {
+						return validation.NewValidateCELHandler(e.client)
+					} else {
+						return validation.NewValidateResourceHandler()
+					}
+				} else if hasVerifyImageChecks {
+					return validation.NewValidateImageHandler(
+						policyContext,
+						policyContext.NewResource(),
+						rule,
+						e.configuration,
+					)
+				}
 				return nil, nil
 			}
-			if hasValidate {
-				hasVerifyManifest := rule.HasVerifyManifests()
-				hasValidatePss := rule.HasValidatePodSecurity()
-				hasValidateCEL := rule.HasValidateCEL()
-				if hasVerifyManifest {
-					return validation.NewValidateManifestHandler(
-						policyContext,
-						e.client,
-					)
-				} else if hasValidatePss {
-					return validation.NewValidatePssHandler()
-				} else if hasValidateCEL {
-					return validation.NewValidateCELHandler(e.client)
-				} else {
-					return validation.NewValidateResourceHandler()
-				}
-			} else if hasVerifyImageChecks {
-				return validation.NewValidateImageHandler(
-					policyContext,
-					policyContext.NewResource(),
-					rule,
-					e.configuration,
-				)
+			resource, ruleResp := e.invokeRuleHandler(
+				ctx,
+				logger,
+				handlerFactory,
+				policyContext,
+				matchedResource,
+				rule,
+				engineapi.Validation,
+			)
+			matchedResource = resource
+			resp.Add(engineapi.NewExecutionStats(startTime, time.Now()), ruleResp...)
+			if applyRules == kyvernov1.ApplyOne && resp.RulesAppliedCount() > 0 {
+				break
 			}
-			return nil, nil
-		}
-		resource, ruleResp := e.invokeRuleHandler(
-			ctx,
-			logger,
-			handlerFactory,
-			policyContext,
-			matchedResource,
-			rule,
-			engineapi.Validation,
-		)
-		matchedResource = resource
-		resp.Add(engineapi.NewExecutionStats(startTime, time.Now()), ruleResp...)
-		if applyRules == kyvernov1.ApplyOne && resp.RulesAppliedCount() > 0 {
-			break
 		}
 	}
 	return resp

--- a/pkg/engine/validation_test.go
+++ b/pkg/engine/validation_test.go
@@ -45,6 +45,7 @@ func testValidate(
 	return e.Validate(
 		ctx,
 		pContext,
+		false,
 	)
 }
 

--- a/pkg/metrics/parsers.go
+++ b/pkg/metrics/parsers.go
@@ -77,6 +77,12 @@ func GetPolicyInfos(policy kyvernov1.PolicyInterface) (string, string, PolicyTyp
 		policyType = Namespaced
 	}
 	backgroundMode := ParsePolicyBackgroundMode(policy)
-	validationMode, err := ParsePolicyValidationMode(policy.GetSpec().GetValidationFailureAction())
-	return name, namespace, policyType, backgroundMode, validationMode, err
+	isEnforce := policy.GetSpec().HasValidateEnforce()
+	var validationMode PolicyValidationMode
+	if isEnforce {
+		validationMode = Enforce
+	} else {
+		validationMode = Audit
+	}
+	return name, namespace, policyType, backgroundMode, validationMode, nil
 }

--- a/pkg/policycache/store.go
+++ b/pkg/policycache/store.go
@@ -79,18 +79,6 @@ func newPolicyMap() *policyMap {
 	}
 }
 
-func computeEnforcePolicy(spec *kyvernov1.Spec) bool {
-	if spec.GetValidationFailureAction().Enforce() {
-		return true
-	}
-	for _, k := range spec.GetValidationFailureActionOverrides() {
-		if k.Action.Enforce() {
-			return true
-		}
-	}
-	return false
-}
-
 func set(set sets.Set[string], item string, value bool) sets.Set[string] {
 	if value {
 		return set.Insert(item)
@@ -101,7 +89,7 @@ func set(set sets.Set[string], item string, value bool) sets.Set[string] {
 
 func (m *policyMap) set(key string, policy kyvernov1.PolicyInterface, client ResourceFinder) error {
 	var errs []error
-	enforcePolicy := computeEnforcePolicy(policy.GetSpec())
+	enforcePolicy := policy.GetSpec().HasValidateEnforce()
 	m.policies[key] = policy
 	type state struct {
 		hasMutate, hasValidate, hasGenerate, hasVerifyImages, hasImagesValidationChecks bool

--- a/pkg/validatingadmissionpolicy/builder.go
+++ b/pkg/validatingadmissionpolicy/builder.go
@@ -77,12 +77,22 @@ func BuildValidatingAdmissionPolicyBinding(vapbinding *admissionregistrationv1al
 
 	// set validation action for vap binding
 	var validationActions []admissionregistrationv1alpha1.ValidationAction
-	action := cpol.GetSpec().GetValidationFailureAction()
-	if action.Enforce() {
-		validationActions = append(validationActions, admissionregistrationv1alpha1.Deny)
-	} else if action.Audit() {
-		validationActions = append(validationActions, admissionregistrationv1alpha1.Audit)
-		validationActions = append(validationActions, admissionregistrationv1alpha1.Warn)
+	validateAction := cpol.GetSpec().Rules[0].Validation.ValidationFailureAction
+	if validateAction != nil {
+		if validateAction.Enforce() {
+			validationActions = append(validationActions, admissionregistrationv1alpha1.Deny)
+		} else if validateAction.Audit() {
+			validationActions = append(validationActions, admissionregistrationv1alpha1.Audit)
+			validationActions = append(validationActions, admissionregistrationv1alpha1.Warn)
+		}
+	} else {
+		validateAction := cpol.GetSpec().ValidationFailureAction
+		if validateAction.Enforce() {
+			validationActions = append(validationActions, admissionregistrationv1alpha1.Deny)
+		} else if validateAction.Audit() {
+			validationActions = append(validationActions, admissionregistrationv1alpha1.Audit)
+			validationActions = append(validationActions, admissionregistrationv1alpha1.Warn)
+		}
 	}
 
 	// set validating admission policy binding spec

--- a/pkg/validatingadmissionpolicy/kyvernopolicy_checker.go
+++ b/pkg/validatingadmissionpolicy/kyvernopolicy_checker.go
@@ -19,14 +19,11 @@ func CanGenerateVAP(spec *kyvernov1.Spec) (bool, string) {
 		return false, msg
 	}
 
-	validationFailureActionOverrides := spec.GetValidationFailureActionOverrides()
-	if len(validationFailureActionOverrides) > 1 {
-		msg = "skip generating ValidatingAdmissionPolicy: multiple validationFailureActionOverrides are not applicable."
+	if ok, msg := checkValidationFailureActionOverrides(spec.ValidationFailureActionOverrides); !ok {
 		return false, msg
 	}
 
-	if len(validationFailureActionOverrides) != 0 && len(validationFailureActionOverrides[0].Namespaces) != 0 {
-		msg = "skip generating ValidatingAdmissionPolicy: Namespaces in validationFailureActionOverrides is not applicable."
+	if ok, msg := checkValidationFailureActionOverrides(rule.Validation.ValidationFailureActionOverrides); !ok {
 		return false, msg
 	}
 
@@ -118,6 +115,20 @@ func checkUserInfo(info kyvernov1.UserInfo) (bool, string) {
 	var msg string
 	if !info.IsEmpty() {
 		msg = "skip generating ValidatingAdmissionPolicy: Roles / ClusterRoles / Subjects in `any/all` is not applicable."
+		return false, msg
+	}
+	return true, msg
+}
+
+func checkValidationFailureActionOverrides(validationFailureActionOverrides []kyvernov1.ValidationFailureActionOverride) (bool, string) {
+	var msg string
+	if len(validationFailureActionOverrides) > 1 {
+		msg = "skip generating ValidatingAdmissionPolicy: multiple validationFailureActionOverrides are not applicable."
+		return false, msg
+	}
+
+	if len(validationFailureActionOverrides) != 0 && len(validationFailureActionOverrides[0].Namespaces) != 0 {
+		msg = "skip generating ValidatingAdmissionPolicy: Namespaces in validationFailureActionOverrides is not applicable."
 		return false, msg
 	}
 	return true, msg

--- a/pkg/webhooks/resource/validation/validation.go
+++ b/pkg/webhooks/resource/validation/validation.go
@@ -109,7 +109,7 @@ func (v *validationHandler) HandleValidationEnforce(
 					failurePolicy = kyvernov1.Fail
 				}
 
-				engineResponse := v.engine.Validate(ctx, policyContext)
+				engineResponse := v.engine.Validate(ctx, policyContext, true)
 				if engineResponse.IsNil() {
 					// we get an empty response if old and new resources created the same response
 					// allow updates if resource update doesn't change the policy evaluation
@@ -118,7 +118,7 @@ func (v *validationHandler) HandleValidationEnforce(
 
 				engineResponses = append(engineResponses, engineResponse)
 				if !engineResponse.IsSuccessful() {
-					logger.V(2).Info("validation failed", "action", policy.GetSpec().GetValidationFailureAction(), "policy", policy.GetName(), "failed rules", engineResponse.GetFailedRules())
+					logger.V(2).Info("validation failed", "action", "Enforce", "policy", policy.GetName(), "failed rules", engineResponse.GetFailedRules())
 					return
 				}
 
@@ -201,7 +201,7 @@ func (v *validationHandler) buildAuditResponses(
 			fmt.Sprintf("POLICY %s/%s", policy.GetNamespace(), policy.GetName()),
 			func(ctx context.Context, span trace.Span) {
 				policyContext := policyContext.WithPolicy(policy)
-				response := v.engine.Validate(ctx, policyContext)
+				response := v.engine.Validate(ctx, policyContext, false)
 				responses = append(responses, response)
 			},
 		)

--- a/pkg/webhooks/resource/validation_test.go
+++ b/pkg/webhooks/resource/validation_test.go
@@ -2108,6 +2108,7 @@ func TestValidate_failure_action_overrides(t *testing.T) {
 			er := eng.Validate(
 				context.TODO(),
 				ctx,
+				policy.GetSpec().HasValidateEnforce(),
 			)
 			if tc.blocked && tc.messages != nil {
 				for _, r := range er.PolicyResponse.Rules {
@@ -2192,6 +2193,7 @@ func Test_RuleSelector(t *testing.T) {
 	resp := eng.Validate(
 		context.TODO(),
 		ctx,
+		policy.GetSpec().HasValidateEnforce(),
 	)
 	assert.Assert(t, resp.PolicyResponse.RulesAppliedCount() == 2)
 	assert.Assert(t, resp.PolicyResponse.RulesErrorCount() == 0)
@@ -2205,6 +2207,7 @@ func Test_RuleSelector(t *testing.T) {
 	resp = eng.Validate(
 		context.TODO(),
 		ctx,
+		policy.GetSpec().HasValidateEnforce(),
 	)
 	assert.Assert(t, resp.PolicyResponse.RulesAppliedCount() == 1)
 	assert.Assert(t, resp.PolicyResponse.RulesErrorCount() == 0)


### PR DESCRIPTION
## Explanation
The fields `validationFailureAction` and `validationFailureActionOverrides` can now be set per rule which means we have to modify the policy cache as it filters policies based on those fields under the `spec` level. 
This PR updates the cache to filter out policies based on the validationFailureAction of the rule if exists.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.13.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
#### Example 1:
1. Create a policy that checks the namespace labels and has 2 rules, one of them is in the enforce mode while the other is in the audit mode:
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: check-ns-labels
spec:
  rules:
  - name: require-ns-purpose-label
    match:
      any:
      - resources:
          kinds:
          - Namespace
    validate:
      validationFailureAction: Enforce
      message: "You must have label `purpose` with value `production` set on all new namespaces."
      pattern:
        metadata:
          labels:
            purpose: production
  - name: require-ns-env-label
    match:
      any:
      - resources:
          kinds:
          - Namespace
    validate:
      validationFailureAction: Audit
      message: "You must have label `environment` with value `production` set on all new namespaces."
      pattern:
        metadata:
          labels:
            environment: production
```
2. Try to create a namespace without the `purpose` label which must exist:
```
apiVersion: v1
kind: Namespace
metadata:
  name: prod-bus-app1
  labels:
    environment: production
```

The namespace is blocked as expected:
```
Error from server: error when creating "../manifests/validate/resource.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 

resource Namespace//prod-bus-app1 was blocked due to the following policies 

check-ns-labels:
  require-ns-purpose-label: 'validation error: You must have label `purpose` with
    value `production` set on all new namespaces. rule require-ns-purpose-label failed
    at path /metadata/labels/purpose/'
```

3. Try to create a namespace with the `purpose` label but without the `environment` variable which isn't required:
```
apiVersion: v1
kind: Namespace
metadata:
  name: prod-bus-app1
  labels:
    purpose: production
```
The namespace is successfully created:
```
namespace/prod-bus-app1 created
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
