### PR TITLE
fix: skip webhook registration if vap is generated from validate.cel subrule

### DIFF
--- a/pkg/controllers/webhook/controller.go
+++ b/pkg/controllers/webhook/controller.go
@@ -1189,7 +1189,9 @@ func (c *controller) getAllPolicies() ([]kyvernov1.PolicyInterface, error) {
 		return nil, err
 	} else {
 		for _, cpol := range cpols {
-			policies = append(policies, cpol)
+			if !cpol.GetStatus().ValidatingAdmissionPolicy.Generated {
+				policies = append(policies, cpol)
+			}
 		}
 	}
 	if pols, err := c.polLister.List(labels.Everything()); err != nil {

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-all-match-resource/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-all-match-resource/chainsaw-test.yaml
@@ -24,3 +24,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-all-match-resource/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-all-match-resource/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-namespace-match-resource/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-namespace-match-resource/chainsaw-test.yaml
@@ -24,3 +24,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-namespace-match-resource/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-namespace-match-resource/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-resource-match-with-namespace-selector/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-resource-match-with-namespace-selector/chainsaw-test.yaml
@@ -24,3 +24,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-resource-match-with-namespace-selector/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-resource-match-with-namespace-selector/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-resource-match-with-object-selector/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-resource-match-with-object-selector/chainsaw-test.yaml
@@ -24,3 +24,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-resource-match-with-object-selector/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-resource-match-with-object-selector/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-resource/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-resource/chainsaw-test.yaml
@@ -24,3 +24,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-resource/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-exclude-resource/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-multiple-resources/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-multiple-resources/chainsaw-test.yaml
@@ -24,3 +24,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-multiple-resources/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-multiple-resources/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-resource/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-resource/chainsaw-test.yaml
@@ -24,3 +24,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-resource/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-resource/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-resources-by-names/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-resources-by-names/chainsaw-test.yaml
@@ -24,3 +24,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-resources-by-names/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-any-match-resources-by-names/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-all-exclude-one/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-all-exclude-one/chainsaw-test.yaml
@@ -24,3 +24,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-all-exclude-one/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-all-exclude-one/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/chainsaw-test.yaml
@@ -24,3 +24,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-kind-with-wildcard/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/chainsaw-test.yaml
@@ -24,3 +24,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-match-resource-in-specific-namespace/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-with-an-exception-excluding-namespaces/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-with-an-exception-excluding-namespaces/chainsaw-test.yaml
@@ -28,3 +28,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-with-an-exception-excluding-namespaces/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-with-an-exception-excluding-namespaces/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-with-an-exception/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-with-an-exception/chainsaw-test.yaml
@@ -28,3 +28,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-with-an-exception/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-with-an-exception/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-with-two-exceptions/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-with-two-exceptions/chainsaw-test.yaml
@@ -28,3 +28,7 @@ spec:
         file: validatingadmissionpolicy.yaml
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-with-two-exceptions/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/clusterpolicy/standard/generate/cpol-with-two-exceptions/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/check-deployment-labels/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/check-deployment-labels/chainsaw-test.yaml
@@ -19,3 +19,7 @@ spec:
     try:
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: check validatingwebhookconfiguration
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/check-deployment-labels/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/check-deployment-labels/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/default/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/default/chainsaw-test.yaml
@@ -19,3 +19,7 @@ spec:
     try:
     - error:
         file: validatingadmissionpolicybinding.yaml
+  - name: check validatingwebhookconfiguration
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/default/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/default/validatingwebhookconfiguration.yaml
@@ -1,0 +1,33 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kyverno-svc
+      namespace: kyverno
+      path: /policies/vpol/validate/fail
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vpol.validate.kyverno.svc-fail
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: '*'
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/disabled/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/disabled/chainsaw-test.yaml
@@ -19,3 +19,7 @@ spec:
     try:
     - error:
         file: validatingadmissionpolicybinding.yaml
+  - name: check validatingwebhookconfiguration
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/disabled/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/disabled/validatingwebhookconfiguration.yaml
@@ -1,0 +1,33 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kyverno-svc
+      namespace: kyverno
+      path: /policies/vpol/validate/fail
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vpol.validate.kyverno.svc-fail
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: '*'
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/enabled/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/enabled/chainsaw-test.yaml
@@ -19,3 +19,7 @@ spec:
     try:
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: check validatingwebhookconfiguration
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/enabled/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/enabled/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/chainsaw-test.yaml
@@ -42,3 +42,7 @@ spec:
           # This check ensures the contents of stderr are exactly as shown.  
           (trim_space($stderr)): |-
             The deployments "bad-deployment" is invalid: : ValidatingAdmissionPolicy 'vpol-check-deployment-labels' with binding 'vpol-check-deployment-labels-binding' denied request: Deployment labels must be env=prod
+  - name: check validatingwebhookconfiguration
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-cel-exception/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/chainsaw-test.yaml
@@ -25,3 +25,7 @@ spec:
     try:
     - assert:
         file: validatingadmissionpolicybinding.yaml
+  - name: check validatingwebhookconfiguration
+    try:
+    - assert:
+        file: validatingwebhookconfiguration.yaml

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/with-multiple-exceptions/validatingwebhookconfiguration.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg


### PR DESCRIPTION
## Explanation
This PR skips webhook registration if VAP is generated from `validate.cel` subrules. Tests are added for `validate.cel` subrules and the new ValidatingPolicies.

Closes #9405 