### PR TITLE
fix: avoid generating empty urs

### DIFF
--- a/pkg/webhooks/updaterequest/generator.go
+++ b/pkg/webhooks/updaterequest/generator.go
@@ -43,6 +43,9 @@ func NewGenerator(client versioned.Interface, urInformer kyvernov2informers.Upda
 
 // Apply creates update request resource
 func (g *generator) Apply(ctx context.Context, ur kyvernov2.UpdateRequestSpec) error {
+	if ur.Type == kyvernov2.Generate && len(ur.RuleContext) == 0 {
+		return nil
+	}
 	logger.V(4).Info("apply Update Request", "request", ur)
 	go g.applyResource(context.TODO(), ur)
 	return nil


### PR DESCRIPTION
An empty updaterequest is generated for a cloneList rule when the trigger and source are the same resource (Chainsaw test `test/conformance/chainsaw/generate/clusterpolicy/cornercases/clone-list-sync-same-trigger-source-delete-source`). This PR fixes the issue.
