### PR TITLE
Do not fail policy restrict-apparmor-profiles for empty annotations

### DIFF
--- a/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
@@ -57,8 +57,12 @@ spec:
           Specifying other AppArmor profiles is disallowed. The annotation
           `container.apparmor.security.beta.kubernetes.io` if defined
           must not be set to anything other than `runtime/default` or `localhost/*`.
-        pattern:
-          =(metadata):
-            =(annotations):
-              =(container.apparmor.security.beta.kubernetes.io/*): "runtime/default | localhost/*"
+        anyPattern:
+          - metadata:
+              =(annotations): {}
+          - metadata:
+              =(annotations): null
+          - metadata:
+              =(annotations):
+                =(container.apparmor.security.beta.kubernetes.io/*): "runtime/default | localhost/*"
 {{- end }}


### PR DESCRIPTION
restrict-apparmor-profiles policy fails for manifest having empty annotations property. Add patterns that allow empty annotations as the default value for container.apparmor.security.beta.kubernetes.io is `runtime/default` that is in line with the policy.

## Explanation

Policy `charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml` fails to validate correctly such manifests which has empty annotation section.

## Related issue

## Milestone of this PR

## Documentation (required for features)

## What type of PR is this

/kind bug


## Proposed Changes

Adding extra patterns to validate rule

```yaml
          - metadata:
              =(annotations): {}
          - metadata:
              =(annotations): null
```
to accept also case when annotations is set empty. 
This can happen in many library chart based projects where annotations are conditionals.

### Proof Manifests

# Kubernetes resource

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: gooddeployment04
spec:
  replicas: 1
  selector:
    matchLabels:
      app: app
  template:
    metadata:
      labels:
        app: app
      annotations:
    spec:
      containers:
      - name: container01
        image: dummyimagename
```

OR

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: gooddeployment05
spec:
  replicas: 1
  selector:
    matchLabels:
      app: app
  template:
    metadata:
      labels:
        app: app
      annotations: {}
    spec:
      containers:
      - name: container01
        image: dummyimagename
```

# Kyverno CLI test manifest

```yaml
apiVersion: cli.kyverno.io/v1alpha1
kind: Test
metadata:
  name: restrict-apparmor-profiles
policies:
- ../restrict-apparmor-profiles.yaml
resources:
- resource.yaml
results:
- kind: Deployment
  policy: restrict-apparmor-profiles
  resources:
  - gooddeployment04
  - gooddeployment05
  result: pass
  rule: app-armor
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ X] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ X] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

