### PR TITLE
fix: Honour generateSuccessEvents config for generating success events (#9870)

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -714,7 +714,7 @@ jobs:
       - name: Create test image
         shell: bash
         run: |
-          DIGEST=$(crane digest cgr.dev/chainguard/static)   
+          DIGEST=$(crane digest cgr.dev/chainguard/static)
           IMAGE_NAME=$(uuidgen | tr "[:upper:]" "[:lower:]")
           TEST_IMAGE_URL=ttl.sh/${IMAGE_NAME}:1h
           crane copy cgr.dev/chainguard/static@$DIGEST $TEST_IMAGE_URL

--- a/pkg/webhooks/resource/handlers.go
+++ b/pkg/webhooks/resource/handlers.go
@@ -158,7 +158,7 @@ func (h *resourceHandlers) Validate(ctx context.Context, logger logr.Logger, req
 	wg.Wait()
 	if !ok {
 		logger.Info("admission request denied")
-		events := webhookutils.GenerateEvents(enforceResponses, true)
+		events := webhookutils.GenerateEvents(enforceResponses, true, h.configuration)
 		h.eventGen.Add(events...)
 		return admissionutils.Response(request.UID, errors.New(msg), warnings...)
 	}
@@ -168,12 +168,12 @@ func (h *resourceHandlers) Validate(ctx context.Context, logger logr.Logger, req
 
 		switch {
 		case len(auditResponses) == 0:
-			events = webhookutils.GenerateEvents(enforceResponses, false)
+			events = webhookutils.GenerateEvents(enforceResponses, false, h.configuration)
 		case len(enforceResponses) == 0:
-			events = webhookutils.GenerateEvents(auditResponses, false)
+			events = webhookutils.GenerateEvents(auditResponses, false, h.configuration)
 		default:
 			responses := mergeEngineResponses(auditResponses, enforceResponses)
-			events = webhookutils.GenerateEvents(responses, false)
+			events = webhookutils.GenerateEvents(responses, false, h.configuration)
 		}
 
 		h.eventGen.Add(events...)
@@ -201,7 +201,7 @@ func (h *resourceHandlers) Mutate(ctx context.Context, logger logr.Logger, reque
 		return admissionutils.Response(request.UID, err)
 	}
 	mh := mutation.NewMutationHandler(logger, h.engine, h.eventGen, h.nsLister, h.metricsConfig)
-	patches, warnings, err := mh.HandleMutation(ctx, request.AdmissionRequest, mutatePolicies, policyContext, startTime)
+	patches, warnings, err := mh.HandleMutation(ctx, request.AdmissionRequest, mutatePolicies, policyContext, startTime, h.configuration)
 	if err != nil {
 		logger.Error(err, "mutation failed")
 		return admissionutils.Response(request.UID, err)

--- a/pkg/webhooks/resource/imageverification/handler.go
+++ b/pkg/webhooks/resource/imageverification/handler.go
@@ -71,7 +71,7 @@ func (h *imageVerificationHandler) Handle(
 	policies []kyvernov1.PolicyInterface,
 	policyContext *engine.PolicyContext,
 ) ([]byte, []string, error) {
-	ok, message, imagePatches, warnings := h.handleVerifyImages(ctx, h.log, request, policyContext, policies)
+	ok, message, imagePatches, warnings := h.handleVerifyImages(ctx, h.log, request, policyContext, policies, h.cfg)
 	if !ok {
 		return nil, nil, errors.New(message)
 	}
@@ -85,6 +85,7 @@ func (h *imageVerificationHandler) handleVerifyImages(
 	request admissionv1.AdmissionRequest,
 	policyContext *engine.PolicyContext,
 	policies []kyvernov1.PolicyInterface,
+	cfg config.Configuration,
 ) (bool, string, []byte, []string) {
 	if len(policies) == 0 {
 		return true, "", nil, nil
@@ -121,7 +122,7 @@ func (h *imageVerificationHandler) handleVerifyImages(
 	}
 
 	blocked := webhookutils.BlockRequest(engineResponses, failurePolicy, logger)
-	events := webhookutils.GenerateEvents(engineResponses, blocked)
+	events := webhookutils.GenerateEvents(engineResponses, blocked, cfg)
 	h.eventGen.Add(events...)
 
 	if blocked {

--- a/pkg/webhooks/resource/mutation/mutation.go
+++ b/pkg/webhooks/resource/mutation/mutation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/engine"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/engine/mutate/patch"
@@ -26,7 +27,7 @@ type MutationHandler interface {
 	// HandleMutation handles validating webhook admission request
 	// If there are no errors in validating rule we apply generation rules
 	// patchedResource is the (resource + patches) after applying mutation rules
-	HandleMutation(context.Context, admissionv1.AdmissionRequest, []kyvernov1.PolicyInterface, *engine.PolicyContext, time.Time) ([]byte, []string, error)
+	HandleMutation(context.Context, admissionv1.AdmissionRequest, []kyvernov1.PolicyInterface, *engine.PolicyContext, time.Time, config.Configuration) ([]byte, []string, error)
 }
 
 func NewMutationHandler(
@@ -59,8 +60,9 @@ func (h *mutationHandler) HandleMutation(
 	policies []kyvernov1.PolicyInterface,
 	policyContext *engine.PolicyContext,
 	admissionRequestTimestamp time.Time,
+	cfg config.Configuration,
 ) ([]byte, []string, error) {
-	mutatePatches, mutateEngineResponses, err := h.applyMutations(ctx, request, policies, policyContext)
+	mutatePatches, mutateEngineResponses, err := h.applyMutations(ctx, request, policies, policyContext, cfg)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,6 +77,7 @@ func (v *mutationHandler) applyMutations(
 	request admissionv1.AdmissionRequest,
 	policies []kyvernov1.PolicyInterface,
 	policyContext *engine.PolicyContext,
+	cfg config.Configuration,
 ) ([]byte, []engineapi.EngineResponse, error) {
 	if len(policies) == 0 {
 		return nil, nil, nil
@@ -127,7 +130,7 @@ func (v *mutationHandler) applyMutations(
 		}
 	}
 
-	events := webhookutils.GenerateEvents(engineResponses, false)
+	events := webhookutils.GenerateEvents(engineResponses, false, cfg)
 	v.eventGen.Add(events...)
 
 	logMutationResponse(patches, engineResponses, v.log)

--- a/pkg/webhooks/utils/event.go
+++ b/pkg/webhooks/utils/event.go
@@ -1,12 +1,13 @@
 package utils
 
 import (
+	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/event"
 )
 
 // GenerateEvents generates event info for the engine responses
-func GenerateEvents(engineResponses []engineapi.EngineResponse, blocked bool) []event.Info {
+func GenerateEvents(engineResponses []engineapi.EngineResponse, blocked bool, cfg config.Configuration) []event.Info {
 	var events []event.Info
 	//   - Some/All policies fail or error
 	//     - report failure events on policy
@@ -37,8 +38,10 @@ func GenerateEvents(engineResponses []engineapi.EngineResponse, blocked bool) []
 				}
 			}
 		} else if !er.IsSkipped() {
-			e := event.NewPolicyAppliedEvent(event.AdmissionController, er)
-			events = append(events, e)
+			if cfg.GetGenerateSuccessEvents() {
+				e := event.NewPolicyAppliedEvent(event.AdmissionController, er)
+				events = append(events, e)
+			}
 		}
 	}
 	return events

--- a/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/README.md
+++ b/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/README.md
@@ -1,0 +1,16 @@
+## Description
+
+This test patches `kyverno` configmap in `kyverno` namespace with `generateSuccessEvents` set to `false`
+Then it creates a policy and a resource.
+The resource is expected to be accepted.
+A `PolicyApplied` event with message `ConfigMap default/foo: pass` from object `policy/require-labels` should not be created as `generateSuccessEvents` config is set to `false`
+
+
+## Steps
+
+1. Patch `kyverno` configmap in `kyverno` namespace with `generateSuccessEvents` set to `false`
+2. Create a policy
+3. Assert the policy becomes ready
+4. Create a resource
+5. Assert there is no `PolicyApplied` event with message `ConfigMap default/foo: pass` is created via script
+6. Exit the script with code `1` if it returns an error

--- a/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/chainsaw-test.yaml
@@ -1,0 +1,33 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: dont-emit-success-events-upon-generate-success-events-set-false
+spec:
+  steps:
+  - name: step-01
+    try:
+    - script:
+        content: kubectl patch configmap kyverno -p '{"data":{"generateSuccessEvents":"false"}}' -n kyverno
+    - assert:
+        file: kyverno-configmap-assert.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
+  - name: step-03
+    try:
+    - apply:
+        file: resource.yaml
+    - assert:
+        file: resource-assert.yaml
+  - name: step-04
+    try:
+    - script:
+        content: kubectl get event -n default
+        check:
+          # This check ensures that the string 'PolicyApplied' is not found
+          # in stdout or else fails
+          (contains($stdout, 'PolicyApplied')): false

--- a/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/kyverno-configmap-assert.yaml
+++ b/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/kyverno-configmap-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kyverno
+  namespace: kyverno
+data:
+  generateSuccessEvents: "false"

--- a/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/policy-assert.yaml
+++ b/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/policy-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: require-labels
+  namespace: default

--- a/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/policy.yaml
+++ b/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: require-labels
+  namespace: default
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+    - name: require-team
+      match:
+        any:
+          - resources:
+              kinds:
+                - ConfigMap
+      validate:
+        message: 'The label `team` is required.'
+        pattern:
+          metadata:
+            labels:
+              team: '?*'

--- a/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/resource-assert.yaml
+++ b/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/resource-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo
+  namespace: default

--- a/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/resource.yaml
+++ b/test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false/resource.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo
+  namespace: default
+  labels:
+    team: kyverno

--- a/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/README.md
+++ b/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/README.md
@@ -1,0 +1,16 @@
+## Description
+
+This test patches `kyverno` configmap in `kyverno` namespace with `generateSuccessEvents` set to `true`
+Then it creates a policy and a resource.
+The resource is expected to be accepted.
+A `PolicyApplied` event with message `ConfigMap default/foo: pass` from object `policy/require-labels` should be created as `generateSuccessEvents` config is set to `true`
+
+
+## Steps
+
+1. Patch `kyverno` configmap in `kyverno` namespace with `generateSuccessEvents` set to `true`
+2. Create a policy
+3. Assert the policy becomes ready
+4. Create a resource,
+5. Assert there is `PolicyApplied` event with message `ConfigMap default/foo: pass` is created via script
+6. Exit the script with code `1` if it returns an error

--- a/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/chainsaw-test.yaml
@@ -2,7 +2,7 @@ apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
   creationTimestamp: null
-  name: generate-events-upon-successful-mutation
+  name: emit-success-events-upon-generate-success-events-set-true
 spec:
   steps:
   - name: step-01
@@ -21,7 +21,13 @@ spec:
     try:
     - apply:
         file: resource.yaml
+    - assert:
+        file: resource-assert.yaml
   - name: step-04
     try:
-    - assert:
-        file: event-assert.yaml
+    - script:
+        content: kubectl get event -n default
+        check:
+          # This check ensures that the string 'reason="PolicyApplied"' is not found
+          # in stdout or else fails
+          (contains($stdout, 'PolicyApplied')): true

--- a/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/kyverno-configmap-assert.yaml
+++ b/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/kyverno-configmap-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kyverno
+  namespace: kyverno
+data:
+  generateSuccessEvents: "true"

--- a/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/policy-assert.yaml
+++ b/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/policy-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: require-labels
+  namespace: default

--- a/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/policy.yaml
+++ b/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: require-labels
+  namespace: default
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+    - name: require-team
+      match:
+        any:
+          - resources:
+              kinds:
+                - ConfigMap
+      validate:
+        message: 'The label `team` is required.'
+        pattern:
+          metadata:
+            labels:
+              team: '?*'

--- a/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/resource-assert.yaml
+++ b/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/resource-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo
+  namespace: default

--- a/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/resource.yaml
+++ b/test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true/resource.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo
+  namespace: default
+  labels:
+    team: kyverno

--- a/test/conformance/chainsaw/e2e-matrix.json
+++ b/test/conformance/chainsaw/e2e-matrix.json
@@ -20,6 +20,9 @@
   "cli": [
     "^cli$/^apply$/^(apply-exception-with-ns-selector|apply-on-cluster-scoped-resources|warn-exit-code)\\[.*\\]$"
   ],
+  "configs": [
+    "^configs$/^(dont-emit-success-events-upon-generateSuccessEvents-set-false|emit-success-events-upon-generateSuccessEvents-set-true)\\[.*\\]$"
+  ],
   "custom-sigstore": [
     "^custom-sigstore$/^standard$/^(basic|basic-deprecated)\\[.*\\]$"
   ],

--- a/test/conformance/chainsaw/events/clusterpolicy/generate-events-upon-successful-generation/README.md
+++ b/test/conformance/chainsaw/events/clusterpolicy/generate-events-upon-successful-generation/README.md
@@ -7,8 +7,9 @@ Two events are generated:
 
 ## Steps
 
-1.  - Create a generate policy
-    - Assert the policy becomes ready
-2.  Create the namespace.
-3.  - An event is created for the policy with message "resource generated"
-    - An event is created for the generated resource.
+1. Patch `kyverno` configmap in `kyverno` namespace with `generateSuccessEvents` set to `true`
+2. Create a generate policy
+   Assert the policy becomes ready
+3. Create the namespace.
+4. An event is created for the policy with message "resource generated"
+   An event is created for the generated resource.

--- a/test/conformance/chainsaw/events/clusterpolicy/generate-events-upon-successful-generation/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/events/clusterpolicy/generate-events-upon-successful-generation/chainsaw-test.yaml
@@ -7,11 +7,17 @@ spec:
   steps:
   - name: step-01
     try:
+    - script:
+        content: kubectl patch configmap kyverno -p '{"data":{"generateSuccessEvents":"true"}}' -n kyverno
+    - assert:
+        file: kyverno-configmap-assert.yaml
+  - name: step-02
+    try:
     - apply:
         file: policy.yaml
     - assert:
         file: policy-assert.yaml
-  - name: step-02
+  - name: step-03
     try:
     - apply:
         file: resource.yaml

--- a/test/conformance/chainsaw/events/clusterpolicy/generate-events-upon-successful-generation/kyverno-configmap-assert.yaml
+++ b/test/conformance/chainsaw/events/clusterpolicy/generate-events-upon-successful-generation/kyverno-configmap-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kyverno
+  namespace: kyverno
+data:
+  generateSuccessEvents: "true"

--- a/test/conformance/chainsaw/events/clusterpolicy/generate-events-upon-successful-mutation/README.md
+++ b/test/conformance/chainsaw/events/clusterpolicy/generate-events-upon-successful-mutation/README.md
@@ -5,7 +5,8 @@ An event is generated upon successful generation.
 
 ## Steps
 
-1.  - Create a mutate policy
-    - Assert the policy becomes ready
-2.  Create a configmap.
-3.  An event is created with a message indicating that the config map is successfully mutated.
+1. Patch `kyverno` configmap in `kyverno` namespace with `generateSuccessEvents` set to `true`
+2. Create a mutate policy
+   Assert the policy becomes ready
+3. Create a configmap.
+4. An event is created with a message indicating that the config map is successfully mutated.

--- a/test/conformance/chainsaw/events/clusterpolicy/generate-events-upon-successful-mutation/kyverno-configmap-assert.yaml
+++ b/test/conformance/chainsaw/events/clusterpolicy/generate-events-upon-successful-mutation/kyverno-configmap-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kyverno
+  namespace: kyverno
+data:
+  generateSuccessEvents: "true"

--- a/test/conformance/chainsaw/events/policy/policy-applied-deprecated/README.md
+++ b/test/conformance/chainsaw/events/policy/policy-applied-deprecated/README.md
@@ -5,7 +5,8 @@ A `PolicyApplied` event should be created.
 
 ## Steps
 
-1.  - Create a policy
-    - Assert the policy becomes ready
-1.  - Create a resource
-1.  - Asset a `PolicyApplied` event is created
+1. Patch `kyverno` configmap in `kyverno` namespace with `generateSuccessEvents` set to `true`
+2. Create a policy
+   Assert the policy becomes ready
+3. Create a resource
+4. Assert a `PolicyApplied` event is created

--- a/test/conformance/chainsaw/events/policy/policy-applied-deprecated/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/events/policy/policy-applied-deprecated/chainsaw-test.yaml
@@ -7,15 +7,21 @@ spec:
   steps:
   - name: step-01
     try:
+    - script:
+        content: kubectl patch configmap kyverno -p '{"data":{"generateSuccessEvents":"true"}}' -n kyverno
+    - assert:
+        file: kyverno-configmap-assert.yaml
+  - name: step-02
+    try:
     - apply:
         file: policy.yaml
     - assert:
         file: policy-assert.yaml
-  - name: step-02
+  - name: step-03
     try:
     - apply:
         file: resource.yaml
-  - name: step-03
+  - name: step-04
     try:
     - assert:
         file: event-assert.yaml

--- a/test/conformance/chainsaw/events/policy/policy-applied-deprecated/kyverno-configmap-assert.yaml
+++ b/test/conformance/chainsaw/events/policy/policy-applied-deprecated/kyverno-configmap-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kyverno
+  namespace: kyverno
+data:
+  generateSuccessEvents: "true"

--- a/test/conformance/chainsaw/events/policy/policy-applied/README.md
+++ b/test/conformance/chainsaw/events/policy/policy-applied/README.md
@@ -5,7 +5,8 @@ A `PolicyApplied` event should be created.
 
 ## Steps
 
-1.  - Create a policy
-    - Assert the policy becomes ready
-1.  - Create a resource
-1.  - Asset a `PolicyApplied` event is created
+1. Patch `kyverno` configmap in `kyverno` namespace with `generateSuccessEvents` set to `true` 
+2. Create a policy
+3. Assert the policy becomes ready
+4. Create a resource
+5. Assert a `PolicyApplied` event is created

--- a/test/conformance/chainsaw/events/policy/policy-applied/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/events/policy/policy-applied/chainsaw-test.yaml
@@ -7,15 +7,21 @@ spec:
   steps:
   - name: step-01
     try:
+    - script:
+        content: kubectl patch configmap kyverno -p '{"data":{"generateSuccessEvents":"true"}}' -n kyverno
+    - assert:
+        file: kyverno-configmap-assert.yaml
+  - name: step-02
+    try:
     - apply:
         file: policy.yaml
     - assert:
         file: policy-assert.yaml
-  - name: step-02
+  - name: step-03
     try:
     - apply:
         file: resource.yaml
-  - name: step-03
+  - name: step-04
     try:
     - assert:
         file: event-assert.yaml

--- a/test/conformance/chainsaw/events/policy/policy-applied/kyverno-configmap-assert.yaml
+++ b/test/conformance/chainsaw/events/policy/policy-applied/kyverno-configmap-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kyverno
+  namespace: kyverno
+data:
+  generateSuccessEvents: "true"

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/two-rules-with-different-action/README.md
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/two-rules-with-different-action/README.md
@@ -4,17 +4,19 @@ This test ensures that a policy with two rules with different modes is applied c
 
 ## Expected Behavior
 
-1. Create a policy that has two rules:
+1. Patch `kyverno` configmap in `kyverno` namespace with `generateSuccessEvents` set to `true`
+
+2. Create a policy that has two rules:
     - The first rule is `require-ns-purpose-label` in the `Enforce` mode that requires the `purpose` label to be set on namespaces.
     - The second rule is `require-ns-env-label` in the `Audit` mode that requires the `environment` field to be set on namespaces.
 
-2. Create a `good-ns-1` namespace that has the `purpose` label. It is expected that the namespace will be created successfully.
+3. Create a `good-ns-1` namespace that has the `purpose` label. It is expected that the namespace will be created successfully.
 
-3. Create a `good-ns-2` namespace that has both the `purpose` and `environment` labels. It is expected that the namespace will be created successfully.
+4. Create a `good-ns-2` namespace that has both the `purpose` and `environment` labels. It is expected that the namespace will be created successfully.
 
-4. Create a `bad-ns-1` namespace that doesn't have the `purpose` label. It is expected that the namespace will be blocked with a message reporting the violation of the `require-ns-purpose-label` rule.
+5. Create a `bad-ns-1` namespace that doesn't have the `purpose` label. It is expected that the namespace will be blocked with a message reporting the violation of the `require-ns-purpose-label` rule.
 
-5. Create a `bad-ns-2` namespace that doesn't have any labels. It is expected that the namespace will be blocked with messages reporting the violations of both rules.
+6. Create a `bad-ns-2` namespace that doesn't have any labels. It is expected that the namespace will be blocked with messages reporting the violations of both rules.
 
 ## Reference Issue(s)
 

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/two-rules-with-different-action/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/two-rules-with-different-action/chainsaw-test.yaml
@@ -7,22 +7,28 @@ spec:
   steps:
     - name: step-01
       try:
+      - script:
+          content: kubectl patch configmap kyverno -p '{"data":{"generateSuccessEvents":"true"}}' -n kyverno
+      - assert:
+          file: kyverno-configmap-assert.yaml
+    - name: step-02
+      try:
         - apply:
             file: policy.yaml
         - assert:
             file: policy-assert.yaml
-    - name: step-02
+    - name: step-03
       try:
       - apply:
           file: good-resources.yaml
-    - name: step-03
+    - name: step-04
       try:
         - apply:
             expect:
               - check:
                   ($error != null): true
             file: bad-resources.yaml
-    - name: step-04
+    - name: step-05
       try:
       - assert:
           file: events-assert.yaml

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/two-rules-with-different-action/kyverno-configmap-assert.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/two-rules-with-different-action/kyverno-configmap-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kyverno
+  namespace: kyverno
+data:
+  generateSuccessEvents: "true"

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/validate-pattern-should-pass-deprecated/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/validate-pattern-should-pass-deprecated/chainsaw-test.yaml
@@ -7,19 +7,25 @@ spec:
   steps:
     - name: step-01
       try:
+      - script:
+          content: kubectl patch configmap kyverno -p '{"data":{"generateSuccessEvents":"true"}}' -n kyverno
+      - assert:
+          file: kyverno-configmap-assert.yaml
+    - name: step-02
+      try:
         - apply:
             file: policy.yaml
         - assert:
             file: policy-assert.yaml
-    - name: step-02
+    - name: step-03
       try:
         - apply:
             file: resource.yaml
-    - name: step-03
+    - name: step-04
       try:
         - assert:
             file: event-assert.yaml
-    - name: step-04
+    - name: step-05
       try:
         - assert:
             file: report-pass-assert.yaml

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/validate-pattern-should-pass-deprecated/kyverno-configmap-assert.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/validate-pattern-should-pass-deprecated/kyverno-configmap-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kyverno
+  namespace: kyverno
+data:
+  generateSuccessEvents: "true"

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/validate-pattern-should-pass/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/validate-pattern-should-pass/chainsaw-test.yaml
@@ -7,19 +7,25 @@ spec:
   steps:
     - name: step-01
       try:
+      - script:
+          content: kubectl patch configmap kyverno -p '{"data":{"generateSuccessEvents":"true"}}' -n kyverno
+      - assert:
+          file: kyverno-configmap-assert.yaml
+    - name: step-02
+      try:
         - apply:
             file: policy.yaml
         - assert:
             file: policy-assert.yaml
-    - name: step-02
+    - name: step-03
       try:
         - apply:
             file: resource.yaml
-    - name: step-03
+    - name: step-04
       try:
         - assert:
             file: event-assert.yaml
-    - name: step-04
+    - name: step-05
       try:
         - assert:
             file: report-pass-assert.yaml

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/validate-pattern-should-pass/kyverno-configmap-assert.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/validate-pattern-should-pass/kyverno-configmap-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kyverno
+  namespace: kyverno
+data:
+  generateSuccessEvents: "true"


### PR DESCRIPTION
## Explanation

As of today despite the `generateSuccessEvents` flag is set to `false`, still we could see success events getting generated. This PR fixes this issue and honours the config `generateSuccessEvents` while generating success events.

## Related issue

Closes #9870


## Milestone of this PR

/milestone 1.13.0


## What type of PR is this

/kind bug


### Proof Manifests

1. Create following cluster-policy

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  background: false
  validationFailureAction: Enforce
  rules:
  - name: check-for-labels
    match:
      any:
      - resources:
          kinds:
          - ConfigMap
    validate:
      message: "The label `team` is required."
      pattern:
        metadata:
          labels:
            team: "?*"
```

2. Create this "good" ConfigMap

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: good
  labels:
    dog: blue
    myservice.net/service: foo
    team: red
data:
  food: cheese
  day: monday
  color: red
```

3. See that the following event will **NOT GET GENERATED** in the default Namespace as `generateSuccessEvents` config is set to `false` by default in the `kyverno` configmap

```
$ kubectl get event
LAST SEEN   TYPE     REASON          OBJECT                         MESSAGE
3s          Normal   PolicyApplied   clusterpolicy/require-labels   ConfigMap default/good: pass
```

4. Set the config `generateSuccessEvents` to `true` in the `kyverno` configmap, restart the kyverno controller, delete the `good` configmap and repeat steps 2 to 3, and observe that now the success event is generated.  


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

