### PR TITLE
Add SHA1 and MD5 hash functions to JMESPath

### DIFF
--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -1745,3 +1745,27 @@ func Test_SHA256(t *testing.T) {
 	assert.Assert(t, ok)
 	assert.Equal(t, str, "75c07bb807f2d80a85d34880b8af0c5f29f7c27577076ed5d0e4b427dee7dbcc")
 }
+
+func Test_SHA1(t *testing.T) {
+	jp, err := jmespathInterface.Query("sha1('Alice & Bob')")
+	assert.NilError(t, err)
+
+	result, err := jp.Search("")
+	assert.NilError(t, err)
+
+	str, ok := result.(string)
+	assert.Assert(t, ok)
+	assert.Equal(t, str, "e3ec484930685a61b0f824cd684a68699d2b98c1")
+}
+
+func Test_MD5(t *testing.T) {
+	jp, err := jmespathInterface.Query("md5('Alice & Bob')")
+	assert.NilError(t, err)
+
+	result, err := jp.Search("")
+	assert.NilError(t, err)
+
+	str, ok := result.(string)
+	assert.Assert(t, ok)
+	assert.Equal(t, str, "def42e1abd2462df1f9f0a4b3d488221")
+}


### PR DESCRIPTION
## Explanation [(#11506)](https://github.com/kyverno/kyverno/issues/11506)

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->
While  SHA256 is secure than other algorithms, SHA256 hashes are 64 characters, so can't be used as part of many Kubernetes [resource names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names) and [annotation keys](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set) which are often limited to <=63 characters. To address this limitation, SHA-1 and MD5 hash functions have been added as alternatives. These algorithms generate shorter hashes (less than 64 characters), making them compatible with Kubernetes naming constraints.

- Adds SHA1 and MD5 hash functions to JMESPath
- Adds Unit tests for the respective functions


## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->
- Solves the issue #11506
## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [x] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is: [/kyverno/website/#1428](https://github.com/kyverno/website/pull/1428)
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
A clone of #11531 
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

Here's the image: [Proof Manifest](https://github.com/user-attachments/assets/456255ac-689c-4e0a-a9ea-b50ecb168eec)


# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
