### PR TITLE
feat(helm): add option to use subPath when mounting a custom CA via volume

### DIFF
--- a/charts/kyverno/templates/admission-controller/deployment.yaml
+++ b/charts/kyverno/templates/admission-controller/deployment.yaml
@@ -265,7 +265,7 @@ spec:
             {{- if or .Values.admissionController.caCertificates.data .Values.global.caCertificates.data .Values.admissionController.caCertificates.volume .Values.global.caCertificates.volume }}
             - name: ca-certificates
               mountPath: /etc/ssl/certs/ca-certificates.crt
-              {{- if or .Values.admissionController.caCertificates.data .Values.global.caCertificates.data }}
+              {{- if or .Values.admissionController.caCertificates.data .Values.global.caCertificates.data .Values.admissionController.caCertificates.useSubPathWithVolume .Values.global.caCertificates.useSubPathWithVolume }}
               subPath: ca-certificates.crt
               {{- end }}
             {{- end }}

--- a/charts/kyverno/templates/background-controller/deployment.yaml
+++ b/charts/kyverno/templates/background-controller/deployment.yaml
@@ -169,7 +169,7 @@ spec:
           volumeMounts:
             - name: ca-certificates
               mountPath: /etc/ssl/certs/ca-certificates.crt
-              {{- if or .Values.backgroundController.caCertificates.data .Values.global.caCertificates.data }}
+              {{- if or .Values.backgroundController.caCertificates.data .Values.global.caCertificates.data .Values.backgroundController.caCertificates.useSubPathWithVolume .Values.global.caCertificates.useSubPathWithVolume }}
               subPath: ca-certificates.crt
               {{- end }}
           {{- end }}

--- a/charts/kyverno/templates/reports-controller/deployment.yaml
+++ b/charts/kyverno/templates/reports-controller/deployment.yaml
@@ -183,7 +183,7 @@ spec:
             {{- if or .Values.reportsController.caCertificates.data .Values.global.caCertificates.data .Values.reportsController.caCertificates.volume .Values.global.caCertificates.volume }}
             - name: ca-certificates
               mountPath: /etc/ssl/certs/ca-certificates.crt
-              {{- if or .Values.reportsController.caCertificates.data .Values.global.caCertificates.data }}
+              {{- if or .Values.reportsController.caCertificates.data .Values.global.caCertificates.data .Values.reportsController.caCertificates.useSubPathWithVolume .Values.global.caCertificates.useSubPathWithVolume }}
               subPath: ca-certificates.crt
               {{- end }}
             {{- end }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -33,6 +33,10 @@ global:
     #   path: /etc/pki/tls/ca-certificates.crt
     #   type: File
 
+    # This option is useful to mount a configmap containing the CA certificates.
+    # when activated, a "subPath" option to "ca-certificates.crt" will be added.
+    useSubPathWithVolume: false
+
   # -- Additional container environment variables to apply to all containers and init containers
   extraEnvVars: []
   # Example setting proxy
@@ -963,6 +967,10 @@ admissionController:
     #   path: /etc/pki/tls/ca-certificates.crt
     #   type: File
 
+    # This option is useful to mount a configmap containing the CA certificates.
+    # when activated, a "subPath" option to "ca-certificates.crt" will be added.
+    useSubPathWithVolume: false
+
   # -- Image pull secrets
   imagePullSecrets: []
     # - secretName
@@ -1382,6 +1390,10 @@ backgroundController:
     # hostPath:
     #   path: /etc/pki/tls/ca-certificates.crt
     #   type: File
+
+    # This option is useful to mount a configmap containing the CA certificates.
+    # when activated, a "subPath" option to "ca-certificates.crt" will be added.
+    useSubPathWithVolume: false
 
   metricsService:
     # -- Create service.
@@ -1992,6 +2004,9 @@ reportsController:
     #   path: /etc/pki/tls/ca-certificates.crt
     #   type: File
 
+    # This option is useful to mount a configmap containing the CA certificates.
+    # when activated, a "subPath" option to "ca-certificates.crt" will be added.
+    useSubPathWithVolume: false
 
   metricsService:
     # -- Create service.


### PR DESCRIPTION
Hello,

/kind feature

I have read the PR documentation (https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md), and I'm not sure where this simple chart change fall.
Given the obviousness of this "feature", I hope it is under "Other changes which are internal to the code base".

My use case is pretty simple, I needed to add a custom CA into Kyverno.
As we need this custom CA everywhere, it is generated automatically in a configmap in our namespaces.
Therefore inlining the CA data into the chart values wasn't a suitable solution.

When I saw that there is an option to mount an existing volume, I thought it was exactly what I need.
Unfortunately it seem it was made with `hostPath` volumes in mind only.

To be able to use a configmap, I added an option to use a `subPath` with the `volume` option as it is already done when using the `data` option.

Best Regards.