### PR TITLE
chore: add local CLI tests for the new policy types in the workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -906,12 +906,27 @@ test-cli-policies: $(CLI_BIN) ## Run CLI tests against the policies repository
 	@$(CLI_BIN) test $(TEST_GIT_REPO)/$(TEST_GIT_BRANCH)
 
 .PHONY: test-cli-local
-test-cli-local: test-cli-local-validate test-cli-local-mutate test-cli-local-generate test-cli-local-registry test-cli-local-scenarios test-cli-local-selector ## Run local CLI tests
+test-cli-local: test-cli-local-validate test-cli-local-vpols test-cli-local-ivpols test-cli-local-vaps test-cli-local-mutate test-cli-local-generate test-cli-local-exceptions test-cli-local-cel-exceptions test-cli-local-registry test-cli-local-scenarios test-cli-local-selector ## Run local CLI tests
 
 .PHONY: test-cli-local-validate
 test-cli-local-validate: $(CLI_BIN) ## Run local CLI validation tests
 	@echo Running local cli validation tests... >&2
 	@$(CLI_BIN) test ./test/cli/test
+
+.PHONY: test-cli-local-vpols
+test-cli-local-vpols: $(CLI_BIN) ## Run local CLI VPOL tests
+	@echo Running local cli vpol tests... >&2
+	@$(CLI_BIN) test ./test/cli/test-validating-policy
+
+.PHONY: test-cli-local-ivpols
+test-cli-local-ivpols: $(CLI_BIN) ## Run local CLI IVPOL tests
+	@echo Running local cli ivpol tests... >&2
+	@$(CLI_BIN) test ./test/cli/test-image-validating-policy
+
+.PHONY: test-cli-local-vaps
+test-cli-local-vaps: $(CLI_BIN) ## Run local CLI VAP tests
+	@echo Running local cli vap tests... >&2
+	@$(CLI_BIN) test ./test/cli/test-validating-admission-policy
 
 .PHONY: test-cli-local-mutate
 test-cli-local-mutate: $(CLI_BIN) ## Run local CLI mutation tests
@@ -922,6 +937,16 @@ test-cli-local-mutate: $(CLI_BIN) ## Run local CLI mutation tests
 test-cli-local-generate: $(CLI_BIN) ## Run local CLI generation tests
 	@echo Running local cli generation tests... >&2
 	@$(CLI_BIN) test ./test/cli/test-generate
+
+.PHONY: test-cli-local-exceptions
+test-cli-local-exceptions: $(CLI_BIN) ## Run local CLI exception tests
+	@echo Running local cli exception tests... >&2
+	@$(CLI_BIN) test ./test/cli/test-exceptions
+
+.PHONY: test-cli-local-cel-exceptions
+test-cli-local-cel-exceptions: $(CLI_BIN) ## Run local CLI cel exception tests
+	@echo Running local cli cel exception tests... >&2
+	@$(CLI_BIN) test ./test/cli/test-cel-exceptions
 
 .PHONY: test-cli-local-selector
 test-cli-local-selector: $(CLI_BIN) ## Run local CLI tests (with test case selector)

--- a/test/cli/test-cel-exceptions/check-deployment-labels/kyverno-test.yaml
+++ b/test/cli/test-cel-exceptions/check-deployment-labels/kyverno-test.yaml
@@ -1,0 +1,31 @@
+apiVersion: cli.kyverno.io/v1alpha1
+exceptions:
+- exception.yaml
+kind: Test
+metadata:
+  name: kyverno-test
+policies:
+- policy.yaml
+resources:
+- bad-deployment.yaml
+- good-deployment.yaml
+- skipped-deployment.yaml
+results:
+- isValidatingPolicy: true
+  kind: Deployment
+  policy: check-deployment-labels
+  resources:
+  - bad-deployment
+  result: fail
+- isValidatingPolicy: true
+  kind: Deployment
+  policy: check-deployment-labels
+  resources:
+  - good-deployment
+  result: pass
+- isValidatingPolicy: true
+  kind: Deployment
+  policy: check-deployment-labels
+  resources:
+  - skipped-deployment
+  result: skip

--- a/test/cli/test-exceptions/exceptions-3/exception.yaml
+++ b/test/cli/test-exceptions/exceptions-3/exception.yaml
@@ -17,4 +17,4 @@ spec:
     - controlName: "HostPath Volumes"
       restrictedField: "spec.volumes[*].hostPath"
       values:
-      - "path"
+      - "/var/lib1"

--- a/test/cli/test-validating-policy/check-deployment-namespace/kyverno-test.yaml
+++ b/test/cli/test-validating-policy/check-deployment-namespace/kyverno-test.yaml
@@ -13,3 +13,4 @@ results:
   resources:
   - good-deployment
   result: pass
+variables: values.yaml

--- a/test/cli/test-validating-policy/check-deployment-namespace/values.yaml
+++ b/test/cli/test-validating-policy/check-deployment-namespace/values.yaml
@@ -1,0 +1,8 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Value
+metadata:
+  name: values
+namespaceSelector:
+- labels:
+    environment: production
+  name: production


### PR DESCRIPTION
## Explanation
Multiple tests are added in the CLI directory but they don't run in the workflow. This PR adds the following CLI test directories to the workflow:
1. test/cli/test-validating-admission-policy
2. test/cli/test-validating-policy
3. test/cli/test-image-validating-policy
4. test/cli/test-exceptions
5. test/cli/test-cel-exceptions