### PR TITLE
Print generate output cli

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -135,7 +135,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&applyCommandConfig.ResourcePaths, "resource", "r", []string{}, "Path to resource files")
 	cmd.Flags().StringSliceVarP(&applyCommandConfig.ResourcePaths, "resources", "", []string{}, "Path to resource files")
 	cmd.Flags().BoolVarP(&applyCommandConfig.Cluster, "cluster", "c", false, "Checks if policies should be applied to cluster in the current context")
-	cmd.Flags().StringVarP(&applyCommandConfig.MutateLogPath, "output", "o", "", "Prints the mutated resources in provided file/directory")
+	cmd.Flags().StringVarP(&applyCommandConfig.MutateLogPath, "output", "o", "", "Prints the mutated/generated resources in provided file/directory")
 	// currently `set` flag supports variable for single policy applied on single resource
 	cmd.Flags().StringVarP(&applyCommandConfig.UserInfoPath, "userinfo", "u", "", "Admission Info including Roles, Cluster Roles and Subjects")
 	cmd.Flags().StringSliceVarP(&applyCommandConfig.Variables, "set", "s", nil, "Variables that are required")

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -203,6 +203,9 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 				} else {
 					generateResponse.PolicyResponse.Rules = newRuleResponse
 				}
+				if err := p.processGenerateResponse(generateResponse, resPath); err != nil {
+					return responses, err
+				}
 				responses = append(responses, generateResponse)
 			}
 			p.Rc.addGenerateResponse(generateResponse)
@@ -342,37 +345,61 @@ func (p *PolicyProcessor) makePolicyContext(
 	return policyContext, nil
 }
 
-func (p *PolicyProcessor) processMutateEngineResponse(response engineapi.EngineResponse, resourcePath string) error {
-	printMutatedRes := p.Rc.addMutateResponse(response)
-	if printMutatedRes && p.PrintPatchResource {
-		yamlEncodedResource, err := yamlv2.Marshal(response.PatchedResource.Object)
+func (p *PolicyProcessor) processGenerateResponse(response engineapi.EngineResponse, resourcePath string) error {
+	generatedResources := []*unstructured.Unstructured{}
+	for _, rule := range response.PolicyResponse.Rules {
+		gen := rule.GeneratedResources()
+		generatedResources = append(generatedResources, gen...)
+	}
+	for _, r := range generatedResources {
+		err := p.printOutput(r.Object, response, resourcePath, true)
 		if err != nil {
-			return fmt.Errorf("failed to marshal (%w)", err)
+			return fmt.Errorf("failed to print generate result (%w)", err)
 		}
-
-		if p.MutateLogPath == "" {
-			mutatedResource := string(yamlEncodedResource) + string("\n---")
-			if len(strings.TrimSpace(mutatedResource)) > 0 {
-				if !p.Stdin {
-					fmt.Fprintf(p.Out, "\nmutate policy %s applied to %s:", response.Policy().GetName(), resourcePath)
-				}
-				fmt.Fprintf(p.Out, "\n"+mutatedResource+"\n") //nolint:govet
-			}
-		} else {
-			err := p.printMutatedOutput(string(yamlEncodedResource))
-			if err != nil {
-				return fmt.Errorf("failed to print mutated result (%w)", err)
-			}
-			fmt.Fprintf(p.Out, "\n\nMutation:\nMutation has been applied successfully. Check the files.")
-		}
+		fmt.Fprintf(p.Out, "\n\nGenerate:\nGeneration completed successfully.")
 	}
 	return nil
 }
 
-func (p *PolicyProcessor) printMutatedOutput(yaml string) error {
+func (p *PolicyProcessor) processMutateEngineResponse(response engineapi.EngineResponse, resourcePath string) error {
+	p.Rc.addMutateResponse(response)
+	err := p.printOutput(response.PatchedResource.Object, response, resourcePath, false)
+	if err != nil {
+		return fmt.Errorf("failed to print mutated result (%w)", err)
+	}
+	fmt.Fprintf(p.Out, "\n\nMutation:\nMutation has been applied successfully.")
+	return nil
+}
+
+func (p *PolicyProcessor) printOutput(resource interface{}, response engineapi.EngineResponse, resourcePath string, isGenerate bool) error {
+	yamlEncodedResource, err := yamlv2.Marshal(resource)
+	if err != nil {
+		return fmt.Errorf("failed to marshal (%w)", err)
+	}
+
+	if p.MutateLogPath == "" {
+		resource := string(yamlEncodedResource) + string("\n---")
+		if len(strings.TrimSpace(resource)) > 0 {
+			if !p.Stdin {
+				fmt.Fprintf(p.Out, "\npolicy %s applied to %s:", response.Policy().GetName(), resourcePath)
+			}
+			fmt.Fprintf(p.Out, "\n"+resource+"\n") //nolint:govet
+		}
+		return nil
+	}
+
 	var file *os.File
 	mutateLogPath := filepath.Clean(p.MutateLogPath)
 	filename := p.Resource.GetName() + "-mutated"
+	if isGenerate {
+		filename = response.Policy().GetName() + "-generated"
+	}
+
+	file, err = os.OpenFile(filepath.Join(mutateLogPath, filename+".yaml"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) // #nosec G304
+	if err != nil {
+		return err
+	}
+
 	if !p.MutateLogPathIsDir {
 		// truncation for the case when mutateLogPath is a file (not a directory) is handled under pkg/kyverno/apply/test_command.go
 		f, err := os.OpenFile(mutateLogPath, os.O_APPEND|os.O_WRONLY, 0o600) // #nosec G304
@@ -380,14 +407,8 @@ func (p *PolicyProcessor) printMutatedOutput(yaml string) error {
 			return err
 		}
 		file = f
-	} else {
-		f, err := os.OpenFile(filepath.Join(mutateLogPath, filename+".yaml"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) // #nosec G304
-		if err != nil {
-			return err
-		}
-		file = f
 	}
-	if _, err := file.Write([]byte(yaml + "\n---\n\n")); err != nil {
+	if _, err := file.Write([]byte(string(yamlEncodedResource) + "\n---\n\n")); err != nil {
 		if err := file.Close(); err != nil {
 			log.Log.Error(err, "failed to close file")
 		}

--- a/docs/user/cli/commands/kyverno_apply.md
+++ b/docs/user/cli/commands/kyverno_apply.md
@@ -51,7 +51,7 @@ kyverno apply [flags]
   -h, --help                               help for apply
       --kubeconfig string                  path to kubeconfig file with authorization and master location information
   -n, --namespace string                   Optional Policy parameter passed with cluster flag
-  -o, --output string                      Prints the mutated resources in provided file/directory
+  -o, --output string                      Prints the mutated/generated resources in provided file/directory
   -p, --policy-report                      Generates policy report when passed (default policyviolation)
       --registry                           If set to true, access the image registry using local docker credentials to populate external data
       --remove-color                       Remove any color from output


### PR DESCRIPTION
## Explanation

The kyverno CLI doesn't print generated resources from generate policies, this PR adds this capability

## Related issue

closes #1610 

## Milestone of this PR


## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind feature

## Proposed Changes

### Proof Manifests

`pol.yaml`
```yaml
---
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  annotations:
    policies.kyverno.io/subject: NetworkPolicy
    policies.kyverno.io/title: Add Network Policy
  name: add-networkpolicy
spec:
  admission: true
  background: true
  rules:
  - generate:
      apiVersion: networking.k8s.io/v1
      data:
        spec:
          podSelector: {}
          policyTypes:
          - Ingress
          - Egress
      kind: NetworkPolicy
      name: default-deny
      namespace: '{{request.object.metadata.name}}'
      synchronize: true
    match:
      any:
      - resources:
          kinds:
          - Namespace
    name: default-deny
```

`ns.yaml`

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: hello-world-namespace
```

invocation: `kyverno apply --resource ns.yaml pol.yaml`

```
Applying 1 policy rule(s) to 1 resource(s)...

policy add-networkpolicy applied to default/Namespace/hello-world-namespace:
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  labels:
    app.kubernetes.io/managed-by: kyverno
    generate.kyverno.io/policy-name: add-networkpolicy
    generate.kyverno.io/policy-namespace: ""
    generate.kyverno.io/rule-name: default-deny
    generate.kyverno.io/trigger-group: ""
    generate.kyverno.io/trigger-kind: Namespace
    generate.kyverno.io/trigger-namespace: default
    generate.kyverno.io/trigger-uid: ""
    generate.kyverno.io/trigger-version: v1
  name: default-deny
  namespace: hello-world-namespace
spec:
  podSelector: {}
  policyTypes:
  - Ingress
  - Egress

---


Generate:
Generation completed successfully. Check the files.
pass: 1, fail: 0, warn: 0, error: 0, skip: 0 
```

with output flag: `kyverno apply --resource ns.yaml pol.yaml -o output`

`add-networkpolicy-generated.yaml`

```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  labels:
    app.kubernetes.io/managed-by: kyverno
    generate.kyverno.io/policy-name: add-networkpolicy
    generate.kyverno.io/policy-namespace: ""
    generate.kyverno.io/rule-name: default-deny
  name: default-deny
  namespace: hello-world-namespace
spec:
  podSelector: {}
  policyTypes:
  - Ingress
  - Egress

---

```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.


