### PR TITLE
chore: add a chainsaw test for vpol to block ephemeral containers

### DIFF
--- a/test/conformance/chainsaw/validating-policies/subresources/block-ephemeral-containers/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validating-policies/subresources/block-ephemeral-containers/chainsaw-test.yaml
@@ -1,0 +1,25 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: block-ephemeral-containers
+spec:
+  steps:
+  - name: create policy
+    try:
+    - apply:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
+  - name: create pod
+    try:
+    - apply:
+        file: pod.yaml
+    - assert:
+        file: pod.yaml
+  - name: create ephemeral container
+    try:
+    - script:
+        content: if kubectl -n test-vpol-subresource-namespace debug -it test-pod --image=busybox:1.35 --target=busybox; then exit 1; else exit 0; fi;
+        # check:
+        #   ($error): >-
+        #     admission webhook "vpol.validate.kyverno.svc-fail" denied the request: Policy block-ephemeral-containers failed: Ephemeral (debug) containers are not permitted.

--- a/test/conformance/chainsaw/validating-policies/subresources/block-ephemeral-containers/pod.yaml
+++ b/test/conformance/chainsaw/validating-policies/subresources/block-ephemeral-containers/pod.yaml
@@ -1,0 +1,15 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: test-vpol-subresource-namespace
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: test-vpol-subresource-namespace
+spec:
+  containers:
+  - name: busybox
+    image: busybox:1.35
+    command: ["sleep", "300"]

--- a/test/conformance/chainsaw/validating-policies/subresources/block-ephemeral-containers/policy-assert.yaml
+++ b/test/conformance/chainsaw/validating-policies/subresources/block-ephemeral-containers/policy-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: block-ephemeral-containers
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    - message: 'Policy is not ready for reporting, missing permissions: get /v1,
+        Resource=pods/ephemeralcontainers: ; list /v1, Resource=pods/ephemeralcontainers:
+        ; watch /v1, Resource=pods/ephemeralcontainers: .'
+      reason: Failed
+      status: "False"
+      type: RBACPermissionsGranted
+    # ready: true

--- a/test/conformance/chainsaw/validating-policies/subresources/block-ephemeral-containers/policy.yaml
+++ b/test/conformance/chainsaw/validating-policies/subresources/block-ephemeral-containers/policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: block-ephemeral-containers
+spec:
+  validationActions: 
+    - Deny
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods","pods/ephemeralcontainers"]
+  validations:
+   - expression: >-
+      object.spec.?ephemeralContainers.orValue([]).size() == 0
+     message: "Ephemeral (debug) containers are not permitted."
+


### PR DESCRIPTION
I don't think we can automatically match `pods/ephemeralcontainers` for a pod's rule, as `spec.matchConstraints` is evaluated through CEL lib, the policy has to match the subresource specifically to apply.

cc @Mohdcode 