### PR TITLE
fix(policy chart): fix the merging of policyExclude customizations to avoid wrong overrides (#11533)

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -26,3 +26,5 @@ annotations:
       description: Remove spec.validationFailureAction field from policies as it is deprecated
     - kind: added
       description: Add spec.validate[*].failureAction field to policies
+    - kind: fixed
+      description: Fix the merging of policyExclude customizations to avoid wrong overrides

--- a/charts/kyverno-policies/templates/baseline/disallow-capabilities.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-capabilities.yaml
@@ -31,7 +31,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "adding-capabilities") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.yaml
@@ -32,7 +32,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "host-namespaces") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/baseline/disallow-host-path.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-path.yaml
@@ -31,7 +31,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "host-path") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/baseline/disallow-host-ports.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-ports.yaml
@@ -31,7 +31,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "host-ports-none") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/baseline/disallow-host-process.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-process.yaml
@@ -32,7 +32,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "host-process-containers") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.yaml
@@ -30,7 +30,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "privileged-containers") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/baseline/disallow-proc-mount.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-proc-mount.yaml
@@ -32,7 +32,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "check-proc-mount") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
@@ -33,7 +33,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "app-armor") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/baseline/restrict-seccomp.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-seccomp.yaml
@@ -31,7 +31,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "check-seccomp") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/baseline/restrict-sysctls.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-sysctls.yaml
@@ -34,7 +34,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "check-sysctls") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.yaml
@@ -30,7 +30,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "privilege-escalation") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
@@ -30,7 +30,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "run-as-non-root-user") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
@@ -31,7 +31,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "run-as-non-root") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.yaml
@@ -33,7 +33,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "check-seccomp-strict") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyverno-policies/templates/restricted/restrict-volume-types.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-volume-types.yaml
@@ -33,7 +33,7 @@ spec:
         - resources:
             kinds:
               - Pod
-      {{- with index .Values "policyExclude" $name }}
+      {{- with merge (index .Values "policyExclude" "restricted-volumes") (index .Values "policyExclude" $name) }}
       exclude:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

Currently only a couple of Kyverno policies from its chart allow correct customization of `policyExclude`, while all the others simply get overriden, breaking multiple exclusions from different places (say, a default platform deployment of `kyverno-policies` with some `policyExclude` and specific teams needing to add their own customizations on top of it.

Without this PR add up customizations won't work in some of the shipped policies.

Unaffected policies are only:

- `./restricted/disallow-capabilities-strict.yaml`
- `./baseline/disallow-selinux.yaml`
- `./other/require-non-root-groups.yaml`

## Related issue

Fixes #11533 

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.13.2`.

-->

Either `1.13.2` or simply a minor semver update of the `kyverno-policies`chart if it's simpler given it doesn't affect Kyverno itself, only templates.

## What type of PR is this

I guess it's a `bug` though it's in the Helm chart, not in Kyverno.

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

This doesn't provide a feature, it just aligns the current correct behavior of some of the shipped templated policies with the ones which are not working with proper YAML merging.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

If this can't be merge for some reason I'd need to vendorize all the policies from the Helm chart just to have this fixed, but I thought contributing this upstream would benefit more people.