### PR TITLE
Moidule test for function evaluation (replace_all) with shallow variables as function parameter

### DIFF
--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -367,7 +367,7 @@ func substituteVariablesIfAny(log logr.Logger, ctx context.EvalInterface, lookup
 					prefix = string(old[0])
 				}
 
-				if shallowSubstitution {
+				if shallowSubstitution && substitutedVar != nil {
 					substitutedVar = strings.ReplaceAll(substitutedVar.(string), "{{", "\\{{")
 				}
 


### PR DESCRIPTION
## Explanation

This MR adds a unit test, which let's one verify if shallow variable can be passed to functions as arguments.

## Related issue

#12137 

## Milestone of this PR
/milestone 1.14.0

## Documentation (required for features)

none.

## What type of PR is this

/kind failing-test

## Proposed Changes

This test can be used to validate any solutions for #12137 . Without any fixes this test is expected to fail.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: vault-auth-backend
spec:
  admission: true
  background: true
  mutateExistingOnPolicyUpdate: true
  validationFailureAction: Audit
  rules:
  - match:
      any:
      - resources:
          kinds:
          - ConfigMap
          names:
          - kyverno-test-*
    mutate:
      patchStrategicMerge:
        data:
          korte_simple: "{{ request.object.data.korte }}"
          szilva_shallow: "{{- request.object.data.szilva }}"
          barack_recursive: '{{ request.object.data.barack }}'
          barack_recursive_replace: '{{ replace_all(''{{ request.object.data.barack }}'', ''barack'', ''bbaarraacckk'') }}'
          # config-init.hcl: '{{ replace_all(''{{- request.object.data."config-init.hcl" }}'',''from_string'',''to_string2'') }}'

          # test_original: '{{ replace_all(''{{- request.object.data.test }}'',''from_string'',''to_string2'') }}'
          #          original: '{{ replace_all(''{{- request.object.data.\"config-init.hcl\" }}'',''from_string'',''to_string2'') }}'
          #          config: 'aaaaa {{ request.object.data.config }} bbb'
      targets:
        - apiVersion: v1
          kind: ConfigMap
          namespace: "{{request.object.metadata.namespace}}"
          name: "{{request.object.metadata.name}}"
    name: vault-injector-config-blue-to-green-auth-backend
---
apiVersion: v1
data:
  config-init.hcl: |-
    {{ alma }}
      from_string
    korte
  test: |-
    {{ alma }}
      from_string   
    korte
  korte: korte_value
  szilva: |-
    {{ szilva_value }}
  barack: |-
    barack_value = {{ request.object.data.korte }}
kind: ConfigMap
metadata:
  name: kyverno-test-alma
    #  namespace: riag-tech-ap-team-ping-ep

```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
