### PR TITLE
feat: add chainsaw tests for generate policies (part 2)

### DIFF
--- a/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/README.md
+++ b/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This test checks to ensure that a generate rule in a Policy (Namespaced) with a data declaration and NO synchronization, when a rule within the Policy having two rules is deleted does NOT cause any of the generated resources corresponding to that removed rule to be deleted.
+
+## Expected Behavior
+
+If both generated resources remain after deletion of the rule, the test passes. If either one is deleted, the test fails.
+
+## Reference Issue(s)
+
+N/A

--- a/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/both-resources-exist.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/both-resources-exist.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+data:
+  KAFKA_ADDRESS: 192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092
+  ZK_ADDRESS: 192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181
+kind: ConfigMap
+metadata:
+  labels:
+    somekey: somevalue
+  name: zk-kafka-address
+  namespace: otter
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: otter
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/chainsaw-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: pol-data-nosync-delete-rule
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: policy.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - sleep:
+        duration: 3s
+  - name: step-03
+    try:
+    - apply:
+        file: resource.yaml
+    - assert:
+        file: resource-generated.yaml
+  - name: step-04
+    try:
+    - apply:
+        file: policy-with-rule-removed.yaml
+    - assert:
+        file: both-resources-exist.yaml

--- a/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/policy-ready.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/policy-ready.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: pol-data-nosync-delete-rule-policy
+  namespace: otter
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/policy-with-rule-removed.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/policy-with-rule-removed.yaml
@@ -9,6 +9,7 @@ metadata:
   name: pol-data-nosync-delete-rule-policy
   namespace: otter
 spec:
+  generateExisting: false
   rules:
   - name: pol-data-nosync-delete-rule-policy-ruleone
     match:
@@ -17,7 +18,6 @@ spec:
           kinds:
           - Secret
     generate:
-      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: ConfigMap

--- a/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/policy.yaml
@@ -9,6 +9,7 @@ metadata:
   name: pol-data-nosync-delete-rule-policy
   namespace: otter
 spec:
+  generateExisting: false
   rules:
   - name: pol-data-nosync-delete-rule-policy-ruleone
     match:
@@ -17,7 +18,6 @@ spec:
           kinds:
           - Secret
     generate:
-      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: ConfigMap
@@ -31,3 +31,21 @@ spec:
         data:
           ZK_ADDRESS: "192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181"
           KAFKA_ADDRESS: "192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092"
+  - name: pol-data-nosync-delete-rule-policy-ruletwo
+    match:
+      any:
+      - resources:
+          kinds:
+          - Service
+    generate:
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      name: default-deny
+      namespace: otter
+      synchronize: false
+      data:
+        spec:
+          podSelector: {}
+          policyTypes:
+          - Ingress
+          - Egress

--- a/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/resource-generated.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/resource-generated.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+data:
+  KAFKA_ADDRESS: 192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092
+  ZK_ADDRESS: 192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181
+kind: ConfigMap
+metadata:
+  labels:
+    somekey: somevalue
+  name: zk-kafka-address
+  namespace: otter
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: otter
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/resource.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule-deprecated/resource.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+  foo: YmFy
+kind: Secret
+metadata:
+  name: test-secret
+  namespace: otter
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: engsvcclusip
+  name: engsvcclusip
+  namespace: otter
+spec:
+  ports:
+  - name: 80-80
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: engsvcclusip
+  sessionAffinity: None
+  type: ClusterIP

--- a/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-delete-rule/policy.yaml
@@ -9,7 +9,6 @@ metadata:
   name: pol-data-nosync-delete-rule-policy
   namespace: otter
 spec:
-  generateExisting: false
   rules:
   - name: pol-data-nosync-delete-rule-policy-ruleone
     match:
@@ -18,6 +17,7 @@ spec:
           kinds:
           - Secret
     generate:
+      generateExisting: false
       synchronize: false
       apiVersion: v1
       kind: ConfigMap
@@ -38,6 +38,7 @@ spec:
           kinds:
           - Service
     generate:
+      generateExisting: false
       apiVersion: networking.k8s.io/v1
       kind: NetworkPolicy
       name: default-deny

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/README.md
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This test checks to ensure that deletion of a rule in a Policy (Namespaced) generate rule, data declaration, with sync enabled, results in the downstream resource's deletion.
+
+## Expected Behavior
+
+The downstream (generated) resource is expected to be deleted if the corresponding rule within a Policy is deleted. If it is not deleted, the test fails. If it is deleted, the test passes.
+
+## Reference Issue(s)
+
+https://github.com/kyverno/kyverno/issues/5744

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-step-01-apply-1-1.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pol-data-sync-delete-rule

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-step-01-apply-1-2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-step-01-apply-1-2.yaml
@@ -4,9 +4,9 @@ metadata:
   name: multiple-gens
   namespace: pol-data-sync-delete-rule
 spec:
+  generateExisting: false
   rules:
   - generate:
-      generateExisting: false
       apiVersion: v1
       data:
         data:
@@ -29,7 +29,6 @@ spec:
           - trigger-secret
     name: k-kafka-address
   - generate:
-      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-step-01-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-step-01-assert-1-1.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: multiple-gens
+  namespace: pol-data-sync-delete-rule
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-step-02-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-step-02-apply-1-1.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  foo: YmFy
+kind: Secret
+metadata:
+  labels:
+    org: kyverno
+  name: trigger-secret
+  namespace: pol-data-sync-delete-rule
+type: Opaque

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-step-04-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-step-04-apply-1-1.yaml
@@ -4,9 +4,9 @@ metadata:
   name: multiple-gens
   namespace: pol-data-sync-delete-rule
 spec:
+  generateExisting: false
   rules:
   - generate:
-      generateExisting: false
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-step-04-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-step-04-assert-1-1.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: multiple-gens
+  namespace: pol-data-sync-delete-rule
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/chainsaw-test.yaml
@@ -1,0 +1,41 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: pol-data-sync-delete-rule
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: chainsaw-step-01-apply-1-1.yaml
+    - apply:
+        file: chainsaw-step-01-apply-1-2.yaml
+    - assert:
+        file: chainsaw-step-01-assert-1-1.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: chainsaw-step-02-apply-1-1.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: configmap.yaml
+    - assert:
+        file: configmap-remain.yaml
+  - name: step-04
+    try:
+    - apply:
+        file: chainsaw-step-04-apply-1-1.yaml
+    - assert:
+        file: chainsaw-step-04-assert-1-1.yaml
+  - name: step-05
+    try:
+    - sleep:
+        duration: 3s
+  - name: step-06
+    try:
+    - assert:
+        file: configmap-remain.yaml
+    - error:
+        file: configmap.yaml

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/configmap-remain.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/configmap-remain.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  key: superconfigmap
+kind: ConfigMap
+metadata:
+  labels:
+    somekey: somevalue
+  name: superconfigmap
+  namespace: pol-data-sync-delete-rule

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/configmap.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-delete-rule-deprecated/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  KAFKA_ADDRESS: 192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092
+  ZK_ADDRESS: 192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181
+kind: ConfigMap
+metadata:
+  labels:
+    somekey: somevalue
+  name: zk-kafka-address
+  namespace: pol-data-sync-delete-rule

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/README.md
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This is a generate test to ensure a generate Policy using a data declaration with sync enabled and modifying the policy/rule propagates those changes to a downstream ConfigMap.
+
+## Expected Behavior
+
+The downstream (generated) resource is expected to be synced from the corresponding rule within a Policy is modified. If it is not sync, the test fails. If it is synced, the test passes.
+
+## Reference Issue(s)
+
+N/A

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-01-apply-1-1.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pol-data-sync-modify-rule

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-01-apply-1-2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-01-apply-1-2.yaml
@@ -4,13 +4,13 @@ metadata:
   name: zk-kafka-address
   namespace: pol-data-sync-modify-rule
 spec:
+  generateExisting: true
   rules:
   - generate:
-      generateExisting: true
       apiVersion: v1
       data:
         data:
-          KAFKA_ADDRESS: 192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9999
+          KAFKA_ADDRESS: 192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092
           ZK_ADDRESS: 192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181
         kind: ConfigMap
         metadata:

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-01-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-01-assert-1-1.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v2beta1
+kind: Policy
+metadata:
+  name: zk-kafka-address
+  namespace: pol-data-sync-modify-rule
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-02-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-02-apply-1-1.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  foo: YmFy
+kind: Secret
+metadata:
+  labels:
+    org: kyverno
+  name: trigger-secret
+  namespace: pol-data-sync-modify-rule
+type: Opaque

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-03-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-03-apply-1-1.yaml
@@ -4,9 +4,9 @@ metadata:
   name: zk-kafka-address
   namespace: pol-data-sync-modify-rule
 spec:
+  generateExisting: true
   rules:
   - generate:
-      generateExisting: true
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-03-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-03-assert-1-1.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  KAFKA_ADDRESS: 192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9999
+  ZK_ADDRESS: 192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181
+kind: ConfigMap
+metadata:
+  labels:
+    somekey: somevalue
+  name: zk-kafka-address
+  namespace: pol-data-sync-modify-rule

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-04-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-step-04-assert-1-1.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  KAFKA_ADDRESS: 192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9999
+  ZK_ADDRESS: 192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181
+kind: ConfigMap
+metadata:
+  labels:
+    somekey: somevalue
+  name: zk-kafka-address
+  namespace: pol-data-sync-modify-rule

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/chainsaw-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: pol-data-sync-modify-rule
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: chainsaw-step-01-apply-1-1.yaml
+    - apply:
+        file: chainsaw-step-01-apply-1-2.yaml
+    - assert:
+        file: chainsaw-step-01-assert-1-1.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: chainsaw-step-02-apply-1-1.yaml
+  - name: step-03
+    try:
+    - apply:
+        file: chainsaw-step-03-apply-1-1.yaml
+    - assert:
+        file: chainsaw-step-03-assert-1-1.yaml
+  - name: step-04
+    try:
+    - assert:
+        file: chainsaw-step-04-assert-1-1.yaml

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/chainsaw-step-01-apply-1-2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/chainsaw-step-01-apply-1-2.yaml
@@ -4,9 +4,9 @@ metadata:
   name: zk-kafka-address
   namespace: pol-data-sync-modify-rule
 spec:
-  generateExisting: true
   rules:
   - generate:
+      generateExisting: true
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/README.md
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This test checks the generateExisting namespaced policy is applied when the trigger is found in the same namespace as the policy.
+
+## Expected Behavior
+
+If the resource secret is created, the test passes. If it is not, the test fails.
+
+## Reference Issue(s)
+
+https://github.com/kyverno/kyverno/issues/6519

--- a/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-1.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: match-trigger-namespace-ns

--- a/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-2.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  foo: YmFy
+kind: Secret
+metadata:
+  labels:
+    example.com/sm-sync: "true"
+  name: regcred
+  namespace: match-trigger-namespace-ns
+type: Opaque

--- a/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-3.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-3.yaml
@@ -1,19 +1,19 @@
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
-  name: non-match-trigger-namespace
-  namespace: non-match-trigger-namespace-ns
+  name: match-trigger-namespace
+  namespace: match-trigger-namespace-ns
 spec:
+  generateExisting: true
   rules:
   - generate:
-      generateExisting: true
       apiVersion: v1
       data:
         data:
           modify: Zm9v
       kind: ConfigMap
       name: '{{request.object.metadata.name}}-modify'
-      namespace: non-match-trigger-namespace-ns
+      namespace: match-trigger-namespace-ns
       synchronize: true
     match:
       resources:

--- a/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/chainsaw-step-01-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/chainsaw-step-01-assert-1-1.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: match-trigger-namespace
+  namespace: match-trigger-namespace-ns
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/chainsaw-step-03-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/chainsaw-step-03-assert-1-1.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  modify: Zm9v
+kind: ConfigMap
+metadata:
+  name: regcred-modify
+  namespace: match-trigger-namespace-ns

--- a/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace-deprecated/chainsaw-test.yaml
@@ -1,0 +1,25 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: match-trigger-namespace
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: chainsaw-step-01-apply-1-1.yaml
+    - apply:
+        file: chainsaw-step-01-apply-1-2.yaml
+    - apply:
+        file: chainsaw-step-01-apply-1-3.yaml
+    - assert:
+        file: chainsaw-step-01-assert-1-1.yaml
+  - name: step-02
+    try:
+    - sleep:
+        duration: 3s
+  - name: step-03
+    try:
+    - assert:
+        file: chainsaw-step-03-assert-1-1.yaml

--- a/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace/chainsaw-step-01-apply-1-3.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/match-trigger-namespace/chainsaw-step-01-apply-1-3.yaml
@@ -4,9 +4,9 @@ metadata:
   name: match-trigger-namespace
   namespace: match-trigger-namespace-ns
 spec:
-  generateExisting: true
   rules:
   - generate:
+      generateExisting: true
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/README.md
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This test checks the generateExisting namespaced policy is not applied when the trigger is not found in the same namespace as the policy.
+
+## Expected Behavior
+
+If the resource secret is not created, the test passes. If it is created, the test fails.
+
+## Reference Issue(s)
+
+https://github.com/kyverno/kyverno/issues/6519

--- a/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-1.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: non-match-trigger-namespace-ns

--- a/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-2.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: non-match-trigger-namespace-ns-2

--- a/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-3.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-3.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  foo: YmFy
+kind: Secret
+metadata:
+  labels:
+    example.com/sm-sync: "true"
+  name: regcred
+  namespace: non-match-trigger-namespace-ns-2
+type: Opaque

--- a/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-4.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-step-01-apply-1-4.yaml
@@ -4,9 +4,9 @@ metadata:
   name: non-match-trigger-namespace
   namespace: non-match-trigger-namespace-ns
 spec:
+  generateExisting: true
   rules:
   - generate:
-      generateExisting: true
       apiVersion: v1
       data:
         data:

--- a/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-step-01-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-step-01-assert-1-1.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: non-match-trigger-namespace
+  namespace: non-match-trigger-namespace-ns
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-step-03-error-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-step-03-error-1-1.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  modify: Zm9v
+kind: ConfigMap
+metadata:
+  name: regcred-modify
+  namespace: non-match-trigger-namespace-ns

--- a/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/existing/non-match-trigger-namespace-deprecated/chainsaw-test.yaml
@@ -1,0 +1,27 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: non-match-trigger-namespace
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: chainsaw-step-01-apply-1-1.yaml
+    - apply:
+        file: chainsaw-step-01-apply-1-2.yaml
+    - apply:
+        file: chainsaw-step-01-apply-1-3.yaml
+    - apply:
+        file: chainsaw-step-01-apply-1-4.yaml
+    - assert:
+        file: chainsaw-step-01-assert-1-1.yaml
+  - name: step-02
+    try:
+    - sleep:
+        duration: 3s
+  - name: step-03
+    try:
+    - error:
+        file: chainsaw-step-03-error-1-1.yaml


### PR DESCRIPTION
## Explanation
This PR adds chainsaw tests for generate policy that makes use of generateExisting under the rule itself.

Related to https://github.com/kyverno/kyverno/issues/5606, https://github.com/kyverno/kyverno/issues/7959