### PR TITLE
chore: remove unused functions in autogen

### DIFF
--- a/pkg/autogen/v1/autogen_test.go
+++ b/pkg/autogen/v1/autogen_test.go
@@ -6,11 +6,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kyverno/kyverno/api/kyverno"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	yamlutils "github.com/kyverno/kyverno/pkg/utils/yaml"
 	"gotest.tools/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 )
@@ -153,156 +151,6 @@ func Test_CanAutoGen(t *testing.T) {
 			if !applyAutoGen {
 				controllers = sets.New("none")
 			}
-
-			equalityTest := test.expectedControllers.Equal(controllers)
-			assert.Assert(t, equalityTest, fmt.Sprintf("expected: %v, got: %v", test.expectedControllers, controllers))
-		})
-	}
-}
-
-func Test_GetSupportedControllers(t *testing.T) {
-	testCases := []struct {
-		name                string
-		policy              []byte
-		expectedControllers sets.Set[string]
-	}{
-		{
-			name:                "rule-with-match-name",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"test","match":{"resources":{"kinds":["Namespace"],"name":"*"}}}]}}`),
-			expectedControllers: sets.New[string](),
-		},
-		{
-			name:                "rule-with-match-selector",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test-getcontrollers"},"spec":{"background":false,"rules":[{"name":"test-getcontrollers","match":{"resources":{"kinds":["Pod"],"selector":{"matchLabels":{"foo":"bar"}}}}}]}}`),
-			expectedControllers: sets.New[string](),
-		},
-		{
-			name:                "rule-with-exclude-name",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test-getcontrollers"},"spec":{"background":false,"rules":[{"name":"test-getcontrollers","match":{"resources":{"kinds":["Pod"]}},"exclude":{"resources":{"name":"test"}}}]}}`),
-			expectedControllers: sets.New[string](),
-		},
-		{
-			name:                "rule-with-exclude-selector",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test-getcontrollers"},"spec":{"background":false,"rules":[{"name":"test-getcontrollers","match":{"resources":{"kinds":["Pod"]}},"exclude":{"resources":{"selector":{"matchLabels":{"foo":"bar"}}}}}]}}`),
-			expectedControllers: sets.New[string](),
-		},
-		{
-			name:                "rule-with-deny",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"require-network-policy","match":{"resources":{"kinds":["Pod"]}},"validate":{"message":"testpolicy","deny":{"conditions":[{"key":"{{request.object.metadata.labels.foo}}","operator":"Equals","value":"bar"}]}}}]}}`),
-			expectedControllers: PodControllers,
-		},
-		{
-			name:                "rule-with-match-mixed-kinds-pod-podcontrollers",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"set-service-labels-env"},"spec":{"background":false,"rules":[{"name":"set-service-label","match":{"resources":{"kinds":["Pod","Deployment"]}},"preconditions":{"any":[{"key":"{{request.operation}}","operator":"Equals","value":"CREATE"}]},"mutate":{"patchStrategicMerge":{"metadata":{"labels":{"+(service)":"{{request.object.spec.template.metadata.labels.app}}"}}}}}]}}`),
-			expectedControllers: sets.New[string](),
-		},
-		{
-			name:                "rule-with-exclude-mixed-kinds-pod-podcontrollers",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"set-service-labels-env"},"spec":{"background":false,"rules":[{"name":"set-service-label","match":{"resources":{"kinds":["Pod"]}},"exclude":{"resources":{"kinds":["Pod","Deployment"]}},"mutate":{"patchStrategicMerge":{"metadata":{"labels":{"+(service)":"{{request.object.spec.template.metadata.labels.app}}"}}}}}]}}`),
-			expectedControllers: sets.New[string](),
-		},
-		{
-			name:                "rule-with-match-kinds-pod-only",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"require-network-policy","match":{"resources":{"kinds":["Pod"]}},"validate":{"message":"testpolicy","pattern":{"metadata":{"labels":{"foo":"bar"}}}}}]}}`),
-			expectedControllers: PodControllers,
-		},
-		{
-			name:                "rule-with-exclude-kinds-pod-only",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"require-network-policy","match":{"resources":{"kinds":["Pod"]}},"exclude":{"resources":{"kinds":["Pod"],"namespaces":["test"]}},"validate":{"message":"testpolicy","pattern":{"metadata":{"labels":{"foo":"bar"}}}}}]}}`),
-			expectedControllers: PodControllers,
-		},
-		{
-			name:                "rule-with-mutate-patches",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"test","match":{"resources":{"kinds":["Pod"]}},"mutate":{"patchesJson6902":"-op:add\npath:/spec/containers/0/env/-1\nvalue:{\"name\":\"SERVICE\",\"value\":{{request.object.spec.template.metadata.labels.app}}}"}}]}}`),
-			expectedControllers: sets.New[string](),
-		},
-		{
-			name:                "rule-with-generate",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"add-networkpolicy"},"spec":{"rules":[{"name":"default-deny-ingress","match":{"resources":{"kinds":["Namespace"],"name":"*"}},"exclude":{"resources":{"namespaces":["kube-system","default","kube-public","kyverno"]}},"generate":{"kind":"NetworkPolicy","name":"default-deny-ingress","namespace":"{{request.object.metadata.name}}","synchronize":true,"data":{"spec":{"podSelector":{},"policyTypes":["Ingress"]}}}}]}}`),
-			expectedControllers: sets.New[string](),
-		},
-		{
-			name:                "rule-with-predefined-invalid-controllers",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"set-service-labels-env"},"annotations":null,"pod-policies.kyverno.io/autogen-controllers":"DaemonSet,Deployment,StatefulSet","spec":{"background":false,"rules":[{"name":"set-service-label","match":{"resources":{"kinds":["Pod","Deployment"]}},"mutate":{"patchStrategicMerge":{"metadata":{"labels":{"+(service)":"{{request.object.spec.template.metadata.labels.app}}"}}}}}]}}`),
-			expectedControllers: sets.New[string](),
-		},
-		{
-			name:                "rule-with-predefined-valid-controllers",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"set-service-labels-env"},"annotations":null,"pod-policies.kyverno.io/autogen-controllers":"none","spec":{"background":false,"rules":[{"name":"set-service-label","match":{"resources":{"kinds":["Pod","Deployment"]}},"mutate":{"patchStrategicMerge":{"metadata":{"labels":{"+(service)":"{{request.object.spec.template.metadata.labels.app}}"}}}}}]}}`),
-			expectedControllers: sets.New[string](),
-		},
-		{
-			name:                "rule-with-only-predefined-valid-controllers",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"set-service-labels-env"},"annotations":null,"pod-policies.kyverno.io/autogen-controllers":"none","spec":{"background":false,"rules":[{"name":"set-service-label","match":{"resources":{"kinds":["Namespace"]}},"mutate":{"patchStrategicMerge":{"metadata":{"labels":{"+(service)":"{{request.object.spec.template.metadata.labels.app}}"}}}}}]}}`),
-			expectedControllers: sets.New[string](),
-		},
-		{
-			name:                "rule-with-match-kinds-pod-only-validate-exclude",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"test"},"spec":{"rules":[{"name":"require-network-policy","match":{"resources":{"kinds":["Pod"]}},"validate":{"message":"testpolicy","podSecurity": {"level": "baseline","version":"v1.24","exclude":[{"controlName":"SELinux","restrictedField":"spec.containers[*].securityContext.seLinuxOptions.role","images":["nginx"],"values":["baz"]}, {"controlName":"SELinux","restrictedField":"spec.initContainers[*].securityContext.seLinuxOptions.role","images":["nodejs"],"values":["init-baz"]}]}}}]}}`),
-			expectedControllers: PodControllers,
-		},
-		{
-			name:                "rule-with-validate-podsecurity",
-			policy:              []byte(`{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"name":"pod-security"},"spec":{"rules":[{"name":"restricted","match":{"all":[{"resources":{"kinds":["Pod"]}}]},"validate":{"failureAction":"enforce","podSecurity":{"level":"restricted","version":"v1.24"}}}]}}`),
-			expectedControllers: PodControllers,
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			var policy kyvernov1.ClusterPolicy
-			err := json.Unmarshal(test.policy, &policy)
-			assert.NilError(t, err)
-
-			controllers := GetSupportedControllers(&policy.Spec)
-
-			equalityTest := test.expectedControllers.Equal(controllers)
-			assert.Assert(t, equalityTest, fmt.Sprintf("expected: %v, got: %v", test.expectedControllers, controllers))
-		})
-	}
-}
-
-func Test_GetRequestedControllers(t *testing.T) {
-	testCases := []struct {
-		name                string
-		meta                metav1.ObjectMeta
-		expectedControllers sets.Set[string]
-	}{
-		{
-			name:                "annotations-nil",
-			meta:                metav1.ObjectMeta{},
-			expectedControllers: nil,
-		},
-		{
-			name:                "annotation-not-set",
-			meta:                metav1.ObjectMeta{Annotations: map[string]string{}},
-			expectedControllers: nil,
-		},
-		{
-			name:                "annotation-empty",
-			meta:                metav1.ObjectMeta{Annotations: map[string]string{kyverno.AnnotationAutogenControllers: ""}},
-			expectedControllers: nil,
-		},
-		{
-			name:                "annotation-none",
-			meta:                metav1.ObjectMeta{Annotations: map[string]string{kyverno.AnnotationAutogenControllers: "none"}},
-			expectedControllers: sets.New[string](),
-		},
-		{
-			name:                "annotation-job",
-			meta:                metav1.ObjectMeta{Annotations: map[string]string{kyverno.AnnotationAutogenControllers: "Job"}},
-			expectedControllers: sets.New[string]("Job"),
-		},
-		{
-			name:                "annotation-job-deployment",
-			meta:                metav1.ObjectMeta{Annotations: map[string]string{kyverno.AnnotationAutogenControllers: "Job,Deployment"}},
-			expectedControllers: sets.New[string]("Job", "Deployment"),
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			controllers := GetRequestedControllers(&test.meta)
 
 			equalityTest := test.expectedControllers.Equal(controllers)
 			assert.Assert(t, equalityTest, fmt.Sprintf("expected: %v, got: %v", test.expectedControllers, controllers))


### PR DESCRIPTION
## Explanation
This PR removes the following functions from the autogen package since they aren't used anywhere in the codebase:
1. GetSupportedControllers()
2. GetRequestedControllers()
3. GetControllers()
