### PR TITLE
changed functions.go and function_test.go by modifying jpRound

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -13,7 +13,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"math"
+
 	"net"
 	"net/url"
 	"path/filepath"
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/shopspring/decimal"
 
 	trunc "github.com/aquilax/truncate"
 	"github.com/blang/semver/v4"
@@ -920,9 +922,17 @@ func jpRound(arguments []interface{}) (interface{}, error) {
 	if intLength < 0 {
 		return nil, formatError(argOutOfBoundsError, round)
 	}
-	shift := math.Pow(10, float64(intLength))
-	rounded := math.Round(op.Float()*shift) / shift
-	return rounded, nil
+
+	// Convert the input to a decimal.Decimal
+	decimalValue := decimal.NewFromFloat(op.Float())
+
+	// Round the decimal value to the specified number of decimal places
+	roundedValue := decimalValue.Round(int32(intLength))
+
+	// Convert the rounded value back to a float64
+	roundedFloat, _ := roundedValue.Float64()
+
+	return roundedFloat, nil
 }
 
 func jpBase64Decode(arguments []interface{}) (interface{}, error) {

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -1745,3 +1745,84 @@ func Test_SHA256(t *testing.T) {
 	assert.Assert(t, ok)
 	assert.Equal(t, str, "75c07bb807f2d80a85d34880b8af0c5f29f7c27577076ed5d0e4b427dee7dbcc")
 }
+
+func Test_jpRound(t *testing.T) {
+	type args struct {
+		arguments []interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name: "round to 2 decimal places",
+			args: args{
+				arguments: []interface{}{123.4567, 2.0},
+			},
+			want:    123.46,
+			wantErr: false,
+		},
+		{
+			name: "round to 0 decimal places",
+			args: args{
+				arguments: []interface{}{123.4567, 0.0},
+			},
+			want:    123.0,
+			wantErr: false,
+		},
+		{
+			name: "round to negative decimal places",
+			args: args{
+				arguments: []interface{}{123.4567, -1.0},
+			},
+			want:    120.0,
+			wantErr: false,
+		},
+		{
+			name: "round to 3 decimal places",
+			args: args{
+				arguments: []interface{}{123.4567, 3.0},
+			},
+			want:    123.457,
+			wantErr: false,
+		},
+		{
+			name: "invalid first argument",
+			args: args{
+				arguments: []interface{}{"123.4567", 2.0},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "invalid second argument",
+			args: args{
+				arguments: []interface{}{123.4567, "2.0"},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "non-integer second argument",
+			args: args{
+				arguments: []interface{}{123.4567, 2.5},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := jpRound(tt.args.arguments)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("jpRound() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("jpRound() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Explanation
## Imported the decimal Package:

Added the import for the github.com/shopspring/decimal package to handle arbitrary-precision decimal arithmetic.

## Modified the jpRound Function:

Validation: The function still validates the input arguments to ensure they are of the correct type.

Conversion to decimal.Decimal: The input float is converted to a decimal.Decimal to perform the rounding operation.

Rounding: The Round method of the decimal.Decimal type is used to round the number to the specified number of decimal places.

Conversion Back to float64: The rounded decimal.Decimal value is converted back to a float64 using the Float64 method.

## Helper Functions:

validateArg: Ensures the type and presence of arguments.

intNumber: Converts a float to an integer and checks if it is a valid integer.

formatError: Formats error messages for different error types.

## Related issue

This PR fixes #8940 

## Milestone of this PR
round() should retain trailing zeros.





## Checklist



- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
