### PR TITLE
fix: Open the mutated resources file in append mode to allow additions to it

### DIFF
--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -381,7 +381,7 @@ func (p *PolicyProcessor) printMutatedOutput(yaml string) error {
 		}
 		file = f
 	} else {
-		f, err := os.OpenFile(filepath.Join(mutateLogPath, filename+".yaml"), os.O_CREATE|os.O_WRONLY, 0o600) // #nosec G304
+		f, err := os.OpenFile(filepath.Join(mutateLogPath, filename+".yaml"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) // #nosec G304
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Explanation

Using the apply command with mutate policies creates a file with the name of the resource suffixed by -mutated and this file is opened in create mode. This has the effect of the file being overridden for resources with the same name

## Related issue

#11615 

## Milestone of this PR


## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind bug

## Proposed Changes

Opening the file with append mode

### Proof Manifests

`pol.yaml`

```yaml
apiVersion: kyverno.io/v1
kind: Policy
metadata:
  name: testpolicy
  namespace: test
spec:
  rules:
  - name: mutate
    match:
      any:
        - resources:
            kinds:
            - apps/v1/Deployment
            - Service
    mutate:
      patchStrategicMerge:
        metadata:
          annotations:
            test.kyverno: mutated
```

`svc.yaml`

```yaml
apiVersion: v1
kind: Service
metadata:
  namespace: test
  name: resource
spec:
  type: ClusterIP
```

`depl.yaml`

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  namespace: test
  name: resource
spec:
  template:
    metadata:
      namespace: test
    spec:
      containers:
      - name: app
        image: app:v1
```

invocation: `kyverno apply --resource depl.yaml --resource svc.yaml pol.yaml -o /proof`

`resource-mutated.yaml`

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    test.kyverno: mutated
  name: resource
  namespace: test
spec:
  template:
    metadata:
      namespace: test
    spec:
      containers:
      - image: app:v1
        name: app

---

apiVersion: v1
kind: Service
metadata:
  annotations:
    test.kyverno: mutated
  name: resource
  namespace: test
spec:
  type: ClusterIP

---
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.


