### PR TITLE
fix VPOL and IVPOL for Kyverno test command

### DIFF
--- a/cmd/cli/kubectl-kyverno/apis/v1alpha1/test_result.go
+++ b/cmd/cli/kubectl-kyverno/apis/v1alpha1/test_result.go
@@ -24,6 +24,11 @@ type TestResultBase struct {
 	// +optional
 	IsValidatingPolicy bool `json:"isValidatingPolicy,omitempty"`
 
+	// IsImageValidatingPolicy indicates if the policy is an image validating policy.
+	// It's required in case the policy is an image validating policy.
+	// +optional
+	IsImageValidatingPolicy bool `json:"isImageValidatingPolicy,omitempty"`
+
 	// Result mentions the result that the user is expecting.
 	// Possible values are pass, fail and skip.
 	Result policyreportv1alpha2.PolicyResult `json:"result"`

--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -198,7 +198,7 @@ func checkResult(test v1alpha1.TestResult, fs billy.Filesystem, resoucePath stri
 func lookupRuleResponses(test v1alpha1.TestResult, responses ...engineapi.RuleResponse) []engineapi.RuleResponse {
 	var matches []engineapi.RuleResponse
 	// Since there are no rules in case of validating admission policies, responses are returned without checking rule names.
-	if test.IsValidatingAdmissionPolicy || test.IsValidatingPolicy {
+	if test.IsValidatingAdmissionPolicy || test.IsValidatingPolicy || test.IsImageValidatingPolicy {
 		matches = responses
 	} else {
 		for _, response := range responses {

--- a/cmd/cli/kubectl-kyverno/commands/test/output.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/output.go
@@ -246,7 +246,7 @@ func printTestResult(
 					for _, rule := range lookupRuleResponses(test, response.PolicyResponse.Rules...) {
 						r := response.Resource
 
-						if test.IsValidatingAdmissionPolicy || test.IsValidatingPolicy {
+						if test.IsValidatingAdmissionPolicy || test.IsValidatingPolicy || test.IsImageValidatingPolicy {
 							ok, message, reason := checkResult(test, fs, resoucePath, response, rule, r)
 							if strings.Contains(message, "not found in manifest") {
 								resourceSkipped = true

--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -39,7 +39,6 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -360,8 +359,12 @@ func applyImageValidatingPolicies(
 		lister,
 		[]imagedataloader.Option{imagedataloader.WithLocalCredentials(registryAccess)},
 	)
+	apiGroupResources, err := data.APIGroupResources()
+	if err != nil {
+		return nil, err
+	}
+	restMapper := restmapper.NewDiscoveryRESTMapper(apiGroupResources)
 	gctxStore := gctxstore.New()
-	var restMapper meta.RESTMapper
 	var contextProvider celpolicy.Context
 	if dclient != nil {
 		contextProvider, err = celpolicy.NewContextProvider(
@@ -372,17 +375,7 @@ func applyImageValidatingPolicies(
 		if err != nil {
 			return nil, err
 		}
-		apiGroupResources, err := restmapper.GetAPIGroupResources(dclient.GetKubeClient().Discovery())
-		if err != nil {
-			return nil, err
-		}
-		restMapper = restmapper.NewDiscoveryRESTMapper(apiGroupResources)
 	} else {
-		apiGroupResources, err := data.APIGroupResources()
-		if err != nil {
-			return nil, err
-		}
-		restMapper = restmapper.NewDiscoveryRESTMapper(apiGroupResources)
 		fakeContextProvider := celpolicy.NewFakeContextProvider()
 		if contextPath != "" {
 			ctx, err := clicontext.Load(nil, contextPath)
@@ -452,7 +445,6 @@ func applyImageValidatingPolicies(
 			responses = append(responses, resp)
 		}
 	}
-
 	ivpols := make([]*eval.CompiledImageValidatingPolicy, 0)
 	pMap := make(map[string]*policiesv1alpha1.ImageValidatingPolicy)
 	for i := range ivps {

--- a/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
@@ -113,6 +113,11 @@ spec:
                     GeneratedResource takes a resource configuration file in yaml format from
                     the user to compare it against the Kyverno generated resource configuration.
                   type: string
+                isImageValidatingPolicy:
+                  description: |-
+                    IsImageValidatingPolicy indicates if the policy is an image validating policy.
+                    It's required in case the policy is an image validating policy.
+                  type: boolean
                 isValidatingAdmissionPolicy:
                   description: |-
                     IsValidatingAdmissionPolicy indicates if the policy is a validating admission policy.

--- a/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
@@ -113,6 +113,11 @@ spec:
                     GeneratedResource takes a resource configuration file in yaml format from
                     the user to compare it against the Kyverno generated resource configuration.
                   type: string
+                isImageValidatingPolicy:
+                  description: |-
+                    IsImageValidatingPolicy indicates if the policy is an image validating policy.
+                    It's required in case the policy is an image validating policy.
+                  type: boolean
                 isValidatingAdmissionPolicy:
                   description: |-
                     IsValidatingAdmissionPolicy indicates if the policy is a validating admission policy.

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -237,7 +237,7 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 		gctxStore := gctxstore.New()
 		var restMapper meta.RESTMapper
 		var contextProvider celpolicy.Context
-		if p.Client != nil {
+		if p.Client != nil && p.Cluster {
 			contextProvider, err = celpolicy.NewContextProvider(
 				p.Client,
 				// TODO

--- a/docs/user/cli/crd/index.html
+++ b/docs/user/cli/crd/index.html
@@ -1142,6 +1142,19 @@ It&rsquo;s required in case the policy is a validating policy.</p>
 </tr>
 <tr>
 <td>
+<code>isImageValidatingPolicy</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IsImageValidatingPolicy indicates if the policy is an image validating policy.
+It&rsquo;s required in case the policy is an image validating policy.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>result</code><br/>
 <em>
 github.com/kyverno/kyverno/api/policyreport/v1alpha2.PolicyResult

--- a/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
+++ b/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
@@ -2492,6 +2492,34 @@ It's required in case the policy is a validating policy.</p>
     
     
       <tr>
+        <td><code>isImageValidatingPolicy</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>IsImageValidatingPolicy indicates if the policy is an image validating policy.
+It's required in case the policy is an image validating policy.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
         <td><code>result</code>
           
           <span style="color:blue;"> *</span>

--- a/test/cli/test-image-validating-policy/sample-policy/bad-pod.yaml
+++ b/test/cli/test-image-validating-policy/sample-policy/bad-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-pod
+  namespace: default
+  labels:
+    prod: "true"
+spec:
+  containers:
+    - name: nginx
+      image: 'ghcr.io/kyverno/test-verify-image:unsigned'

--- a/test/cli/test-image-validating-policy/sample-policy/good-pod.yaml
+++ b/test/cli/test-image-validating-policy/sample-policy/good-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+  namespace: default
+  labels:
+    prod: "true"
+spec:
+  containers:
+    - name: nginx
+      image: 'ghcr.io/kyverno/test-verify-image:signed'

--- a/test/cli/test-image-validating-policy/sample-policy/kyverno-test.yaml
+++ b/test/cli/test-image-validating-policy/sample-policy/kyverno-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kyverno-test
+policies:
+- policy.yaml
+resources:
+- bad-pod.yaml
+- good-pod.yaml
+results:
+- isImageValidatingPolicy: true
+  kind: Pod
+  policy: ivpol-sample
+  resources:
+  - bad-pod
+  result: fail
+- isImageValidatingPolicy: true
+  kind: Pod
+  policy: ivpol-sample
+  resources:
+  - good-pod
+  result: pass

--- a/test/cli/test-image-validating-policy/sample-policy/policy.yaml
+++ b/test/cli/test-image-validating-policy/sample-policy/policy.yaml
@@ -1,0 +1,58 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ImageValidatingPolicy
+metadata:
+  name: ivpol-sample
+spec:
+  failurePolicy: Ignore
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+  matchConditions:
+    - name: "check-prod-label"
+      expression: >-
+        has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
+  imageRules:
+    - glob: ghcr.io/*
+  attestors:
+    - name: notary
+      notary:
+        certs: |-
+          -----BEGIN CERTIFICATE-----
+          MIIDTTCCAjWgAwIBAgIJAPI+zAzn4s0xMA0GCSqGSIb3DQEBCwUAMEwxCzAJBgNV
+          BAYTAlVTMQswCQYDVQQIDAJXQTEQMA4GA1UEBwwHU2VhdHRsZTEPMA0GA1UECgwG
+          Tm90YXJ5MQ0wCwYDVQQDDAR0ZXN0MB4XDTIzMDUyMjIxMTUxOFoXDTMzMDUxOTIx
+          MTUxOFowTDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMRAwDgYDVQQHDAdTZWF0
+          dGxlMQ8wDQYDVQQKDAZOb3RhcnkxDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3
+          DQEBAQUAA4IBDwAwggEKAoIBAQDNhTwv+QMk7jEHufFfIFlBjn2NiJaYPgL4eBS+
+          b+o37ve5Zn9nzRppV6kGsa161r9s2KkLXmJrojNy6vo9a6g6RtZ3F6xKiWLUmbAL
+          hVTCfYw/2n7xNlVMjyyUpE+7e193PF8HfQrfDFxe2JnX5LHtGe+X9vdvo2l41R6m
+          Iia04DvpMdG4+da2tKPzXIuLUz/FDb6IODO3+qsqQLwEKmmUee+KX+3yw8I6G1y0
+          Vp0mnHfsfutlHeG8gazCDlzEsuD4QJ9BKeRf2Vrb0ywqNLkGCbcCWF2H5Q80Iq/f
+          ETVO9z88R7WheVdEjUB8UrY7ZMLdADM14IPhY2Y+tLaSzEVZAgMBAAGjMjAwMAkG
+          A1UdEwQCMAAwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMDMA0G
+          CSqGSIb3DQEBCwUAA4IBAQBX7x4Ucre8AIUmXZ5PUK/zUBVOrZZzR1YE8w86J4X9
+          kYeTtlijf9i2LTZMfGuG0dEVFN4ae3CCpBst+ilhIndnoxTyzP+sNy4RCRQ2Y/k8
+          Zq235KIh7uucq96PL0qsF9s2RpTKXxyOGdtp9+HO0Ty5txJE2txtLDUIVPK5WNDF
+          ByCEQNhtHgN6V20b8KU2oLBZ9vyB8V010dQz0NRTDLhkcvJig00535/LUylECYAJ
+          5/jn6XKt6UYCQJbVNzBg/YPGc1RF4xdsGVDBben/JXpeGEmkdmXPILTKd9tZ5TC0
+          uOKpF5rWAruB5PCIrquamOejpXV9aQA/K2JQDuc0mcKz
+          -----END CERTIFICATE-----
+  attestations:
+    - name: sbom
+      referrer:
+        type: sbom/cyclone-dx
+  validations:
+    - expression: >-
+        images.containers.map(image, verifyImageSignatures(image, [attestors.notary])).all(e, e > 0)
+      message: failed to verify image with notary cert
+    - expression: >-
+        images.containers.map(image, verifyAttestationSignatures(image, attestations.sbom ,[attestors.notary])).all(e, e > 0)
+      message: failed to verify attestation with notary cer
+    - expression: >-
+        images.containers.map(image, payload(image, attestations.sbom).bomFormat == 'CycloneDX').all(e, e)
+      message: sbom is not a cyclone dx sbom

--- a/test/cli/test-validating-policy/check-deployment-labels/deployment1.yaml
+++ b/test/cli/test-validating-policy/check-deployment-labels/deployment1.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: good-deployment
   labels:
     app: nginx
     env: prod

--- a/test/cli/test-validating-policy/check-deployment-labels/deployment2.yaml
+++ b/test/cli/test-validating-policy/check-deployment-labels/deployment2.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: bad-deployment
   labels:
     app: nginx
     env: testing

--- a/test/cli/test-validating-policy/check-deployment-labels/kyverno-test.yaml
+++ b/test/cli/test-validating-policy/check-deployment-labels/kyverno-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kyverno-test
+policies:
+- policy.yaml
+resources:
+- deployment1.yaml
+- deployment2.yaml
+results:
+- isValidatingPolicy: true
+  kind: Deployment
+  policy: check-deployment-labels
+  resources:
+  - bad-deployment
+  result: fail
+- isValidatingPolicy: true
+  kind: Deployment
+  policy: check-deployment-labels
+  resources:
+  - good-deployment
+  result: pass

--- a/test/cli/test-validating-policy/check-deployment-namespace/kyverno-test.yaml
+++ b/test/cli/test-validating-policy/check-deployment-namespace/kyverno-test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kyverno-test
+policies:
+- policy.yaml
+resources:
+- resources.yaml
+results:
+- isValidatingPolicy: true
+  kind: Deployment
+  policy: check-deployment-namespace
+  resources:
+  - good-deployment
+  result: pass

--- a/test/cli/test-validating-policy/check-deployment-namespace/policy.yaml
+++ b/test/cli/test-validating-policy/check-deployment-namespace/policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: check-deployment-namespace
+spec:
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [apps]
+      apiVersions: [v1]
+      operations:  [CREATE, UPDATE]
+      resources:   [deployments]
+  validations:
+    - expression: >-
+        namespaceObject.metadata.name == "production"
+      message: >-
+        Deployment namespace must be "production"

--- a/test/cli/test-validating-policy/check-deployment-namespace/resources.yaml
+++ b/test/cli/test-validating-policy/check-deployment-namespace/resources.yaml
@@ -1,11 +1,13 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: bad-deployment
+  name: good-deployment
+  namespace: production
   labels:
     app: nginx
+    env: prod
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: nginx
@@ -15,5 +17,5 @@ spec:
         app: nginx
     spec:
       containers:
-      - name: nginx
-        image: nginx:latest
+        - name: nginx
+          image: nginx:latest

--- a/test/cli/test-validating-policy/check-deployments-replica/deployment1.yaml
+++ b/test/cli/test-validating-policy/check-deployments-replica/deployment1.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: good-deployment
   labels:
     app: nginx
 spec:

--- a/test/cli/test-validating-policy/check-deployments-replica/kyverno-test.yaml
+++ b/test/cli/test-validating-policy/check-deployments-replica/kyverno-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kyverno-test
+policies:
+- policy.yaml
+resources:
+- deployment1.yaml
+- deployment2.yaml
+results:
+- isValidatingPolicy: true
+  kind: Deployment
+  policy: check-deployment-replicas
+  resources:
+  - bad-deployment
+  result: fail
+- isValidatingPolicy: true
+  kind: Deployment
+  policy: check-deployment-replicas
+  resources:
+  - good-deployment
+  result: pass

--- a/test/cli/test-validating-policy/disallow-host-path/kyverno-test.yaml
+++ b/test/cli/test-validating-policy/disallow-host-path/kyverno-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kyverno-test
+policies:
+- policy.yaml
+resources:
+- pod1.yaml
+- pod2.yaml
+results:
+- isValidatingPolicy: true
+  kind: Pod
+  policy: disallow-host-path
+  resources:
+  - bad-pod
+  result: fail
+- isValidatingPolicy: true
+  kind: Pod
+  policy: disallow-host-path
+  resources:
+  - good-pod
+  result: pass


### PR DESCRIPTION
## Explanation
This PR does the following:
1. Add a field named `isImageValidatingPolicy` in the kyverno-test file.
2. Fix an error related to converting GVK to GVR. The main issue is that we create a fake client for the `test` command and [this](https://github.com/kyverno/kyverno/blob/c7366b88645e608284961e955655a1465ba47a20/cmd/cli/kubectl-kyverno/commands/test/test.go#L375-L379) part is executed which shouldn't be.

Tests are added for both ValidatingPolicies and ImageValidatingPolicies.

Closes #12707 
Closes #12668