### PR TITLE
fix: Generated resources labels

### DIFF
--- a/pkg/background/common/labels.go
+++ b/pkg/background/common/labels.go
@@ -74,6 +74,7 @@ func TriggerInfo(labels map[string]string, obj unstructured.Unstructured) {
 	labels[GenerateTriggerVersionLabel] = obj.GroupVersionKind().Version
 	labels[GenerateTriggerGroupLabel] = obj.GroupVersionKind().Group
 	labels[GenerateTriggerKindLabel] = obj.GetKind()
+	labels[GenerateTriggerNameLabel] = obj.GetName()
 	labels[GenerateTriggerNSLabel] = obj.GetNamespace()
 	labels[GenerateTriggerUIDLabel] = string(obj.GetUID())
 }

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-data-sync-create-upon-generated-resource/chainsaw-step-02-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-data-sync-create-upon-generated-resource/chainsaw-step-02-assert-1-1.yaml
@@ -7,6 +7,7 @@ metadata:
     generate.kyverno.io/rule-name: generate-otel-secret-config
     generate.kyverno.io/trigger-group: ""
     generate.kyverno.io/trigger-kind: Secret
+    generate.kyverno.io/trigger-name: otel-collector-signalfx-token
     generate.kyverno.io/trigger-namespace: cpol-data-sync-create-upon-generated-resource-ns
     generate.kyverno.io/trigger-version: v1
   name: otel-collector-signalfx-secret
@@ -22,6 +23,7 @@ metadata:
     generate.kyverno.io/rule-name: generate-otel-sa
     generate.kyverno.io/trigger-group: ""
     generate.kyverno.io/trigger-kind: Secret
+    generate.kyverno.io/trigger-name: otel-collector-signalfx-secret
     generate.kyverno.io/trigger-namespace: cpol-data-sync-create-upon-generated-resource-ns
     generate.kyverno.io/trigger-version: v1
   name: otel-collector-signalfx-sa

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-data-sync-no-creation-upon-generated-resource/chainsaw-step-02-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-data-sync-no-creation-upon-generated-resource/chainsaw-step-02-assert-1-1.yaml
@@ -7,6 +7,7 @@ metadata:
     generate.kyverno.io/rule-name: generate-otel-secret-config
     generate.kyverno.io/trigger-group: ""
     generate.kyverno.io/trigger-kind: Secret
+    generate.kyverno.io/trigger-name: otel-collector-signalfx-token
     generate.kyverno.io/trigger-namespace: cpol-data-sync-no-creation-upon-generated-resource-ns
     generate.kyverno.io/trigger-version: v1
   name: otel-collector-signalfx-secret

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/generate-event-upon-edit/chainsaw-step-05-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/generate-event-upon-edit/chainsaw-step-05-assert-1-1.yaml
@@ -12,6 +12,7 @@ metadata:
     generate.kyverno.io/policy-namespace: ""
     generate.kyverno.io/rule-name: generate-event-on-edit
     generate.kyverno.io/trigger-group: ""
+    generate.kyverno.io/trigger-name: generate-event-on-edit-configmap
     generate.kyverno.io/trigger-kind: ConfigMap
     generate.kyverno.io/trigger-namespace: generate-event-on-edit-ns
     generate.kyverno.io/trigger-version: v1

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/generate-event-upon-edit/chainsaw-step-07-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/generate-event-upon-edit/chainsaw-step-07-assert-1-1.yaml
@@ -12,6 +12,7 @@ metadata:
     generate.kyverno.io/policy-namespace: ""
     generate.kyverno.io/rule-name: generate-event-on-edit
     generate.kyverno.io/trigger-group: ""
+    generate.kyverno.io/trigger-name: generate-event-on-edit-configmap
     generate.kyverno.io/trigger-kind: ConfigMap
     generate.kyverno.io/trigger-namespace: generate-event-on-edit-ns
     generate.kyverno.io/trigger-version: v1

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/generate-event-upon-edit/chainsaw-step-07-assert-1-2.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/generate-event-upon-edit/chainsaw-step-07-assert-1-2.yaml
@@ -13,6 +13,7 @@ metadata:
     generate.kyverno.io/rule-name: generate-event-on-edit
     generate.kyverno.io/trigger-group: ""
     generate.kyverno.io/trigger-kind: ConfigMap
+    generate.kyverno.io/trigger-name: generate-event-on-edit-configmap
     generate.kyverno.io/trigger-namespace: generate-event-on-edit-ns
     generate.kyverno.io/trigger-version: v1
   namespace: generate-event-on-edit-ns

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync-deprecated/generate-on-subresource-trigger/chainsaw-step-03-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync-deprecated/generate-on-subresource-trigger/chainsaw-step-03-assert-1-1.yaml
@@ -11,6 +11,7 @@ metadata:
     generate.kyverno.io/rule-name: k-kafka-address
     generate.kyverno.io/trigger-group: ""
     generate.kyverno.io/trigger-kind: PodExecOptions
+    generate.kyverno.io/trigger-name: ""
     generate.kyverno.io/trigger-namespace: test-generate-exec
     generate.kyverno.io/trigger-version: v1
     somekey: somevalue

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/generate-on-eviction-subresource-trigger/chainsaw-step-03-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/generate-on-eviction-subresource-trigger/chainsaw-step-03-assert-1-1.yaml
@@ -11,6 +11,7 @@ metadata:
     generate.kyverno.io/rule-name: k-kafka-address
     generate.kyverno.io/trigger-group: policy
     generate.kyverno.io/trigger-kind: Eviction
+    generate.kyverno.io/trigger-name: "nginx"
     generate.kyverno.io/trigger-namespace: test-generate-eviction
     generate.kyverno.io/trigger-version: v1
     somekey: somevalue

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/generate-on-subresource-trigger/chainsaw-step-03-assert-1-1.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/data/nosync/generate-on-subresource-trigger/chainsaw-step-03-assert-1-1.yaml
@@ -11,6 +11,7 @@ metadata:
     generate.kyverno.io/rule-name: k-kafka-address
     generate.kyverno.io/trigger-group: ""
     generate.kyverno.io/trigger-kind: PodExecOptions
+    generate.kyverno.io/trigger-name: ""
     generate.kyverno.io/trigger-namespace: test-generate-exec
     generate.kyverno.io/trigger-version: v1
     somekey: somevalue


### PR DESCRIPTION
## Explanation

The generated resources should have the `generate.kyverno.io/trigger-name` label to match with the cleanup workflow:
If the trigger resource is not found by uid, it will be searched by name based on the `generate.kyverno.io/trigger-name`
https://github.com/kyverno/kyverno/blob/84e9517bad2e52cd17c4ee7258373a063286cdba/pkg/background/generate/cleanup.go#L128-L135

## What type of PR is this

/kind bug

## Proposed Changes

Add the generate.kyverno.io/trigger-name label to generated resources

### Proof Manifests

# Kubernetes resource

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: test-ns
---
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: default
spec:
  rules:
  - name: deny-all-traffic
    match:
      any:
      - resources:
          kinds:
          - Namespace
    exclude:
      any:
      - resources:
          namespaces:
          - kube-system
          - default
          - kube-public
          - kyverno
    generate:
      kind: NetworkPolicy
      apiVersion: networking.k8s.io/v1
      name: deny-all-traffic
      namespace: "{{request.object.metadata.name}}"
      data:
        spec:
          # select all pods in the namespace
          podSelector: {}
          policyTypes:
          - Ingress
          - Egress
```

   1. apply policy and namespace
   2. check generated NetworkPolicy labels


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
