### PR TITLE
fix: bump docker in release 1.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -189,7 +189,7 @@ require (
 	github.com/djherbis/times v1.6.0 // indirect
 	github.com/docker/cli v25.0.1+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/docker v26.1.4+incompatible // indirect
+	github.com/docker/docker v27.2.1+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,8 @@ github.com/docker/cli v25.0.1+incompatible h1:mFpqnrS6Hsm3v1k7Wa/BO23oz0k121MTbT
 github.com/docker/cli v25.0.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v26.1.4+incompatible h1:vuTpXDuoga+Z38m1OZHzl7NKisKWaWlhjQk7IDPSLsU=
-github.com/docker/docker v26.1.4+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.2.1+incompatible h1:fQdiLfW7VLscyoeYEBz7/J8soYFDZV1u6VW6gJEjNMI=
+github.com/docker/docker v27.2.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #11087 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
```bash
9:19:[vishal@nirmata kyverno]:bump-docker $ KO_DOCKER_REPO=ghcr.io/vishal-chdhry/kyverno ko build ./cmd/kyverno --bare --tags=release-1.12 --platform=all
2024/09/11 09:19:43 Using base cgr.dev/chainguard/static:latest@sha256:bde549df44d5158013856a778b34d8972cf52bb2038ec886475d857ec7c365ed for github.com/kyverno/kyverno/cmd/kyverno
2024/09/11 09:19:44 Using build config kyverno for github.com/kyverno/kyverno/cmd/kyverno
2024/09/11 09:19:44 Using build config kyverno for github.com/kyverno/kyverno/cmd/kyverno
2024/09/11 09:19:44 Building github.com/kyverno/kyverno/cmd/kyverno for linux/arm64
2024/09/11 09:19:44 Building github.com/kyverno/kyverno/cmd/kyverno for linux/amd64
2024/09/11 09:20:08 Publishing ghcr.io/vishal-chdhry/kyverno:release-1.12
2024/09/11 09:20:12 existing blob: sha256:1d3fb019ec1c649fcc9b962843b5e812375e3e6c8d3d180adc44a10c535c37ca
2024/09/11 09:20:12 existing blob: sha256:250c06f7c38e52dc77e5c7586c3e40280dc7ff9bb9007c396e06d96736cf8542
2024/09/11 09:20:12 existing blob: sha256:a99857011b7de1316db7f610fa000f78098b1e67f5ef6c21e560f17161fe7879
2024/09/11 09:20:14 pushed blob: sha256:cbac9d73aaf37e4a76d84b1456327fa663cdada4a61cb9fc5c0a4f1560618f9c
2024/09/11 09:20:15 pushed blob: sha256:cb0ea30998dadf139ab0a5b16c267d5d7b6707b0f0fd0c7c3149139610dccef7
2024/09/11 09:20:15 pushed blob: sha256:8ffdb0f5a6c92476655c9b69016e6ed1dc9aaa78069edb5f8833a39e9d0f97f5
2024/09/11 09:20:15 pushed blob: sha256:689a7dceee9496094fb8962b954e91477543ff6ef2137422d0f6a7f9dbb0db2b
2024/09/11 09:20:16 pushed blob: sha256:f98e8520b7d6717001ce49054fd7ec45287dcf97d0fd6be049d13da003573d1d
2024/09/11 09:20:16 pushed blob: sha256:3f1a3255b448b4be1d2fcdb47ddb736ae21d8d3f433b2c4e339a02ce16fa01e5
2024/09/11 09:20:16 pushed blob: sha256:43eee22cdd6b9ce5a77463b76846f8a89d999be227fc2e3cf1289c8c8f08ed04
2024/09/11 09:20:16 ghcr.io/vishal-chdhry/kyverno:sha256-e24bd9f42be1beb83009f68ccca70cbf085f361803fa9f820f45e4d8eb1df024.sbom: digest: sha256:f4d2a18bed492e5e46fbdaa13a1477773b4b838b0fd5d82a8b19c175666a98c4 size: 373
2024/09/11 09:20:16 Published SBOM ghcr.io/vishal-chdhry/kyverno:sha256-e24bd9f42be1beb83009f68ccca70cbf085f361803fa9f820f45e4d8eb1df024.sbom
2024/09/11 09:20:16 pushed blob: sha256:4a093a83cd4f89254a128cf9e880434313140ea23b7317bb1ba60a0e06e14033
2024/09/11 09:20:17 ghcr.io/vishal-chdhry/kyverno:sha256-9fdffedfa5692ff67df0b636ad157e43d6344d196fed1397250e6dd4a59f4dc2.sbom: digest: sha256:2437097897597c94f77b5b80e6e58f95eeb5145d1d7d27f8bc607366eed07cb0 size: 375
2024/09/11 09:20:17 Published SBOM ghcr.io/vishal-chdhry/kyverno:sha256-9fdffedfa5692ff67df0b636ad157e43d6344d196fed1397250e6dd4a59f4dc2.sbom
2024/09/11 09:20:17 ghcr.io/vishal-chdhry/kyverno:sha256-e5df4cf543b132451163b4d80d0e0ae1bcbcef728069e6046e7d9c8f6839caef.sbom: digest: sha256:ff50050f3382787a94fb96bdd88391acd735f5cb9a88510b63582a79fd7d24fe size: 375
2024/09/11 09:20:17 Published SBOM ghcr.io/vishal-chdhry/kyverno:sha256-e5df4cf543b132451163b4d80d0e0ae1bcbcef728069e6046e7d9c8f6839caef.sbom
2024/09/11 09:20:37 pushed blob: sha256:856978831785536257af919de55bc05aad69973533ec2b4f58466f408bfaefba
2024/09/11 09:20:38 ghcr.io/vishal-chdhry/kyverno@sha256:9fdffedfa5692ff67df0b636ad157e43d6344d196fed1397250e6dd4a59f4dc2: digest: sha256:9fdffedfa5692ff67df0b636ad157e43d6344d196fed1397250e6dd4a59f4dc2 size: 1246
2024/09/11 09:20:39 pushed blob: sha256:90a120d0671e637f4c91c9dde6dc2276b1e0e0b4d1ee7fab43e59cc3c4f6efbf
2024/09/11 09:20:39 ghcr.io/vishal-chdhry/kyverno@sha256:e5df4cf543b132451163b4d80d0e0ae1bcbcef728069e6046e7d9c8f6839caef: digest: sha256:e5df4cf543b132451163b4d80d0e0ae1bcbcef728069e6046e7d9c8f6839caef size: 1246
2024/09/11 09:20:40 ghcr.io/vishal-chdhry/kyverno:release-1.12: digest: sha256:e24bd9f42be1beb83009f68ccca70cbf085f361803fa9f820f45e4d8eb1df024 size: 1021
2024/09/11 09:20:40 Published ghcr.io/vishal-chdhry/kyverno:release-1.12@sha256:e24bd9f42be1beb83009f68ccca70cbf085f361803fa9f820f45e4d8eb1df024
ghcr.io/vishal-chdhry/kyverno:release-1.12@sha256:e24bd9f42be1beb83009f68ccca70cbf085f361803fa9f820f45e4d8eb1df024
9:20:[vishal@nirmata kyverno]:bump-docker $ trivy image ghcr.io/vishal-chdhry/kyverno:release-1.12@sha256:e24bd9f42be1beb83009f68ccca70cbf085f361803fa9f820f45e4d8eb1df024 --severity=HIGH,CRITICAL
2024-09-11T09:21:10.135+0530    INFO    Need to update DB
2024-09-11T09:21:10.135+0530    INFO    DB Repository: ghcr.io/aquasecurity/trivy-db:2
2024-09-11T09:21:10.135+0530    INFO    Downloading DB...
52.91 MiB / 52.91 MiB [----------------------------------------------------------------------------------------------------------------------------------] 100.00% 7.18 MiB p/s 7.6s
2024-09-11T09:21:25.928+0530    INFO    Vulnerability scanning is enabled
2024-09-11T09:21:25.929+0530    INFO    Secret scanning is enabled
2024-09-11T09:21:25.929+0530    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-09-11T09:21:25.929+0530    INFO    Please see also https://aquasecurity.github.io/trivy/v0.50/docs/scanner/secret/#recommendation for faster secret detection
2024-09-11T09:21:33.585+0530    WARN    Ignore the OS package as no OS is detected.
2024-09-11T09:21:33.585+0530    WARN    Ignore the OS package as no OS is detected.
2024-09-11T09:21:33.585+0530    WARN    Ignore the OS package as no OS is detected.
2024-09-11T09:21:42.228+0530    INFO    Detected OS: wolfi
2024-09-11T09:21:42.228+0530    INFO    Detecting Wolfi vulnerabilities...
2024-09-11T09:21:42.229+0530    INFO    Number of language-specific files: 1
2024-09-11T09:21:42.229+0530    INFO    Detecting gobinary vulnerabilities...

ghcr.io/vishal-chdhry/kyverno:release-1.12@sha256:e24bd9f42be1beb83009f68ccca70cbf085f361803fa9f820f45e4d8eb1df024 (wolfi 20230201)

Total: 0 (HIGH: 0, CRITICAL: 0)
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
