### PR TITLE
fix(chart): correct behavior for global image registry

### DIFF
--- a/charts/kyverno/templates/_helpers/_image.tpl
+++ b/charts/kyverno/templates/_helpers/_image.tpl
@@ -5,7 +5,7 @@
 {{- if not (typeIs "string" $tag) -}}
   {{ fail "Image tags must be strings." }}
 {{- end -}}
-{{- $imageRegistry := default .image.registry .globalRegistry -}}
+{{- $imageRegistry := default .globalRegistry .image.registry -}}
 {{- if $imageRegistry -}}
   {{- print $imageRegistry "/" (required "An image repository is required" .image.repository) ":" $tag -}}
 {{- else -}}


### PR DESCRIPTION
## Explanation

This fix behavior when both `global.image.registry` and specific eg. `policyReportsCleanup.image.registry` are set. 

Before this change `global.image.registry` has priority upon more specific setting for "component".

We need this change to be able to use registry pull through cache. We are setting `global.image.registry` to our GitHub proxy and we need to set different registry for `policyReportsCleanup` and `webhooksCleanup` since they are using bitnami images on Docker Hub.

## What type of PR is this

/kind bug

## Proposed Changes

We are proposing change of priority for determination with registry to use to prefer more specific registry instead of global one.

### Proof Manifests

```yaml
global:
  image:
    registry: "ghcr.io"
policyReportsCleanup:
  image:
    registry: "docker.io"
webhooksCleanup:
  image:
    registry: "docker.io"
```

Befor change

```yaml
# Source: kyverno/templates/hooks/pre-delete-configmap.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: test-kyverno-remove-configmap
  namespace: default
  labels:
    app.kubernetes.io/component: hooks
    app.kubernetes.io/instance: test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: test-kyverno
    app.kubernetes.io/version: v0.0.0
    helm.sh/chart: kyverno-v0.0.0
  annotations:
    helm.sh/hook: pre-delete
    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
    helm.sh/hook-weight: "10"
spec:
  backoffLimit: 2
  template:
    metadata:
    spec:
      serviceAccount: test-kyverno-remove-configmap
      restartPolicy: Never
      containers:
        - name: kubectl
          image: "ghcr.io/bitnami/kubectl:1.30.2"
          imagePullPolicy: 
          command:
            - /bin/bash
            - '-c'
            - |-
              set -euo pipefail
              kubectl delete cm -n default test-kyverno
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsGroup: 65534
            runAsNonRoot: true
            runAsUser: 65534
            seccompProfile:
              type: RuntimeDefault
```

After change

```yaml
# Source: kyverno/templates/hooks/pre-delete-configmap.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: test-kyverno-remove-configmap
  namespace: default
  labels:
    app.kubernetes.io/component: hooks
    app.kubernetes.io/instance: test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: test-kyverno
    app.kubernetes.io/version: v0.0.0
    helm.sh/chart: kyverno-v0.0.0
  annotations:
    helm.sh/hook: pre-delete
    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
    helm.sh/hook-weight: "10"
spec:
  backoffLimit: 2
  template:
    metadata:
    spec:
      serviceAccount: test-kyverno-remove-configmap
      restartPolicy: Never
      containers:
        - name: kubectl
          image: "docker.io/bitnami/kubectl:1.30.2"
          imagePullPolicy: 
          command:
            - /bin/bash
            - '-c'
            - |-
              set -euo pipefail
              kubectl delete cm -n default test-kyverno
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsGroup: 65534
            runAsNonRoot: true
            runAsUser: 65534
            seccompProfile:
              type: RuntimeDefault
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
