### PR TITLE
fix: concurrent map read and map write when applying a validate.podSecurity rule

### DIFF
--- a/pkg/pss/utils/mapping.go
+++ b/pkg/pss/utils/mapping.go
@@ -1,5 +1,7 @@
 package utils
 
+import "sync"
+
 var PSS_baseline_control_names = []string{
 	"HostProcess",
 	"Host Namespaces",
@@ -110,17 +112,21 @@ var PSS_control_name_to_ids = map[string][]string{
 	},
 }
 
-// reverse mapping of PSS_control_name_to_ids
-var pss_control_id_to_name = map[string]string{}
+var pssControlIDToNameOnce = sync.OnceValue(initPSSControlNameToIdsMapping)
 
-func PSSControlIDToName(id string) string {
-	if len(pss_control_id_to_name) == 0 {
-		for name, ids := range PSS_control_name_to_ids {
-			for _, id := range ids {
-				pss_control_id_to_name[id] = name
-			}
+// initialize reverse mapping of PSS_control_name_to_ids
+func initPSSControlNameToIdsMapping() map[string]string {
+	pss_control_id_to_name := make(map[string]string)
+	for name, ids := range PSS_control_name_to_ids {
+		for _, id := range ids {
+			pss_control_id_to_name[id] = name
 		}
 	}
+	return pss_control_id_to_name
+}
+
+func PSSControlIDToName(id string) string {
+	pss_control_id_to_name := pssControlIDToNameOnce()
 	return pss_control_id_to_name[id]
 }
 


### PR DESCRIPTION
## Explanation
Use sync.OnceValue for initialization to avoid concurrent read-write issues.

## Related issue
Closes #11005 

## Milestone of this PR
/milestone 1.13.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
