### PR TITLE
handle runtime error resulted by false

### DIFF
--- a/pkg/cel/policy/policy.go
+++ b/pkg/cel/policy/policy.go
@@ -165,7 +165,11 @@ func (p *compiledPolicy) evaluateWithData(
 		return nil, err
 	}
 	if !match {
-		return nil, nil
+		return &EvaluationResult{
+			Result:  true,
+			Message: "Resource does not match conditions, considered compliant",
+			Index:   -1,
+		}, nil
 	}
 
 	vars := lazy.NewMapValue(VariablesType)


### PR DESCRIPTION
Fix matchConditions handling: Previously, a false evaluation resulted in runtime error instead of being skipped or passed. This fix prevents matchConditions from causing runtime errors.