### PR TITLE
fix: pass resource names to auth check for mutateExisting policies

### DIFF
--- a/pkg/policy/auth/auth.go
+++ b/pkg/policy/auth/auth.go
@@ -11,13 +11,13 @@ import (
 // Operations provides methods to performing operations on resource
 type Operations interface {
 	// CanICreate returns 'true' if self can 'create' resource
-	CanICreate(ctx context.Context, gvk, namespace, subresource string) (bool, error)
+	CanICreate(ctx context.Context, gvk, namespace, name, subresource string) (bool, error)
 	// CanIUpdate returns 'true' if self can 'update' resource
-	CanIUpdate(ctx context.Context, gvk, namespace, subresource string) (bool, error)
+	CanIUpdate(ctx context.Context, gvk, namespace, name, subresource string) (bool, error)
 	// CanIDelete returns 'true' if self can 'delete' resource
-	CanIDelete(ctx context.Context, gvk, namespace, subresource string) (bool, error)
+	CanIDelete(ctx context.Context, gvk, namespace, name, subresource string) (bool, error)
 	// CanIGet returns 'true' if self can 'get' resource
-	CanIGet(ctx context.Context, gvk, namespace, subresource string) (bool, error)
+	CanIGet(ctx context.Context, gvk, namespace, name, subresource string) (bool, error)
 }
 
 // Auth provides implementation to check if caller/self/kyverno has access to perofrm operations
@@ -38,8 +38,8 @@ func NewAuth(client dclient.Interface, user string, log logr.Logger) *Auth {
 }
 
 // CanICreate returns 'true' if self can 'create' resource
-func (a *Auth) CanICreate(ctx context.Context, gvk, namespace, subresource string) (bool, error) {
-	canI := auth.NewCanI(a.client.Discovery(), a.client.GetKubeClient().AuthorizationV1().SubjectAccessReviews(), gvk, namespace, "", "create", "", a.user)
+func (a *Auth) CanICreate(ctx context.Context, gvk, namespace, name, subresource string) (bool, error) {
+	canI := auth.NewCanI(a.client.Discovery(), a.client.GetKubeClient().AuthorizationV1().SubjectAccessReviews(), gvk, namespace, name, "create", "", a.user)
 	ok, _, err := canI.RunAccessCheck(ctx)
 	if err != nil {
 		return false, err
@@ -48,8 +48,8 @@ func (a *Auth) CanICreate(ctx context.Context, gvk, namespace, subresource strin
 }
 
 // CanIUpdate returns 'true' if self can 'update' resource
-func (a *Auth) CanIUpdate(ctx context.Context, gvk, namespace, subresource string) (bool, error) {
-	canI := auth.NewCanI(a.client.Discovery(), a.client.GetKubeClient().AuthorizationV1().SubjectAccessReviews(), gvk, namespace, "", "update", "", a.user)
+func (a *Auth) CanIUpdate(ctx context.Context, gvk, namespace, name, subresource string) (bool, error) {
+	canI := auth.NewCanI(a.client.Discovery(), a.client.GetKubeClient().AuthorizationV1().SubjectAccessReviews(), gvk, namespace, name, "update", "", a.user)
 	ok, _, err := canI.RunAccessCheck(ctx)
 	if err != nil {
 		return false, err
@@ -58,8 +58,8 @@ func (a *Auth) CanIUpdate(ctx context.Context, gvk, namespace, subresource strin
 }
 
 // CanIDelete returns 'true' if self can 'delete' resource
-func (a *Auth) CanIDelete(ctx context.Context, gvk, namespace, subresource string) (bool, error) {
-	canI := auth.NewCanI(a.client.Discovery(), a.client.GetKubeClient().AuthorizationV1().SubjectAccessReviews(), gvk, namespace, "", "delete", "", a.user)
+func (a *Auth) CanIDelete(ctx context.Context, gvk, namespace, name, subresource string) (bool, error) {
+	canI := auth.NewCanI(a.client.Discovery(), a.client.GetKubeClient().AuthorizationV1().SubjectAccessReviews(), gvk, namespace, name, "delete", "", a.user)
 	ok, _, err := canI.RunAccessCheck(ctx)
 	if err != nil {
 		return false, err
@@ -68,8 +68,8 @@ func (a *Auth) CanIDelete(ctx context.Context, gvk, namespace, subresource strin
 }
 
 // CanIGet returns 'true' if self can 'get' resource
-func (a *Auth) CanIGet(ctx context.Context, gvk, namespace, subresource string) (bool, error) {
-	canI := auth.NewCanI(a.client.Discovery(), a.client.GetKubeClient().AuthorizationV1().SubjectAccessReviews(), gvk, namespace, "", "get", "", a.user)
+func (a *Auth) CanIGet(ctx context.Context, gvk, namespace, name, subresource string) (bool, error) {
+	canI := auth.NewCanI(a.client.Discovery(), a.client.GetKubeClient().AuthorizationV1().SubjectAccessReviews(), gvk, namespace, name, "get", "", a.user)
 	ok, _, err := canI.RunAccessCheck(ctx)
 	if err != nil {
 		return false, err

--- a/pkg/policy/auth/fake/auth.go
+++ b/pkg/policy/auth/fake/auth.go
@@ -12,21 +12,21 @@ func NewFakeAuth() *FakeAuth {
 }
 
 // CanICreate returns 'true'
-func (a *FakeAuth) CanICreate(_ context.Context, kind, namespace, sub string) (bool, error) {
+func (a *FakeAuth) CanICreate(_ context.Context, kind, namespace, name, sub string) (bool, error) {
 	return true, nil
 }
 
 // CanIUpdate returns 'true'
-func (a *FakeAuth) CanIUpdate(_ context.Context, kind, namespace, sub string) (bool, error) {
+func (a *FakeAuth) CanIUpdate(_ context.Context, kind, namespace, name, sub string) (bool, error) {
 	return true, nil
 }
 
 // CanIDelete returns 'true'
-func (a *FakeAuth) CanIDelete(_ context.Context, kind, namespace, sub string) (bool, error) {
+func (a *FakeAuth) CanIDelete(_ context.Context, kind, namespace, name, sub string) (bool, error) {
 	return true, nil
 }
 
 // CanIGet returns 'true'
-func (a *FakeAuth) CanIGet(_ context.Context, kind, namespace, sub string) (bool, error) {
+func (a *FakeAuth) CanIGet(_ context.Context, kind, namespace, name, sub string) (bool, error) {
 	return true, nil
 }

--- a/pkg/policy/generate/validate.go
+++ b/pkg/policy/generate/validate.go
@@ -110,7 +110,7 @@ func (g *Generate) canIGenerate(ctx context.Context, gvk, namespace, subresource
 	// Skip if there is variable defined
 	authCheck := g.authCheck
 	if !regex.IsVariable(gvk) {
-		ok, err := authCheck.CanICreate(ctx, gvk, namespace, subresource)
+		ok, err := authCheck.CanICreate(ctx, gvk, namespace, "", subresource)
 		if err != nil {
 			return err
 		}
@@ -118,7 +118,7 @@ func (g *Generate) canIGenerate(ctx context.Context, gvk, namespace, subresource
 			return fmt.Errorf("%s does not have permissions to 'create' resource %s/%s/%s. Grant proper permissions to the background controller", g.user, gvk, subresource, namespace)
 		}
 
-		ok, err = authCheck.CanIUpdate(ctx, gvk, namespace, subresource)
+		ok, err = authCheck.CanIUpdate(ctx, gvk, namespace, "", subresource)
 		if err != nil {
 			return err
 		}
@@ -126,7 +126,7 @@ func (g *Generate) canIGenerate(ctx context.Context, gvk, namespace, subresource
 			return fmt.Errorf("%s does not have permissions to 'update' resource %s/%s/%s. Grant proper permissions to the background controller", g.user, gvk, subresource, namespace)
 		}
 
-		ok, err = authCheck.CanIGet(ctx, gvk, namespace, subresource)
+		ok, err = authCheck.CanIGet(ctx, gvk, namespace, "", subresource)
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ func (g *Generate) canIGenerate(ctx context.Context, gvk, namespace, subresource
 			return fmt.Errorf("%s does not have permissions to 'get' resource %s/%s/%s. Grant proper permissions to the background controller", g.user, gvk, subresource, namespace)
 		}
 
-		ok, err = authCheck.CanIDelete(ctx, gvk, namespace, subresource)
+		ok, err = authCheck.CanIDelete(ctx, gvk, namespace, "", subresource)
 		if err != nil {
 			return err
 		}

--- a/pkg/policy/mutate/validate.go
+++ b/pkg/policy/mutate/validate.go
@@ -101,13 +101,13 @@ func (m *Mutate) validateAuth(ctx context.Context, targets []kyvernov1.TargetRes
 				srcKey = srcKey + "/" + sub
 			}
 
-			if ok, err := m.authChecker.CanIUpdate(ctx, strings.Join([]string{target.APIVersion, k}, "/"), target.Namespace, sub); err != nil {
+			if ok, err := m.authChecker.CanIUpdate(ctx, strings.Join([]string{target.APIVersion, k}, "/"), target.Namespace, target.Name, sub); err != nil {
 				errs = append(errs, err)
 			} else if !ok {
 				errs = append(errs, fmt.Errorf("cannot %s/%s/%s in namespace %s", "update", target.APIVersion, srcKey, target.Namespace))
 			}
 
-			if ok, err := m.authChecker.CanIGet(ctx, strings.Join([]string{target.APIVersion, k}, "/"), target.Namespace, sub); err != nil {
+			if ok, err := m.authChecker.CanIGet(ctx, strings.Join([]string{target.APIVersion, k}, "/"), target.Namespace, target.Name, sub); err != nil {
 				errs = append(errs, err)
 			} else if !ok {
 				errs = append(errs, fmt.Errorf("cannot %s/%s/%s in namespace %s", "get", target.APIVersion, srcKey, target.Namespace))


### PR DESCRIPTION
## Explanation
This PR passes the target name to the auth check for mutateExisting policies.
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #9133 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.13.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. Create the following ClusterRole:
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  labels:
    app.kubernetes.io/component: background-controller
    app.kubernetes.io/instance: kyverno
    app.kubernetes.io/part-of: kyverno
  name: kyverno:generate-deployments
rules:
- apiGroups:
  - apps
  resources:
  - deployments
  resourceNames:
  - "monitor-grafana"
  verbs:
  - get
  - list
  - patch
  - update
  - watch
```
2. Create the following mutateExisting policy:
```
---
apiVersion: kyverno.io/v1
kind: Policy
metadata:
  name: policy-reload-on-secret-update
spec:
  mutateExistingOnPolicyUpdate: false
  rules:
  - name: update-secret
    match:
      any:
      - resources:
          kinds:
          - Secret
          names:
          - applicationsecret
    preconditions:
      all:
      - key: "{{ request.operation || 'BACKGROUND' }}"
        operator: Equals
        value: UPDATE
    mutate:
      targets:
        - apiVersion: apps/v1
          kind: Deployment
          name: monitor-grafana
      patchStrategicMerge:
        spec:
          template:
            metadata:
              annotations:
                example.com/triggerrestart: "{{ request.object.metadata.resourceVersion }}"
```
The policy is successfully created.
```
policy.kyverno.io/policy-reload-on-secret-update created
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
