### PR TITLE
fix(chart): global image registry bug in 3.3.3

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -35,6 +35,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: fixed
       description: fix validation error in validate.yaml
+    - kind: fixed
+      description: fixed global image registry config by introducing *.image.defaultRegistry.
 dependencies:
   - name: grafana
     version: v0.0.0

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -264,7 +264,8 @@ The chart values are organised per component.
 | crds.customLabels | object | `{}` | Additional CRDs labels |
 | crds.migration.enabled | bool | `true` | Enable CRDs migration using helm post upgrade hook |
 | crds.migration.resources | list | `["cleanuppolicies.kyverno.io","clustercleanuppolicies.kyverno.io","clusterpolicies.kyverno.io","globalcontextentries.kyverno.io","policies.kyverno.io","policyexceptions.kyverno.io","updaterequests.kyverno.io"]` | Resources to migrate |
-| crds.migration.image.registry | string | `"ghcr.io"` | Image registry |
+| crds.migration.image.registry | string | `nil` | Image registry |
+| crds.migration.image.defaultRegistry | string | `"ghcr.io"` |  |
 | crds.migration.image.repository | string | `"kyverno/kyverno-cli"` | Image repository |
 | crds.migration.image.tag | string | `nil` | Image tag Defaults to appVersion in Chart.yaml if omitted |
 | crds.migration.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
@@ -404,7 +405,8 @@ The chart values are organised per component.
 | admissionController.caCertificates.data | string | `nil` | CA certificates to use with Kyverno deployments This value is expected to be one large string of CA certificates |
 | admissionController.caCertificates.volume | object | `{}` | Volume to be mounted for CA certificates Not used when `.Values.admissionController.caCertificates.data` is defined |
 | admissionController.imagePullSecrets | list | `[]` | Image pull secrets |
-| admissionController.initContainer.image.registry | string | `"ghcr.io"` | Image registry |
+| admissionController.initContainer.image.registry | string | `nil` | Image registry |
+| admissionController.initContainer.image.defaultRegistry | string | `"ghcr.io"` |  |
 | admissionController.initContainer.image.repository | string | `"kyverno/kyvernopre"` | Image repository |
 | admissionController.initContainer.image.tag | string | `nil` | Image tag If missing, defaults to image.tag |
 | admissionController.initContainer.image.pullPolicy | string | `nil` | Image pull policy If missing, defaults to image.pullPolicy |
@@ -413,7 +415,8 @@ The chart values are organised per component.
 | admissionController.initContainer.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context |
 | admissionController.initContainer.extraArgs | object | `{}` | Additional container args. |
 | admissionController.initContainer.extraEnvVars | list | `[]` | Additional container environment variables. |
-| admissionController.container.image.registry | string | `"ghcr.io"` | Image registry |
+| admissionController.container.image.registry | string | `nil` | Image registry |
+| admissionController.container.image.defaultRegistry | string | `"ghcr.io"` |  |
 | admissionController.container.image.repository | string | `"kyverno/kyverno"` | Image repository |
 | admissionController.container.image.tag | string | `nil` | Image tag Defaults to appVersion in Chart.yaml if omitted |
 | admissionController.container.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
@@ -471,7 +474,8 @@ The chart values are organised per component.
 | backgroundController.rbac.serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
 | backgroundController.rbac.coreClusterRole.extraResources | list | See [values.yaml](values.yaml) | Extra resource permissions to add in the core cluster role. This was introduced to avoid breaking change in the chart but should ideally be moved in `clusterRole.extraResources`. |
 | backgroundController.rbac.clusterRole.extraResources | list | `[]` | Extra resource permissions to add in the cluster role |
-| backgroundController.image.registry | string | `"ghcr.io"` | Image registry |
+| backgroundController.image.registry | string | `nil` | Image registry |
+| backgroundController.image.defaultRegistry | string | `"ghcr.io"` |  |
 | backgroundController.image.repository | string | `"kyverno/background-controller"` | Image repository |
 | backgroundController.image.tag | string | `nil` | Image tag Defaults to appVersion in Chart.yaml if omitted |
 | backgroundController.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
@@ -546,7 +550,8 @@ The chart values are organised per component.
 | cleanupController.rbac.serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
 | cleanupController.rbac.clusterRole.extraResources | list | `[]` | Extra resource permissions to add in the cluster role |
 | cleanupController.createSelfSignedCert | bool | `false` | Create self-signed certificates at deployment time. The certificates won't be automatically renewed if this is set to `true`. |
-| cleanupController.image.registry | string | `"ghcr.io"` | Image registry |
+| cleanupController.image.registry | string | `nil` | Image registry |
+| cleanupController.image.defaultRegistry | string | `"ghcr.io"` |  |
 | cleanupController.image.repository | string | `"kyverno/cleanup-controller"` | Image repository |
 | cleanupController.image.tag | string | `nil` | Image tag Defaults to appVersion in Chart.yaml if omitted |
 | cleanupController.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
@@ -629,7 +634,8 @@ The chart values are organised per component.
 | reportsController.rbac.serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
 | reportsController.rbac.coreClusterRole.extraResources | list | See [values.yaml](values.yaml) | Extra resource permissions to add in the core cluster role. This was introduced to avoid breaking change in the chart but should ideally be moved in `clusterRole.extraResources`. |
 | reportsController.rbac.clusterRole.extraResources | list | `[]` | Extra resource permissions to add in the cluster role |
-| reportsController.image.registry | string | `"ghcr.io"` | Image registry |
+| reportsController.image.registry | string | `nil` | Image registry |
+| reportsController.image.defaultRegistry | string | `"ghcr.io"` |  |
 | reportsController.image.repository | string | `"kyverno/reports-controller"` | Image repository |
 | reportsController.image.tag | string | `nil` | Image tag Defaults to appVersion in Chart.yaml if omitted |
 | reportsController.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |

--- a/charts/kyverno/templates/_helpers/_image.tpl
+++ b/charts/kyverno/templates/_helpers/_image.tpl
@@ -5,7 +5,7 @@
 {{- if not (typeIs "string" $tag) -}}
   {{ fail "Image tags must be strings." }}
 {{- end -}}
-{{- $imageRegistry := default .globalRegistry .image.registry -}}
+{{- $imageRegistry := default (default .image.defaultRegistry .globalRegistry) .image.registry -}}
 {{- if $imageRegistry -}}
   {{- print $imageRegistry "/" (required "An image repository is required" .image.repository) ":" $tag -}}
 {{- else -}}

--- a/charts/kyverno/templates/background-controller/_helpers.tpl
+++ b/charts/kyverno/templates/background-controller/_helpers.tpl
@@ -19,7 +19,7 @@
 {{- end -}}
 
 {{- define "kyverno.background-controller.image" -}}
-{{- $imageRegistry := default .image.registry .globalRegistry -}}
+{{- $imageRegistry := default (default .image.defaultRegistry .globalRegistry) .image.registry -}}
 {{- if $imageRegistry -}}
   {{ $imageRegistry }}/{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
 {{- else -}}

--- a/charts/kyverno/templates/cleanup-controller/_helpers.tpl
+++ b/charts/kyverno/templates/cleanup-controller/_helpers.tpl
@@ -19,7 +19,7 @@
 {{- end -}}
 
 {{- define "kyverno.cleanup-controller.image" -}}
-{{- $imageRegistry := default .image.registry .globalRegistry -}}
+{{- $imageRegistry := default (default .image.defaultRegistry .globalRegistry) .image.registry -}}
 {{- if $imageRegistry -}}
   {{ $imageRegistry }}/{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
 {{- else -}}

--- a/charts/kyverno/templates/reports-controller/_helpers.tpl
+++ b/charts/kyverno/templates/reports-controller/_helpers.tpl
@@ -19,7 +19,7 @@
 {{- end -}}
 
 {{- define "kyverno.reports-controller.image" -}}
-{{- $imageRegistry := default .image.registry .globalRegistry -}}
+{{- $imageRegistry := default (default .image.defaultRegistry .globalRegistry) .image.registry -}}
 {{- if $imageRegistry -}}
   {{ $imageRegistry }}/{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
 {{- else -}}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -118,7 +118,8 @@ crds:
 
     image:
       # -- (string) Image registry
-      registry: ghcr.io
+      registry: ~
+      defaultRegistry: ghcr.io
       # -- (string) Image repository
       repository: kyverno/kyverno-cli
       # -- (string) Image tag
@@ -957,7 +958,8 @@ admissionController:
 
     image:
       # -- Image registry
-      registry: ghcr.io
+      registry: ~
+      defaultRegistry: ghcr.io
       # -- Image repository
       repository: kyverno/kyvernopre
       # -- (string) Image tag
@@ -1003,7 +1005,8 @@ admissionController:
 
     image:
       # -- Image registry
-      registry: ghcr.io
+      registry: ~
+      defaultRegistry: ghcr.io
       # -- Image repository
       repository: kyverno/kyverno
       # -- (string) Image tag
@@ -1220,7 +1223,8 @@ backgroundController:
 
   image:
     # -- Image registry
-    registry: ghcr.io
+    registry: ~
+    defaultRegistry: ghcr.io
     # -- Image repository
     repository: kyverno/background-controller
     # -- Image tag
@@ -1486,7 +1490,8 @@ cleanupController:
 
   image:
     # -- Image registry
-    registry: ghcr.io
+    registry: ~
+    defaultRegistry: ghcr.io
     # -- Image repository
     repository: kyverno/cleanup-controller
     # -- (string) Image tag
@@ -1802,7 +1807,8 @@ reportsController:
 
   image:
     # -- Image registry
-    registry: ghcr.io
+    registry: ~
+    defaultRegistry: ghcr.io
     # -- Image repository
     repository: kyverno/reports-controller
     # -- (string) Image tag


### PR DESCRIPTION
## Explanation

This PR fixies bug with was introduced with my previous PR https://github.com/kyverno/kyverno/pull/11482

## Related issue

Closes #11579

## What type of PR is this

/kind bug

## Proposed Changes

```
$ helm template ./charts/kyverno | grep image:
                          image:
                              image:
                              image:
                          image:
                              image:
                              image:
          image: "ghcr.io/kyverno/kyvernopre:latest"
          image: "ghcr.io/kyverno/kyverno:latest"
          image: "ghcr.io/kyverno/background-controller:latest"
          image: "kyverno/cleanup-controller:latest"
          image: "kyverno/reports-controller:latest"
      image: busybox:1.35
      image: busybox:1.35
      image: busybox:1.35
      image: busybox:1.35
      image: busybox:1.35
          image: "bitnami/kubectl:1.30.2"
          image: "bitnami/kubectl:1.30.2"
          image: "ghcr.io/kyverno/kyverno-cli:latest"
          image: "bitnami/kubectl:1.30.2"
```

```
$ helm template ./charts/kyverno --set global.image.registry=myregistry | grep image:
                          image:
                              image:
                              image:
                          image:
                              image:
                              image:
          image: "myregistry/kyverno/kyvernopre:latest"
          image: "myregistry/kyverno/kyverno:latest"
          image: "myregistry/kyverno/background-controller:latest"
          image: "myregistry/kyverno/cleanup-controller:latest"
          image: "myregistry/kyverno/reports-controller:latest"
      image: busybox:1.35
      image: busybox:1.35
      image: busybox:1.35
      image: busybox:1.35
      image: busybox:1.35
          image: "myregistry/bitnami/kubectl:1.30.2"
          image: "myregistry/bitnami/kubectl:1.30.2"
          image: "myregistry/kyverno/kyverno-cli:latest"
          image: "myregistry/bitnami/kubectl:1.30.2"
```

```
$ helm template ./charts/kyverno --set global.image.registry=myregistry --set webhooksCleanup.image.registry="docker.io"
                          image:
                              image:
                              image:
                          image:
                              image:
                              image:
          image: "myregistry/kyverno/kyvernopre:latest"
          image: "myregistry/kyverno/kyverno:latest"
          image: "myregistry/kyverno/background-controller:latest"
          image: "myregistry/kyverno/cleanup-controller:latest"
          image: "myregistry/kyverno/reports-controller:latest"
      image: busybox:1.35
      image: busybox:1.35
      image: busybox:1.35
      image: busybox:1.35
      image: busybox:1.35
          image: "docker.io/bitnami/kubectl:1.30.2"
          image: "myregistry/bitnami/kubectl:1.30.2"
          image: "myregistry/kyverno/kyverno-cli:latest"
          image: "docker.io/bitnami/kubectl:1.30.2"
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

