### PR TITLE
test: Add HTTP-CEL chainsaw test with test server

### DIFF
--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/README.md
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/README.md
@@ -1,0 +1,18 @@
+## Description
+
+This test validates the HTTP CEL library functionality in Kyverno policies. It tests various HTTP operations including:
+- GET requests with and without headers
+- POST requests with and without headers
+- Client creation with custom CA bundle
+
+## Expected Behavior
+
+The policy should be able to:
+1. Make HTTP GET requests and process responses
+2. Make HTTP POST requests and process responses
+3. Create HTTP clients with custom CA bundles
+4. Handle various response status codes and body formats
+
+## Related Issue
+
+https://github.com/kyverno/kyverno/issues/12690 

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/assert.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-server
+  namespace: http-cel-test
+spec:
+  selector:
+    matchLabels:
+      app: test-server
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-server
+  namespace: http-cel-test 

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/chainsaw-test.yaml
@@ -1,0 +1,62 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: http-cel
+spec:
+  namespace: http-cel-test
+  skipDelete: true
+  steps:
+  - name: create namespace
+    try:
+    - apply:
+        file: namespace.yaml
+  - name: deploy test server
+    try:
+    - apply:
+        file: test-server.yaml
+    - assert:
+        file: test-server.yaml
+  - name: wait for test server
+    try:
+    - script:
+        content: |
+          kubectl wait --for=condition=available deployment/test-server -n http-cel-test --timeout=120s
+          echo "Test server is available"
+          kubectl get pods -l app=test-server -n http-cel-test -o wide
+          echo "Test server pod details"
+          kubectl describe pods -l app=test-server -n http-cel-test
+          echo "Test server logs"
+          kubectl logs -l app=test-server -n http-cel-test
+          echo "Test server service"
+          kubectl get svc test-server -n http-cel-test -o wide
+          echo "Testing server endpoint"
+          kubectl run curl --image=curlimages/curl -n http-cel-test -- curl -s http://test-server:8080/health
+          sleep 30
+  - name: create policy
+    use:
+      template: ../../../../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait policy ready
+    use:
+      template: ../../../../../_step-templates/cluster-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: http-cel-test
+  - name: create test pod
+    try:
+    - apply:
+        file: test-pod.yaml
+    - assert:
+        file: test-pod.yaml
+    - script:
+        content: |
+          echo "Test pod details"
+          kubectl get pods test-pod -n http-cel-test -o wide
+          echo "Test pod description"
+          kubectl describe pods test-pod -n http-cel-test
+          echo "Test server logs"
+          kubectl logs -l app=test-server -n http-cel-test 

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/namespace.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: http-cel-test 

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/policy.yaml
@@ -1,0 +1,96 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: test-http-cel
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+  - name: test-http-get
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: "HTTP GET test failed"
+      cel:
+        expressions:
+        - expression: "http.send('GET', 'http://test-server.http-cel-test:8080/health').response.code == 200"
+        - expression: "http.send('GET', 'http://test-server.http-cel-test:8080/health').response.body.get('status') == 'ok'"
+  - name: test-http-get-echo
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: "HTTP GET echo test failed"
+      cel:
+        expressions:
+        - expression: "http.send('GET', 'http://test-server.http-cel-test:8080/echo').response.code == 200"
+        - expression: "http.send('GET', 'http://test-server.http-cel-test:8080/echo').response.body.get('method') == 'GET'"
+  - name: test-http-get-with-headers
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      cel:
+        expressions:
+        - expression: |
+            let response = http.Get("http://test-server.http-cel-test:8080/auth", {"Authorization": "Bearer test-token"})
+            response.statusCode == 200 && response.body.headers.authorization == "Bearer test-token"
+        message: "Authentication failed"
+  - name: test-http-post
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      cel:
+        expressions:
+        - expression: |
+            let response = http.Post("http://test-server.http-cel-test:8080/data", {"key": "value"})
+            response.statusCode == 200 && response.body.method == "POST"
+        message: "Data submission failed"
+  - name: test-http-post-with-headers
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      cel:
+        expressions:
+        - expression: |
+            let response = http.Post("http://test-server.http-cel-test:8080/data", {"key": "value"}, {"Content-Type": "application/json"})
+            response.statusCode == 200 && response.body.headers["content-type"] == "application/json"
+        message: "Data submission with headers failed"
+  - name: test-http-client
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      cel:
+        expressions:
+        - expression: |
+            http.Client(caBundle).Get("https://secure-server:8443/health").body.status == "ok"
+        message: "Secure health check failed"
+  - name: test-http-response-handling
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      cel:
+        expressions:
+        - expression: |
+            let response = http.Get("http://test-server.http-cel-test:8080/echo")
+            response.statusCode == 200 && response.body.method == "GET"
+        message: "Response handling failed" 

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/test-pod.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/test-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: http-cel-test
+spec:
+  containers:
+  - name: test-container
+    image: nginx:latest
+    ports:
+    - containerPort: 80 

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/test-server.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/test-server.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-server
+  namespace: http-cel-test
+spec:
+  selector:
+    matchLabels:
+      app: test-server
+  template:
+    metadata:
+      labels:
+        app: test-server
+    spec:
+      containers:
+      - name: test-server
+        image: kyverno/test-server:latest
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-server
+  namespace: http-cel-test
+spec:
+  selector:
+    app: test-server
+  ports:
+  - port: 8080
+    targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-server-config
+  namespace: http-cel-test
+data:
+  health: |
+    {"status": "ok"}
+  echo: |
+    {"method": "GET"}
+  auth: |
+    {"authenticated": true}
+  data: |
+    {"success": true} 

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/cel/http-cel/test.yaml
@@ -1,0 +1,22 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: test-http-cel
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: test-server.yaml
+    - assert:
+        file: assert.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: policy.yaml
+  - name: step-03
+    try:
+    - apply:
+        file: resources/pod.yaml
+    - assert:
+        file: assert-pod.yaml 


### PR DESCRIPTION
Add chainsaw conformance test for HTTP-CEL in ClusterPolicy validation with a dedicated test-server deployment. The test covers HTTP GET and POST methods, header validation, and response body handling.

## Explanation

This PR adds a new chainsaw conformance test for the HTTP-CEL feature in ClusterPolicy validation. The test validates that HTTP-CEL expressions can properly perform GET and POST requests, validate headers, and process response bodies through a dedicated test server deployment.

## Related issue

Closes #10544

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind test

## Proposed Changes

This PR adds a comprehensive test for HTTP-CEL functionality in ClusterPolicy validations. It includes:
- A dedicated test server deployment and service for HTTP endpoint testing
- A ClusterPolicy with HTTP-CEL expressions that test GET and POST methods
- Validation of header parameters and response body handling
- Proper assertions to verify the test server is working as expected

### Proof Manifests

```yaml
# Test Server Deployment and Service
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-server
  namespace: http-cel-test
spec:
  replicas: 1
  selector:
    matchLabels:
      app: test-server
  template:
    metadata:
      labels:
        app: test-server
    spec:
      containers:
      - name: test-server
        image: kyverno/test-server:latest
        ports:
        - containerPort: 8080
---
apiVersion: v1
kind: Service
metadata:
  name: test-server
  namespace: http-cel-test
spec:
  selector:
    app: test-server
  ports:
  - port: 8080
    targetPort: 8080
  type: ClusterIP
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality. 