### PR TITLE
fix: check permissions for validate.cel subrules only

### DIFF
--- a/pkg/validation/policy/actions.go
+++ b/pkg/validation/policy/actions.go
@@ -55,7 +55,7 @@ func validateActions(idx int, rule *kyvernov1.Rule, client dclient.Interface, mo
 		}
 
 		// In case generateValidatingAdmissionPolicy flag is set to true, check the required permissions.
-		if toggle.FromContext(context.TODO()).GenerateValidatingAdmissionPolicy() {
+		if rule.HasValidateCEL() && toggle.FromContext(context.TODO()).GenerateValidatingAdmissionPolicy() {
 			authCheck := authChecker.NewSelfChecker(client.GetKubeClient().AuthorizationV1().SelfSubjectAccessReviews())
 			// check if the controller has the required permissions to generate validating admission policies.
 			if !validatingadmissionpolicy.HasValidatingAdmissionPolicyPermission(authCheck) {


### PR DESCRIPTION
## Explanation
This PR checks the required permissions to generate VAPs if Kyverno policy has `validate.cel` subrule. Previously, the permissions were checked in case the rule is of type Validation but we only need the permissions in case of `cel` subrule.