### PR TITLE
chore: add resource manifests in autogen tests

### DIFF
--- a/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-cronjobs/bad-deployment.yaml
+++ b/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-cronjobs/bad-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bad-deployment-1
+  labels:
+    prod: "true"
+    app: bad-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      prod: "true"
+      app: bad-nginx
+  template:
+    metadata:
+      labels:
+        prod: "true"
+        app: bad-nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        securityContext:
+          allowPrivilegeEscalation: true

--- a/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-cronjobs/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-cronjobs/chainsaw-test.yaml
@@ -10,8 +10,19 @@ spec:
     - create:
         file: policy.yaml
     - sleep:
-        duration: 2s
+        duration: 10s
   - name: check autogen policy
     try:
     - assert:
         file: check-autogen.yaml
+  - name: create good deployment
+    try:
+    - create:
+        file: good-deployment.yaml
+  - name: create bad deployment
+    try:
+    - create:
+        file: bad-deployment.yaml
+        expect:
+          - check:
+              ($error != null): true

--- a/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-cronjobs/good-deployment.yaml
+++ b/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-cronjobs/good-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: good-deployment-1
+  labels:
+    prod: "true"
+    app: good-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      prod: "true"
+      app: good-nginx
+  template:
+    metadata:
+      labels:
+        prod: "true"
+        app: good-nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        securityContext:
+          allowPrivilegeEscalation: false

--- a/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-statefulsets/bad-statefulset.yaml
+++ b/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-statefulsets/bad-statefulset.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: bad-statefulset-1
+  labels:
+    prod: "true"
+spec:
+  serviceName: my-app-service
+  replicas: 3
+  selector:
+    matchLabels:
+      prod: "true"
+      app: busybox
+  template:
+    metadata:
+      labels:
+        prod: "true"
+        app: busybox
+    spec:
+      containers:
+      - name: my-app-container
+        image: busybox:latest
+        securityContext:
+          allowPrivilegeEscalation: true
+        

--- a/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-statefulsets/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-statefulsets/chainsaw-test.yaml
@@ -2,7 +2,7 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: autogen-deployments-statefulsets
+  name: autogen-statefulsets-statefulsets
 spec:
   steps:
   - name: create policy
@@ -10,8 +10,19 @@ spec:
     - create:
         file: policy.yaml
     - sleep:
-        duration: 2s
+        duration: 10s
   - name: check autogen policy
     try:
     - assert:
         file: check-autogen.yaml
+  - name: create good statefulset
+    try:
+    - create:
+        file: good-statefulset.yaml
+  - name: create bad statefulset
+    try:
+    - create:
+        file: bad-statefulset.yaml
+        expect:
+          - check:
+              ($error != null): true

--- a/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-statefulsets/good-statefulset.yaml
+++ b/test/conformance/chainsaw/validating-policies/autogen/autogen-deployments-statefulsets/good-statefulset.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: good-statefulset-1
+  labels:
+    prod: "true"
+    app: nginx
+spec:
+  serviceName: headless-service
+  replicas: 1
+  selector:
+    matchLabels:
+      prod: "true"
+      app: nginx
+  template:
+    metadata:
+      labels:
+        prod: "true"
+        app: nginx
+    spec:
+      containers:
+      - name: my-app-container
+        image: nginx
+        securityContext:
+          allowPrivilegeEscalation: false
+        


### PR DESCRIPTION
## Explanation
This PR adds resource manifests i,e bad/good deployments and statefulsets in autogen chainsaw tests.