### PR TITLE
feat: add more policy validation around policies using kyverno-json

### DIFF
--- a/test/conformance/chainsaw/policy-validation/cluster-policy/assert/README.md
+++ b/test/conformance/chainsaw/policy-validation/cluster-policy/assert/README.md
@@ -1,0 +1,9 @@
+## Description
+
+This test tries to create cluster policies that are potentially not valid and verifies the creation outcome.
+
+## Expected Behavior
+
+- `ok` policy should be accepted
+- `foreach` policy should be rejected
+- `bad-context-name` policy should be rejected

--- a/test/conformance/chainsaw/policy-validation/cluster-policy/assert/bad-context-name.yaml
+++ b/test/conformance/chainsaw/policy-validation/cluster-policy/assert/bad-context-name.yaml
@@ -1,0 +1,24 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bad-context-name
+spec:
+  rules:
+  - name: test
+    match:
+      all:
+      - resources:
+          kinds:
+            - Namespace
+    context:
+    - name: bad-name
+      variable:
+        value: dummy
+    validate:
+      validationFailureAction: Enforce
+      message: "namespace must have an env label"
+      assert:
+        object:
+          metadata:
+            labels:
+              env: {}

--- a/test/conformance/chainsaw/policy-validation/cluster-policy/assert/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/policy-validation/cluster-policy/assert/chainsaw-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: assert-validation
+spec:
+  steps:
+  - try:
+    - create:
+        file: ok.yaml
+  - try:
+    - create:
+        file: no-foreach.yaml
+        bindings:
+        - name: errPattern
+          value: |-
+            *path: spec.rules[0].validate..: only one of pattern, anyPattern, deny, foreach, cel can be specified
+        expect:
+        - check:
+            (wildcard($errPattern, $error)): true
+  - try:
+    - create:
+        file: bad-context-name.yaml
+        bindings:
+        - name: errPattern
+          value: |-
+            *path: spec.rules[0]: context entry name bad-name is invalid, it must be a single word when the validation rule uses `assert`
+        expect:
+        - check:
+            (wildcard($errPattern, $error)): true

--- a/test/conformance/chainsaw/policy-validation/cluster-policy/assert/no-foreach.yaml
+++ b/test/conformance/chainsaw/policy-validation/cluster-policy/assert/no-foreach.yaml
@@ -1,0 +1,23 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: foreach
+spec:
+  rules:
+  - name: test
+    match:
+      all:
+      - resources:
+          kinds:
+            - Namespace
+    validate:
+      validationFailureAction: Enforce
+      message: "namespace must have an env label"
+      foreach:
+      - list: "['dummy']"
+        deny: {}
+      assert:
+        object:
+          metadata:
+            labels:
+              env: {}

--- a/test/conformance/chainsaw/policy-validation/cluster-policy/assert/ok.yaml
+++ b/test/conformance/chainsaw/policy-validation/cluster-policy/assert/ok.yaml
@@ -1,0 +1,20 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: ok
+spec:
+  rules:
+  - name: test
+    match:
+      all:
+      - resources:
+          kinds:
+            - Namespace
+    validate:
+      validationFailureAction: Enforce
+      message: "namespace must have an env label"
+      assert:
+        object:
+          metadata:
+            labels:
+              env: {}

--- a/test/conformance/chainsaw/policy-validation/policy/assert/README.md
+++ b/test/conformance/chainsaw/policy-validation/policy/assert/README.md
@@ -1,0 +1,9 @@
+## Description
+
+This test tries to create policies that are potentially not valid and verifies the creation outcome.
+
+## Expected Behavior
+
+- `ok` policy should be accepted
+- `foreach` policy should be rejected
+- `bad-context-name` policy should be rejected

--- a/test/conformance/chainsaw/policy-validation/policy/assert/bad-context-name.yaml
+++ b/test/conformance/chainsaw/policy-validation/policy/assert/bad-context-name.yaml
@@ -1,0 +1,24 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: bad-context-name
+spec:
+  rules:
+  - name: test
+    match:
+      all:
+      - resources:
+          kinds:
+            - Pod
+    context:
+    - name: bad-name
+      variable:
+        value: dummy
+    validate:
+      validationFailureAction: Enforce
+      message: "pod must have an env label"
+      assert:
+        object:
+          metadata:
+            labels:
+              env: {}

--- a/test/conformance/chainsaw/policy-validation/policy/assert/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/policy-validation/policy/assert/chainsaw-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: assert-validation
+spec:
+  steps:
+  - try:
+    - create:
+        file: ok.yaml
+  - try:
+    - create:
+        file: no-foreach.yaml
+        bindings:
+        - name: errPattern
+          value: |-
+            *path: spec.rules[0].validate..: only one of pattern, anyPattern, deny, foreach, cel can be specified
+        expect:
+        - check:
+            (wildcard($errPattern, $error)): true
+  - try:
+    - create:
+        file: bad-context-name.yaml
+        bindings:
+        - name: errPattern
+          value: |-
+            *path: spec.rules[0]: context entry name bad-name is invalid, it must be a single word when the validation rule uses `assert`
+        expect:
+        - check:
+            (wildcard($errPattern, $error)): true

--- a/test/conformance/chainsaw/policy-validation/policy/assert/no-foreach.yaml
+++ b/test/conformance/chainsaw/policy-validation/policy/assert/no-foreach.yaml
@@ -1,0 +1,23 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: foreach
+spec:
+  rules:
+  - name: test
+    match:
+      all:
+      - resources:
+          kinds:
+            - Pod
+    validate:
+      validationFailureAction: Enforce
+      message: "pod must have an env label"
+      foreach:
+      - list: "['dummy']"
+        deny: {}
+      assert:
+        object:
+          metadata:
+            labels:
+              env: {}

--- a/test/conformance/chainsaw/policy-validation/policy/assert/ok.yaml
+++ b/test/conformance/chainsaw/policy-validation/policy/assert/ok.yaml
@@ -1,0 +1,20 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: ok
+spec:
+  rules:
+  - name: test
+    match:
+      all:
+      - resources:
+          kinds:
+            - Pod
+    validate:
+      validationFailureAction: Enforce
+      message: "pod must have an env label"
+      assert:
+        object:
+          metadata:
+            labels:
+              env: {}


### PR DESCRIPTION
## Explanation

Add more policy validation around policies using kyverno-json:
- make sure a rule with `assert` and `foreach` is rejected
- validate context entry names when `assert` is used to verify we will be able to create the corresponding binding
