### PR TITLE
chore: move CEL package to admissionpolicy package

### DIFF
--- a/cmd/cli/kubectl-kyverno/processor/vap_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/vap_processor.go
@@ -1,9 +1,9 @@
 package processor
 
 import (
+	"github.com/kyverno/kyverno/pkg/admissionpolicy"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
-	"github.com/kyverno/kyverno/pkg/validatingadmissionpolicy"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -21,13 +21,13 @@ type ValidatingAdmissionPolicyProcessor struct {
 func (p *ValidatingAdmissionPolicyProcessor) ApplyPolicyOnResource() ([]engineapi.EngineResponse, error) {
 	responses := make([]engineapi.EngineResponse, 0, len(p.Policies))
 	for _, policy := range p.Policies {
-		policyData := validatingadmissionpolicy.NewPolicyData(policy)
+		policyData := admissionpolicy.NewPolicyData(policy)
 		for _, binding := range p.Bindings {
 			if binding.Spec.PolicyName == policy.Name {
 				policyData.AddBinding(binding)
 			}
 		}
-		response, _ := validatingadmissionpolicy.Validate(policyData, *p.Resource, p.NamespaceSelectorMap, p.Client)
+		response, _ := admissionpolicy.Validate(policyData, *p.Resource, p.NamespaceSelectorMap, p.Client)
 		responses = append(responses, response)
 		p.Rc.addValidatingAdmissionResponse(response)
 	}

--- a/cmd/cli/kubectl-kyverno/utils/common/fetch.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/fetch.go
@@ -12,10 +12,10 @@ import (
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/apis/v1alpha1"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/log"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/resource"
+	"github.com/kyverno/kyverno/pkg/admissionpolicy"
 	"github.com/kyverno/kyverno/pkg/autogen"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
-	"github.com/kyverno/kyverno/pkg/validatingadmissionpolicy"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -254,7 +254,7 @@ func getKindsFromValidatingAdmissionPolicy(policy admissionregistrationv1beta1.V
 	resourceTypesMap := make(map[schema.GroupVersionKind]bool)
 	subresourceMap := make(map[schema.GroupVersionKind]v1alpha1.Subresource)
 
-	kinds := validatingadmissionpolicy.GetKinds(policy)
+	kinds := admissionpolicy.GetKinds(policy)
 	for _, kind := range kinds {
 		addGVKToResourceTypesMap(kind, resourceTypesMap, subresourceMap, client)
 	}

--- a/cmd/cli/kubectl-kyverno/utils/common/validating_admission_resources.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/validating_admission_resources.go
@@ -24,9 +24,6 @@ func (r *ValidatingAdmissionResources) FetchResourcesFromPolicy(out io.Writer, r
 	for _, policy := range r.policies {
 		var resourceTypesInRule map[schema.GroupVersionKind]bool
 		resourceTypesInRule, subresourceMap = getKindsFromValidatingAdmissionPolicy(policy, dClient)
-		if err != nil {
-			return resources, err
-		}
 		for resourceKind := range resourceTypesInRule {
 			resourceTypesMap[resourceKind] = true
 		}

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/kyverno/kyverno/cmd/internal"
+	"github.com/kyverno/kyverno/pkg/admissionpolicy"
 	"github.com/kyverno/kyverno/pkg/auth/checker"
 	"github.com/kyverno/kyverno/pkg/breaker"
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
@@ -38,7 +39,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/utils/generator"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	runtimeutils "github.com/kyverno/kyverno/pkg/utils/runtime"
-	"github.com/kyverno/kyverno/pkg/validatingadmissionpolicy"
 	"github.com/kyverno/kyverno/pkg/validation/exception"
 	"github.com/kyverno/kyverno/pkg/webhooks"
 	webhooksexception "github.com/kyverno/kyverno/pkg/webhooks/exception"
@@ -338,7 +338,7 @@ func main() {
 		// check if validating admission policies are registered in the API server
 		generateValidatingAdmissionPolicy := toggle.FromContext(context.TODO()).GenerateValidatingAdmissionPolicy()
 		if generateValidatingAdmissionPolicy {
-			registered, err := validatingadmissionpolicy.IsValidatingAdmissionPolicyRegistered(setup.KubeClient)
+			registered, err := admissionpolicy.IsValidatingAdmissionPolicyRegistered(setup.KubeClient)
 			if !registered {
 				setup.Logger.Error(err, "ValidatingAdmissionPolicies isn't supported in the API server")
 				os.Exit(1)

--- a/cmd/reports-controller/main.go
+++ b/cmd/reports-controller/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kyverno/kyverno/cmd/internal"
+	"github.com/kyverno/kyverno/pkg/admissionpolicy"
 	"github.com/kyverno/kyverno/pkg/breaker"
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	kyvernoinformer "github.com/kyverno/kyverno/pkg/client/informers/externalversions"
@@ -28,7 +29,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/logging"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
-	"github.com/kyverno/kyverno/pkg/validatingadmissionpolicy"
 	apiserver "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kubeinformers "k8s.io/client-go/informers"
 	admissionregistrationv1beta1informers "k8s.io/client-go/informers/admissionregistration/v1beta1"
@@ -266,7 +266,7 @@ func main() {
 		setup.Logger.Info("background scan interval", "duration", backgroundScanInterval.String())
 		// check if validating admission policies are registered in the API server
 		if validatingAdmissionPolicyReports {
-			registered, err := validatingadmissionpolicy.IsValidatingAdmissionPolicyRegistered(setup.KubeClient)
+			registered, err := admissionpolicy.IsValidatingAdmissionPolicyRegistered(setup.KubeClient)
 			if !registered {
 				setup.Logger.Error(err, "ValidatingAdmissionPolicies isn't supported in the API server")
 				os.Exit(1)

--- a/pkg/admissionpolicy/api.go
+++ b/pkg/admissionpolicy/api.go
@@ -1,4 +1,4 @@
-package validatingadmissionpolicy
+package admissionpolicy
 
 import (
 	"context"

--- a/pkg/admissionpolicy/builder.go
+++ b/pkg/admissionpolicy/builder.go
@@ -1,4 +1,4 @@
-package validatingadmissionpolicy
+package admissionpolicy
 
 import (
 	"fmt"

--- a/pkg/admissionpolicy/compiler.go
+++ b/pkg/admissionpolicy/compiler.go
@@ -1,4 +1,4 @@
-package cel
+package admissionpolicy
 
 import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"

--- a/pkg/admissionpolicy/kyvernopolicy_checker.go
+++ b/pkg/admissionpolicy/kyvernopolicy_checker.go
@@ -1,4 +1,4 @@
-package validatingadmissionpolicy
+package admissionpolicy
 
 import (
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"

--- a/pkg/admissionpolicy/kyvernopolicy_checker_test.go
+++ b/pkg/admissionpolicy/kyvernopolicy_checker_test.go
@@ -1,4 +1,4 @@
-package validatingadmissionpolicy
+package admissionpolicy
 
 import (
 	"encoding/json"

--- a/pkg/admissionpolicy/log.go
+++ b/pkg/admissionpolicy/log.go
@@ -1,4 +1,4 @@
-package validatingadmissionpolicy
+package admissionpolicy
 
 import "github.com/kyverno/kyverno/pkg/logging"
 

--- a/pkg/admissionpolicy/matcher.go
+++ b/pkg/admissionpolicy/matcher.go
@@ -1,4 +1,4 @@
-package validatingadmissionpolicy
+package admissionpolicy
 
 import (
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"

--- a/pkg/admissionpolicy/utils.go
+++ b/pkg/admissionpolicy/utils.go
@@ -1,4 +1,4 @@
-package validatingadmissionpolicy
+package admissionpolicy
 
 import (
 	"context"

--- a/pkg/admissionpolicy/validate.go
+++ b/pkg/admissionpolicy/validate.go
@@ -1,4 +1,4 @@
-package validatingadmissionpolicy
+package admissionpolicy
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
-	celutils "github.com/kyverno/kyverno/pkg/utils/cel"
 	datautils "github.com/kyverno/kyverno/pkg/utils/data"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"golang.org/x/text/cases"
@@ -193,7 +192,7 @@ func validateResource(
 
 	// compile CEL expressions
 	matchConditions := ConvertMatchConditionsV1(policy.Spec.MatchConditions)
-	compiler, err := celutils.NewCompiler(policy.Spec.Validations, policy.Spec.AuditAnnotations, matchConditions, policy.Spec.Variables)
+	compiler, err := NewCompiler(policy.Spec.Validations, policy.Spec.AuditAnnotations, matchConditions, policy.Spec.Variables)
 	if err != nil {
 		return engineResponse, err
 	}

--- a/pkg/admissionpolicy/validate_test.go
+++ b/pkg/admissionpolicy/validate_test.go
@@ -1,4 +1,4 @@
-package validatingadmissionpolicy
+package admissionpolicy
 
 import (
 	"reflect"

--- a/pkg/admissionpolicy/version_converter.go
+++ b/pkg/admissionpolicy/version_converter.go
@@ -1,4 +1,4 @@
-package validatingadmissionpolicy
+package admissionpolicy
 
 import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/kyverno/kyverno/pkg/admissionpolicy"
 	kyvernov1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1"
 	kyvernov1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
@@ -16,7 +17,6 @@ import (
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
-	"github.com/kyverno/kyverno/pkg/validatingadmissionpolicy"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -249,7 +249,7 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 		}
 		// fetch kinds from validating admission policies
 		for _, policy := range vapPolicies {
-			kinds := validatingadmissionpolicy.GetKinds(policy)
+			kinds := admissionpolicy.GetKinds(policy)
 			for _, kind := range kinds {
 				group, version, kind, subresource := kubeutils.ParseKindSelector(kind)
 				c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)

--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -6,13 +6,13 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kyverno/kyverno/api/kyverno"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/admissionpolicy"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/engine"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/engine/jmespath"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
-	"github.com/kyverno/kyverno/pkg/validatingadmissionpolicy"
 	"go.uber.org/multierr"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -96,13 +96,13 @@ func (s *scanner) ScanResource(ctx context.Context, resource unstructured.Unstru
 			}
 		} else {
 			pol := policy.AsValidatingAdmissionPolicy()
-			policyData := validatingadmissionpolicy.NewPolicyData(*pol)
+			policyData := admissionpolicy.NewPolicyData(*pol)
 			for _, binding := range bindings {
 				if binding.Spec.PolicyName == pol.Name {
 					policyData.AddBinding(binding)
 				}
 			}
-			res, err := validatingadmissionpolicy.Validate(policyData, resource, map[string]map[string]string{}, s.client)
+			res, err := admissionpolicy.Validate(policyData, resource, map[string]map[string]string{}, s.client)
 			if err != nil {
 				errors = append(errors, err)
 			}

--- a/pkg/engine/handlers/validation/validate_cel.go
+++ b/pkg/engine/handlers/validation/validate_cel.go
@@ -8,13 +8,12 @@ import (
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	"github.com/kyverno/kyverno/pkg/admissionpolicy"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/engine/handlers"
 	"github.com/kyverno/kyverno/pkg/engine/internal"
 	engineutils "github.com/kyverno/kyverno/pkg/engine/utils"
-	celutils "github.com/kyverno/kyverno/pkg/utils/cel"
 	datautils "github.com/kyverno/kyverno/pkg/utils/data"
-	vaputils "github.com/kyverno/kyverno/pkg/validatingadmissionpolicy"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,7 +119,7 @@ func (h validateCELHandler) Process(
 	optionalVars := cel.OptionalVariableDeclarations{HasParams: hasParam, HasAuthorizer: true}
 	expressionOptionalVars := cel.OptionalVariableDeclarations{HasParams: hasParam, HasAuthorizer: false}
 	// compile CEL expressions
-	compiler, err := celutils.NewCompiler(validations, auditAnnotations, vaputils.ConvertMatchConditionsV1(matchConditions), variables)
+	compiler, err := admissionpolicy.NewCompiler(validations, auditAnnotations, admissionpolicy.ConvertMatchConditionsV1(matchConditions), variables)
 	if err != nil {
 		return resource, handlers.WithError(rule, engineapi.Validation, "Error while creating composited compiler", err)
 	}

--- a/pkg/engine/internal/match.go
+++ b/pkg/engine/internal/match.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/admissionpolicy"
 	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
-	celutils "github.com/kyverno/kyverno/pkg/utils/cel"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -88,7 +88,7 @@ func checkMatchConditions(logger logr.Logger, policyContext engineapi.PolicyCont
 	}
 
 	optionalVars := cel.OptionalVariableDeclarations{HasParams: false, HasAuthorizer: false}
-	compiler, err := celutils.NewCompiler(nil, nil, policy.GetSpec().GetMatchConditions(), nil)
+	compiler, err := admissionpolicy.NewCompiler(nil, nil, policy.GetSpec().GetMatchConditions(), nil)
 	if err != nil {
 		logger.Error(err, "error creating composited compiler")
 		return false

--- a/pkg/validation/policy/actions.go
+++ b/pkg/validation/policy/actions.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/admissionpolicy"
 	authChecker "github.com/kyverno/kyverno/pkg/auth/checker"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/config"
@@ -14,7 +15,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/policy/mutate"
 	"github.com/kyverno/kyverno/pkg/policy/validate"
 	"github.com/kyverno/kyverno/pkg/toggle"
-	"github.com/kyverno/kyverno/pkg/validatingadmissionpolicy"
 )
 
 // Validation provides methods to validate a rule
@@ -54,11 +54,11 @@ func validateActions(idx int, rule *kyvernov1.Rule, client dclient.Interface, mo
 
 		if rule.HasValidateCEL() && toggle.FromContext(context.TODO()).GenerateValidatingAdmissionPolicy() {
 			authCheck := authChecker.NewSelfChecker(client.GetKubeClient().AuthorizationV1().SelfSubjectAccessReviews())
-			if !validatingadmissionpolicy.HasValidatingAdmissionPolicyPermission(authCheck) {
+			if !admissionpolicy.HasValidatingAdmissionPolicyPermission(authCheck) {
 				warnings = append(warnings, "insufficient permissions to generate ValidatingAdmissionPolicies")
 			}
 
-			if !validatingadmissionpolicy.HasValidatingAdmissionPolicyBindingPermission(authCheck) {
+			if !admissionpolicy.HasValidatingAdmissionPolicyBindingPermission(authCheck) {
 				warnings = append(warnings, "insufficient permissions to generate ValidatingAdmissionPolicies")
 			}
 		}

--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -19,6 +19,7 @@ import (
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov2alpha1 "github.com/kyverno/kyverno/api/kyverno/v2alpha1"
 	"github.com/kyverno/kyverno/ext/wildcard"
+	"github.com/kyverno/kyverno/pkg/admissionpolicy"
 	"github.com/kyverno/kyverno/pkg/autogen"
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
@@ -27,10 +28,8 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine/variables/operator"
 	"github.com/kyverno/kyverno/pkg/engine/variables/regex"
 	"github.com/kyverno/kyverno/pkg/logging"
-	celutils "github.com/kyverno/kyverno/pkg/utils/cel"
 	datautils "github.com/kyverno/kyverno/pkg/utils/data"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
-	vaputils "github.com/kyverno/kyverno/pkg/validatingadmissionpolicy"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -483,7 +482,7 @@ func Validate(policy, oldPolicy kyvernov1.PolicyInterface, client dclient.Interf
 	}
 
 	// check for CEL expression warnings in case of CEL subrules
-	if ok, _ := vaputils.CanGenerateVAP(spec, nil); ok && client != nil {
+	if ok, _ := admissionpolicy.CanGenerateVAP(spec, nil); ok && client != nil {
 		resolver := &resolver.ClientDiscoveryResolver{
 			Discovery: client.GetKubeClient().Discovery(),
 		}
@@ -503,11 +502,11 @@ func Validate(policy, oldPolicy kyvernov1.PolicyInterface, client dclient.Interf
 				Name: policy.GetName(),
 			},
 		}
-		err = vaputils.BuildValidatingAdmissionPolicy(client.Discovery(), vap, policy, nil)
+		err = admissionpolicy.BuildValidatingAdmissionPolicy(client.Discovery(), vap, policy, nil)
 		if err != nil {
 			return nil, err
 		}
-		v1vap := vaputils.ConvertValidatingAdmissionPolicy(*vap)
+		v1vap := admissionpolicy.ConvertValidatingAdmissionPolicy(*vap)
 
 		// check cel expression warnings
 		ctx := checker.CreateContext(&v1vap)
@@ -542,7 +541,7 @@ func isGlobalContextEntryReady(name string, gctxentries *kyvernov2alpha1.GlobalC
 }
 
 func ValidateCustomWebhookMatchConditions(wc []admissionregistrationv1.MatchCondition) error {
-	c, err := celutils.NewCompiler(nil, nil, wc, nil)
+	c, err := admissionpolicy.NewCompiler(nil, nil, wc, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Explanation
This PR does the following:
1. Rename the package `validatingadmissionpolicy` to `admissionpolicy`. This package is used in generating VAPs, CLI and reporting system.
2. Delete the [CEL](https://github.com/kyverno/kyverno/tree/main/pkg/utils/cel) package and add it in the `admissionpolicy` package since it uses the upstream functions to compile VAPs for the CLI.

