### PR TITLE
fix CEL autogen

### DIFF
--- a/pkg/cel/autogen/rule.go
+++ b/pkg/cel/autogen/rule.go
@@ -196,9 +196,9 @@ var (
 	}
 
 	podControllerMatchConditionName        = "autogen-"
-	podControllersMatchConditionExpression = "!(object.Kind =='Deployment' || object.Kind =='ReplicaSet' || object.Kind =='StatefulSet' || object.Kind =='DaemonSet') || "
+	podControllersMatchConditionExpression = "!(object.kind =='Deployment' || object.kind =='ReplicaSet' || object.kind =='StatefulSet' || object.kind =='DaemonSet') || "
 	cronjobMatchConditionName              = "autogen-cronjobs-"
-	cronJobMatchConditionExpression        = "!(object.Kind =='CronJob') || "
+	cronJobMatchConditionExpression        = "!(object.kind =='CronJob') || "
 )
 
 func updateFields(data []byte, resource string) []byte {

--- a/pkg/cel/autogen/rule_test.go
+++ b/pkg/cel/autogen/rule_test.go
@@ -181,7 +181,7 @@ func TestGenerateRuleForControllers(t *testing.T) {
 				MatchConditions: []admissionregistrationv1.MatchCondition{
 					{
 						Name:       "autogen-only for production",
-						Expression: "!(object.Kind =='Deployment' || object.Kind =='ReplicaSet' || object.Kind =='StatefulSet' || object.Kind =='DaemonSet') || has(object.spec.template.metadata.labels) && has(object.spec.template.metadata.labels.prod) && object.spec.template.metadata.labels.prod == 'true'",
+						Expression: "!(object.kind =='Deployment' || object.kind =='ReplicaSet' || object.kind =='StatefulSet' || object.kind =='DaemonSet') || has(object.spec.template.metadata.labels) && has(object.spec.template.metadata.labels.prod) && object.spec.template.metadata.labels.prod == 'true'",
 					},
 				},
 				Validations: []admissionregistrationv1.Validation{
@@ -320,7 +320,7 @@ func TestGenerateCronJobRule(t *testing.T) {
 				MatchConditions: []admissionregistrationv1.MatchCondition{
 					{
 						Name:       "autogen-cronjobs-only for production",
-						Expression: "!(object.Kind =='CronJob') || has(object.spec.jobTemplate.spec.template.metadata.labels) && has(object.spec.jobTemplate.spec.template.metadata.labels.prod) && object.spec.jobTemplate.spec.template.metadata.labels.prod == 'true'",
+						Expression: "!(object.kind =='CronJob') || has(object.spec.jobTemplate.spec.template.metadata.labels) && has(object.spec.jobTemplate.spec.template.metadata.labels.prod) && object.spec.jobTemplate.spec.template.metadata.labels.prod == 'true'",
 					},
 				},
 				Validations: []admissionregistrationv1.Validation{

--- a/pkg/controllers/webhook/validatingpolicy.go
+++ b/pkg/controllers/webhook/validatingpolicy.go
@@ -55,7 +55,7 @@ func buildWebhookRules(cfg config.Configuration, server string, servicePort int3
 				if ok, _ := autogen.CanAutoGen(vpol.GetSpec()); ok {
 					webhook.MatchConditions = append(webhook.MatchConditions, admissionregistrationv1.MatchCondition{
 						Name:       m.Name,
-						Expression: "!(object.Kind == 'Pod') || " + m.Expression,
+						Expression: "!(object.kind == 'Pod') || " + m.Expression,
 					})
 				} else {
 					webhook.MatchConditions = vpol.GetMatchConditions()

--- a/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-cronjobs/check-autogen.yaml
+++ b/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-cronjobs/check-autogen.yaml
@@ -6,7 +6,7 @@ status:
   autogen:
     rules:
     - matchConditions:
-      - expression: "!(object.Kind =='Deployment' || object.Kind =='ReplicaSet' || object.Kind =='StatefulSet' || object.Kind =='DaemonSet') || has(object.spec.template.metadata.labels) && has(object.spec.template.metadata.labels.prod)
+      - expression: "!(object.kind =='Deployment' || object.kind =='ReplicaSet' || object.kind =='StatefulSet' || object.kind =='DaemonSet') || has(object.spec.template.metadata.labels) && has(object.spec.template.metadata.labels.prod)
           && object.spec.template.metadata.labels.prod == 'true'"
         name: autogen-check-prod-label
       matchConstraints:
@@ -27,7 +27,7 @@ status:
         message: Privilege escalation is disallowed. The field spec.containers[*].securityContext.allowPrivilegeEscalation
           must be set to `false`.
     - matchConditions:
-      - expression: "!(object.Kind =='CronJob') || has(object.spec.jobTemplate.spec.template.metadata.labels)
+      - expression: "!(object.kind =='CronJob') || has(object.spec.jobTemplate.spec.template.metadata.labels)
           && has(object.spec.jobTemplate.spec.template.metadata.labels.prod)
           && object.spec.jobTemplate.spec.template.metadata.labels.prod
           == 'true'"

--- a/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-statefulsets/check-autogen.yaml
+++ b/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-statefulsets/check-autogen.yaml
@@ -6,7 +6,7 @@ status:
   autogen:
     rules:
     - matchConditions:
-      - expression: "!(object.Kind =='Deployment' || object.Kind =='ReplicaSet' || object.Kind =='StatefulSet' || object.Kind =='DaemonSet') || has(object.spec.template.metadata.labels) && has(object.spec.template.metadata.labels.prod)
+      - expression: "!(object.kind =='Deployment' || object.kind =='ReplicaSet' || object.kind =='StatefulSet' || object.kind =='DaemonSet') || has(object.spec.template.metadata.labels) && has(object.spec.template.metadata.labels.prod)
           && object.spec.template.metadata.labels.prod == 'true'"
         name: autogen-check-prod-label
       matchConstraints:

--- a/test/conformance/chainsaw/validating-policies/autogen/should-autogen/check-autogen.yaml
+++ b/test/conformance/chainsaw/validating-policies/autogen/should-autogen/check-autogen.yaml
@@ -6,7 +6,7 @@ status:
   autogen:
     rules:
     - matchConditions:
-      - expression: "!(object.Kind =='Deployment' || object.Kind =='ReplicaSet' || object.Kind =='StatefulSet' || object.Kind =='DaemonSet') || has(object.spec.template.metadata.labels) && has(object.spec.template.metadata.labels.prod)
+      - expression: "!(object.kind =='Deployment' || object.kind =='ReplicaSet' || object.kind =='StatefulSet' || object.kind =='DaemonSet') || has(object.spec.template.metadata.labels) && has(object.spec.template.metadata.labels.prod)
           && object.spec.template.metadata.labels.prod == 'true'"
         name: autogen-check-prod-label
       matchConstraints:
@@ -39,7 +39,7 @@ status:
         message: Privilege escalation is disallowed. The field spec.containers[*].securityContext.allowPrivilegeEscalation
           must be set to `false`.
     - matchConditions:
-      - expression: "!(object.Kind =='CronJob') || has(object.spec.jobTemplate.spec.template.metadata.labels)
+      - expression: "!(object.kind =='CronJob') || has(object.spec.jobTemplate.spec.template.metadata.labels)
           && has(object.spec.jobTemplate.spec.template.metadata.labels.prod)
           && object.spec.jobTemplate.spec.template.metadata.labels.prod
           == 'true'"


### PR DESCRIPTION
## Explanation
This PR uses `object.kind` instead of `object.Kind` for the auto-generated match conditions