### PR TITLE
fixes #11699: dont escape shallow vars during validation

### DIFF
--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -367,7 +367,7 @@ func substituteVariablesIfAny(log logr.Logger, ctx context.EvalInterface, lookup
 					prefix = string(old[0])
 				}
 
-				if shallowSubstitution {
+				if shallowSubstitution && substitutedVar != nil {
 					substitutedVar = strings.ReplaceAll(substitutedVar.(string), "{{", "\\{{")
 				}
 


### PR DESCRIPTION
## Explanation

This PR conditionally (in case of validation) disables escaping '{{' and '}}' markers

## Related issue
fixes #11699 

## Milestone of this PR
/milestone v1.13.3

## Documentation (required for features)
not needed

## What type of PR is this

/kind bug

## Proposed Changes

Without this change the shallow variable evaluation feature is not usable with request objects

### Proof Manifests

Included as a test in the PR

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

