### PR TITLE
log non fatal parsing errors

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -422,6 +422,9 @@ func (c *ApplyCommandConfig) loadPolicies() (
 			}
 			for _, policyYaml := range policyYamls {
 				loaderResults, err := policy.Load(fs, "", policyYaml)
+				for _, err := range loaderResults.NonFatalErrors {
+					log.Log.V(3).Info("Non-fatal parsing error for single document " + err.Error.Error())
+				}
 				if err != nil {
 					continue
 				}
@@ -431,6 +434,9 @@ func (c *ApplyCommandConfig) loadPolicies() (
 			}
 		} else {
 			loaderResults, err := policy.Load(nil, "", path)
+			for _, err := range loaderResults.NonFatalErrors {
+				log.Log.V(3).Info("Non-fatal parsing error for single document " + err.Error.Error())
+			}
 			if err != nil {
 				log.Log.V(3).Info("skipping invalid YAML file", "path", path, "error", err)
 			} else {


### PR DESCRIPTION
## Explanation

For the kyverno apply command, non fatal parsing errors are being collected but not logged or used. this PR simply adds logging of those errors

## Related issue

https://github.com/kyverno/kyverno/issues/11689

## Milestone of this PR


## What type of PR is this
/kind bug


## Proposed Changes

log the errors

### Proof Manifests

```
kyverno[fix-apply-command*] % kubectl get clusterpolicies -o yaml | ./cmd/cli/kubectl-kyverno/kubectl-kyverno apply -v=3 - --cluster
2025-01-15T15:43:45+02:00 -2 cmd/cli/kubectl-kyverno/commands/apply/command.go:438 > Non-fatal parsing error for single document failed to parse document (failed to retrieve validator: kind List not found in v1 groupversion) logger=kubectl-kyverno v=3
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

