### PR TITLE
fix: For multiple generate rules in single policy results in duplication of generated resources (#10587)

### DIFF
--- a/pkg/background/generate/generate.go
+++ b/pkg/background/generate/generate.go
@@ -282,7 +282,10 @@ func (c *GenerateController) applyGenerate(resource unstructured.Unstructured, u
 				}
 			}
 		} else {
-			applicableRules = append(applicableRules, r.Name())
+			ruleName := r.Name()
+			if ruleName == ur.Spec.Rule {
+				applicableRules = append(applicableRules, ruleName)
+			}
 		}
 	}
 

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/README.md
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/README.md
@@ -1,0 +1,12 @@
+## Description
+
+This test checks when there are multiple generate rules in a policy, a single downstream per rule is created.
+
+## Expected Behavior
+
+Expect a single downstream (generated) resource to be created for each generate rule.
+There should be a single configmap and single secret generated in the `default` namespace after the trigger ingress object is created.
+
+## Reference Issue(s)
+
+https://github.com/kyverno/kyverno/issues/10587

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/chainsaw-test.yaml
@@ -1,0 +1,37 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: cpol-multiple-generate-rules
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: cluster-role-binding.yaml
+    - apply:
+        file: cluster-role.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: policy.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-03
+    try:
+    - apply:
+        file: ingress.yaml
+    - assert:
+        file: ingress-ready.yaml
+  - name: step-03
+    try:
+    - sleep:
+        duration: 10s
+    - script:
+        content: if [ $(kubectl get secret -n default | grep "cpol-multiple-generate-rules-" | wc -l | tr -s ' ') -eq 1 ]; then exit; else (exit 1); fi
+  - name: step-04
+    try:
+    - sleep:
+        duration: 10s
+    - script:
+        content: if [ $(kubectl get configmap -n default | grep "cpol-multiple-generate-rules-" | wc -l | tr -s ' ') -eq 1 ]; then exit; else (exit 1); fi

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/cluster-role-binding.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cpol-multiple-generate-rules
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cpol-multiple-generate-rules
+subjects:
+- namespace: kyverno
+  kind: ServiceAccount
+  name: kyverno-background-controller

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/cluster-role.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/cluster-role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cpol-multiple-generate-rules
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - update
+  - delete

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/ingress-ready.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/ingress-ready.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cpol-multiple-generate-rules
+spec:
+  ingressClassName: test
+  rules:
+  - host: test.ingress.local
+    http:
+      paths:
+      - backend:
+          service:
+            name: test-service
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - test.ingress.local

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/ingress.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    example.com/patch-me: "1"
+  name: cpol-multiple-generate-rules
+spec:
+  ingressClassName: test
+  rules:
+  - host: test.ingress.local
+    http:
+      paths:
+      - backend:
+          service:
+            name: test-service
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - test.ingress.local

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/policy-ready.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/policy-ready.yaml
@@ -1,0 +1,8 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cpol-multiple-generate-rules
+spec:
+  admission: true
+  background: true
+  generateExisting: true

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-multiple-generate-rules/policy.yaml
@@ -1,0 +1,55 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cpol-multiple-generate-rules
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+    policies.kyverno.io/title: Automation for ingress
+    policies.kyverno.io/category: Automation
+    policies.kyverno.io/description: Policies to automate resource creation for ingress
+spec:
+  generateExisting: true
+  mutateExistingOnPolicyUpdate: true
+  rules:
+  # Generate a ConfigMap
+  - name: generate-configmap
+    match:
+      any:
+      - resources:
+          kinds:
+          - "Ingress"
+          selector:
+            matchLabels:
+              example.com/patch-me: "1"
+    generate:
+      orphanDownstreamOnPolicyDelete: true
+      synchronize: true
+      apiVersion: v1
+      kind: ConfigMap
+      name: "{{ request.object.metadata.name }}-{{ random('[0-9a-z]{5}') }}"
+      namespace: "default"
+      data:
+        data:
+          serviceName: "{{ request.object.spec.rules[0].http.paths[0].backend.service.name }}"
+          servicePort: "port-num-{{ request.object.spec.rules[0].http.paths[0].backend.service.port.number }}"
+  # Generate a Secret
+  - name: generate-secret
+    match:
+      any:
+      - resources:
+          kinds:
+          - "Ingress"
+          selector:
+            matchLabels:
+              example.com/patch-me: "1"
+    generate:
+      orphanDownstreamOnPolicyDelete: true
+      synchronize: true
+      apiVersion: v1
+      kind: Secret
+      name: "{{ request.object.metadata.name }}-{{ random('[0-9a-z]{5}') }}"
+      namespace: "default"
+      data:
+        stringData:
+          serviceName: "{{ request.object.spec.rules[0].http.paths[0].backend.service.name }}"
+          servicePort: "port-num-{{ request.object.spec.rules[0].http.paths[0].backend.service.port.number }}"


### PR DESCRIPTION
## Explanation

When a Kyverno ClusterPolicy that has multiple (two) generate rules was created followed by the creation of trigger resource, the expectation is a single downstream (generated) resource to be created for each generate rule but it was observed that duplicate(multiple) downstream resources were created per rule. 

This PR fixes this issue. After merging this MR as per expectation only a single downstream resource will be created per generate rule.


## Related issue
Closes #10587

## Milestone of this PR
/milestone 1.13.0

## What type of PR is this
/kind bug

### Proof Manifests

Step 1: Create a `ClusterRole`, `ClusterRoleBinding` and `ClusterPolicy` (with 2 generate rules)
```yaml
kubectl apply -f -<<EOF
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: kyverno-test
rules:
- apiGroups:
  - ""
  resources:
  - configmaps
  - secrets
  verbs:
  - create
  - update
  - delete
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: kyverno-test
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: kyverno-test
subjects:
- namespace: kyverno
  kind: ServiceAccount
  name: kyverno-background-controller
---
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: ingress-automation
  annotations:
    pod-policies.kyverno.io/autogen-controllers: none
    policies.kyverno.io/title: Automation for ingress
    policies.kyverno.io/category: Automation
    policies.kyverno.io/description: Policies to automate resource creation for ingress
spec:
  generateExisting: true
  mutateExistingOnPolicyUpdate: true
  rules:
  # Generate a ConfigMap
  - name: generate-configmap
    match:
      any:
      - resources:
          kinds:
          - "Ingress"
          selector:
            matchLabels:
              example.com/patch-me: "1"
    generate:
      orphanDownstreamOnPolicyDelete: true
      synchronize: true
      apiVersion: v1
      kind: ConfigMap
      name: "{{ request.object.metadata.name }}-{{ random('[0-9a-z]{5}') }}"
      namespace: "default"
      data:
        data:
          serviceName: "{{ request.object.spec.rules[0].http.paths[0].backend.service.name }}"
          servicePort: "port-num-{{ request.object.spec.rules[0].http.paths[0].backend.service.port.number }}"
  # Generate a Secret
  - name: generate-secret
    match:
      any:
      - resources:
          kinds:
          - "Ingress"
          selector:
            matchLabels:
              example.com/patch-me: "1"
    generate:
      orphanDownstreamOnPolicyDelete: true
      synchronize: true
      apiVersion: v1
      kind: Secret
      name: "{{ request.object.metadata.name }}-{{ random('[0-9a-z]{5}') }}"
      namespace: "default"
      data:
        stringData:
          serviceName: "{{ request.object.spec.rules[0].http.paths[0].backend.service.name }}"
          servicePort: "port-num-{{ request.object.spec.rules[0].http.paths[0].backend.service.port.number }}"
EOF
```

Step 2: Once the `ClusterPolicy` is Ready, deploy the trigger resource:
```yaml
kubectl apply -f -<<EOF
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    example.com/patch-me: "1"
  name: test
  namespace: default
spec:
  ingressClassName: test
  rules:
  - host: test.ingress.local
    http:
      paths:
      - backend:
          service:
            name: test-service
            port:
              number: 8080
        path: /
        pathType: Prefix
  tls:
  - hosts:
    - test.ingress.local
EOF
```

Step 3: Check and verify that there is only a single downstream resource (one `Configmap` and one `Secret`) is created in the default namespace per generate rule having name starting with prefix `test-` using following commands

```
kubectl get cm -n default | grep "test-"
kubectl get secret -n default | grep "test-"
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
