### PR TITLE
fix(webhook): update policy status after both validating and mutating…

### DIFF
--- a/pkg/controllers/webhook/controller_test.go
+++ b/pkg/controllers/webhook/controller_test.go
@@ -1,0 +1,147 @@
+package webhook
+
+import (
+	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckIfPolicyIsConfiguredInWebhooks(t *testing.T) {
+	tests := []struct {
+		name       string
+		policy     kyvernov1.PolicyInterface
+		mExists    bool
+		vExists    bool
+		wantResult bool
+	}{
+		{
+			name: "Policy with mutate rule and mutating webhook exists",
+			policy: &kyvernov1.ClusterPolicy{
+				Spec: kyvernov1.Spec{
+					Rules: []kyvernov1.Rule{
+						{
+							Mutation: &kyvernov1.Mutation{
+								PatchesJSON6902: "test",
+							},
+						},
+					},
+				},
+			},
+			mExists:    true,
+			vExists:    false,
+			wantResult: true,
+		},
+		{
+			name: "Policy with validate rule and validating webhook exists",
+			policy: &kyvernov1.ClusterPolicy{
+				Spec: kyvernov1.Spec{
+					Rules: []kyvernov1.Rule{
+						{
+							Validation: &kyvernov1.Validation{
+								Message: "test",
+							},
+						},
+					},
+				},
+			},
+			mExists:    false,
+			vExists:    true,
+			wantResult: true,
+		},
+		{
+			name: "Policy with generate rule and validating webhook exists",
+			policy: &kyvernov1.ClusterPolicy{
+				Spec: kyvernov1.Spec{
+					Rules: []kyvernov1.Rule{
+						{
+							Generation: &kyvernov1.Generation{
+								Synchronize: true,
+							},
+						},
+					},
+				},
+			},
+			mExists:    false,
+			vExists:    true,
+			wantResult: true,
+		},
+		{
+			name: "Policy with mutateExisting rule while validating and mutating webhook exists",
+			policy: &kyvernov1.ClusterPolicy{
+				Spec: kyvernov1.Spec{
+					Rules: []kyvernov1.Rule{
+						{
+							Mutation: &kyvernov1.Mutation{
+								PatchesJSON6902: "test",
+							},
+						},
+					},
+				},
+			},
+			mExists:    true,
+			vExists:    true,
+			wantResult: true,
+		},
+		{
+			name: "Policy with verifyImages rule and both webhooks exist",
+			policy: &kyvernov1.ClusterPolicy{
+				Spec: kyvernov1.Spec{
+					Rules: []kyvernov1.Rule{
+						{
+							VerifyImages: []kyvernov1.ImageVerification{
+								{
+									Image: "test",
+								},
+							},
+						},
+					},
+				},
+			},
+			mExists:    true,
+			vExists:    true,
+			wantResult: true,
+		},
+		{
+			name: "Policy with mutate rule and mutating webhook does not exist",
+			policy: &kyvernov1.ClusterPolicy{
+				Spec: kyvernov1.Spec{
+					Rules: []kyvernov1.Rule{
+						{
+							Mutation: &kyvernov1.Mutation{
+								PatchesJSON6902: "test",
+							},
+						},
+					},
+				},
+			},
+			mExists:    false,
+			vExists:    false,
+			wantResult: false,
+		},
+		{
+			name: "Policy with validate rule and validating webhook does not exist",
+			policy: &kyvernov1.ClusterPolicy{
+				Spec: kyvernov1.Spec{
+					Rules: []kyvernov1.Rule{
+						{
+							Validation: &kyvernov1.Validation{
+								Message: "test",
+							},
+						},
+					},
+				},
+			},
+			mExists:    false,
+			vExists:    false,
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkIfPolicyIsConfiguredInWebhooks(tt.policy, tt.mExists, tt.vExists)
+			assert.Equal(t, tt.wantResult, result)
+		})
+	}
+}


### PR DESCRIPTION
… webhooks are built

## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

This PR updates the policy status only once after both resource Validating and Mutating webhooks are built. I created a new key because it's more descriptive to the purpose instead of using on of the two already existing. I could have used a sync mechanism, actually I tried it, but it's useless since both webhooks are always reconciled together so it makes no sense to separate them.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

Fixes #11560

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
