### PR TITLE
feat: generate VAPs given celexceptions

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -291,6 +291,7 @@ func createrLeaderControllers(
 			kyvernoInformer.Kyverno().V1().ClusterPolicies(),
 			kyvernoInformer.Policies().V1alpha1().ValidatingPolicies(),
 			kyvernoInformer.Kyverno().V2().PolicyExceptions(),
+			kyvernoInformer.Policies().V1alpha1().CELPolicyExceptions(),
 			kubeInformer.Admissionregistration().V1().ValidatingAdmissionPolicies(),
 			kubeInformer.Admissionregistration().V1().ValidatingAdmissionPolicyBindings(),
 			eventGenerator,

--- a/pkg/admissionpolicy/builder.go
+++ b/pkg/admissionpolicy/builder.go
@@ -5,7 +5,6 @@ import (
 	"slices"
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
-	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
@@ -19,7 +18,7 @@ func BuildValidatingAdmissionPolicy(
 	discoveryClient dclient.IDiscovery,
 	vap *admissionregistrationv1.ValidatingAdmissionPolicy,
 	policy engineapi.GenericPolicy,
-	exceptions []kyvernov2.PolicyException,
+	exceptions []engineapi.GenericException,
 ) error {
 	var matchResources admissionregistrationv1.MatchResources
 	var matchConditions []admissionregistrationv1.MatchCondition
@@ -75,16 +74,18 @@ func BuildValidatingAdmissionPolicy(
 
 		// convert the exceptions if exist
 		for _, exception := range exceptions {
-			match := exception.Spec.Match
-			if match.Any != nil {
-				if err := translateResourceFilters(discoveryClient, &matchResources, &excludeRules, match.Any, false); err != nil {
-					return err
+			if polex := exception.AsException(); polex != nil {
+				match := polex.Spec.Match
+				if match.Any != nil {
+					if err := translateResourceFilters(discoveryClient, &matchResources, &excludeRules, match.Any, false); err != nil {
+						return err
+					}
 				}
-			}
 
-			if match.All != nil {
-				if err := translateResourceFilters(discoveryClient, &matchResources, &excludeRules, match.All, false); err != nil {
-					return err
+				if match.All != nil {
+					if err := translateResourceFilters(discoveryClient, &matchResources, &excludeRules, match.All, false); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -100,6 +101,20 @@ func BuildValidatingAdmissionPolicy(
 		validations = vpol.Spec.Validations
 		auditAnnotations = vpol.Spec.AuditAnnotations
 		variables = vpol.Spec.Variables
+
+		// convert celexceptions if exist
+		for _, exception := range exceptions {
+			if celpolex := exception.AsCELException(); celpolex != nil {
+				for _, matchCondition := range celpolex.Spec.MatchConditions {
+					// negate the match condition
+					expression := "!(" + matchCondition.Expression + ")"
+					matchConditions = append(matchConditions, admissionregistrationv1.MatchCondition{
+						Name:       matchCondition.Name,
+						Expression: expression,
+					})
+				}
+			}
+		}
 	}
 
 	// set owner reference

--- a/pkg/controllers/validatingadmissionpolicy-generate/controller.go
+++ b/pkg/controllers/validatingadmissionpolicy-generate/controller.go
@@ -339,8 +339,8 @@ func (c *controller) enqueueVAPbinding(vb *admissionregistrationv1.ValidatingAdm
 
 func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, namespace, name string) error {
 	var policy engineapi.GenericPolicy
-	var genericExceptions []engineapi.GenericException
 	var vapName string
+	genericExceptions := make([]engineapi.GenericException, 0)
 
 	polType := strings.Split(key, "/")[0]
 	if polType == "ClusterPolicy" {

--- a/pkg/controllers/validatingadmissionpolicy-generate/utils.go
+++ b/pkg/controllers/validatingadmissionpolicy-generate/utils.go
@@ -59,6 +59,23 @@ func (c *controller) getExceptions(policyName, rule string) ([]kyvernov2.PolicyE
 	return exceptions, nil
 }
 
+// getCELExceptions get CELPolicyExceptions that match the ValidatingPolicy.
+func (c *controller) getCELExceptions(policyName string) ([]policiesv1alpha1.CELPolicyException, error) {
+	var exceptions []policiesv1alpha1.CELPolicyException
+	polexs, err := c.celpolexLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	for _, polex := range polexs {
+		for _, policy := range polex.Spec.PolicyRefs {
+			if policy.Name == policyName {
+				exceptions = append(exceptions, *polex)
+			}
+		}
+	}
+	return exceptions, nil
+}
+
 func constructVapBindingName(vapName string) string {
 	return vapName + "-binding"
 }

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/bad-deployment.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/bad-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bad-deployment
+  labels:
+    app: nginx
+    env: testing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/chainsaw-test.yaml
@@ -2,13 +2,19 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: check-deployment-labels
+  name: with-cel-exception
 spec:
   steps:
   - name: create policy
     try:
     - create:
         file: policy.yaml
+    - sleep:
+        duration: 10s
+  - name: create exception
+    try:
+    - create:
+        file: exception.yaml
     - sleep:
         duration: 10s
   - name: check validatingadmissionpolicy

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/chainsaw-test.yaml
@@ -25,3 +25,16 @@ spec:
     try:
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: create a skipped deployment
+    try:
+    - apply:
+        file: skipped-deployment.yaml
+  - name: create a bad deployment
+    try:
+    - script:
+        content: kubectl apply -f bad-deployment.yaml
+        check:  
+          ($error != null): true
+          # This check ensures the contents of stderr are exactly as shown.  
+          (trim_space($stderr)): |-
+            The deployments "bad-deployment" is invalid: : ValidatingAdmissionPolicy 'vpol-check-deployment-labels' with binding 'vpol-check-deployment-labels-binding' denied request: Deployment labels must be env=prod

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/exception.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/exception.yaml
@@ -1,0 +1,12 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: CELPolicyException
+metadata:
+  name: check-deployment-name
+spec:
+  policyRefs:
+  - name: "check-deployment-labels"
+    kind: ValidatingPolicy
+  matchConditions:
+    - name: "check-name"
+      expression: "object.metadata.name == 'skipped-deployment'"
+  

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/policy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: check-deployment-labels
+spec:
+  validationActions:
+    - Audit
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [apps]
+      apiVersions: [v1]
+      operations:  [CREATE, UPDATE]
+      resources:   [deployments]
+  variables:
+    - name: environment
+      expression: >-
+        has(object.metadata.labels) && 'env' in object.metadata.labels && object.metadata.labels['env'] == 'prod'
+  validations:
+    - expression: >-
+        variables.environment == true
+      message: >-
+        Deployment labels must be env=prod

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/policy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: check-deployment-labels
 spec:
   validationActions:
-    - Audit
+    - Deny
   matchConstraints:
     resourceRules:
     - apiGroups:   [apps]

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/skipped-deployment.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/skipped-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skipped-deployment
+  labels:
+    app: nginx
+    env: testing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/validatingadmissionpolicy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/validatingadmissionpolicy.yaml
@@ -1,0 +1,33 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kyverno
+  name: vpol-check-deployment-labels
+  ownerReferences:
+  - apiVersion: policies.kyverno.io/v1alpha1
+    kind: ValidatingPolicy
+    name: check-deployment-labels
+spec:
+  failurePolicy: Fail
+  matchConditions:
+  - expression: '!(object.metadata.name == ''skipped-deployment'')'
+    name: check-name
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+  variables:
+  - expression: has(object.metadata.labels) && 'env' in object.metadata.labels &&
+      object.metadata.labels['env'] == 'prod'
+    name: environment
+  validations:
+  - expression: variables.environment == true
+    message: Deployment labels must be env=prod

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/validatingadmissionpolicybinding.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/validatingadmissionpolicybinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kyverno
+  name: vpol-check-deployment-labels-binding
+  ownerReferences:
+  - apiVersion: policies.kyverno.io/v1alpha1
+    kind: ValidatingPolicy
+    name: check-deployment-labels
+spec:
+  policyName: vpol-check-deployment-labels
+  validationActions:
+  - Audit

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/validatingadmissionpolicybinding.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/validatingadmissionpolicybinding.yaml
@@ -11,4 +11,4 @@ metadata:
 spec:
   policyName: vpol-check-deployment-labels
   validationActions:
-  - Audit
+  - Deny

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/chainsaw-test.yaml
@@ -2,13 +2,19 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: check-deployment-labels
+  name: with-multiple-exceptions
 spec:
   steps:
   - name: create policy
     try:
     - create:
         file: policy.yaml
+    - sleep:
+        duration: 10s
+  - name: create exception
+    try:
+    - create:
+        file: exception.yaml
     - sleep:
         duration: 10s
   - name: check validatingadmissionpolicy

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/exception.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/exception.yaml
@@ -1,0 +1,23 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: CELPolicyException
+metadata:
+  name: check-deployment-name
+spec:
+  policyRefs:
+  - name: "check-deployment-labels"
+    kind: ValidatingPolicy
+  matchConditions:
+    - name: "check-name"
+      expression: "object.metadata.name == 'skipped-deployment'"
+---
+apiVersion: policies.kyverno.io/v1alpha1
+kind: CELPolicyException
+metadata:
+  name: check-deployment-namespace
+spec:
+  policyRefs:
+  - name: "check-deployment-labels"
+    kind: ValidatingPolicy
+  matchConditions:
+    - name: "check-namespace"
+      expression: "namespaceObject.metadata.name == 'testing-ns'"

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/policy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: check-deployment-labels
+spec:
+  validationActions:
+    - Audit
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [apps]
+      apiVersions: [v1]
+      operations:  [CREATE, UPDATE]
+      resources:   [deployments]
+  variables:
+    - name: environment
+      expression: >-
+        has(object.metadata.labels) && 'env' in object.metadata.labels && object.metadata.labels['env'] == 'prod'
+  validations:
+    - expression: >-
+        variables.environment == true
+      message: >-
+        Deployment labels must be env=prod

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/policy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: check-deployment-labels
 spec:
   validationActions:
-    - Audit
+    - Deny
   matchConstraints:
     resourceRules:
     - apiGroups:   [apps]

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/validatingadmissionpolicy.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/validatingadmissionpolicy.yaml
@@ -1,0 +1,35 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kyverno
+  name: vpol-check-deployment-labels
+  ownerReferences:
+  - apiVersion: policies.kyverno.io/v1alpha1
+    kind: ValidatingPolicy
+    name: check-deployment-labels
+spec:
+  failurePolicy: Fail
+  matchConditions:
+  - expression: '!(object.metadata.name == ''skipped-deployment'')'
+    name: check-name
+  - expression: '!(namespaceObject.metadata.name == ''testing-ns'')'
+    name: check-namespace
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+  variables:
+  - expression: has(object.metadata.labels) && 'env' in object.metadata.labels &&
+      object.metadata.labels['env'] == 'prod'
+    name: environment
+  validations:
+  - expression: variables.environment == true
+    message: Deployment labels must be env=prod

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/validatingadmissionpolicybinding.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/validatingadmissionpolicybinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kyverno
+  name: vpol-check-deployment-labels-binding
+  ownerReferences:
+  - apiVersion: policies.kyverno.io/v1alpha1
+    kind: ValidatingPolicy
+    name: check-deployment-labels
+spec:
+  policyName: vpol-check-deployment-labels
+  validationActions:
+  - Audit

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/validatingadmissionpolicybinding.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/validatingadmissionpolicybinding.yaml
@@ -11,4 +11,4 @@ metadata:
 spec:
   policyName: vpol-check-deployment-labels
   validationActions:
-  - Audit
+  - Deny


### PR DESCRIPTION
## Explanation
This PR generates VAPs given cel policy exceptions.
Related to #12018 

1. Create a ValidatingPolicy:
```
apiVersion: policies.kyverno.io/v1alpha1
kind: ValidatingPolicy
metadata:
  name: check-deployment-labels
spec:
  validationActions:
    - Deny
  matchConstraints:
    resourceRules:
    - apiGroups:   [apps]
      apiVersions: [v1]
      operations:  [CREATE, UPDATE]
      resources:   [deployments]
  variables:
    - name: environment
      expression: >-
        has(object.metadata.labels) && 'env' in object.metadata.labels && object.metadata.labels['env'] == 'prod'
  validations:
    - expression: >-
        variables.environment == true
      message: >-
        Deployment labels must be env=prod
```
2. Create a CELPolicyException:
```
apiVersion: policies.kyverno.io/v1alpha1
kind: CELPolicyException
metadata:
  name: check-deployment-name
spec:
  policyRefs:
  - name: "check-deployment-labels"
    kind: ValidatingPolicy
  matchConditions:
    - name: "check-name"
      expression: "object.metadata.name == 'skipped-deployment'"
```
3. Check the generated VAP:
```
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingAdmissionPolicy
metadata:
  labels:
    app.kubernetes.io/managed-by: kyverno
  name: vpol-check-deployment-labels
  ownerReferences:
  - apiVersion: policies.kyverno.io/v1alpha1
    kind: ValidatingPolicy
    name: check-deployment-labels
spec:
  failurePolicy: Fail
  matchConditions:
  - expression: '!(object.metadata.name == ''skipped-deployment'')'
    name: check-name
  matchConstraints:
    resourceRules:
    - apiGroups:
      - apps
      apiVersions:
      - v1
      operations:
      - CREATE
      - UPDATE
      resources:
      - deployments
  variables:
  - expression: has(object.metadata.labels) && 'env' in object.metadata.labels &&
      object.metadata.labels['env'] == 'prod'
    name: environment
  validations:
  - expression: variables.environment == true
    message: Deployment labels must be env=prod
```
4. Create a deployment whose name is `skipped-deployment`:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: skipped-deployment
  labels:
    app: nginx
    env: testing
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:latest
```
The deployment is successfully created since the VAP's match conditions are evaluated as false.
5. Create a bad deployment:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: bad-deployment
  labels:
    app: nginx
    env: testing
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:latest
```
The deployment is blocked because it violates the generated VAP:
```
The deployments "bad-deployment" is invalid: : ValidatingAdmissionPolicy 'vpol-check-deployment-labels' with binding 'vpol-check-deployment-labels-binding' denied request: Deployment labels must be env=prod
```