### PR TITLE
fix: Check all rules in the test in case no rule is specified

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/output.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/output.go
@@ -201,7 +201,7 @@ func printTestResult(
 						RowCompact: table.RowCompact{
 							ID:        testCount,
 							Policy:    color.Policy("", test.Policy),
-							Rule:      color.Rule(test.Rule),
+							Rule:      color.Rule(rule.Name()),
 							Resource:  color.Resource(test.Kind, test.Namespace, resource),
 							Reason:    reason,
 							IsFailure: !success,

--- a/cmd/cli/kubectl-kyverno/commands/test/output.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/output.go
@@ -186,7 +186,13 @@ func printTestResult(
 			// lookup matching engine responses (with the resource name this time)
 			for _, response := range lookupEngineResponses(test, resource, responses...) {
 				// lookup matching rule responses
-				for _, rule := range lookupRuleResponses(test, response.PolicyResponse.Rules...) {
+				var rulesToCheck []engineapi.RuleResponse
+				if test.Rule == "" {
+					rulesToCheck = append(rulesToCheck, response.PolicyResponse.Rules...)
+				} else {
+					rulesToCheck = append(rulesToCheck, lookupRuleResponses(test, response.PolicyResponse.Rules...)...)
+				}
+				for _, rule := range rulesToCheck {
 					// perform test checks
 					ok, message, reason := checkResult(test, fs, resoucePath, response, rule)
 					// if checks failed but we were expecting a fail it's considered a success


### PR DESCRIPTION
## Explanation

Configures the kyverno test to check all rules in case no rule is specified in the results

## Related issue
Closes #11687 

## Milestone of this PR


## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind bug

## Proposed Changes


### Proof Manifests

Test `kyverno-test.yaml`
```yaml
apiVersion: cli.kyverno.io/v1alpha1
kind: Test
metadata:
  name: kyverno-test.yaml
policies:
- policy.yaml
resources:
- resources.yaml
results:
- kind: Namespace
  policy: restrict-labels
  resources:
  - kyverno-system-tst
  result: fail
```

Policy `policy.yaml`
```yaml
---
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  annotations:
    policies.kyverno.io/category: Labels
    policies.kyverno.io/description: This policy prevents the use of an label beginning
      with a common key name (in this case "platform.das-schiff.telekom.de/owner |
      owner"). This can be useful to ensure users either don't set reserved labels
      or to force them to use a newer version of an label.
    policies.kyverno.io/minversion: 1.3.0
    policies.kyverno.io/title: Restrict Labels on Namespaces
  labels:
    policy.schiff.telekom.de: enforced
  name: restrict-labels
spec:
  admission: true
  background: false
  rules:
  - exclude:
      any:
      - clusterRoles:
        - cluster-admin
        resources: {}
    match:
      any:
      - resources:
          kinds:
          - Namespace
    name: restrict-labels
    validate:
      message: Every namespace has to have `platform.das-schiff.telekom.de/owner`
        label. It must not have value `das-schiff` which is reserved for system namespaces
      pattern:
        metadata:
          labels:
            =(schiff.telekom.de/owner): '!schiff'
            platform.das-schiff.telekom.de/owner: '!das-schiff'
      failureAction: Enforce
```

Resources `resources.yaml`

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: kyverno-system-tst
  labels:
    name: kyverno-system-tst
    schiff.telekom.de/owner: schiff
    platform.das-schiff.telekom.de/owner: das-schiff
```

```bash
Loading test  ( /Users/ammaryasser/kyverno/test/cli/test-fail/invalid-ns/kyverno-test.yaml ) ...
  Loading values/variables ...
  Loading policies ...
  Loading resources ...
  Loading exceptions ...
  Applying 1 policy to 1 resource ...
  Checking results ...

│────│─────────────────│─────────────────│──────────────────────────────│────────│────────│
│ ID │ POLICY          │ RULE            │ RESOURCE                     │ RESULT │ REASON │
│────│─────────────────│─────────────────│──────────────────────────────│────────│────────│
│ 1  │ restrict-labels │ restrict-labels │ Namespace/kyverno-system-tst │ Pass   │ Ok     │
│────│─────────────────│─────────────────│──────────────────────────────│────────│────────│


Test Summary: 1 tests passed and 0 tests failed
```

## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

