### PR TITLE
[enhancement] Skipped policies handled as warning based on --ignoreSk…

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -70,6 +70,7 @@ type ApplyCommandConfig struct {
 	TargetResourcePaths   []string
 	GitBranch             string
 	warnExitCode          int
+	ignoreSkippedExitCode bool
 	warnNoPassed          bool
 	Exception             []string
 	ContinueOnFail        bool
@@ -137,7 +138,11 @@ func Command() *cobra.Command {
 				}
 				printViolations(out, rc)
 			}
-			return exit(out, rc, applyCommandConfig.warnExitCode, applyCommandConfig.warnNoPassed)
+			err = exit(out, rc, applyCommandConfig.warnExitCode, applyCommandConfig.warnNoPassed, applyCommandConfig.ignoreSkippedExitCode)
+			if err != nil {
+				fmt.Fprintln(out, err.Error())
+			}
+			return err
 		},
 	}
 	cmd.Flags().StringSliceVarP(&applyCommandConfig.ResourcePaths, "resource", "r", []string{}, "Path to resource files")
@@ -160,6 +165,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVarP(&applyCommandConfig.GitBranch, "git-branch", "b", "", "test git repository branch")
 	cmd.Flags().BoolVar(&applyCommandConfig.AuditWarn, "audit-warn", false, "If set to true, will flag audit policies as warnings instead of failures")
 	cmd.Flags().IntVar(&applyCommandConfig.warnExitCode, "warn-exit-code", 0, "Set the exit code for warnings; if failures or errors are found, will exit 1")
+	cmd.Flags().BoolVar(&applyCommandConfig.ignoreSkippedExitCode, "ignore-skipped-exit-code", false, "Ignore skipped policies when determining the exit code")
 	cmd.Flags().BoolVar(&applyCommandConfig.warnNoPassed, "warn-no-pass", false, "Specify if warning exit code should be raised if no objects satisfied a policy; can be used together with --warn-exit-code flag")
 	cmd.Flags().BoolVar(&removeColor, "remove-color", false, "Remove any color from output")
 	cmd.Flags().BoolVar(&detailedResults, "detailed-results", false, "If set to true, display detailed results")
@@ -625,7 +631,7 @@ func (w WarnExitCodeError) Error() string {
 	return fmt.Sprintf("exit as warnExitCode is %d", w.ExitCode)
 }
 
-func exit(out io.Writer, rc *processor.ResultCounts, warnExitCode int, warnNoPassed bool) error {
+func exit(out io.Writer, rc *processor.ResultCounts, warnExitCode int, warnNoPassed bool, ignoreSkippedExitCode bool) error {
 	if rc.Fail > 0 {
 		return fmt.Errorf("exit as there are policy violations")
 	} else if rc.Error > 0 {
@@ -640,6 +646,9 @@ func exit(out io.Writer, rc *processor.ResultCounts, warnExitCode int, warnNoPas
 		return WarnExitCodeError{
 			ExitCode: warnExitCode,
 		}
+	} else if ignoreSkippedExitCode && rc.Skip > 0 {
+		fmt.Println("Skipping policies ignored, exiting with code 0.")
+		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
…ippedExitCode flag

## Explanation

In Progress ...

Issue was that exit code != 0 when policies are skipped. Now changing it completely to exit code should be 0 when policies are skipped is not a good idea. Hence making it optional to users by adding a extra bool flag sounds good. 
Implementing the same. 

## Related issue

#12292 

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
> /kind bug


## Proposed Changes

1. Adding a new bool flag var. 
2. Making change to exit() logic.
3. Adding test to test the enhancement.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [X] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
