### PR TITLE
Add PolicyReport and ClusterPolicyReport to the default resources filter

### DIFF
--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -243,6 +243,8 @@ config:
     - '[ReplicaSet/*,*,*]'
     - '[EphemeralReport,*,*]'
     - '[ClusterEphemeralReport,*,*]'
+    - '[PolicyReport,*,*]'
+    - '[ClusterPolicyReport,*,*]'
     # exclude resources from the chart
     - '[ClusterRole,*,{{ template "kyverno.admission-controller.roleName" . }}]'
     - '[ClusterRole,*,{{ template "kyverno.admission-controller.roleName" . }}:core]'


### PR DESCRIPTION
## Explanation

`EphemeralReport` and `ClusterEphemeralReport` are already present so it only makes sense to have the final object excluded from evaluation as well.

Without this filter, a policy targeting `kind: - '*'` will apply to those reports even if you scope it to a namespace as they are created in the same one, which triggers a loop.
## What type of PR is this

/kind cleanup

## Proposed Changes

This will help avoid one type of evaluation loop in a very simple way, and is in line with the rest of Kyverno's resources being excluded already.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

No further comments, this is a minor change that I believe fixes something that was overlooked in the filter list.