### PR TITLE
feat: add validation action to VPs

### DIFF
--- a/api/kyverno/v2alpha1/spec_types.go
+++ b/api/kyverno/v2alpha1/spec_types.go
@@ -8,6 +8,9 @@ import (
 type ValidatingPolicySpec struct {
 	admissionregistrationv1.ValidatingAdmissionPolicySpec `json:",inline"`
 
+	// ValidationAction specifies the action to be taken when the matched resource violates the policy.
+	ValidationAction []admissionregistrationv1.ValidationAction `json:"validationActions,omitempty"`
+
 	// WebhookConfiguration defines the configuration for the webhook.
 	// +optional
 	WebhookConfiguration *WebhookConfiguration `json:"webhookConfiguration,omitempty"`

--- a/api/kyverno/v2alpha1/zz_generated.deepcopy.go
+++ b/api/kyverno/v2alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v2alpha1
 
 import (
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -244,6 +245,11 @@ func (in *ValidatingPolicyList) DeepCopyObject() runtime.Object {
 func (in *ValidatingPolicySpec) DeepCopyInto(out *ValidatingPolicySpec) {
 	*out = *in
 	in.ValidatingAdmissionPolicySpec.DeepCopyInto(&out.ValidatingAdmissionPolicySpec)
+	if in.ValidationAction != nil {
+		in, out := &in.ValidationAction, &out.ValidationAction
+		*out = make([]admissionregistrationv1.ValidationAction, len(*in))
+		copy(*out, *in)
+	}
 	if in.WebhookConfiguration != nil {
 		in, out := &in.WebhookConfiguration, &out.WebhookConfiguration
 		*out = new(WebhookConfiguration)

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_validatingpolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_validatingpolicies.yaml
@@ -530,6 +530,13 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              validationActions:
+                description: ValidationAction specifies the action to be taken when
+                  the matched resource violates the policy.
+                items:
+                  description: ValidationAction specifies a policy enforcement action.
+                  type: string
+                type: array
               validations:
                 description: |-
                   Validations contain CEL expressions which is used to apply the validation.

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_validatingpolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_validatingpolicies.yaml
@@ -524,6 +524,13 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              validationActions:
+                description: ValidationAction specifies the action to be taken when
+                  the matched resource violates the policy.
+                items:
+                  description: ValidationAction specifies a policy enforcement action.
+                  type: string
+                type: array
               validations:
                 description: |-
                   Validations contain CEL expressions which is used to apply the validation.

--- a/config/crds/kyverno/kyverno.io_validatingpolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_validatingpolicies.yaml
@@ -524,6 +524,13 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              validationActions:
+                description: ValidationAction specifies the action to be taken when
+                  the matched resource violates the policy.
+                items:
+                  description: ValidationAction specifies a policy enforcement action.
+                  type: string
+                type: array
               validations:
                 description: |-
                   Validations contain CEL expressions which is used to apply the validation.

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -48944,6 +48944,13 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              validationActions:
+                description: ValidationAction specifies the action to be taken when
+                  the matched resource violates the policy.
+                items:
+                  description: ValidationAction specifies a policy enforcement action.
+                  type: string
+                type: array
               validations:
                 description: |-
                   Validations contain CEL expressions which is used to apply the validation.

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -7445,6 +7445,19 @@ Kubernetes admissionregistration/v1.ValidatingAdmissionPolicySpec
 </tr>
 <tr>
 <td>
+<code>validationActions</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#validationaction-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.ValidationAction
+</a>
+</em>
+</td>
+<td>
+<p>ValidationAction specifies the action to be taken when the matched resource violates the policy.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>webhookConfiguration</code><br/>
 <em>
 <a href="#kyverno.io/v2alpha1.WebhookConfiguration">
@@ -7734,6 +7747,19 @@ Kubernetes admissionregistration/v1.ValidatingAdmissionPolicySpec
 <p>
 (Members of <code>ValidatingAdmissionPolicySpec</code> are embedded into this type.)
 </p>
+</td>
+</tr>
+<tr>
+<td>
+<code>validationActions</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#validationaction-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.ValidationAction
+</a>
+</em>
+</td>
+<td>
+<p>ValidationAction specifies the action to be taken when the matched resource violates the policy.</p>
 </td>
 </tr>
 <tr>

--- a/docs/user/crd/kyverno.v2alpha1.html
+++ b/docs/user/crd/kyverno.v2alpha1.html
@@ -381,6 +381,35 @@ It can also be used to make calls to the Kubernetes API server in such cases:</p
     
     
       <tr>
+        <td><code>validationActions</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]admissionregistration/v1.ValidationAction</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>ValidationAction specifies the action to be taken when the matched resource violates the policy.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
         <td><code>webhookConfiguration</code>
           
           </br>
@@ -972,6 +1001,35 @@ If left empty for namespaced resources, all resources from all namespaces will b
           
 
           
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>validationActions</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]admissionregistration/v1.ValidationAction</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>ValidationAction specifies the action to be taken when the matched resource violates the policy.</p>
+
 
           
 

--- a/pkg/client/applyconfigurations/kyverno/v2alpha1/validatingpolicyspec.go
+++ b/pkg/client/applyconfigurations/kyverno/v2alpha1/validatingpolicyspec.go
@@ -26,6 +26,7 @@ import (
 // with apply.
 type ValidatingPolicySpecApplyConfiguration struct {
 	v1.ValidatingAdmissionPolicySpec `json:",inline"`
+	ValidationAction                 []v1.ValidationAction                   `json:"validationActions,omitempty"`
 	WebhookConfiguration             *WebhookConfigurationApplyConfiguration `json:"webhookConfiguration,omitempty"`
 }
 
@@ -95,6 +96,16 @@ func (b *ValidatingPolicySpecApplyConfiguration) WithMatchConditions(values ...v
 func (b *ValidatingPolicySpecApplyConfiguration) WithVariables(values ...v1.Variable) *ValidatingPolicySpecApplyConfiguration {
 	for i := range values {
 		b.Variables = append(b.Variables, values[i])
+	}
+	return b
+}
+
+// WithValidationAction adds the given value to the ValidationAction field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the ValidationAction field.
+func (b *ValidatingPolicySpecApplyConfiguration) WithValidationAction(values ...v1.ValidationAction) *ValidatingPolicySpecApplyConfiguration {
+	for i := range values {
+		b.ValidationAction = append(b.ValidationAction, values[i])
 	}
 	return b
 }


### PR DESCRIPTION
## Explanation
This PR adds the `validationAction` in the ValidatingPolicies. This field doesn't exist in the VAP spec, it exists in the binding.