### PR TITLE
feat: add tests for different values of generateExisting

### DIFF
--- a/api/kyverno/v1/common_types.go
+++ b/api/kyverno/v1/common_types.go
@@ -781,10 +781,6 @@ type Generation struct {
 	CloneList CloneList `json:"cloneList,omitempty" yaml:"cloneList,omitempty"`
 }
 
-func (g *Generation) IsGenerateExisting() *bool {
-	return g.GenerateExisting
-}
-
 type CloneList struct {
 	// Namespace specifies source resource namespace.
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`

--- a/api/kyverno/v1/spec_types.go
+++ b/api/kyverno/v1/spec_types.go
@@ -254,18 +254,15 @@ func (s *Spec) GetMutateExistingOnPolicyUpdate() bool {
 	return s.MutateExistingOnPolicyUpdate
 }
 
-// IsGenerateExisting return GenerateExisting set value
+// IsGenerateExisting returns true if any of the generate rules has generateExisting set to true
 func (s *Spec) IsGenerateExisting() bool {
 	for _, rule := range s.Rules {
 		if rule.HasGenerate() {
-			isGenerateExisting := rule.Generation.IsGenerateExisting()
-			if isGenerateExisting != nil {
-				return *isGenerateExisting
+			isGenerateExisting := rule.Generation.GenerateExisting
+			if isGenerateExisting != nil && *isGenerateExisting {
+				return true
 			}
 		}
-	}
-	if s.GenerateExistingOnPolicyUpdate != nil && *s.GenerateExistingOnPolicyUpdate {
-		return true
 	}
 	return s.GenerateExisting
 }
@@ -340,15 +337,8 @@ func (s *Spec) validateDeprecatedFields(path *field.Path) (errs field.ErrorList)
 		errs = append(errs, field.Forbidden(path.Child("failurePolicy"), "remove the deprecated field and use spec.webhookConfiguration.failurePolicy instead"))
 	}
 
-	for _, rule := range s.Rules {
-		if rule.HasGenerate() && rule.Generation.IsGenerateExisting() != nil {
-			if s.GenerateExistingOnPolicyUpdate != nil {
-				errs = append(errs, field.Forbidden(path.Child("generateExistingOnPolicyUpdate"), "remove the deprecated field and use spec.generate[*].generateExisting instead"))
-			}
-			if s.GenerateExisting {
-				errs = append(errs, field.Forbidden(path.Child("generateExisting"), "remove the deprecated field and use spec.generate[*].generateExisting instead"))
-			}
-		}
+	if s.GenerateExistingOnPolicyUpdate != nil {
+		errs = append(errs, field.Forbidden(path.Child("generateExistingOnPolicyUpdate"), "remove the deprecated field and use spec.generate[*].generateExisting instead"))
 	}
 	return errs
 }

--- a/api/kyverno/v2beta1/spec_types.go
+++ b/api/kyverno/v2beta1/spec_types.go
@@ -223,18 +223,15 @@ func (s *Spec) GetMutateExistingOnPolicyUpdate() bool {
 	return s.MutateExistingOnPolicyUpdate
 }
 
-// IsGenerateExisting return GenerateExisting set value
+// IsGenerateExisting returns true if any of the generate rules has generateExisting set to true
 func (s *Spec) IsGenerateExisting() bool {
 	for _, rule := range s.Rules {
 		if rule.HasGenerate() {
-			isGenerateExisting := rule.Generation.IsGenerateExisting()
-			if isGenerateExisting != nil {
-				return *isGenerateExisting
+			isGenerateExisting := rule.Generation.GenerateExisting
+			if isGenerateExisting != nil && *isGenerateExisting {
+				return true
 			}
 		}
-	}
-	if s.GenerateExistingOnPolicyUpdate != nil && *s.GenerateExistingOnPolicyUpdate {
-		return true
 	}
 	return s.GenerateExisting
 }
@@ -300,15 +297,8 @@ func (s *Spec) ValidateDeprecatedFields(path *field.Path) (errs field.ErrorList)
 		errs = append(errs, field.Forbidden(path.Child("failurePolicy"), "remove the deprecated field and use spec.webhookConfiguration.failurePolicy instead"))
 	}
 
-	for _, rule := range s.Rules {
-		if rule.HasGenerate() && rule.Generation.IsGenerateExisting() != nil {
-			if s.GenerateExistingOnPolicyUpdate != nil {
-				errs = append(errs, field.Forbidden(path.Child("generateExistingOnPolicyUpdate"), "remove the deprecated field and use spec.generate[*].generateExisting instead"))
-			}
-			if s.GenerateExisting {
-				errs = append(errs, field.Forbidden(path.Child("generateExisting"), "remove the deprecated field and use spec.generate[*].generateExisting instead"))
-			}
-		}
+	if s.GenerateExistingOnPolicyUpdate != nil {
+		errs = append(errs, field.Forbidden(path.Child("generateExistingOnPolicyUpdate"), "remove the deprecated field and use spec.generate[*].generateExisting instead"))
 	}
 	return errs
 }

--- a/pkg/utils/fuzz/policy_spec.go
+++ b/pkg/utils/fuzz/policy_spec.go
@@ -96,12 +96,6 @@ func CreatePolicySpec(ff *fuzz.ConsumeFuzzer) (kyvernov1.Spec, error) {
 	}
 	spec.MutateExistingOnPolicyUpdate = mutateExistingOnPolicyUpdate
 
-	generateExistingOnPolicyUpdate, err := ff.GetBool()
-	if err != nil {
-		return *spec, err
-	}
-	spec.GenerateExistingOnPolicyUpdate = &generateExistingOnPolicyUpdate
-
 	generateExisting, err := ff.GetBool()
 	if err != nil {
 		return *spec, err

--- a/test/cli/test-generate/sync-multiple-resources/policy.yaml
+++ b/test/cli/test-generate/sync-multiple-resources/policy.yaml
@@ -10,7 +10,7 @@ metadata:
       Sync Secret and Configmap from kube-system namespace
 spec:
   failurePolicy: Ignore
-  generateExistingOnPolicyUpdate: true
+  generateExisting: true
   rules:
   - name: sync-controller-secret
     match:

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/README.md
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/README.md
@@ -1,0 +1,17 @@
+## Description
+
+This test ensures that a generate policy works as expected in case one rule sets the `generateExisting` field whereas the other don't set it. It is expected that rules which don't set the field will use the higher level value `spec.generateExisting`. 
+
+## Expected Behavior
+
+1. Create two Namespaces named `red-ns` and `green-ns`.
+
+2. Create a policy with two generate rules:
+    - The first rule named `generate-network-policy` matches Namespaces sets the `generateExisting` to `true`.
+    - The second rule named `generate-config-map` matches Namespaces and it doesn't set the field. It is expected that the rule will use the `spec.generateExisting` value which is `false`.
+
+3. It is expected that a NetworkPolicy will be generated for each Namespace whereas ConfigMaps will not be generated.
+
+## Reference Issue(s)
+
+N/A

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/chainsaw-test.yaml
@@ -1,0 +1,27 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: different-configurations-for-generate-existing
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: existing-resources.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: policy.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-03
+    try:
+    - sleep:
+        duration: 3s
+  - name: step-04
+    try:
+    - assert:
+        file: generated-resources.yaml
+    - error:
+        file: fail-generated-resources.yaml

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/existing-resources.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/existing-resources.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: red-ns
+  labels:
+    color: red
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: green-ns
+  labels:
+    color: green

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/fail-generated-resources.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/fail-generated-resources.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+data:
+  KAFKA_ADDRESS: 192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092
+  ZK_ADDRESS: 192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181
+kind: ConfigMap
+metadata:
+  labels:
+    somekey: somevalue
+  name: zk-kafka-address
+  namespace: red-ns
+---
+apiVersion: v1
+data:
+  KAFKA_ADDRESS: 192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092
+  ZK_ADDRESS: 192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181
+kind: ConfigMap
+metadata:
+  labels:
+    somekey: somevalue
+  name: zk-kafka-address
+  namespace: green-ns

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/generated-resources.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/generated-resources.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    created-by: kyverno
+  name: default-deny
+  namespace: red-ns
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    created-by: kyverno
+  name: default-deny
+  namespace: green-ns
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/policy-ready.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/policy-ready.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: different-generate-existing-values
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-configurations-for-generate-existing/policy.yaml
@@ -1,0 +1,49 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: different-generate-existing-values
+spec:
+  generateExisting: false
+  rules:
+  - name: generate-network-policy
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+    generate:
+      generateExisting: true
+      kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      name: default-deny
+      namespace: "{{request.object.metadata.name}}"
+      synchronize: true
+      data:
+        metadata:
+          labels:
+            created-by: kyverno
+        spec:
+          podSelector: {}
+          policyTypes:
+          - Ingress
+          - Egress
+  - name: generate-config-map
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+    generate:
+      synchronize: true
+      apiVersion: v1
+      kind: ConfigMap
+      name: zk-kafka-address
+      namespace: "{{request.object.metadata.name}}"
+      data:
+        kind: ConfigMap
+        metadata:
+          labels:
+            somekey: somevalue
+        data:
+          ZK_ADDRESS: "192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181"
+          KAFKA_ADDRESS: "192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092"

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/README.md
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/README.md
@@ -1,0 +1,17 @@
+## Description
+
+This test ensures that a generate policy works as expected in case the rules have a different value for the `generateExisting` field.
+
+## Expected Behavior
+
+1. Create two Namespaces named `red-ns` and `green-ns`.
+
+2. Create a policy with two generate rules:
+    - The first rule named `generate-network-policy` matches Namespaces sets the `generateExisting` to `true`.
+    - The second rule named `generate-config-map` matches Namespaces sets the `generateExisting` to `false`.
+
+3. It is expected that a NetworkPolicy will be generated for each Namespace whereas ConfigMaps will not be generated.
+
+## Reference Issue(s)
+
+N/A

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/chainsaw-test.yaml
@@ -1,0 +1,27 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: different-generate-existing-values
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: existing-resources.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: policy.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-03
+    try:
+    - sleep:
+        duration: 3s
+  - name: step-04
+    try:
+    - assert:
+        file: generated-resources.yaml
+    - error:
+        file: fail-generated-resources.yaml

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/existing-resources.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/existing-resources.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: red-ns
+  labels:
+    color: red
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: green-ns
+  labels:
+    color: green

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/fail-generated-resources.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/fail-generated-resources.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+data:
+  KAFKA_ADDRESS: 192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092
+  ZK_ADDRESS: 192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181
+kind: ConfigMap
+metadata:
+  labels:
+    somekey: somevalue
+  name: zk-kafka-address
+  namespace: red-ns
+---
+apiVersion: v1
+data:
+  KAFKA_ADDRESS: 192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092
+  ZK_ADDRESS: 192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181
+kind: ConfigMap
+metadata:
+  labels:
+    somekey: somevalue
+  name: zk-kafka-address
+  namespace: green-ns

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/generated-resources.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/generated-resources.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    created-by: kyverno
+  name: default-deny
+  namespace: red-ns
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    created-by: kyverno
+  name: default-deny
+  namespace: green-ns
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/policy-ready.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/policy-ready.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: different-generate-existing-values
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/existing/different-generate-existing-values/policy.yaml
@@ -1,0 +1,49 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: different-generate-existing-values
+spec:
+  rules:
+  - name: generate-network-policy
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+    generate:
+      generateExisting: true
+      kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      name: default-deny
+      namespace: "{{request.object.metadata.name}}"
+      synchronize: true
+      data:
+        metadata:
+          labels:
+            created-by: kyverno
+        spec:
+          podSelector: {}
+          policyTypes:
+          - Ingress
+          - Egress
+  - name: generate-config-map
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+    generate:
+      generateExisting: false
+      synchronize: true
+      apiVersion: v1
+      kind: ConfigMap
+      name: zk-kafka-address
+      namespace: "{{request.object.metadata.name}}"
+      data:
+        kind: ConfigMap
+        metadata:
+          labels:
+            somekey: somevalue
+        data:
+          ZK_ADDRESS: "192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181"
+          KAFKA_ADDRESS: "192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092"

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/target-namespace-scope/policy-fail-2-ns-cluster-target.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/target-namespace-scope/policy-fail-2-ns-cluster-target.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: target-namespace-scope-pass-1
 spec:
-  generateExistingOnPolicyUpdate: true
+  generateExisting: true
   rules:
     - generate:
         apiVersion: iam.aws.crossplane.io/v1beta1

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/target-namespace-scope/policy-pass-1-ns-namespaced-target.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/target-namespace-scope/policy-pass-1-ns-namespaced-target.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: user-per-namespace-pass-2
 spec:
-  generateExistingOnPolicyUpdate: true
+  generateExisting: true
   rules:
     - generate:
         apiVersion: rbac.authorization.k8s.io/v1

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/target-namespace-scope/policy-pass-2-no-ns-cluster-target.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/target-namespace-scope/policy-pass-2-no-ns-cluster-target.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: target-namespace-scope-pass-1
 spec:
-  generateExistingOnPolicyUpdate: true
+  generateExisting: true
   rules:
     - generate:
         apiVersion: iam.aws.crossplane.io/v1beta1

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/use-generate-existing-on-policy-update/README.md
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/use-generate-existing-on-policy-update/README.md
@@ -1,0 +1,7 @@
+## Description
+
+This test ensures that the creation of a generate policy that makes use of `spec.generateExistingOnPolicyUpdate` is blocked since it is a deprecated field.
+
+## Expected Behavior
+
+The test passes if the policy creation is blocked, otherwise fails.

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/use-generate-existing-on-policy-update/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/use-generate-existing-on-policy-update/chainsaw-test.yaml
@@ -1,0 +1,14 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: use-generate-existing-on-policy-update
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: policy.yaml

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/use-generate-existing-on-policy-update/policy.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/use-generate-existing-on-policy-update/policy.yaml
@@ -1,0 +1,31 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: generate-policy
+spec:
+  generateExistingOnPolicyUpdate: true
+  rules:
+  - name: generate-rule
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              color: blue
+    generate:
+      kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      name: default-deny
+      namespace: "{{request.object.metadata.name}}"
+      synchronize: true
+      data:
+        metadata:
+          labels:
+            created-by: kyverno
+        spec:
+          podSelector: {}
+          policyTypes:
+          - Ingress
+          - Egress

--- a/test/conformance/chainsaw/generate/validation/policy/target-namespace-scope/policy-fail-1.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/target-namespace-scope/policy-fail-1.yaml
@@ -5,7 +5,7 @@ metadata:
   name: pol-target-namespace-scope-fail-1
   namespace: default
 spec:
-  generateExistingOnPolicyUpdate: true
+  generateExisting: true
   rules:
     - generate:
         apiVersion: iam.aws.crossplane.io/v1beta1

--- a/test/conformance/chainsaw/generate/validation/policy/target-namespace-scope/policy-fail-2.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/target-namespace-scope/policy-fail-2.yaml
@@ -5,7 +5,7 @@ metadata:
   name: pol-target-namespace-scope-fail-2
   namespace: default
 spec:
-  generateExistingOnPolicyUpdate: true
+  generateExisting: true
   rules:
     - generate:
         apiVersion: rbac.authorization.k8s.io/v1

--- a/test/conformance/chainsaw/generate/validation/policy/target-namespace-scope/policy-fail-3.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/target-namespace-scope/policy-fail-3.yaml
@@ -5,7 +5,7 @@ metadata:
   name: pol-target-namespace-scope-fail-3
   namespace: default
 spec:
-  generateExistingOnPolicyUpdate: true
+  generateExisting: true
   rules:
     - generate:
         apiVersion: rbac.authorization.k8s.io/v1

--- a/test/conformance/chainsaw/generate/validation/policy/target-namespace-scope/policy-pass.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/target-namespace-scope/policy-pass.yaml
@@ -4,7 +4,7 @@ metadata:
   name: user-per-namespace-pass
   namespace: default
 spec:
-  generateExistingOnPolicyUpdate: true
+  generateExisting: true
   rules:
     - generate:
         apiVersion: rbac.authorization.k8s.io/v1

--- a/test/conformance/chainsaw/generate/validation/policy/use-generate-existing-on-policy-update/README.md
+++ b/test/conformance/chainsaw/generate/validation/policy/use-generate-existing-on-policy-update/README.md
@@ -1,0 +1,7 @@
+## Description
+
+This test ensures that the creation of a generate policy that makes use of `spec.generateExistingOnPolicyUpdate` is blocked since it is a deprecated field.
+
+## Expected Behavior
+
+The test passes if the policy creation is blocked, otherwise fails.

--- a/test/conformance/chainsaw/generate/validation/policy/use-generate-existing-on-policy-update/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/use-generate-existing-on-policy-update/chainsaw-test.yaml
@@ -1,0 +1,14 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: use-generate-existing-on-policy-update
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: policy.yaml

--- a/test/conformance/chainsaw/generate/validation/policy/use-generate-existing-on-policy-update/policy.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/use-generate-existing-on-policy-update/policy.yaml
@@ -1,0 +1,32 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: generate-policy
+  namespace: default
+spec:
+  generateExistingOnPolicyUpdate: true
+  rules:
+  - name: generate-rule
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              color: blue
+    generate:
+      kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      name: default-deny
+      namespace: "{{request.object.metadata.name}}"
+      synchronize: true
+      data:
+        metadata:
+          labels:
+            created-by: kyverno
+        spec:
+          podSelector: {}
+          policyTypes:
+          - Ingress
+          - Egress


### PR DESCRIPTION
## Explanation
This PR does the following: 
1. It adds chainsaw tests for a generate policy with different values of `generateExisting` field.

    - The 1st chainsaw test defines a policy with two rules, each sets the `generateExisting` field with a different value.
    
    - The 2nd chainsaw test defines a policy with two rules; one of which doesn't specify the field so it is expected to use the higher level field while the other sets the field.
2. Block the policy creation if `spec.generateExistingOnPolicyUpdate` is used as it has been deprecated since 1.10.

Related to https://github.com/kyverno/kyverno/issues/5606, https://github.com/kyverno/kyverno/issues/7959