### PR TITLE
Feature defer enforce

### DIFF
--- a/api/kyverno/v1/common_types.go
+++ b/api/kyverno/v1/common_types.go
@@ -472,9 +472,9 @@ type Validation struct {
 	// FailureAction defines if a validation policy rule violation should block
 	// the admission review request (Enforce), or allow (Audit) the admission review request
 	// and report an error in a policy report. Optional.
-	// Allowed values are Audit or Enforce.
+	// Allowed values are Audit, Enforce, or DeferEnforce.
 	// +optional
-	// +kubebuilder:validation:Enum=Audit;Enforce
+	// +kubebuilder:validation:Enum=Audit;Enforce;DeferEnforce
 	FailureAction *ValidationFailureAction `json:"failureAction,omitempty"`
 
 	// FailureActionOverrides is a Cluster Policy attribute that specifies FailureAction

--- a/api/kyverno/v1/spec_types.go
+++ b/api/kyverno/v1/spec_types.go
@@ -26,6 +26,8 @@ const (
 	Enforce ValidationFailureAction = "Enforce"
 	// Audit doesn't block the request on failure
 	Audit ValidationFailureAction = "Audit"
+	// DeferEnforce blocks the request on failure, but only after all other policies have been evaluated
+	DeferEnforce ValidationFailureAction = "DeferEnforce"
 )
 
 func (a ValidationFailureAction) Enforce() bool {
@@ -33,15 +35,19 @@ func (a ValidationFailureAction) Enforce() bool {
 }
 
 func (a ValidationFailureAction) Audit() bool {
-	return !a.Enforce()
+	return !a.Enforce() && !a.DeferEnforcement()
+}
+
+func (a ValidationFailureAction) DeferEnforcement() bool {
+	return a == DeferEnforce
 }
 
 func (a ValidationFailureAction) IsValid() bool {
-	return a == enforceOld || a == auditOld || a == Enforce || a == Audit
+	return a == enforceOld || a == auditOld || a == Enforce || a == Audit || a == DeferEnforce
 }
 
 type ValidationFailureActionOverride struct {
-	// +kubebuilder:validation:Enum=audit;enforce;Audit;Enforce
+	// +kubebuilder:validation:Enum=audit;enforce;Audit;Enforce;DeferEnforce
 	Action            ValidationFailureAction `json:"action,omitempty"`
 	Namespaces        []string                `json:"namespaces,omitempty"`
 	NamespaceSelector *metav1.LabelSelector   `json:"namespaceSelector,omitempty"`

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -89,6 +89,8 @@ func resolveTimestampFormat(format string) string {
 		return time.UnixDate
 	case RFC3339NANO:
 		return time.RFC3339Nano
+	case DefaultTime:
+		return time.RFC3339
 	default:
 		return time.RFC3339
 	}

--- a/pkg/logging/log_test.go
+++ b/pkg/logging/log_test.go
@@ -1,0 +1,64 @@
+package logging
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolveTimestampFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   string
+		expected string
+	}{
+		{
+			name:     "default format",
+			format:   DefaultTime,
+			expected: time.RFC3339,
+		},
+		{
+			name:     "iso8601 format",
+			format:   ISO8601,
+			expected: time.RFC3339,
+		},
+		{
+			name:     "rfc3339 format",
+			format:   RFC3339,
+			expected: time.RFC3339,
+		},
+		{
+			name:     "millis format",
+			format:   MILLIS,
+			expected: time.StampMilli,
+		},
+		{
+			name:     "nanos format",
+			format:   NANOS,
+			expected: time.StampNano,
+		},
+		{
+			name:     "epoch format",
+			format:   EPOCH,
+			expected: time.UnixDate,
+		},
+		{
+			name:     "rfc3339nano format",
+			format:   RFC3339NANO,
+			expected: time.RFC3339Nano,
+		},
+		{
+			name:     "unknown format",
+			format:   "unknown",
+			expected: time.RFC3339,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveTimestampFormat(tt.format)
+			if result != tt.expected {
+				t.Errorf("resolveTimestampFormat(%s) = %s, want %s", tt.format, result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/utils/engine/response.go
+++ b/pkg/utils/engine/response.go
@@ -18,6 +18,7 @@ func IsResponseSuccessful(engineReponses []engineapi.EngineResponse) bool {
 // BlockRequest returns true when:
 // 1. a policy fails (i.e. creates a violation) and validationFailureAction is set to 'enforce'
 // 2. a policy has a processing error and failurePolicy is set to 'Fail`
+// 3. Note: DeferEnforce actions are handled at a higher level in the webhooks/utils.BlockRequest function
 func BlockRequest(er engineapi.EngineResponse, failurePolicy kyvernov1.FailurePolicyType) bool {
 	if er.IsFailed() && er.GetValidationFailureAction().Enforce() {
 		return true


### PR DESCRIPTION
# Explanation

This PR introduces a new validation failure action mode called `DeferEnforce` which allows more granular control over policy enforcement order. DeferEnforce policies will block non-compliant resources similar to Enforce, but only after all other policies are evaluated. This enables organizations to prioritize critical security policies (using Enforce) while ensuring less critical policies (using DeferEnforce) can still block admission when needed.

## Related issue

Closes #11519

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind feature

## Proposed Changes

This PR introduces a new ValidationFailureAction called `DeferEnforce` which provides a more sophisticated way to enforce policies with different priorities:

1. Adds a new ValidationFailureAction constant `DeferEnforce` in the Kyverno v1 API
2. Updates validation rules to accept DeferEnforce as a valid action
3. Modifies the BlockRequest function to process policies in two phases:
   - First process non-deferred policies (Enforce or Audit)
   - Then process DeferEnforce policies only if no Enforce policy has already blocked

This allows organizations to define a clear policy priority order, where critical security policies use `Enforce` and are evaluated first, while secondary best-practice policies use `DeferEnforce` and block admission only when no higher-priority policy has already blocked the request.

### Before/After Comparison

**Before:**
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: policy-with-validation
spec:
  validationFailureAction: Enforce  # Only Audit or Enforce was available
  rules:
    - name: require-labels
      match:
        resources:
          kinds:
            - Pod
      validate:
        message: "Pod must have specific labels"
        pattern:
          metadata:
            labels:
              app: "?*"
```

With the previous approach, all policies using `Enforce` would block immediately on failure, and there was no way to ensure certain policies took precedence over others.

**After:**
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: secondary-policy
spec:
  validationFailureAction: DeferEnforce  # New option
  rules:
    - name: require-specific-labels
      match:
        resources:
          kinds:
            - Pod 
      validate:
        message: "Pod should have recommended labels"
        pattern:
          metadata:
            labels:
              team: "?*"
              environment: "?*"
```

Now you can have critical security policies with `Enforce` that get evaluated first, and less critical ones with `DeferEnforce` that still block admission if no higher-priority policy has already done so.

### Proof Manifests

# Critical security policy (evaluated first)
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: critical-security-policy
spec:
  validationFailureAction: Enforce
  rules:
    - name: block-privileged
      match:
        resources:
          kinds:
            - Pod
      validate:
        message: "Privileged containers are not allowed"
        pattern:
          spec:
            containers:
              - name: "*"
                securityContext:
                  privileged: false
```

# Secondary operational policy (evaluated after security policies)
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: operational-standards-policy
spec:
  validationFailureAction: DeferEnforce
  rules:
    - name: require-labels
      match:
        resources:
          kinds:
            - Pod
      validate:
        message: "Required labels are missing"
        pattern:
          metadata:
            labels:
              team: "?*"
              environment: "?*"
```

# Test Resources

When a Pod violates both policies, the critical security policy blocks it:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test-pod-violates-both-policies
  labels:
    app: my-app
spec:
  containers:
  - name: nginx
    image: nginx:latest
    securityContext:
      privileged: true
```

When a Pod violates only the operational policy, it's still blocked:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test-pod-violates-operational-policy
  labels:
    app: my-app
spec:
  containers:
  - name: nginx
    image: nginx:latest
    securityContext:
      privileged: false
```

When a Pod complies with both policies, it's admitted:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test-pod-complies-with-both
  labels:
    app: my-app
    team: dev
    environment: prod
spec:
  containers:
  - name: nginx
    image: nginx:latest
    securityContext:
      privileged: false
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The `DeferEnforce` feature enables a more sophisticated policy enforcement hierarchy. Organizations can now:

1. Set high-priority security policies with `Enforce` that block immediately
2. Set lower-priority operational policies with `DeferEnforce` that still block when needed
3. Set policies for monitoring/reporting only with `Audit`

This creates a clear and predictable policy evaluation order while ensuring all necessary guardrails are in place.