### PR TITLE
fix: add conversion function in Helm template

### DIFF
--- a/charts/kyverno/templates/config/_helpers.tpl
+++ b/charts/kyverno/templates/config/_helpers.tpl
@@ -68,14 +68,14 @@
       {{- $newWebhooks = merge $newWebhooks (dict $webhook.name $newWebhook) }}
     {{- end -}}
   {{- end -}}
-  {{- $newWebhooks | toYaml | nindent 2 }}
+  {{- $newWebhooks | toJson | nindent 2 }}
 {{- else -}}
   {{- $webhook := $webhooks }}
   {{- $namespaceSelector := default (dict) $webhook.namespaceSelector }}
   {{- $matchExpressions := default (list) $namespaceSelector.matchExpressions }}
   {{- $newNamespaceSelector := dict "matchLabels" $namespaceSelector.matchLabels "matchExpressions" (append $matchExpressions $excludeDefault) }}
   {{- $newWebhook := merge (omit $webhook "namespaceSelector") (dict "namespaceSelector" $newNamespaceSelector) }}
-  {{- $newWebhook | toYaml | nindent 2 }}
+  {{- $newWebhook | toJson | nindent 2 }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/kyverno/templates/config/_helpers.tpl
+++ b/charts/kyverno/templates/config/_helpers.tpl
@@ -55,13 +55,20 @@
 {{- end -}}
 
 {{- define "kyverno.config.webhooks" -}}
+{{- $webhooks := .Values.config.webhooks -}}
 {{- $excludeDefault := dict "key" "kubernetes.io/metadata.name" "operator" "NotIn" "values" (list (include "kyverno.namespace" .)) }}
-{{- $webhook := .Values.config.webhooks }}
-{{- $namespaceSelector := default dict $webhook.namespaceSelector }}
-{{- $matchExpressions := default list $namespaceSelector.matchExpressions }}
-{{- $newNamespaceSelector := dict "matchLabels" $namespaceSelector.matchLabels "matchExpressions" (append $matchExpressions $excludeDefault) }}
-{{- $newWebhook := merge (omit $webhook "namespaceSelector") (dict "namespaceSelector" $newNamespaceSelector) }}
-{{- $newWebhook | toJson }}
+  {{- if $webhooks | typeIs "slice" -}}
+    {{- $newWebhooks := dict -}}
+    {{- range $index, $webhook := $webhooks -}}
+      {{- if $webhook.namespaceSelector -}}
+        {{- $namespaceSelector := $webhook.namespaceSelector }}
+        {{- $newWebhooks := merge $newWebhooks (dict "namespaceSelector" $namespaceSelector) }}
+      {{- end -}}
+    {{- end -}}
+    {{- $newWebhooks | toJson | nindent 2 }}
+  {{- else -}}
+    {{- .Values.config.webhooks | toJson | nindent 2 }}
+  {{- end -}}
 {{- end -}}
 
 {{- define "kyverno.config.imagePullSecret" -}}

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -175,7 +175,7 @@ data:
     [Secret,kyverno,kyverno-svc.kyverno.svc.*]
     [Secret,kyverno,kyverno-cleanup-controller.kyverno.svc.*]
   updateRequestThreshold: "1000"
-  webhooks: "{\"namespaceSelector\":{\"matchExpressions\":[{\"key\":\"kubernetes.io/metadata.name\",\"operator\":\"NotIn\",\"values\":[\"kube-system\"]},{\"key\":\"kubernetes.io/metadata.name\",\"operator\":\"NotIn\",\"values\":[\"kyverno\"]}],\"matchLabels\":null}}"
+  webhooks: "\n  {\"namespaceSelector\":{\"matchExpressions\":[{\"key\":\"kubernetes.io/metadata.name\",\"operator\":\"NotIn\",\"values\":[\"kube-system\"]},{\"key\":\"kubernetes.io/metadata.name\",\"operator\":\"NotIn\",\"values\":[\"kyverno\"]}],\"matchLabels\":null}}"
   webhookAnnotations: "{\"admissions.enforcer/disabled\":\"true\"}"
 ---
 apiVersion: v1


### PR DESCRIPTION
## Explanation

This PR adds a type conversion function in Helm to fix the breaking change of switch a list to an object.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes https://github.com/kyverno/kyverno/issues/11661.

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
Upgrade from 3.2.6 to the latest:

3.2.6 values.yaml:
```yaml
config:
  webhooks:
    # Exclude namespaces
    - namespaceSelector:
        matchExpressions:
        - key: kubernetes.io/metadata.name
          operator: NotIn
          values:
            - test
```
validating webhook:
```
✗ kg validatingwebhookconfigurations  kyverno-resource-validating-webhook-cfg -o yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  name: kyverno-resource-validating-webhook-cfg
webhooks:
- admissionReviewVersions:
  - v1
  namespaceSelector:
    matchExpressions:
    - key: kubernetes.io/metadata.name
      operator: NotIn
      values:
      - test
    - key: kubernetes.io/metadata.name
      operator: NotIn
      values:
      - kyverno
...
```
latest values.yaml:
```yaml
config:
  webhooks:
    namespaceSelector:
      matchExpressions:
      - key: kubernetes.io/metadata.name
        operator: NotIn
        values:
          - kube-system
      - key: kubernetes.io/metadata.name
        operator: NotIn
        values:
          - test-2
```
validating webhook:
```
$ ✗ kg validatingwebhookconfigurations  kyverno-resource-validating-webhook-cfg -o yaml | grep namespaceSelector: -A15
  namespaceSelector:
    matchExpressions:
    - key: kubernetes.io/metadata.name
      operator: NotIn
      values:
      - kube-system
    - key: kubernetes.io/metadata.name
      operator: NotIn
      values:
      - test-2
    - key: kubernetes.io/metadata.name
      operator: NotIn
      values:
      - kyverno
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
