### PR TITLE
fix: Updated Go version to v1.23.1 to address CVE-2024-34156

### DIFF
--- a/.github/actions/setup-build-env/action.yaml
+++ b/.github/actions/setup-build-env/action.yaml
@@ -29,7 +29,7 @@ runs:
         git fetch --prune --unshallow
     - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: ~1.22.4
+        go-version: ~1.23.1
     - shell: bash
       run: |
         go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyverno/kyverno
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6


### PR DESCRIPTION
## Explanation

Addressing vulnerability `CVE-2024-34156` by upgrading Go version to `v1.23.1`

## Related issue
Closes #11105

## Milestone of this PR
milestone 1.12.5

## What type of PR is this
/kind bug

## Checklist

- [x ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

