### PR TITLE
chore: use upstream images for tests

### DIFF
--- a/test/conformance/chainsaw/verifyImages/clusterpolicy/standard/update-multi-containers/policy.yaml
+++ b/test/conformance/chainsaw/verifyImages/clusterpolicy/standard/update-multi-containers/policy.yaml
@@ -23,7 +23,7 @@ spec:
               HZKwYP5XkHhU436FGDD5Zi2nVFem6AbzXWHssIQRkAI3yJgKkB4J6Qe4OQ==
               -----END PUBLIC KEY-----
       imageReferences:
-        - ghcr.io/seankhliao/*
+        - ghcr.io/stefanprodan/*
       mutateDigest: false
       required: true
       verifyDigest: false

--- a/test/conformance/chainsaw/verifyImages/clusterpolicy/standard/update-multi-containers/resource-v1.yaml
+++ b/test/conformance/chainsaw/verifyImages/clusterpolicy/standard/update-multi-containers/resource-v1.yaml
@@ -13,6 +13,6 @@ spec:
     spec:
       containers:
         - name: podinfo-a
-          image: ghcr.io/seankhliao/podinfo:6.3.3
+          image: ghcr.io/stefanprodan/podinfo:6.3.3
         - name: podinfo-b
-          image: ghcr.io/seankhliao/podinfo:6.3.4
+          image: ghcr.io/stefanprodan/podinfo:6.3.4

--- a/test/conformance/chainsaw/verifyImages/clusterpolicy/standard/update-multi-containers/resource-v2.yaml
+++ b/test/conformance/chainsaw/verifyImages/clusterpolicy/standard/update-multi-containers/resource-v2.yaml
@@ -13,6 +13,6 @@ spec:
     spec:
       containers:
         - name: podinfo-a
-          image: ghcr.io/seankhliao/podinfo:6.3.3
+          image: ghcr.io/stefanprodan/podinfo:6.3.3
         - name: podinfo-b
-          image: ghcr.io/seankhliao/podinfo:6.3.5
+          image: ghcr.io/stefanprodan/podinfo:6.3.5


### PR DESCRIPTION
## Explanation

While I was cleaning out my github packages, I noticed one had an unusually high number of downloads.
I believe it mostly comes from the test cases in this repo.
I don't think they should depend on images in my account (which were ones I mirrored for other uses cases), so I'm changing them to point to upstream images (they contain the same content / signatures).

## Related issue

#7651 was my original bug report that used these images to demonstrate the issue

## Milestone of this PR


## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind cleanup

## Proposed Changes

Change tests to reference https://github.com/stefanprodan/podinfo/pkgs/container/podinfo
instead of https://github.com/users/seankhliao/packages/container/podinfo

### Proof Manifests

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
