### PR TITLE
feat: removed erroneous warning about matching on scale subresource

### DIFF
--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -405,7 +405,7 @@ func Validate(policy, oldPolicy kyvernov1.PolicyInterface, client dclient.Interf
 			if err != nil {
 				return nil, err
 			}
-			checkForScaleSubresource(validationJson, allKinds, &warnings)
+			checkForScaleSubresource(validationJson, allKinds)
 			checkForStatusSubresource(validationJson, allKinds, &warnings)
 		}
 
@@ -418,7 +418,7 @@ func Validate(policy, oldPolicy kyvernov1.PolicyInterface, client dclient.Interf
 			if err != nil {
 				return nil, err
 			}
-			checkForScaleSubresource(mutationJson, allKinds, &warnings)
+			checkForScaleSubresource(mutationJson, allKinds)
 			checkForStatusSubresource(mutationJson, allKinds, &warnings)
 
 			mutateExisting := rule.Mutation.MutateExistingOnPolicyUpdate
@@ -448,7 +448,7 @@ func Validate(policy, oldPolicy kyvernov1.PolicyInterface, client dclient.Interf
 					if err != nil {
 						return nil, err
 					}
-					checkForScaleSubresource(validationJson, allKinds, &warnings)
+					checkForScaleSubresource(validationJson, allKinds)
 					checkForStatusSubresource(validationJson, allKinds, &warnings)
 				}
 			}
@@ -1683,15 +1683,13 @@ func validateNamespaces(validationFailureActionOverrides []kyvernov1.ValidationF
 	return nil
 }
 
-func checkForScaleSubresource(ruleTypeJson []byte, allKinds []string, warnings *[]string) {
+func checkForScaleSubresource(ruleTypeJson []byte, allKinds []string) {
 	if strings.Contains(string(ruleTypeJson), "replicas") {
 		for _, kind := range allKinds {
 			if strings.Contains(strings.ToLower(kind), "scale") {
 				return
 			}
 		}
-		msg := "You are matching on replicas but not including the scale subresource in the policy."
-		*warnings = append(*warnings, msg)
 	}
 }
 


### PR DESCRIPTION
## Explanation
I've removed erroneous warning from relevant code as discussed in the related issue.

## Related issue
Closes: #9840 @chipzoller 

## Milestone of this PR

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind cleanup

## Proposed Changes
removed error prone warning

### Proof Manifests

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
