### PR TITLE
fix: restrict failurePolicy to either Fail or Ignore

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/imageverification_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/imageverification_policy.go
@@ -164,6 +164,7 @@ type ImageValidatingPolicySpec struct {
 	// occur from CEL expression parse errors, type check errors, runtime errors and invalid
 	// or mis-configured policy definitions or bindings.
 	// +optional
+	// +kubebuilder:validation:Enum=Ignore;Fail
 	FailurePolicy *admissionregistrationv1.FailurePolicyType `json:"failurePolicy"`
 
 	// ValidationAction specifies the action to be taken when the matched resource violates the policy.

--- a/api/policies.kyverno.io/v1alpha1/validating_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/validating_policy.go
@@ -112,8 +112,6 @@ type ValidatingPolicyList struct {
 type ValidatingPolicySpec struct {
 	// MatchConstraints specifies what resources this policy is designed to validate.
 	// The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-	// However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API
-	// ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
 	// Required.
 	MatchConstraints *admissionregistrationv1.MatchResources `json:"matchConstraints,omitempty"`
 
@@ -128,16 +126,13 @@ type ValidatingPolicySpec struct {
 	// occur from CEL expression parse errors, type check errors, runtime errors and invalid
 	// or mis-configured policy definitions or bindings.
 	//
-	// A policy is invalid if spec.paramKind refers to a non-existent Kind.
-	// A binding is invalid if spec.paramRef.name refers to a non-existent resource.
-	//
 	// failurePolicy does not define how validations that evaluate to false are handled.
 	//
-	// When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions
-	// define how failures are enforced.
+	// When failurePolicy is set to Fail, the validationActions field define how failures are enforced.
 	//
 	// Allowed values are Ignore or Fail. Defaults to Fail.
 	// +optional
+	// +kubebuilder:validation:Enum=Ignore;Fail
 	FailurePolicy *admissionregistrationv1.FailurePolicyType `json:"failurePolicy,omitempty"`
 
 	// auditAnnotations contains CEL expressions which are used to produce audit

--- a/charts/kyverno/charts/crds/templates/policies.kyverno.io/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/policies.kyverno.io/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -394,6 +394,9 @@ spec:
                   FailurePolicy defines how to handle failures for the admission policy. Failures can
                   occur from CEL expression parse errors, type check errors, runtime errors and invalid
                   or mis-configured policy definitions or bindings.
+                enum:
+                - Ignore
+                - Fail
                 type: string
               imageRules:
                 description: |-
@@ -1332,6 +1335,9 @@ spec:
                                 FailurePolicy defines how to handle failures for the admission policy. Failures can
                                 occur from CEL expression parse errors, type check errors, runtime errors and invalid
                                 or mis-configured policy definitions or bindings.
+                              enum:
+                              - Ignore
+                              - Fail
                               type: string
                             imageRules:
                               description: |-

--- a/charts/kyverno/charts/crds/templates/policies.kyverno.io/policies.kyverno.io_validatingpolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/policies.kyverno.io/policies.kyverno.io_validatingpolicies.yaml
@@ -171,15 +171,14 @@ spec:
                   occur from CEL expression parse errors, type check errors, runtime errors and invalid
                   or mis-configured policy definitions or bindings.
 
-                  A policy is invalid if spec.paramKind refers to a non-existent Kind.
-                  A binding is invalid if spec.paramRef.name refers to a non-existent resource.
-
                   failurePolicy does not define how validations that evaluate to false are handled.
 
-                  When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions
-                  define how failures are enforced.
+                  When failurePolicy is set to Fail, the validationActions field define how failures are enforced.
 
                   Allowed values are Ignore or Fail. Defaults to Fail.
+                enum:
+                - Ignore
+                - Fail
                 type: string
               matchConditions:
                 description: |-
@@ -241,8 +240,6 @@ spec:
                 description: |-
                   MatchConstraints specifies what resources this policy is designed to validate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API
-                  ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
                   Required.
                 properties:
                   excludeResourceRules:

--- a/cmd/cli/kubectl-kyverno/data/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -388,6 +388,9 @@ spec:
                   FailurePolicy defines how to handle failures for the admission policy. Failures can
                   occur from CEL expression parse errors, type check errors, runtime errors and invalid
                   or mis-configured policy definitions or bindings.
+                enum:
+                - Ignore
+                - Fail
                 type: string
               imageRules:
                 description: |-
@@ -1326,6 +1329,9 @@ spec:
                                 FailurePolicy defines how to handle failures for the admission policy. Failures can
                                 occur from CEL expression parse errors, type check errors, runtime errors and invalid
                                 or mis-configured policy definitions or bindings.
+                              enum:
+                              - Ignore
+                              - Fail
                               type: string
                             imageRules:
                               description: |-

--- a/cmd/cli/kubectl-kyverno/data/crds/policies.kyverno.io_validatingpolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/policies.kyverno.io_validatingpolicies.yaml
@@ -165,15 +165,14 @@ spec:
                   occur from CEL expression parse errors, type check errors, runtime errors and invalid
                   or mis-configured policy definitions or bindings.
 
-                  A policy is invalid if spec.paramKind refers to a non-existent Kind.
-                  A binding is invalid if spec.paramRef.name refers to a non-existent resource.
-
                   failurePolicy does not define how validations that evaluate to false are handled.
 
-                  When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions
-                  define how failures are enforced.
+                  When failurePolicy is set to Fail, the validationActions field define how failures are enforced.
 
                   Allowed values are Ignore or Fail. Defaults to Fail.
+                enum:
+                - Ignore
+                - Fail
                 type: string
               matchConditions:
                 description: |-
@@ -235,8 +234,6 @@ spec:
                 description: |-
                   MatchConstraints specifies what resources this policy is designed to validate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API
-                  ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
                   Required.
                 properties:
                   excludeResourceRules:

--- a/config/crds/policies.kyverno.io/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -388,6 +388,9 @@ spec:
                   FailurePolicy defines how to handle failures for the admission policy. Failures can
                   occur from CEL expression parse errors, type check errors, runtime errors and invalid
                   or mis-configured policy definitions or bindings.
+                enum:
+                - Ignore
+                - Fail
                 type: string
               imageRules:
                 description: |-
@@ -1326,6 +1329,9 @@ spec:
                                 FailurePolicy defines how to handle failures for the admission policy. Failures can
                                 occur from CEL expression parse errors, type check errors, runtime errors and invalid
                                 or mis-configured policy definitions or bindings.
+                              enum:
+                              - Ignore
+                              - Fail
                               type: string
                             imageRules:
                               description: |-

--- a/config/crds/policies.kyverno.io/policies.kyverno.io_validatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io/policies.kyverno.io_validatingpolicies.yaml
@@ -165,15 +165,14 @@ spec:
                   occur from CEL expression parse errors, type check errors, runtime errors and invalid
                   or mis-configured policy definitions or bindings.
 
-                  A policy is invalid if spec.paramKind refers to a non-existent Kind.
-                  A binding is invalid if spec.paramRef.name refers to a non-existent resource.
-
                   failurePolicy does not define how validations that evaluate to false are handled.
 
-                  When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions
-                  define how failures are enforced.
+                  When failurePolicy is set to Fail, the validationActions field define how failures are enforced.
 
                   Allowed values are Ignore or Fail. Defaults to Fail.
+                enum:
+                - Ignore
+                - Fail
                 type: string
               matchConditions:
                 description: |-
@@ -235,8 +234,6 @@ spec:
                 description: |-
                   MatchConstraints specifies what resources this policy is designed to validate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API
-                  ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
                   Required.
                 properties:
                   excludeResourceRules:

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -48876,6 +48876,9 @@ spec:
                   FailurePolicy defines how to handle failures for the admission policy. Failures can
                   occur from CEL expression parse errors, type check errors, runtime errors and invalid
                   or mis-configured policy definitions or bindings.
+                enum:
+                - Ignore
+                - Fail
                 type: string
               imageRules:
                 description: |-
@@ -49814,6 +49817,9 @@ spec:
                                 FailurePolicy defines how to handle failures for the admission policy. Failures can
                                 occur from CEL expression parse errors, type check errors, runtime errors and invalid
                                 or mis-configured policy definitions or bindings.
+                              enum:
+                              - Ignore
+                              - Fail
                               type: string
                             imageRules:
                               description: |-
@@ -50784,15 +50790,14 @@ spec:
                   occur from CEL expression parse errors, type check errors, runtime errors and invalid
                   or mis-configured policy definitions or bindings.
 
-                  A policy is invalid if spec.paramKind refers to a non-existent Kind.
-                  A binding is invalid if spec.paramRef.name refers to a non-existent resource.
-
                   failurePolicy does not define how validations that evaluate to false are handled.
 
-                  When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions
-                  define how failures are enforced.
+                  When failurePolicy is set to Fail, the validationActions field define how failures are enforced.
 
                   Allowed values are Ignore or Fail. Defaults to Fail.
+                enum:
+                - Ignore
+                - Fail
                 type: string
               matchConditions:
                 description: |-
@@ -50854,8 +50859,6 @@ spec:
                 description: |-
                   MatchConstraints specifies what resources this policy is designed to validate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API
-                  ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
                   Required.
                 properties:
                   excludeResourceRules:

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -10338,8 +10338,6 @@ Kubernetes admissionregistration/v1.MatchResources
 <td>
 <p>MatchConstraints specifies what resources this policy is designed to validate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
-However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API
-ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
 Required.</p>
 </td>
 </tr>
@@ -10373,11 +10371,8 @@ Kubernetes admissionregistration/v1.FailurePolicyType
 <p>failurePolicy defines how to handle failures for the admission policy. Failures can
 occur from CEL expression parse errors, type check errors, runtime errors and invalid
 or mis-configured policy definitions or bindings.</p>
-<p>A policy is invalid if spec.paramKind refers to a non-existent Kind.
-A binding is invalid if spec.paramRef.name refers to a non-existent resource.</p>
 <p>failurePolicy does not define how validations that evaluate to false are handled.</p>
-<p>When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions
-define how failures are enforced.</p>
+<p>When failurePolicy is set to Fail, the validationActions field define how failures are enforced.</p>
 <p>Allowed values are Ignore or Fail. Defaults to Fail.</p>
 </td>
 </tr>
@@ -12952,8 +12947,6 @@ Kubernetes admissionregistration/v1.MatchResources
 <td>
 <p>MatchConstraints specifies what resources this policy is designed to validate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
-However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API
-ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
 Required.</p>
 </td>
 </tr>
@@ -12987,11 +12980,8 @@ Kubernetes admissionregistration/v1.FailurePolicyType
 <p>failurePolicy defines how to handle failures for the admission policy. Failures can
 occur from CEL expression parse errors, type check errors, runtime errors and invalid
 or mis-configured policy definitions or bindings.</p>
-<p>A policy is invalid if spec.paramKind refers to a non-existent Kind.
-A binding is invalid if spec.paramRef.name refers to a non-existent resource.</p>
 <p>failurePolicy does not define how validations that evaluate to false are handled.</p>
-<p>When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions
-define how failures are enforced.</p>
+<p>When failurePolicy is set to Fail, the validationActions field define how failures are enforced.</p>
 <p>Allowed values are Ignore or Fail. Defaults to Fail.</p>
 </td>
 </tr>


### PR DESCRIPTION
## Explanation
This PR adds a kubebuilder marker on the field `failurePolicy` so that its value would be either Fail or Ignore. It also updates the comments on some of the fields, as it isn't relevant.