### PR TITLE
fix: switch configmap removal to use post-delete helm hook

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -34,7 +34,7 @@ annotations:
   # valid kinds are: added, changed, deprecated, removed, fixed and security
   artifacthub.io/changes: |
     - kind: fixed
-      description: Add spec.emitWarning to v2beta1 policy
+      description: switch to post-delete helm hook to clean up Kyverno configmap
 dependencies:
   - name: grafana
     version: v0.0.0

--- a/charts/kyverno/templates/hooks/post-delete-configmap.yaml
+++ b/charts/kyverno/templates/hooks/post-delete-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "kyverno.hooks.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-delete
+    helm.sh/hook: post-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "0"
 rules:
@@ -29,7 +29,7 @@ metadata:
   labels:
     {{- include "kyverno.hooks.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-delete
+    helm.sh/hook: post-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "0"
 roleRef:
@@ -49,7 +49,7 @@ metadata:
   labels:
     {{- include "kyverno.hooks.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-delete
+    helm.sh/hook: post-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     helm.sh/hook-weight: "0"
 ---
@@ -61,7 +61,7 @@ metadata:
   labels:
     {{- include "kyverno.hooks.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-delete
+    helm.sh/hook: post-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "10"
 spec:


### PR DESCRIPTION
## Explanation
Helm chart 3.3.0 and 3.3.1 (kyverno v1.13.0) uses a pre-delete helm hook to clean up the Kyverno configmap (won't handled by helm uninstall automatically because the CM is preserved `helm.sh/resource-policy: "keep"` by default) upon uninstallation. This could be an issue if any Enforce policy is installed, as the configmap has the default value for webhook `namespaceSelector` to exclude the kyverno namespace.

This PR fixes the issue by switch the job to use post-delete helm hook, the configmap will be cleaned up as the last step upon uninstallation.
