### PR TITLE
feat: add auditAnnotation in CEL Compiler

### DIFF
--- a/pkg/cel/policy/compiler.go
+++ b/pkg/cel/policy/compiler.go
@@ -110,6 +110,10 @@ func (c *compiler) Compile(policy *kyvernov2alpha1.ValidatingPolicy) (*CompiledP
 			if err := issues.Err(); err != nil {
 				return nil, append(allErrs, field.Invalid(path, auditAnnotation.ValueExpression, err.Error()))
 			}
+			if !ast.OutputType().IsExactType(types.StringType) && !ast.OutputType().IsExactType(types.NullType) {
+				msg := fmt.Sprintf("output is expected to be either of type %s or %s", types.StringType.TypeName(), types.NullType.TypeName())
+				return nil, append(allErrs, field.Invalid(path, auditAnnotation.ValueExpression, msg))
+			}
 			prog, err := env.Program(ast)
 			if err != nil {
 				return nil, append(allErrs, field.Invalid(path, auditAnnotation.ValueExpression, err.Error()))

--- a/pkg/cel/policy/policy.go
+++ b/pkg/cel/policy/policy.go
@@ -6,8 +6,9 @@ import (
 )
 
 type CompiledPolicy struct {
-	failurePolicy   admissionregistrationv1.FailurePolicyType
-	matchConditions []cel.Program
-	variables       map[string]cel.Program
-	validations     []cel.Program
+	failurePolicy    admissionregistrationv1.FailurePolicyType
+	matchConditions  []cel.Program
+	variables        map[string]cel.Program
+	validations      []cel.Program
+	auditAnnotations map[string]cel.Program
 }


### PR DESCRIPTION
## Explanation
This PR adds auditAnnotation expressions in the CEL compiler as it will be used later in the policy report properties.

Related to #11894 