### PR TITLE
chore: use v1 of VAPs in the tests

### DIFF
--- a/test/cli/test-validating-admission-policy/check-deployment-labels/policy.yaml
+++ b/test/cli/test-validating-admission-policy/check-deployment-labels/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "chech-deployment-labels"

--- a/test/cli/test-validating-admission-policy/check-deployments-replica/policy.yaml
+++ b/test/cli/test-validating-admission-policy/check-deployments-replica/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "chech-deployment-replicas"

--- a/test/cli/test-validating-admission-policy/disallow-host-path/policy.yaml
+++ b/test/cli/test-validating-admission-policy/disallow-host-path/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "disallow-host-path"

--- a/test/cli/test-validating-admission-policy/with-bindings-1/policy.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-1/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "check-deployment-replicas"
@@ -17,7 +17,7 @@ spec:
   validations:
   - expression: object.spec.replicas <= 2
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "check-deployment-replicas-binding"

--- a/test/cli/test-validating-admission-policy/with-bindings-2/policy.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-2/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "check-deployment-replicas"
@@ -17,7 +17,7 @@ spec:
   validations:
   - expression: object.spec.replicas <= 2
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "check-deployment-replicas-binding"

--- a/test/cli/test-validating-admission-policy/with-bindings-3/policy.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-3/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "check-deployment-replicas"
@@ -17,7 +17,7 @@ spec:
   validations:
   - expression: object.spec.replicas <= 2
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "check-deployment-replicas-binding"

--- a/test/cli/test-validating-admission-policy/with-bindings-4/policy.yaml
+++ b/test/cli/test-validating-admission-policy/with-bindings-4/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "check-deployment-replicas"
@@ -17,7 +17,7 @@ spec:
   validations:
   - expression: object.spec.replicas <= 2
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "check-deployment-replicas-binding"

--- a/test/cli/test-validating-admission-policy/with-match-conditions/disallow-host-path.yaml
+++ b/test/cli/test-validating-admission-policy/with-match-conditions/disallow-host-path.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "disallow-host-path"

--- a/test/cli/test-validating-admission-policy/with-namespaceObject-1/policy.yaml
+++ b/test/cli/test-validating-admission-policy/with-namespaceObject-1/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "check-deployment-namespace"

--- a/test/cli/test-validating-admission-policy/with-namespaceObject-2/policy.yaml
+++ b/test/cli/test-validating-admission-policy/with-namespaceObject-2/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "check-deployment-namespace"
@@ -18,7 +18,7 @@ spec:
   - expression: "namespaceObject.metadata.name != 'default'"
     message: "Using 'default' namespace is not allowed for pod controllers."
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "check-deployment-namespace-binding"

--- a/test/cli/test/validating-admission-policies/disallow-host-path/disallow-host-path.yaml
+++ b/test/cli/test/validating-admission-policies/disallow-host-path/disallow-host-path.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: disallow-host-path


### PR DESCRIPTION
## Explanation
This PR uses `v1` instead of `v1beta1` for VAPs in the tests.