### PR TITLE
feat: add tests checking policy creation

### DIFF
--- a/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/README.md
+++ b/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This test ensures that a policy is successfully created since it is given the necessary permissions to delete a secret named `test-secret`.
+
+## Expected Behavior
+
+The test passes if the policy is successfully created. Otherwise, it fails.
+
+## Reference Issue(s)
+
+https://github.com/kyverno/kyverno/issues/10221

--- a/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/chainsaw-test.yaml
@@ -1,0 +1,17 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: cleanup-policy-with-clusterrole
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: clusterrole.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml

--- a/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/clusterrole.yaml
+++ b/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/clusterrole.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: cleanup-controller
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/part-of: kyverno
+  name: kyverno:cleanup-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - test-secret
+  verbs:
+  - list
+  - delete

--- a/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/policy-assert.yaml
+++ b/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/policy-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kyverno.io/v2beta1
+kind: ClusterCleanupPolicy
+metadata:
+  name: test-secret-removal
+spec: {}

--- a/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/policy.yaml
+++ b/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: kyverno.io/v2beta1
+kind: ClusterCleanupPolicy
+metadata:
+  name: test-secret-removal
+spec:
+  match:
+    any:
+    - resources:
+        kinds:
+        - Secret
+        names:
+        - test-secret
+  schedule: "*/10 * * * *"

--- a/test/conformance/chainsaw/rbac/mutate-policy-with-clusterrole/README.md
+++ b/test/conformance/chainsaw/rbac/mutate-policy-with-clusterrole/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This test ensures that a policy is successfully created since it is given the necessary permissions to mutate a Deployment named `monitor-grafana`.
+
+## Expected Behavior
+
+The test passes if the policy is successfully created. Otherwise, it fails.
+
+## Reference Issue(s)
+
+https://github.com/kyverno/kyverno/issues/9133

--- a/test/conformance/chainsaw/rbac/mutate-policy-with-clusterrole/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/rbac/mutate-policy-with-clusterrole/chainsaw-test.yaml
@@ -1,0 +1,17 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: mutate-policy-with-clusterrole
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: clusterrole.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml

--- a/test/conformance/chainsaw/rbac/mutate-policy-with-clusterrole/clusterrole.yaml
+++ b/test/conformance/chainsaw/rbac/mutate-policy-with-clusterrole/clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: background-controller
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/part-of: kyverno
+  name: kyverno:mutate-deployments
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  resourceNames:
+  - "monitor-grafana"
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/test/conformance/chainsaw/rbac/mutate-policy-with-clusterrole/policy-assert.yaml
+++ b/test/conformance/chainsaw/rbac/mutate-policy-with-clusterrole/policy-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: policy-reload-on-secret-update
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/test/conformance/chainsaw/rbac/mutate-policy-with-clusterrole/policy.yaml
+++ b/test/conformance/chainsaw/rbac/mutate-policy-with-clusterrole/policy.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: policy-reload-on-secret-update
+spec:
+  rules:
+  - name: update-secret
+    match:
+      any:
+      - resources:
+          kinds:
+          - Secret
+          names:
+          - applicationsecret
+    preconditions:
+      all:
+      - key: "{{ request.operation || 'BACKGROUND' }}"
+        operator: Equals
+        value: UPDATE
+    mutate:
+      mutateExistingOnPolicyUpdate: false
+      targets:
+        - apiVersion: apps/v1
+          kind: Deployment
+          name: monitor-grafana
+      patchStrategicMerge:
+        spec:
+          template:
+            metadata:
+              annotations:
+                example.com/triggerrestart: "{{ request.object.metadata.resourceVersion }}"


### PR DESCRIPTION
## Explanation
This PR adds chainsaw tests to check the creation of mutate policy/cleanup policy after it is given the necessary permissions through clusterroles

Related to https://github.com/kyverno/kyverno/pull/10808, https://github.com/kyverno/kyverno/pull/10221