### PR TITLE
[feat] Using --audit-warn respected if FailureAction = Enforce

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -139,6 +139,9 @@ func Command() *cobra.Command {
 						if applyCommandConfig.AuditWarn && response.GetValidationFailureAction().Audit() {
 							auditWarn = true
 						}
+						if applyCommandConfig.AuditWarn && response.GetValidationFailureAction().Enforce() {
+							auditWarn = true
+						}
 						if auditWarn {
 							fmt.Fprintln(out, "policy", response.Policy().GetName(), "->", "resource", resPath, "failed as audit warning:")
 						} else {

--- a/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
@@ -63,15 +63,16 @@ func Test_Apply(t *testing.T) {
 			config: ApplyCommandConfig{
 				PolicyPaths:   []string{"../../../../../test/best_practices/disallow_latest_tag.yaml"},
 				ResourcePaths: []string{"../../../../../test/resources/pod_with_latest_tag.yaml"},
+				AuditWarn:     true,
 				PolicyReport:  true,
 			},
 			expectedPolicyReports: []policyreportv1alpha2.PolicyReport{{
 				Summary: policyreportv1alpha2.PolicyReportSummary{
 					Pass:  1,
-					Fail:  1,
+					Fail:  0,
 					Skip:  0,
 					Error: 0,
-					Warn:  0,
+					Warn:  1,
 				},
 			}},
 		},

--- a/cmd/cli/kubectl-kyverno/processor/result.go
+++ b/cmd/cli/kubectl-kyverno/processor/result.go
@@ -45,6 +45,8 @@ func (rc *ResultCounts) addEngineResponse(auditWarn bool, response engineapi.Eng
 								break
 							} else if auditWarn && response.GetValidationFailureAction().Audit() {
 								rc.Warn++
+							} else if auditWarn && response.GetValidationFailureAction().Enforce() {
+								rc.Warn++
 							} else {
 								rc.Fail++
 							}

--- a/cmd/cli/kubectl-kyverno/report/report.go
+++ b/cmd/cli/kubectl-kyverno/report/report.go
@@ -21,7 +21,11 @@ func ComputePolicyReportResult(auditWarn bool, engineResponse engineapi.EngineRe
 	result := reportutils.ToPolicyReportResult(engineResponse.Policy(), ruleResponse, resorceRef)
 	if result.Result == policyreportv1alpha2.StatusFail {
 		audit := engineResponse.GetValidationFailureAction().Audit()
+		enforce := engineResponse.GetValidationFailureAction().Enforce()
 		if audit && auditWarn {
+			result.Result = policyreportv1alpha2.StatusWarn
+		}
+		if enforce && auditWarn {
 			result.Result = policyreportv1alpha2.StatusWarn
 		}
 	}

--- a/test/best_practices/disallow_latest_tag.yaml
+++ b/test/best_practices/disallow_latest_tag.yaml
@@ -20,6 +20,7 @@ spec:
           - Pod
     name: require-image-tag
     validate:
+      failureAction: Enforce
       message: An image tag is required
       pattern:
         spec:
@@ -32,6 +33,7 @@ spec:
           - Pod
     name: validate-image-tag
     validate:
+      failureAction: Enforce
       message: Using a mutable image tag e.g. 'latest' is not allowed
       pattern:
         spec:


### PR DESCRIPTION
## Explanation

Issue describes that  : 
1. When `failureAction : Enforce ` then `auditWarn` flag doesnt work. 

Solution : Respect auditwarn when true, even in Enforce failureAction.

## Related issue

#12538 

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

> /kind bug


### Proof Manifests

**Policy.yaml :** 
```

apiVersion: kyverno.io/v1
kind: Policy
metadata:
  name: test-validation-failureaction
  namespace: default
spec:
  validationFailureAction: Audit  
  rules:
    - name: enforce-rule
      match:
        resources:
          kinds:
            - Pod
      validate:
        failureAction: Enforce 
        message: "Pod must have 'team' label."
        pattern:
          metadata:
            labels:
              team: "?*"

    - name: audit-rule
      match:
        resources:
          kinds:
            - Pod
      validate:
        failureAction: Audit  
        message: "Pod must have 'owner' label."
        pattern:
          metadata:
            labels:
              owner: "?*"

```

**resource.yaml :** 
```

resource.yaml : 
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
  namespace: default
  labels: 
    app: "test-app"
spec:
  containers:
    - name: nginx
      image: nginx:latest

```
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [X] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
