### PR TITLE
chore: remove unused field in vap processor

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -401,7 +401,6 @@ func (c *ApplyCommandConfig) applyValidatingAdmissionPolicies(
 			Bindings:             vapBindings,
 			Resource:             resource,
 			NamespaceSelectorMap: namespaceSelectorMap,
-			PolicyReport:         c.PolicyReport,
 			Rc:                   rc,
 			Client:               dClient,
 		}

--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -258,7 +258,6 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 			Bindings:             results.VAPBindings,
 			Resource:             resource,
 			NamespaceSelectorMap: vars.NamespaceSelectors(),
-			PolicyReport:         true,
 			Rc:                   &resultCounts,
 		}
 		ers, err := processor.ApplyPolicyOnResource()

--- a/cmd/cli/kubectl-kyverno/processor/vap_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/vap_processor.go
@@ -13,7 +13,6 @@ type ValidatingAdmissionPolicyProcessor struct {
 	Bindings             []admissionregistrationv1.ValidatingAdmissionPolicyBinding
 	Resource             *unstructured.Unstructured
 	NamespaceSelectorMap map[string]map[string]string
-	PolicyReport         bool
 	Rc                   *ResultCounts
 	Client               dclient.Interface
 }


### PR DESCRIPTION
## Explanation

Remove unused field in vap processor.
