### PR TITLE
Duplicate Test Entry Deduplication

### DIFF
--- a/cmd/cli/kubectl-kyverno/test/load.go
+++ b/cmd/cli/kubectl-kyverno/test/load.go
@@ -73,9 +73,31 @@ func LoadTest(fs billy.Filesystem, path string) TestCase {
 			Err:  err,
 		}
 	}
+	cleanTest(&test)
 	return TestCase{
 		Path: path,
 		Fs:   fs,
 		Test: &test,
 	}
+}
+
+func cleanTest(test *v1alpha1.Test) {
+	test.Policies = removeDuplicateStrings(test.Policies)
+	test.Resources = removeDuplicateStrings(test.Resources)
+	for index, result := range test.Results {
+		test.Results[index].Resources = removeDuplicateStrings(result.Resources)
+	}
+}
+
+func removeDuplicateStrings(strings []string) []string {
+	seen := make(map[string]struct{})
+	var result []string
+
+	for _, str := range strings {
+		if _, exists := seen[str]; !exists {
+			seen[str] = struct{}{}
+			result = append(result, str)
+		}
+	}
+	return result
 }


### PR DESCRIPTION
## Explanation

This PR addresses an issue where Kyverno CLI processes duplicate policy and resource files multiple times during testing, leading to unnecessary test executions.

## Related issue
Closes #11702.


## What type of PR is this

/kind bug

## Proposed Changes

- Implemented `cleanTest` function to remove duplicate entries
- Deduplication occurs before test execution
- Preserves original order of first occurrences

## milestones
/milestone 1.14.0

### Proof Manifests

On this Yaml
```bash
apiVersion: cli.kyverno.io/v1alpha1
kind: Test
metadata:
  name: test
policies:
  - policies/policy1.yaml
  - policies/policy1.yaml
resources:
  - resources/resource.yaml
  - resources/resource.yaml
results:
  - policy: validate-team-label
    rule: check-team-label
    resources: 
    - resource
    - resource
    kind: Deployment
    result: pass
```
We get
![image](https://github.com/user-attachments/assets/3299678c-9128-4391-91a3-03813df7538d)


## Checklist

- [ x ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ x ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.