### PR TITLE
fix: use pointer in context config map getter

### DIFF
--- a/pkg/cel/libs/context/impl_test.go
+++ b/pkg/cel/libs/context/impl_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type ctx struct {
-	GetConfigMapFunc        func(string, string) (unstructured.Unstructured, error)
+	GetConfigMapFunc        func(string, string) (*unstructured.Unstructured, error)
 	GetGlobalReferenceFunc  func(string, string) (any, error)
 	GetImageDataFunc        func(string) (*imagedataloader.ImageData, error)
 	ParseImageReferenceFunc func(string) (imagedataloader.ImageReference, error)
@@ -22,7 +22,7 @@ type ctx struct {
 	GetResourcesFunc        func(string, string, string, string) (*unstructured.Unstructured, error)
 }
 
-func (mock *ctx) GetConfigMap(ns string, n string) (unstructured.Unstructured, error) {
+func (mock *ctx) GetConfigMap(ns string, n string) (*unstructured.Unstructured, error) {
 	return mock.GetConfigMapFunc(ns, n)
 }
 
@@ -66,9 +66,9 @@ func Test_impl_get_configmap_string_string(t *testing.T) {
 	called := false
 	data := map[string]any{
 		"context": Context{&ctx{
-			GetConfigMapFunc: func(string, string) (unstructured.Unstructured, error) {
+			GetConfigMapFunc: func(string, string) (*unstructured.Unstructured, error) {
 				called = true
-				return unstructured.Unstructured{}, nil
+				return &unstructured.Unstructured{}, nil
 			},
 		}},
 	}

--- a/pkg/cel/libs/context/types.go
+++ b/pkg/cel/libs/context/types.go
@@ -15,7 +15,7 @@ var (
 )
 
 type ContextInterface interface {
-	GetConfigMap(string, string) (unstructured.Unstructured, error)
+	GetConfigMap(string, string) (*unstructured.Unstructured, error)
 	GetGlobalReference(string, string) (any, error)
 	GetImageData(string) (*imagedataloader.ImageData, error)
 	ParseImageReference(string) (imagedataloader.ImageReference, error)

--- a/pkg/cel/policy/context.go
+++ b/pkg/cel/policy/context.go
@@ -45,16 +45,16 @@ func NewContextProvider(
 	}, nil
 }
 
-func (cp *contextProvider) GetConfigMap(namespace string, name string) (unstructured.Unstructured, error) {
+func (cp *contextProvider) GetConfigMap(namespace string, name string) (*unstructured.Unstructured, error) {
 	cm, err := cp.client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
-		return unstructured.Unstructured{}, err
+		return nil, err
 	}
 	out, err := kubeutils.ObjToUnstructured(cm)
 	if err != nil {
-		return unstructured.Unstructured{}, err
+		return nil, err
 	}
-	return *out, nil
+	return out, nil
 }
 
 func (cp *contextProvider) GetGlobalReference(name, projection string) (any, error) {

--- a/pkg/cel/policy/fake_context.go
+++ b/pkg/cel/policy/fake_context.go
@@ -38,12 +38,8 @@ func (cp *FakeContextProvider) AddResource(gvr schema.GroupVersionResource, obj 
 	return nil
 }
 
-func (cp *FakeContextProvider) GetConfigMap(ns, n string) (unstructured.Unstructured, error) {
-	cm, err := cp.GetResource("v1", "configmaps", ns, n)
-	if err != nil {
-		return unstructured.Unstructured{}, err
-	}
-	return *cm, nil
+func (cp *FakeContextProvider) GetConfigMap(ns, n string) (*unstructured.Unstructured, error) {
+	return cp.GetResource("v1", "configmaps", ns, n)
 }
 
 func (cp *FakeContextProvider) GetGlobalReference(string, string) (any, error) {


### PR DESCRIPTION
## Explanation

Use pointer in context config map getter.
