### PR TITLE
chore: Add a new field in the test results CRD to specify patched resources

### DIFF
--- a/cmd/cli/kubectl-kyverno/apis/v1alpha1/test_result.go
+++ b/cmd/cli/kubectl-kyverno/apis/v1alpha1/test_result.go
@@ -26,9 +26,15 @@ type TestResultBase struct {
 	// Kind mentions the kind of the resource on which the policy is to be applied.
 	Kind string `json:"kind"`
 
+	// Deprecated. Use `patchedResources` instead.
 	// PatchedResource takes a resource configuration file in yaml format from
 	// the user to compare it against the Kyverno mutated resource configuration.
 	PatchedResource string `json:"patchedResource,omitempty"`
+
+	// PatchedResource takes a resource configuration file in yaml format from
+	// the user to compare it against the Kyverno mutated resource configuration.
+	// Multiple resources can be passed in the same file
+	PatchedResources string `json:"patchedResources,omitempty"`
 
 	// GeneratedResource takes a resource configuration file in yaml format from
 	// the user to compare it against the Kyverno generated resource configuration.

--- a/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
@@ -123,8 +123,15 @@ spec:
                   type: string
                 patchedResource:
                   description: |-
+                    Deprecated. Use `patchedResources` instead.
                     PatchedResource takes a resource configuration file in yaml format from
                     the user to compare it against the Kyverno mutated resource configuration.
+                  type: string
+                patchedResources:
+                  description: |-
+                    PatchedResource takes a resource configuration file in yaml format from
+                    the user to compare it against the Kyverno mutated resource configuration.
+                    Multiple resources can be passed in the same file
                   type: string
                 policy:
                   description: Policy mentions the name of the policy.

--- a/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
@@ -123,8 +123,15 @@ spec:
                   type: string
                 patchedResource:
                   description: |-
+                    Deprecated. Use `patchedResources` instead.
                     PatchedResource takes a resource configuration file in yaml format from
                     the user to compare it against the Kyverno mutated resource configuration.
+                  type: string
+                patchedResources:
+                  description: |-
+                    PatchedResource takes a resource configuration file in yaml format from
+                    the user to compare it against the Kyverno mutated resource configuration.
+                    Multiple resources can be passed in the same file
                   type: string
                 policy:
                   description: Policy mentions the name of the policy.

--- a/docs/user/cli/crd/index.html
+++ b/docs/user/cli/crd/index.html
@@ -801,8 +801,22 @@ string
 </em>
 </td>
 <td>
-<p>PatchedResource takes a resource configuration file in yaml format from
+<p>Deprecated. Use <code>patchedResources</code> instead.
+PatchedResource takes a resource configuration file in yaml format from
 the user to compare it against the Kyverno mutated resource configuration.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>patchedResources</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>PatchedResource takes a resource configuration file in yaml format from
+the user to compare it against the Kyverno mutated resource configuration.
+Multiple resources can be passed in the same file</p>
 </td>
 </tr>
 <tr>

--- a/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
+++ b/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
@@ -1691,8 +1691,40 @@ Possible values are pass, fail and skip.</p>
         <td>
           
 
-          <p>PatchedResource takes a resource configuration file in yaml format from
+          <p>Deprecated. Use <code>patchedResources</code> instead.
+PatchedResource takes a resource configuration file in yaml format from
 the user to compare it against the Kyverno mutated resource configuration.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>patchedResources</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>PatchedResource takes a resource configuration file in yaml format from
+the user to compare it against the Kyverno mutated resource configuration.
+Multiple resources can be passed in the same file</p>
 
 
           


### PR DESCRIPTION
## Explanation

- The currently existing PatchedResource field has a misleading name, leading to users believing that it can only take a yaml containing a single resource. Another field with proper naming is added until this field is removed completely.
- Generate the new CRD from the struct.

## Related issue

closes: #11629

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind bug

## Proposed Changes

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
