### PR TITLE
Add flag for JSON output in policy reports

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -57,6 +57,7 @@ type ApplyCommandConfig struct {
 	UserInfoPath          string
 	Cluster               bool
 	PolicyReport          bool
+	OutputFormat          string
 	Stdin                 bool
 	RegistryAccess        bool
 	AuditWarn             bool
@@ -93,9 +94,9 @@ func Command() *cobra.Command {
 			cmd.SilenceErrors = true
 			printSkippedAndInvalidPolicies(out, skipInvalidPolicies)
 			if applyCommandConfig.PolicyReport {
-				printReports(out, responses, applyCommandConfig.AuditWarn)
+				printReports(out, responses, applyCommandConfig.AuditWarn, applyCommandConfig.OutputFormat)
 			} else if applyCommandConfig.GenerateExceptions {
-				printExceptions(out, responses, applyCommandConfig.AuditWarn, applyCommandConfig.GeneratedExceptionTTL)
+				printExceptions(out, responses, applyCommandConfig.AuditWarn, applyCommandConfig.OutputFormat, applyCommandConfig.GeneratedExceptionTTL)
 			} else if table {
 				printTable(out, detailedResults, applyCommandConfig.AuditWarn, responses...)
 			} else {
@@ -146,6 +147,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&applyCommandConfig.Variables, "set", "s", nil, "Variables that are required")
 	cmd.Flags().StringVarP(&applyCommandConfig.ValuesFile, "values-file", "f", "", "File containing values for policy variables")
 	cmd.Flags().BoolVarP(&applyCommandConfig.PolicyReport, "policy-report", "p", false, "Generates policy report when passed (default policyviolation)")
+	cmd.Flags().StringVarP(&applyCommandConfig.OutputFormat, "output-format", "", "yaml", "Specifies the policy report format (json or yaml). Default: yaml.")
 	cmd.Flags().StringVarP(&applyCommandConfig.Namespace, "namespace", "n", "", "Optional Policy parameter passed with cluster flag")
 	cmd.Flags().BoolVarP(&applyCommandConfig.Stdin, "stdin", "i", false, "Optional mutate policy parameter to pipe directly through to kubectl")
 	cmd.Flags().BoolVar(&applyCommandConfig.RegistryAccess, "registry", false, "If set to true, access the image registry using local docker credentials to populate external data")

--- a/cmd/cli/kubectl-kyverno/commands/apply/print.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/print.go
@@ -40,26 +40,36 @@ func printSkippedAndInvalidPolicies(out io.Writer, skipInvalidPolicies SkippedIn
 	}
 }
 
-func printReports(out io.Writer, engineResponses []engineapi.EngineResponse, auditWarn bool) {
+func printReports(out io.Writer, engineResponses []engineapi.EngineResponse, auditWarn bool, outputFormat string) {
 	clustered, namespaced := report.ComputePolicyReports(auditWarn, engineResponses...)
-	if len(clustered) > 0 {
-		report := report.MergeClusterReports(clustered)
-		yamlReport, _ := yaml.Marshal(report)
-		fmt.Fprintln(out, string(yamlReport))
+
+	printReport := func(report interface{}) {
+		var output []byte
+		if outputFormat == "json" {
+			output, _ = json.Marshal(report)
+		} else {
+			output, _ = yaml.Marshal(report)
+		}
+		fmt.Fprintln(out, string(output))
 	}
+
+	if len(clustered) > 0 {
+		clusterReport := report.MergeClusterReports(clustered)
+		printReport(clusterReport)
+	}
+
 	for _, r := range namespaced {
-		fmt.Fprintln(out, string("---"))
-		yamlReport, _ := yaml.Marshal(r)
-		fmt.Fprintln(out, string(yamlReport))
+		fmt.Fprintln(out, "---")
+		printReport(r)
 	}
 }
 
-func printExceptions(out io.Writer, engineResponses []engineapi.EngineResponse, auditWarn bool, ttl time.Duration) {
+func printExceptions(out io.Writer, engineResponses []engineapi.EngineResponse, auditWarn bool, outputFormat string, ttl time.Duration) {
 	clustered, _ := report.ComputePolicyReports(auditWarn, engineResponses...)
 	for _, report := range clustered {
 		for _, result := range report.Results {
 			if result.Result == "fail" {
-				if err := printException(out, result, ttl); err != nil {
+				if err := printException(out, result, ttl, outputFormat); err != nil {
 					log.Error(err)
 				}
 			}
@@ -67,7 +77,7 @@ func printExceptions(out io.Writer, engineResponses []engineapi.EngineResponse, 
 	}
 }
 
-func printException(out io.Writer, result v1alpha2.PolicyReportResult, ttl time.Duration) error {
+func printException(out io.Writer, result v1alpha2.PolicyReportResult, ttl time.Duration, outputFormat string) error {
 	for _, r := range result.Resources {
 		name := strings.Join([]string{result.Policy, result.Rule, r.Namespace, r.Name}, "-")
 
@@ -141,13 +151,21 @@ func printException(out io.Writer, result v1alpha2.PolicyReportResult, ttl time.
 			exception.Spec.PodSecurity = pssList
 		}
 
-		exceptionYAML, err := yaml.Marshal(exception)
+		var exceptionReport []byte
+		marshal := func(report interface{}) ([]byte, error) {
+			if outputFormat == "json" {
+				return json.Marshal(report)
+			}
+			return yaml.Marshal(report)
+		}
+
+		exceptionReport, err := marshal(exception)
 		if err != nil {
 			return err
 		}
 
 		fmt.Fprint(out, "---\n")
-		fmt.Fprint(out, string(exceptionYAML))
+		fmt.Fprint(out, string(exceptionReport))
 		fmt.Fprint(out, "\n")
 	}
 

--- a/docs/user/cli/commands/kyverno_apply.md
+++ b/docs/user/cli/commands/kyverno_apply.md
@@ -52,6 +52,7 @@ kyverno apply [flags]
       --kubeconfig string                  path to kubeconfig file with authorization and master location information
   -n, --namespace string                   Optional Policy parameter passed with cluster flag
   -o, --output string                      Prints the mutated/generated resources in provided file/directory
+      --output-format string               Specifies the policy report format (json or yaml). Default: yaml. (default "yaml")
   -p, --policy-report                      Generates policy report when passed (default policyviolation)
       --registry                           If set to true, access the image registry using local docker credentials to populate external data
       --remove-color                       Remove any color from output


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

Added a new flag `--output-format` (to the Kyverno CLI, which enables the kyverno apply command to output results in either YAML (default) or JSON format for easier integration with tools and automation workflows.

Policy and Deployment manifest:
```
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingAdmissionPolicy
metadata:
  name: "check-deployment-replicas"
spec:
  matchConstraints:
    resourceRules:
    - apiGroups:
      - apps
      apiVersions:
      - v1
      operations:
      - CREATE
      - UPDATE
      resources:
      - deployments
  validations:
  - expression: object.spec.replicas <= 5
```
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-pass
spec:
  replicas: 2
  selector:
    matchLabels:
      app: nginx-pass
  template:
    metadata:
      labels:
        app: nginx-pass
    spec:
      containers:
      - name: nginx-server
        image: nginx
```
Run the kyverno apply command with the --output-json or -j flag like this: `./cmd/cli/kubectl-kyverno/kubectl-kyverno apply /path/to/policy.yaml --resource /path/to/deployment.yaml --policy-report --output-json` or `./cmd/cli/kubectl-kyverno/kubectl-kyverno apply /path/to/policy.yaml --resource /path/to/deployment.yaml --policy-report -j`

```
{
  "kind": "ClusterPolicyReport",
  "apiVersion": "wgpolicyk8s.io/v1alpha2",
  "metadata": {
    "name": "merged",
    "creationTimestamp": null
  },
  "summary": {
    "pass": 1,
    "fail": 0,
    "warn": 0,
    "error": 0,
    "skip": 0
  },
  "results": [
    {
      "source": "ValidatingAdmissionPolicy",
      "policy": "check-deployment-replicas",
      "rule": "check-deployment-replicas",
      "resources": [
        {
          "kind": "Deployment",
          "namespace": "default",
          "name": "nginx-pass",
          "apiVersion": "apps/v1"
        }
      ],
      "result": "pass",
      "scored": true,
      "timestamp": {
        "seconds": 1735962318,
        "nanos": 0
      }
    }
  ]
}
```
## Related issue
#11401

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
 /kind feature

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
