### PR TITLE
Added support for setting expected API call response type

### DIFF
--- a/api/kyverno/v1/common_types.go
+++ b/api/kyverno/v1/common_types.go
@@ -56,6 +56,15 @@ const (
 	Descending ForeachOrder = "Descending"
 )
 
+// ResponseType specifies how the HTTP response content should be treated.
+// +kubebuilder:validation:Enum=JSON;text
+type ResponseType string
+
+const (
+	JSON ResponseType = "JSON"
+	Text ResponseType = "text"
+)
+
 // WebhookConfiguration specifies the configuration for Kubernetes admission webhookconfiguration.
 type WebhookConfiguration struct {
 	// FailurePolicy defines how unexpected policy errors and webhook response timeout errors are handled.
@@ -212,6 +221,13 @@ type APICall struct {
 	// It's mutually exclusive with the URLPath field.
 	// +kubebuilder:validation:Optional
 	Service *ServiceCall `json:"service,omitempty"`
+
+	// ResponseType is an optional parameter that allows for configuring the
+	// expected HTTP response body content type. If set to "text", the content
+	// will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=JSON
+	ResponseType ResponseType `json:"responseType,omitempty"`
 }
 
 type ContextAPICall struct {

--- a/api/kyverno/v2alpha1/global_context_entry_types_test.go
+++ b/api/kyverno/v2alpha1/global_context_entry_types_test.go
@@ -59,6 +59,19 @@ func TestGlobalContextEntrySpecValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid text APICall",
+			spec: GlobalContextEntrySpec{
+				APICall: &ExternalAPICall{
+					APICall: kyvernov1.APICall{
+						URLPath:      "https://kyverno.io/",
+						ResponseType: kyvernov1.Text,
+					},
+					RefreshInterval: &metav1.Duration{Duration: 10 * time.Minute},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "both KubernetesResource and APICall",
 			spec: GlobalContextEntrySpec{
 				KubernetesResource: &KubernetesResource{
@@ -164,7 +177,8 @@ func TestExternalAPICallValidate(t *testing.T) {
 			name: "valid ExternalAPICall",
 			apiCall: ExternalAPICall{
 				APICall: kyvernov1.APICall{
-					URLPath: "/api/v1/namespaces",
+					URLPath:      "/api/v1/namespaces",
+					ResponseType: kyvernov1.Text,
 				},
 				RefreshInterval: &metav1.Duration{Duration: 10 * time.Minute},
 			},
@@ -209,7 +223,6 @@ func TestExternalAPICallValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
-
 		{
 			name: "non-POST method with data",
 			apiCall: ExternalAPICall{
@@ -235,6 +248,7 @@ func TestExternalAPICallValidate(t *testing.T) {
 		})
 	}
 }
+
 func generateRandomVersion() string {
 	rand.NewSource(time.Now().UnixNano())
 	for {

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_cleanuppolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_cleanuppolicies.yaml
@@ -213,6 +213,16 @@ spec:
                           - GET
                           - POST
                           type: string
+                        responseType:
+                          default: JSON
+                          description: |-
+                            ResponseType is an optional parameter that allows for configuring the
+                            expected HTTP response body content type. If set to "text", the content
+                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                          enum:
+                          - JSON
+                          - text
+                          type: string
                         service:
                           description: |-
                             Service is an API call to a JSON web service.
@@ -1505,6 +1515,16 @@ spec:
                           enum:
                           - GET
                           - POST
+                          type: string
+                        responseType:
+                          default: JSON
+                          description: |-
+                            ResponseType is an optional parameter that allows for configuring the
+                            expected HTTP response body content type. If set to "text", the content
+                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                          enum:
+                          - JSON
+                          - text
                           type: string
                         service:
                           description: |-

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clustercleanuppolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clustercleanuppolicies.yaml
@@ -213,6 +213,16 @@ spec:
                           - GET
                           - POST
                           type: string
+                        responseType:
+                          default: JSON
+                          description: |-
+                            ResponseType is an optional parameter that allows for configuring the
+                            expected HTTP response body content type. If set to "text", the content
+                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                          enum:
+                          - JSON
+                          - text
+                          type: string
                         service:
                           description: |-
                             Service is an API call to a JSON web service.
@@ -1505,6 +1515,16 @@ spec:
                           enum:
                           - GET
                           - POST
+                          type: string
+                        responseType:
+                          default: JSON
+                          description: |-
+                            ResponseType is an optional parameter that allows for configuring the
+                            expected HTTP response body content type. If set to "text", the content
+                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                          enum:
+                          - JSON
+                          - text
                           type: string
                         service:
                           description: |-

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clusterpolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clusterpolicies.yaml
@@ -249,6 +249,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -1282,6 +1292,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -2368,6 +2388,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -2750,6 +2780,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -3501,6 +3541,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -5323,6 +5373,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -6366,6 +6426,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -7464,6 +7534,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -7855,6 +7935,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -8619,6 +8709,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -10521,6 +10621,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -11348,6 +11458,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -12228,6 +12348,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -12610,6 +12740,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -13526,6 +13666,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -15317,6 +15467,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -16360,6 +16520,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -17458,6 +17628,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -17849,6 +18029,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -18613,6 +18803,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_globalcontextentries.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_globalcontextentries.yaml
@@ -110,6 +110,16 @@ spec:
                       such as "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                     format: duration
                     type: string
+                  responseType:
+                    default: JSON
+                    description: |-
+                      ResponseType is an optional parameter that allows for configuring the
+                      expected HTTP response body content type. If set to "text", the content
+                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                    enum:
+                    - JSON
+                    - text
+                    type: string
                   retryLimit:
                     default: 3
                     description: RetryLimit defines the number of times the APICall

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policies.yaml
@@ -250,6 +250,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -1283,6 +1293,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -2369,6 +2389,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -2751,6 +2781,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -3502,6 +3542,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -5325,6 +5375,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -6368,6 +6428,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -7466,6 +7536,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -7857,6 +7937,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -8621,6 +8711,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -10524,6 +10624,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -11351,6 +11461,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -12231,6 +12351,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -12613,6 +12743,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -13529,6 +13669,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -15320,6 +15470,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -16363,6 +16523,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -17461,6 +17631,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -17852,6 +18032,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -18616,6 +18806,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
@@ -243,6 +243,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -1276,6 +1286,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -2362,6 +2382,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -2744,6 +2774,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -3495,6 +3535,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -5317,6 +5367,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -6360,6 +6420,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -7458,6 +7528,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -7849,6 +7929,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -8613,6 +8703,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -10515,6 +10615,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -11342,6 +11452,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -12222,6 +12342,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -12604,6 +12734,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -13520,6 +13660,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -15311,6 +15461,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -16354,6 +16514,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -17452,6 +17622,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -17843,6 +18023,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -18607,6 +18797,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policies.yaml
@@ -244,6 +244,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -1277,6 +1287,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -2363,6 +2383,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -2745,6 +2775,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -3496,6 +3536,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -5319,6 +5369,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -6362,6 +6422,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -7460,6 +7530,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -7851,6 +7931,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -8615,6 +8705,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -10518,6 +10618,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -11345,6 +11455,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -12225,6 +12345,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -12607,6 +12737,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -13523,6 +13663,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -15314,6 +15464,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -16357,6 +16517,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -17455,6 +17625,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -17846,6 +18026,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -18610,6 +18800,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-

--- a/config/crds/kyverno/kyverno.io_cleanuppolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_cleanuppolicies.yaml
@@ -207,6 +207,16 @@ spec:
                           - GET
                           - POST
                           type: string
+                        responseType:
+                          default: JSON
+                          description: |-
+                            ResponseType is an optional parameter that allows for configuring the
+                            expected HTTP response body content type. If set to "text", the content
+                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                          enum:
+                          - JSON
+                          - text
+                          type: string
                         service:
                           description: |-
                             Service is an API call to a JSON web service.
@@ -1499,6 +1509,16 @@ spec:
                           enum:
                           - GET
                           - POST
+                          type: string
+                        responseType:
+                          default: JSON
+                          description: |-
+                            ResponseType is an optional parameter that allows for configuring the
+                            expected HTTP response body content type. If set to "text", the content
+                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                          enum:
+                          - JSON
+                          - text
                           type: string
                         service:
                           description: |-

--- a/config/crds/kyverno/kyverno.io_clustercleanuppolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_clustercleanuppolicies.yaml
@@ -207,6 +207,16 @@ spec:
                           - GET
                           - POST
                           type: string
+                        responseType:
+                          default: JSON
+                          description: |-
+                            ResponseType is an optional parameter that allows for configuring the
+                            expected HTTP response body content type. If set to "text", the content
+                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                          enum:
+                          - JSON
+                          - text
+                          type: string
                         service:
                           description: |-
                             Service is an API call to a JSON web service.
@@ -1499,6 +1509,16 @@ spec:
                           enum:
                           - GET
                           - POST
+                          type: string
+                        responseType:
+                          default: JSON
+                          description: |-
+                            ResponseType is an optional parameter that allows for configuring the
+                            expected HTTP response body content type. If set to "text", the content
+                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                          enum:
+                          - JSON
+                          - text
                           type: string
                         service:
                           description: |-

--- a/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
@@ -243,6 +243,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -1276,6 +1286,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -2362,6 +2382,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -2744,6 +2774,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -3495,6 +3535,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -5317,6 +5367,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -6360,6 +6420,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -7458,6 +7528,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -7849,6 +7929,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -8613,6 +8703,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -10515,6 +10615,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -11342,6 +11452,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -12222,6 +12342,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -12604,6 +12734,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -13520,6 +13660,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -15311,6 +15461,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -16354,6 +16514,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -17452,6 +17622,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -17843,6 +18023,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -18607,6 +18797,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-

--- a/config/crds/kyverno/kyverno.io_globalcontextentries.yaml
+++ b/config/crds/kyverno/kyverno.io_globalcontextentries.yaml
@@ -104,6 +104,16 @@ spec:
                       such as "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                     format: duration
                     type: string
+                  responseType:
+                    default: JSON
+                    description: |-
+                      ResponseType is an optional parameter that allows for configuring the
+                      expected HTTP response body content type. If set to "text", the content
+                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                    enum:
+                    - JSON
+                    - text
+                    type: string
                   retryLimit:
                     default: 3
                     description: RetryLimit defines the number of times the APICall

--- a/config/crds/kyverno/kyverno.io_policies.yaml
+++ b/config/crds/kyverno/kyverno.io_policies.yaml
@@ -244,6 +244,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -1277,6 +1287,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -2363,6 +2383,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -2745,6 +2775,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -3496,6 +3536,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -5319,6 +5369,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -6362,6 +6422,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -7460,6 +7530,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -7851,6 +7931,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -8615,6 +8705,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -10518,6 +10618,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -11345,6 +11455,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -12225,6 +12345,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -12607,6 +12737,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -13523,6 +13663,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -15314,6 +15464,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -16357,6 +16517,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -17455,6 +17625,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -17846,6 +18026,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -18610,6 +18800,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -408,6 +408,16 @@ spec:
                           - GET
                           - POST
                           type: string
+                        responseType:
+                          default: JSON
+                          description: |-
+                            ResponseType is an optional parameter that allows for configuring the
+                            expected HTTP response body content type. If set to "text", the content
+                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                          enum:
+                          - JSON
+                          - text
+                          type: string
                         service:
                           description: |-
                             Service is an API call to a JSON web service.
@@ -1700,6 +1710,16 @@ spec:
                           enum:
                           - GET
                           - POST
+                          type: string
+                        responseType:
+                          default: JSON
+                          description: |-
+                            ResponseType is an optional parameter that allows for configuring the
+                            expected HTTP response body content type. If set to "text", the content
+                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                          enum:
+                          - JSON
+                          - text
                           type: string
                         service:
                           description: |-
@@ -3020,6 +3040,16 @@ spec:
                           - GET
                           - POST
                           type: string
+                        responseType:
+                          default: JSON
+                          description: |-
+                            ResponseType is an optional parameter that allows for configuring the
+                            expected HTTP response body content type. If set to "text", the content
+                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                          enum:
+                          - JSON
+                          - text
+                          type: string
                         service:
                           description: |-
                             Service is an API call to a JSON web service.
@@ -4312,6 +4342,16 @@ spec:
                           enum:
                           - GET
                           - POST
+                          type: string
+                        responseType:
+                          default: JSON
+                          description: |-
+                            ResponseType is an optional parameter that allows for configuring the
+                            expected HTTP response body content type. If set to "text", the content
+                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                          enum:
+                          - JSON
+                          - text
                           type: string
                         service:
                           description: |-
@@ -5668,6 +5708,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -6701,6 +6751,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -7787,6 +7847,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -8169,6 +8239,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -8920,6 +9000,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -10742,6 +10832,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -11785,6 +11885,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -12883,6 +12993,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -13274,6 +13394,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -14038,6 +14168,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -15940,6 +16080,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -16767,6 +16917,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -17647,6 +17807,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -18029,6 +18199,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -18945,6 +19125,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -20736,6 +20926,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -21779,6 +21979,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -22877,6 +23087,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -23268,6 +23488,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -24032,6 +24262,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -25822,6 +26062,16 @@ spec:
                       such as "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
                     format: duration
                     type: string
+                  responseType:
+                    default: JSON
+                    description: |-
+                      ResponseType is an optional parameter that allows for configuring the
+                      expected HTTP response body content type. If set to "text", the content
+                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                    enum:
+                    - JSON
+                    - text
+                    type: string
                   retryLimit:
                     default: 3
                     description: RetryLimit defines the number of times the APICall
@@ -26226,6 +26476,16 @@ spec:
                                 enum:
                                 - GET
                                 - POST
+                                type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
                                 type: string
                               service:
                                 description: |-
@@ -27260,6 +27520,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -28346,6 +28616,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -28728,6 +29008,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -29479,6 +29769,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -31302,6 +31602,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -32345,6 +32655,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -33443,6 +33763,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -33834,6 +34164,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -34598,6 +34938,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -36501,6 +36851,16 @@ spec:
                                 - GET
                                 - POST
                                 type: string
+                              responseType:
+                                default: JSON
+                                description: |-
+                                  ResponseType is an optional parameter that allows for configuring the
+                                  expected HTTP response body content type. If set to "text", the content
+                                  will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                enum:
+                                - JSON
+                                - text
+                                type: string
                               service:
                                 description: |-
                                   Service is an API call to a JSON web service.
@@ -37328,6 +37688,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -38208,6 +38578,16 @@ spec:
                                           - GET
                                           - POST
                                           type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
+                                          type: string
                                         service:
                                           description: |-
                                             Service is an API call to a JSON web service.
@@ -38590,6 +38970,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -39506,6 +39896,16 @@ spec:
                                           enum:
                                           - GET
                                           - POST
+                                          type: string
+                                        responseType:
+                                          default: JSON
+                                          description: |-
+                                            ResponseType is an optional parameter that allows for configuring the
+                                            expected HTTP response body content type. If set to "text", the content
+                                            will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                          enum:
+                                          - JSON
+                                          - text
                                           type: string
                                         service:
                                           description: |-
@@ -41297,6 +41697,16 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  responseType:
+                                    default: JSON
+                                    description: |-
+                                      ResponseType is an optional parameter that allows for configuring the
+                                      expected HTTP response body content type. If set to "text", the content
+                                      will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                    enum:
+                                    - JSON
+                                    - text
+                                    type: string
                                   service:
                                     description: |-
                                       Service is an API call to a JSON web service.
@@ -42340,6 +42750,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -43438,6 +43858,16 @@ spec:
                                               - GET
                                               - POST
                                               type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
+                                              type: string
                                             service:
                                               description: |-
                                                 Service is an API call to a JSON web service.
@@ -43829,6 +44259,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-
@@ -44593,6 +45033,16 @@ spec:
                                               enum:
                                               - GET
                                               - POST
+                                              type: string
+                                            responseType:
+                                              default: JSON
+                                              description: |-
+                                                ResponseType is an optional parameter that allows for configuring the
+                                                expected HTTP response body content type. If set to "text", the content
+                                                will be parsed as a JSON string for JMESPath logic. Defaults to JSON.
+                                              enum:
+                                              - JSON
+                                              - text
                                               type: string
                                             service:
                                               description: |-

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -672,6 +672,21 @@ This is used for non-Kubernetes API server calls.
 It&rsquo;s mutually exclusive with the URLPath field.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>responseType</code><br/>
+<em>
+<a href="#kyverno.io/v1.ResponseType">
+ResponseType
+</a>
+</em>
+</td>
+<td>
+<p>ResponseType is an optional parameter that allows for configuring the
+expected HTTP response body content type. If set to &ldquo;text&rdquo;, the content
+will be parsed as a JSON string for JMESPath logic. Defaults to JSON.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr />
@@ -3900,6 +3915,15 @@ k8s.io/apimachinery/pkg/types.UID
 </tbody>
 </table>
 <hr />
+<h3 id="kyverno.io/v1.ResponseType">ResponseType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#kyverno.io/v1.APICall">APICall</a>)
+</p>
+<p>
+<p>ResponseType specifies how the HTTP response content should be treated.</p>
+</p>
 <h3 id="kyverno.io/v1.Rule">Rule
 </h3>
 <p>

--- a/docs/user/crd/kyverno.v1.html
+++ b/docs/user/crd/kyverno.v1.html
@@ -1360,6 +1360,39 @@ It's mutually exclusive with the URLPath field.</p>
       </tr>
     
   
+    
+    
+      <tr>
+        <td><code>responseType</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kyverno-io-v1-ResponseType">
+                <span style="font-family: monospace">ResponseType</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>ResponseType is an optional parameter that allows for configuring the
+expected HTTP response body content type. If set to &quot;text&quot;, the content
+will be parsed as a JSON string for JMESPath logic. Defaults to JSON.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
 
 
       </tbody>
@@ -7763,6 +7796,21 @@ does not match an empty label set.</p>
 
       </tbody>
     </table>
+  
+
+  <H3 id="kyverno-io-v1-ResponseType">ResponseType
+    (<code>string</code> alias)</p></H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kyverno-io-v1-APICall">APICall</a>)
+    </p>
+  
+
+  <p><p>ResponseType specifies how the HTTP response content should be treated.</p>
+</p>
+
   
 
   <H3 id="kyverno-io-v1-Rule">Rule

--- a/pkg/client/applyconfigurations/kyverno/v1/apicall.go
+++ b/pkg/client/applyconfigurations/kyverno/v1/apicall.go
@@ -25,10 +25,11 @@ import (
 // APICallApplyConfiguration represents an declarative configuration of the APICall type for use
 // with apply.
 type APICallApplyConfiguration struct {
-	URLPath *string                         `json:"urlPath,omitempty"`
-	Method  *v1.Method                      `json:"method,omitempty"`
-	Data    []RequestDataApplyConfiguration `json:"data,omitempty"`
-	Service *ServiceCallApplyConfiguration  `json:"service,omitempty"`
+	URLPath      *string                         `json:"urlPath,omitempty"`
+	Method       *v1.Method                      `json:"method,omitempty"`
+	Data         []RequestDataApplyConfiguration `json:"data,omitempty"`
+	Service      *ServiceCallApplyConfiguration  `json:"service,omitempty"`
+	ResponseType *v1.ResponseType                `json:"responseType,omitempty"`
 }
 
 // APICallApplyConfiguration constructs an declarative configuration of the APICall type for use with
@@ -71,5 +72,13 @@ func (b *APICallApplyConfiguration) WithData(values ...*RequestDataApplyConfigur
 // If called multiple times, the Service field is set to the value of the last call.
 func (b *APICallApplyConfiguration) WithService(value *ServiceCallApplyConfiguration) *APICallApplyConfiguration {
 	b.Service = value
+	return b
+}
+
+// WithResponseType sets the ResponseType field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ResponseType field is set to the value of the last call.
+func (b *APICallApplyConfiguration) WithResponseType(value v1.ResponseType) *APICallApplyConfiguration {
+	b.ResponseType = &value
 	return b
 }

--- a/pkg/client/applyconfigurations/kyverno/v1/contextapicall.go
+++ b/pkg/client/applyconfigurations/kyverno/v1/contextapicall.go
@@ -74,6 +74,14 @@ func (b *ContextAPICallApplyConfiguration) WithService(value *ServiceCallApplyCo
 	return b
 }
 
+// WithResponseType sets the ResponseType field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ResponseType field is set to the value of the last call.
+func (b *ContextAPICallApplyConfiguration) WithResponseType(value kyvernov1.ResponseType) *ContextAPICallApplyConfiguration {
+	b.ResponseType = &value
+	return b
+}
+
 // WithDefault sets the Default field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Default field is set to the value of the last call.

--- a/pkg/client/applyconfigurations/kyverno/v2alpha1/externalapicall.go
+++ b/pkg/client/applyconfigurations/kyverno/v2alpha1/externalapicall.go
@@ -75,6 +75,14 @@ func (b *ExternalAPICallApplyConfiguration) WithService(value *v1.ServiceCallApp
 	return b
 }
 
+// WithResponseType sets the ResponseType field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ResponseType field is set to the value of the last call.
+func (b *ExternalAPICallApplyConfiguration) WithResponseType(value kyvernov1.ResponseType) *ExternalAPICallApplyConfiguration {
+	b.ResponseType = &value
+	return b
+}
+
 // WithRefreshInterval sets the RefreshInterval field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the RefreshInterval field is set to the value of the last call.


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

This adds the ability to set the expected response type on external data source calls. Currently, data source calls _must_ return a JSON response, which can limit their usefulness in some cases. This allows for specifying that a response should be treated as either JSON (which is unmarshaled, causing non-JSON responses to error), or plain text.

When a "plain text" response is specified, Kyverno will treat the response as a JSON string literal (i.e. `"response content"`). This means that JMESPath queries (such as `contains(@, 'response')`) will still work with the response.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

No issue filed

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

I will take the time to file a doc PR when/if this passes an initial review from maintainers, and prior to merge of this PR.

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind feature

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

From what I can tell from the CLI docs and local testing, it's not possible for the CLI to actually query external data sources (with or without this change). This means that I cannot generate a meaningful set of manifests to test this feature via the CLI.

Because of this limitation, the best I can provide is a policy that demonstrates how this change can be used:

# Kubernetes resource

```yaml
---
apiVersion: kyverno.io/v1
kind: Policy
metadata:
  name: test-policy
spec:
  rules:
    - name: test-policy
      match:
        any:
          - resources:
              kinds:
                - ConfigMap
              name: dummy-for-trigger
      skipBackgroundRequests: true
      context:
        - name: apiCallContext
          apiCall:
            method: GET
            service:
              # This is just a publicly reachable HTTP service that returns
              # a text response that would plausibly be useful for this feature
              url: https://platform.teleport.sh/webapi/auth/export?type=db
            responseType: text
      generate:
        generateExisting: true
        synchronize: true
        apiVersion: v1
        kind: Secret
        name: database-public-certificate
        namespace: "{{ request.object.metadata.namespace }}"
        data:
          type: Opaque
          data:
            ca.crt: |-
              {{ apiCallContext | base64_encode(@) }}
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [x] My PR contains new or altered behavior to Kyverno and
  - [x] CLI support should be added and my PR doesn't contain that functionality. - See note about CLI missing functionality to test this

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

This _vast_ majority of this PR by line count is auto-generated code for CRDs. The majority of the "meaningful" changes take up 
about 10% of the PR size, with another ~15% for tests.

This does add a field to the v1 CRDs, but it's done in an entirely backwards compatible way that should have zero impact on existing deployments.