### PR TITLE
feat: Show textual diff when generate test fails

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/report"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/test/filter"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
@@ -163,21 +164,25 @@ func checkResult(test v1alpha1.TestResult, fs billy.Filesystem, resoucePath stri
 		patchedResource = test.PatchedResources
 	}
 	if patchedResource != "" {
-		equals, err := getAndCompareResource([]*unstructured.Unstructured{&response.PatchedResource}, fs, filepath.Join(resoucePath, patchedResource))
+		equals, diff, err := getAndCompareResource([]*unstructured.Unstructured{&response.PatchedResource}, fs, filepath.Join(resoucePath, patchedResource))
 		if err != nil {
 			return false, err.Error(), "Resource error"
 		}
 		if !equals {
-			return false, "Patched resource didn't match the patched resource in the test result", "Resource diff"
+			dmp := diffmatchpatch.New()
+			legend := dmp.DiffPrettyText(dmp.DiffMain("only in expected", "only in actual", false))
+			return false, fmt.Sprintf("Patched resource didn't match the patched resource in the test result\n(%s)\n\n%s", legend, diff), "Resource diff"
 		}
 	}
 	if test.GeneratedResource != "" {
-		equals, err := getAndCompareResource(rule.GeneratedResources(), fs, filepath.Join(resoucePath, test.GeneratedResource))
+		equals, diff, err := getAndCompareResource(rule.GeneratedResources(), fs, filepath.Join(resoucePath, test.GeneratedResource))
 		if err != nil {
 			return false, err.Error(), "Resource error"
 		}
 		if !equals {
-			return false, "Generated resource didn't match the generated resource in the test result", "Resource diff"
+			dmp := diffmatchpatch.New()
+			legend := dmp.DiffPrettyText(dmp.DiffMain("only in expected", "only in actual", false))
+			return false, fmt.Sprintf("Generated resource didn't match the generated resource in the test result\n(%s)\n\n%s", legend, diff), "Resource diff"
 		}
 	}
 	result := report.ComputePolicyReportResult(false, response, rule)

--- a/cmd/cli/kubectl-kyverno/commands/test/compare.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/compare.go
@@ -38,12 +38,12 @@ func getAndCompareResource(actualResources []*unstructured.Unstructured, fs bill
 			return false, fmt.Errorf("error: failed to compare resources (%s)", err)
 		}
 		if !equals {
-			log.Log.V(8).Info("Resource diff", "expected", expectedResourcesMap[r.GetNamespace()+"/"+r.GetName()], "actual", r)
+			log.Log.V(4).Info("Resource diff", "expected", expectedResourcesMap[r.GetNamespace()+"/"+r.GetName()], "actual", r)
 			es, _ := yaml.Marshal(expectedResourcesMap[r.GetNamespace()+"/"+r.GetName()])
 			as, _ := yaml.Marshal(r)
 			dmp := diffmatchpatch.New()
 			diffs := dmp.DiffMain(string(es), string(as), false)
-			log.Log.V(8).Info("\n" + dmp.DiffPrettyText(diffs) + "\n")
+			log.Log.V(4).Info("\n" + dmp.DiffPrettyText(diffs) + "\n")
 			return false, nil
 		}
 	}

--- a/cmd/cli/kubectl-kyverno/commands/test/compare.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/compare.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 
 	"github.com/go-git/go-billy/v5"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/log"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/resource"
+	"github.com/sergi/go-diff/diffmatchpatch"
+	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -35,6 +38,12 @@ func getAndCompareResource(actualResources []*unstructured.Unstructured, fs bill
 			return false, fmt.Errorf("error: failed to compare resources (%s)", err)
 		}
 		if !equals {
+			log.Log.V(8).Info("Resource diff", "expected", expectedResourcesMap[r.GetNamespace()+"/"+r.GetName()], "actual", r)
+			es, _ := yaml.Marshal(expectedResourcesMap[r.GetNamespace()+"/"+r.GetName()])
+			as, _ := yaml.Marshal(r)
+			dmp := diffmatchpatch.New()
+			diffs := dmp.DiffMain(string(es), string(as), false)
+			log.Log.V(8).Info("\n" + dmp.DiffPrettyText(diffs) + "\n")
 			return false, nil
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -318,7 +318,7 @@ require (
 	github.com/sassoftware/relic v7.2.1+incompatible // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.8.0 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
-	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
+	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sigstore/fulcio v1.6.3 // indirect


### PR DESCRIPTION
## Explanation

When running tests locally with `kyverno test`, even with `--detailed-results` there is currently no way to make the CLI actually show what the diff was.

This change adds some logging which (only if you've specified `-v=4` or higher) will log a textual diff between expected and actual results.

## Related issue

#9727

## Milestone of this PR

Not sure; this can easily be backported, but should it be?

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.

- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind feature

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
