### PR TITLE
fix: check the patchedResources in kyverno-test

### DIFF
--- a/cmd/cli/kubectl-kyverno/apis/v1alpha1/test_result.go
+++ b/cmd/cli/kubectl-kyverno/apis/v1alpha1/test_result.go
@@ -26,11 +26,6 @@ type TestResultBase struct {
 	// Kind mentions the kind of the resource on which the policy is to be applied.
 	Kind string `json:"kind"`
 
-	// Deprecated. Use `patchedResources` instead.
-	// PatchedResource takes a resource configuration file in yaml format from
-	// the user to compare it against the Kyverno mutated resource configuration.
-	PatchedResource string `json:"patchedResource,omitempty"`
-
 	// PatchedResource takes a resource configuration file in yaml format from
 	// the user to compare it against the Kyverno mutated resource configuration.
 	// Multiple resources can be passed in the same file
@@ -59,6 +54,11 @@ type TestResultDeprecated struct {
 	// Namespace mentions the namespace of the policy which has namespace scope.
 	// This is DEPRECATED, use a name in the form `<namespace>/<name>` for policies and/or resources instead.
 	Namespace string `json:"namespace,omitempty"`
+
+	// PatchedResource takes a resource configuration file in yaml format from
+	// the user to compare it against the Kyverno mutated resource configuration.
+	// This is DEPRECATED, Use `patchedResources` instead.
+	PatchedResource string `json:"patchedResource,omitempty"`
 }
 
 // TestResultBase declares a test result

--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -158,8 +158,12 @@ func checkResult(test v1alpha1.TestResult, fs billy.Filesystem, resoucePath stri
 		expected = test.Status
 	}
 	// fallback on deprecated field
-	if test.PatchedResource != "" {
-		equals, err := getAndCompareResource([]*unstructured.Unstructured{&response.PatchedResource}, fs, filepath.Join(resoucePath, test.PatchedResource))
+	patchedResource := test.PatchedResource
+	if test.PatchedResources != "" {
+		patchedResource = test.PatchedResources
+	}
+	if patchedResource != "" {
+		equals, err := getAndCompareResource([]*unstructured.Unstructured{&response.PatchedResource}, fs, filepath.Join(resoucePath, patchedResource))
 		if err != nil {
 			return false, err.Error(), "Resource error"
 		}

--- a/cmd/cli/kubectl-kyverno/deprecations/check.go
+++ b/cmd/cli/kubectl-kyverno/deprecations/check.go
@@ -35,14 +35,14 @@ func CheckTest(out io.Writer, path string, resource *v1alpha1.Test) bool {
 	if resource != nil {
 		if resource.APIVersion == "" || resource.Kind == "" || resource.Name != "" {
 			if out != nil {
-				fmt.Fprintf(out, "\nWARNING: test file (%s) uses a deprecated schema that will be removed in 1.13\n", path)
+				fmt.Fprintf(out, "\nWARNING: test file (%s) uses a deprecated schema that will be removed in 1.14\n", path)
 			}
 			return true
 		}
 		for _, result := range resource.Results {
-			if result.TestResultDeprecated.Status != "" || result.TestResultDeprecated.Namespace != "" || result.TestResultDeprecated.Resource != "" {
+			if result.TestResultDeprecated.Status != "" || result.TestResultDeprecated.Namespace != "" || result.TestResultDeprecated.Resource != "" || result.TestResultDeprecated.PatchedResource != "" {
 				if out != nil {
-					fmt.Fprintf(out, "\nWARNING: test file (%s) uses a deprecated schema that will be removed in 1.13\n", path)
+					fmt.Fprintf(out, "\nWARNING: test file (%s) uses a deprecated schema that will be removed in 1.14\n", path)
 				}
 				return true
 			}

--- a/docs/user/cli/crd/index.html
+++ b/docs/user/cli/crd/index.html
@@ -795,19 +795,6 @@ string
 </tr>
 <tr>
 <td>
-<code>patchedResource</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Deprecated. Use <code>patchedResources</code> instead.
-PatchedResource takes a resource configuration file in yaml format from
-the user to compare it against the Kyverno mutated resource configuration.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>patchedResources</code><br/>
 <em>
 string
@@ -898,6 +885,19 @@ string
 <td>
 <p>Namespace mentions the namespace of the policy which has namespace scope.
 This is DEPRECATED, use a name in the form <code>&lt;namespace&gt;/&lt;name&gt;</code> for policies and/or resources instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>patchedResource</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>PatchedResource takes a resource configuration file in yaml format from
+the user to compare it against the Kyverno mutated resource configuration.
+This is DEPRECATED, Use <code>patchedResources</code> instead.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
+++ b/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
@@ -1675,37 +1675,6 @@ Possible values are pass, fail and skip.</p>
     
     
       <tr>
-        <td><code>patchedResource</code>
-          
-          <span style="color:blue;"> *</span>
-          
-          </br>
-
-          
-          
-            
-              <span style="font-family: monospace">string</span>
-            
-          
-        </td>
-        <td>
-          
-
-          <p>Deprecated. Use <code>patchedResources</code> instead.
-PatchedResource takes a resource configuration file in yaml format from
-the user to compare it against the Kyverno mutated resource configuration.</p>
-
-
-          
-
-          
-        </td>
-      </tr>
-    
-  
-    
-    
-      <tr>
         <td><code>patchedResources</code>
           
           <span style="color:blue;"> *</span>
@@ -1912,6 +1881,37 @@ This is DEPRECATED, use <code>Resources</code> instead.</p>
 
           <p>Namespace mentions the namespace of the policy which has namespace scope.
 This is DEPRECATED, use a name in the form <code>&lt;namespace&gt;/&lt;name&gt;</code> for policies and/or resources instead.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>patchedResource</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>PatchedResource takes a resource configuration file in yaml format from
+the user to compare it against the Kyverno mutated resource configuration.
+This is DEPRECATED, Use <code>patchedResources</code> instead.</p>
 
 
           

--- a/test/cli/scenarios_to_cli/other/scenario_mutate_endpoint/kyverno-test.yaml
+++ b/test/cli/scenarios_to_cli/other/scenario_mutate_endpoint/kyverno-test.yaml
@@ -8,7 +8,7 @@ resources:
 - resource.yaml
 results:
 - kind: Endpoints
-  patchedResource: patchedresource.yaml
+  patchedResources: patchedresource.yaml
   policy: policy-endpoints
   resources:
   - test-endpoint

--- a/test/cli/scenarios_to_cli/other/scenario_mutate_pod_spec/kyverno-test.yaml
+++ b/test/cli/scenarios_to_cli/other/scenario_mutate_pod_spec/kyverno-test.yaml
@@ -8,7 +8,7 @@ resources:
 - resource.yaml
 results:
 - kind: Deployment
-  patchedResource: patchedresource.yaml
+  patchedResources: patchedresource.yaml
   policy: mutate-pods-spec
   resources:
   - nginx-deployment

--- a/test/cli/test-mutate/add-default-resources/kyverno-test.yaml
+++ b/test/cli/test-mutate/add-default-resources/kyverno-test.yaml
@@ -8,21 +8,21 @@ resources:
 - resource.yaml
 results:
 - kind: Pod
-  patchedResource: patchedResource1.yaml
+  patchedResources: patchedResource1.yaml
   policy: add-default-resources
   resources:
   - nginx-demo1
   result: pass
   rule: add-default-requests
 - kind: Pod
-  patchedResource: patchedResource3.yaml
+  patchedResources: patchedResource3.yaml
   policy: add-default-resources
   resources:
   - nginx-demo3
   result: pass
   rule: add-default-requests
 - kind: Pod
-  patchedResource: patchedResource2.yaml
+  patchedResources: patchedResource2.yaml
   policy: add-default-resources
   resources:
   - nginx-demo2

--- a/test/cli/test-mutate/bug-demo/kyverno-test.yaml
+++ b/test/cli/test-mutate/bug-demo/kyverno-test.yaml
@@ -8,7 +8,7 @@ resources:
 - ./resource.yaml
 results:
 - kind: Pod
-  patchedResource: patched-resource-pattern.yaml
+  patchedResources: patched-resource-pattern.yaml
   policy: bug-demo
   resources:
   - pod1

--- a/test/cli/test-mutate/connection-draining/kyverno-test.yaml
+++ b/test/cli/test-mutate/connection-draining/kyverno-test.yaml
@@ -14,7 +14,7 @@ results:
   result: skip
   rule: clb
 - kind: Service
-  patchedResource: patched.yaml
+  patchedResources: patched.yaml
   policy: disable-connection-draining
   resources:
   - nlb-aws-controller-no-attributes

--- a/test/cli/test-mutate/foreach/addIfNotPresent/kyverno-test.yaml
+++ b/test/cli/test-mutate/foreach/addIfNotPresent/kyverno-test.yaml
@@ -8,7 +8,7 @@ resources:
 - resources.yaml
 results:
 - kind: Deployment
-  patchedResource: deploy-patched.yaml
+  patchedResources: deploy-patched.yaml
   policy: mutate-emptydir
   resources:
   - svc-sizelimit-test

--- a/test/cli/test-mutate/foreach/cumulativePatch/kyverno-test.yaml
+++ b/test/cli/test-mutate/foreach/cumulativePatch/kyverno-test.yaml
@@ -8,7 +8,7 @@ resources:
 - resources.yaml
 results:
 - kind: Pod
-  patchedResource: patched.yaml
+  patchedResources: patched.yaml
   policy: add-default-resources
   resources:
   - badpod

--- a/test/cli/test-mutate/foreach/kyverno-test.yaml
+++ b/test/cli/test-mutate/foreach/kyverno-test.yaml
@@ -8,14 +8,14 @@ resources:
 - resources.yaml
 results:
 - kind: Pod
-  patchedResource: patched-resource.yaml
+  patchedResources: patched-resource.yaml
   policy: foreach-json-patch
   resources:
   - nginx
   result: pass
   rule: add-security-context
 - kind: Pod
-  patchedResource: pod-updated-image.yaml
+  patchedResources: pod-updated-image.yaml
   policy: mutate-images
   resources:
   - mypod

--- a/test/cli/test-mutate/foreach/replaceRegistry/kyverno-test.yaml
+++ b/test/cli/test-mutate/foreach/replaceRegistry/kyverno-test.yaml
@@ -8,7 +8,7 @@ resources:
 - resources.yaml
 results:
 - kind: Pod
-  patchedResource: pod-patched.yaml
+  patchedResources: pod-patched.yaml
   policy: replace-image-registry-containers
   resources:
   - test-patched-image

--- a/test/cli/test-mutate/global-anchor/kyverno-test.yaml
+++ b/test/cli/test-mutate/global-anchor/kyverno-test.yaml
@@ -8,14 +8,14 @@ resources:
 - resources.yaml
 results:
 - kind: Pod
-  patchedResource: patchedResource.yaml
+  patchedResources: patchedResource.yaml
   policy: add-safe-to-evict
   resources:
   - pod-with-emptydir-hostpath
   result: pass
   rule: annotate-empty-dir
 - kind: Pod
-  patchedResource: patchedResourceWithVolume.yaml
+  patchedResources: patchedResourceWithVolume.yaml
   policy: add-safe-to-evict
   resources:
   - pod-with-emptydir-hostpath-1

--- a/test/cli/test-mutate/karpenter-annotations-to-nodeselector/kyverno-test.yaml
+++ b/test/cli/test-mutate/karpenter-annotations-to-nodeselector/kyverno-test.yaml
@@ -14,7 +14,7 @@ results:
   result: pass
   rule: hard-nodeselector-lifecycle-on-demand
 - kind: Pod
-  patchedResource: patched.yaml
+  patchedResources: patched.yaml
   policy: karpenter-annotations-to-nodeselector
   resources:
   - soft-pod-antiaffinity-1

--- a/test/cli/test-mutate/karpenter-annotations-to-nodeselector/kyverno-test.yaml
+++ b/test/cli/test-mutate/karpenter-annotations-to-nodeselector/kyverno-test.yaml
@@ -8,15 +8,15 @@ resources:
 - resource.yaml
 results:
 - kind: Pod
-  policy: karpenter-annotations-to-nodeselector
-  resources:
-  - soft-pod-antiaffinity-1-copy
-  result: pass
-  rule: hard-nodeselector-lifecycle-on-demand
-- kind: Pod
   patchedResources: patched.yaml
   policy: karpenter-annotations-to-nodeselector
   resources:
   - soft-pod-antiaffinity-1
+  result: pass
+  rule: hard-nodeselector-lifecycle-on-demand
+- kind: Pod
+  policy: karpenter-annotations-to-nodeselector
+  resources:
+  - soft-pod-antiaffinity-1-copy
   result: pass
   rule: hard-nodeselector-lifecycle-on-demand

--- a/test/cli/test-mutate/kyverno-test.yaml
+++ b/test/cli/test-mutate/kyverno-test.yaml
@@ -15,13 +15,6 @@ results:
   result: pass
   rule: add-label
 - kind: Pod
-  patchedResources: patchedResource2.yaml
-  policy: add-label
-  resources:
-  - testing/same-name-but-diff-namespace
-  result: pass
-  rule: add-label
-- kind: Pod
   patchedResources: patchedResource3.yaml
   policy: add-label
   resources:
@@ -33,6 +26,13 @@ results:
   policy: add-label
   resources:
   - same-name-but-diff-kind
+  result: pass
+  rule: add-label
+- kind: Pod
+  patchedResources: patchedResource2.yaml
+  policy: add-label
+  resources:
+  - testing/same-name-but-diff-namespace
   result: pass
   rule: add-label
 - kind: Pod

--- a/test/cli/test-mutate/kyverno-test.yaml
+++ b/test/cli/test-mutate/kyverno-test.yaml
@@ -8,49 +8,49 @@ resources:
 - resource.yaml
 results:
 - kind: Deployment
-  patchedResource: patchedResource4.yaml
+  patchedResources: patchedResource4.yaml
   policy: add-label
   resources:
   - mydeploy
   result: pass
   rule: add-label
 - kind: Pod
-  patchedResource: patchedResource2.yaml
+  patchedResources: patchedResource2.yaml
   policy: add-label
   resources:
   - testing/same-name-but-diff-namespace
   result: pass
   rule: add-label
 - kind: Pod
-  patchedResource: patchedResource3.yaml
+  patchedResources: patchedResource3.yaml
   policy: add-label
   resources:
   - production/same-name-but-diff-namespace
   result: pass
   rule: add-label
 - kind: Pod
-  patchedResource: patchedResource6.yaml
+  patchedResources: patchedResource6.yaml
   policy: add-label
   resources:
   - same-name-but-diff-kind
   result: pass
   rule: add-label
 - kind: Pod
-  patchedResource: patchedResource1.yaml
+  patchedResources: patchedResource1.yaml
   policy: add-label
   resources:
   - practice/resource-equal-to-patch-res-for-cp
   result: skip
   rule: add-label
 - kind: Pod
-  patchedResource: patched-resource.yaml
+  patchedResources: patched-resource.yaml
   policy: example
   resources:
   - example
   result: pass
   rule: object_from_lists
 - kind: Pod
-  patchedResource: patchedResource8.yaml
+  patchedResources: patchedResource8.yaml
   policy: testing/add-ndots
   resources:
   - same-name-but-diff-namespace

--- a/test/cli/test-mutate/patched-resource/kyverno-test.yaml
+++ b/test/cli/test-mutate/patched-resource/kyverno-test.yaml
@@ -8,7 +8,7 @@ resources:
 - resource.yaml
 results:
 - kind: Pod
-  patchedResource: patched-resource.yaml
+  patchedResources: patched-resource.yaml
   policy: add-default-resources
   resources:
   - nginx-demo

--- a/test/cli/test/mixed-deprecated/kyverno-test.yaml
+++ b/test/cli/test/mixed-deprecated/kyverno-test.yaml
@@ -20,7 +20,7 @@ results:
   result: pass
   rule: ondemand-managed_by
 - kind: Pod
-  patchedResource: patched-resource.yaml
+  patchedResources: patched-resource.yaml
   policy: ondemand
   resources:
   - user-space/nodeselector-with-labels-on-mutation

--- a/test/cli/test/mixed/kyverno-test.yaml
+++ b/test/cli/test/mixed/kyverno-test.yaml
@@ -20,7 +20,7 @@ results:
   result: pass
   rule: ondemand-managed_by
 - kind: Pod
-  patchedResource: patched-resource.yaml
+  patchedResources: patched-resource.yaml
   policy: ondemand
   resources:
   - user-space/nodeselector-with-labels-on-mutation

--- a/test/cli/test/mutate-keda-scaled-object/kyverno-test.yaml
+++ b/test/cli/test/mutate-keda-scaled-object/kyverno-test.yaml
@@ -8,14 +8,14 @@ resources:
 - resources.yaml
 results:
 - kind: ScaledObject
-  patchedResource: patchedResource1.yaml
+  patchedResources: patchedResource1.yaml
   policy: keda-prometheus-serveraddress
   resources:
   - service-1
   result: pass
   rule: keda-prometheus-serveraddress
 - kind: ScaledObject
-  patchedResource: patchedResource2.yaml
+  patchedResources: patchedResource2.yaml
   policy: keda-prometheus-serveraddress
   resources:
   - service-2

--- a/test/cli/test/secret/kyverno-test.yaml
+++ b/test/cli/test/secret/kyverno-test.yaml
@@ -8,14 +8,14 @@ resources:
 - resources.yaml
 results:
 - kind: Secret
-  patchedResource: patched-resource1.yaml
+  patchedResources: patched-resource1.yaml
   policy: add-maintainer
   resources:
   - secrete-fail-example
   result: fail
   rule: add-maintainer
 - kind: Secret
-  patchedResource: patched-resource.yaml
+  patchedResources: patched-resource.yaml
   policy: add-maintainer
   resources:
   - example

--- a/test/cli/test/wildcard_mutate/kyverno-test.yaml
+++ b/test/cli/test/wildcard_mutate/kyverno-test.yaml
@@ -8,14 +8,14 @@ resources:
 - resources.yaml
 results:
 - kind: Pod
-  patchedResource: patchedResource1.yaml
+  patchedResources: patchedResource1.yaml
   policy: mutate-wildcard
   resources:
   - wildcard-mutate-fail
   result: fail
   rule: mutate-wildcard
 - kind: Pod
-  patchedResource: patchedResource.yaml
+  patchedResources: patchedResource.yaml
   policy: mutate-wildcard
   resources:
   - wildcard-mutate


### PR DESCRIPTION
## Explanation
This PR checks that the expected `patchedResources` from the `kyverno-test` files is equal to the mutated resource returned from the engine. There is also a warning added in case the user used the deprecated field `patchResource`.

Related to https://github.com/kyverno/kyverno/pull/11297
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #11685 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.13.2
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
1. `policy.yaml`:
```
apiVersion: kyverno.io/v2beta1
kind: ClusterPolicy
metadata:
  name: secret-store-defaults
spec:
  rules:
    - name: vault-server-default
      match:
        any:
          - resources:
              kinds:
                - SecretStore
      mutate:
        patchStrategicMerge:
          spec:
            provider:
              (vault):
                +(server): ${VAULT_ADDR}
```
2. `resource.yaml`:
```
apiVersion: external-secrets.io/v1beta1
kind: SecretStore
metadata:
  name: order-processor
spec:
  provider:
    vault:
      path: your-team
      auth:
        kubernetes:
          role: your-team-order_order-processor
          serviceAccountRef:
            name: order-processor
```
3. `patched-resource.yaml`:
```
apiVersion: external-secrets.io/v1beta1
kind: SecretStore
metadata:
  name: order-processor
spec:
  provider:
    vault:
      path: your-team
      auth:
        kubernetes:
          role: your-team-order_order-processor
          serviceAccountRef:
            name: order-processor
```
The patched resource doesn't have the `server` field so this is the wrong resource.
4. `kyverno-test.yaml`:
```
apiVersion: cli.kyverno.io/v1alpha1
kind: Test
metadata:
  name: kyverno-test
policies:
  - policy.yaml
resources:
  - resource.yaml
results:
  - policy: secret-store-defaults
    rule: vault-server-default
    patchedResources: patched-resource.yaml
    resources:
    - order-processor
    kind: SecretStore
    result: pass
```

It should fail since the patchedResource file is wrong:
```
./cmd/cli/kubectl-kyverno/kubectl-kyverno test ./mutate-test                     

Loading test  ( mutate-test/kyverno-test.yaml ) ...
  Loading values/variables ...
  Loading policies ...
  Loading resources ...
  Loading exceptions ...
  Applying 1 policy to 1 resource ...

policy secret-store-defaults applied to default/SecretStore/order-processor:
apiVersion: external-secrets.io/v1beta1
kind: SecretStore
metadata:
  name: order-processor
  namespace: default
spec:
  provider:
    vault:
      auth:
        kubernetes:
          role: your-team-order_order-processor
          serviceAccountRef:
            name: order-processor
      path: your-team
      server: ${VAULT_ADDR}

---


Mutation:
Mutation has been applied successfully.  Checking results ...

│────│───────────────────────│──────────────────────│─────────────────────────────│────────│───────────────│
│ ID │ POLICY                │ RULE                 │ RESOURCE                    │ RESULT │ REASON        │
│────│───────────────────────│──────────────────────│─────────────────────────────│────────│───────────────│
│ 1  │ secret-store-defaults │ vault-server-default │ SecretStore/order-processor │ Fail   │ Resource diff │
│────│───────────────────────│──────────────────────│─────────────────────────────│────────│───────────────│


Test Summary: 0 tests passed and 1 tests failed

Aggregated Failed Test Cases : 
│────│───────────────────────│──────────────────────│─────────────────────────────│────────│───────────────│
│ ID │ POLICY                │ RULE                 │ RESOURCE                    │ RESULT │ REASON        │
│────│───────────────────────│──────────────────────│─────────────────────────────│────────│───────────────│
│ 1  │ secret-store-defaults │ vault-server-default │ SecretStore/order-processor │ Fail   │ Resource diff │
│────│───────────────────────│──────────────────────│─────────────────────────────│────────│───────────────│
Error: 1 tests failed
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
