### PR TITLE
fix: restrict validationActions in IVPOLs

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/imageverification_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/imageverification_policy.go
@@ -116,7 +116,7 @@ func (s ImageValidatingPolicySpec) BackgroundEnabled() bool {
 // ValidationActions returns the validation actions.
 func (s ImageValidatingPolicySpec) ValidationActions() []admissionregistrationv1.ValidationAction {
 	const defaultValue = admissionregistrationv1.Deny
-	if s.ValidationAction == nil {
+	if len(s.ValidationAction) == 0 {
 		return []admissionregistrationv1.ValidationAction{defaultValue}
 	}
 	return s.ValidationAction

--- a/api/policies.kyverno.io/v1alpha1/imageverification_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/imageverification_policy.go
@@ -113,6 +113,15 @@ func (s ImageValidatingPolicySpec) BackgroundEnabled() bool {
 	return *s.EvaluationConfiguration.Background.Enabled
 }
 
+// ValidationActions returns the validation actions.
+func (s ImageValidatingPolicySpec) ValidationActions() []admissionregistrationv1.ValidationAction {
+	const defaultValue = admissionregistrationv1.Deny
+	if s.ValidationAction == nil {
+		return []admissionregistrationv1.ValidationAction{defaultValue}
+	}
+	return s.ValidationAction
+}
+
 func (status *IvpolStatus) SetReadyByCondition(c PolicyConditionType, s metav1.ConditionStatus, message string) {
 	reason := "Succeeded"
 	if s != metav1.ConditionTrue {
@@ -170,6 +179,7 @@ type ImageValidatingPolicySpec struct {
 	// ValidationAction specifies the action to be taken when the matched resource violates the policy.
 	// Required.
 	// +listType=set
+	// +kubebuilder:validation:items:Enum=Deny;Audit;Warn
 	ValidationAction []admissionregistrationv1.ValidationAction `json:"validationActions,omitempty"`
 
 	// MatchConditions is a list of conditions that must be met for a request to be validated.

--- a/api/policies.kyverno.io/v1alpha1/validating_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/validating_policy.go
@@ -243,7 +243,7 @@ func (s ValidatingPolicySpec) EvaluationMode() EvaluationMode {
 // ValidationActions returns the validation actions.
 func (s ValidatingPolicySpec) ValidationActions() []admissionregistrationv1.ValidationAction {
 	const defaultValue = admissionregistrationv1.Deny
-	if s.ValidationAction == nil {
+	if len(s.ValidationAction) == 0 {
 		return []admissionregistrationv1.ValidationAction{defaultValue}
 	}
 	return s.ValidationAction

--- a/api/policies.kyverno.io/v1alpha1/validating_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/validating_policy.go
@@ -240,6 +240,7 @@ func (s ValidatingPolicySpec) EvaluationMode() EvaluationMode {
 	return s.EvaluationConfiguration.Mode
 }
 
+// ValidationActions returns the validation actions.
 func (s ValidatingPolicySpec) ValidationActions() []admissionregistrationv1.ValidationAction {
 	const defaultValue = admissionregistrationv1.Deny
 	if s.ValidationAction == nil {

--- a/charts/kyverno/charts/crds/templates/policies.kyverno.io/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/policies.kyverno.io/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -827,6 +827,10 @@ spec:
                   Required.
                 items:
                   description: ValidationAction specifies a policy enforcement action.
+                  enum:
+                  - Deny
+                  - Audit
+                  - Warn
                   type: string
                 type: array
                 x-kubernetes-list-type: set
@@ -1778,6 +1782,10 @@ spec:
                               items:
                                 description: ValidationAction specifies a policy enforcement
                                   action.
+                                enum:
+                                - Deny
+                                - Audit
+                                - Warn
                                 type: string
                               type: array
                               x-kubernetes-list-type: set

--- a/cmd/cli/kubectl-kyverno/data/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -821,6 +821,10 @@ spec:
                   Required.
                 items:
                   description: ValidationAction specifies a policy enforcement action.
+                  enum:
+                  - Deny
+                  - Audit
+                  - Warn
                   type: string
                 type: array
                 x-kubernetes-list-type: set
@@ -1772,6 +1776,10 @@ spec:
                               items:
                                 description: ValidationAction specifies a policy enforcement
                                   action.
+                                enum:
+                                - Deny
+                                - Audit
+                                - Warn
                                 type: string
                               type: array
                               x-kubernetes-list-type: set

--- a/config/crds/policies.kyverno.io/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -821,6 +821,10 @@ spec:
                   Required.
                 items:
                   description: ValidationAction specifies a policy enforcement action.
+                  enum:
+                  - Deny
+                  - Audit
+                  - Warn
                   type: string
                 type: array
                 x-kubernetes-list-type: set
@@ -1772,6 +1776,10 @@ spec:
                               items:
                                 description: ValidationAction specifies a policy enforcement
                                   action.
+                                enum:
+                                - Deny
+                                - Audit
+                                - Warn
                                 type: string
                               type: array
                               x-kubernetes-list-type: set

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -49309,6 +49309,10 @@ spec:
                   Required.
                 items:
                   description: ValidationAction specifies a policy enforcement action.
+                  enum:
+                  - Deny
+                  - Audit
+                  - Warn
                   type: string
                 type: array
                 x-kubernetes-list-type: set
@@ -50260,6 +50264,10 @@ spec:
                               items:
                                 description: ValidationAction specifies a policy enforcement
                                   action.
+                                enum:
+                                - Deny
+                                - Audit
+                                - Warn
                                 type: string
                               type: array
                               x-kubernetes-list-type: set

--- a/pkg/cel/engine/ivpolprovider.go
+++ b/pkg/cel/engine/ivpolprovider.go
@@ -6,7 +6,6 @@ import (
 	"github.com/kyverno/kyverno/api/policies.kyverno.io/v1alpha1"
 	policiesv1alpha1 "github.com/kyverno/kyverno/api/policies.kyverno.io/v1alpha1"
 	"github.com/kyverno/kyverno/pkg/cel/autogen"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -22,10 +21,7 @@ func NewIVPOLProvider(policies []v1alpha1.ImageValidatingPolicy, exceptions []*p
 				}
 			}
 		}
-		actions := sets.New(policy.Spec.ValidationAction...)
-		if len(actions) == 0 {
-			actions.Insert(admissionregistrationv1.Deny)
-		}
+		actions := sets.New(policy.Spec.ValidationActions()...)
 		compiled = append(compiled, CompiledImageValidatingPolicy{
 			Actions:    actions,
 			Policy:     &p,

--- a/pkg/cel/engine/provider.go
+++ b/pkg/cel/engine/provider.go
@@ -72,10 +72,7 @@ func NewProvider(compiler policy.Compiler, vpolicies []policiesv1alpha1.Validati
 		if err != nil {
 			return nil, fmt.Errorf("failed to compile policy %s (%w)", vp.GetName(), err.ToAggregate())
 		}
-		actions := sets.New(vp.Spec.ValidationAction...)
-		if len(actions) == 0 {
-			actions.Insert(admissionregistrationv1.Deny)
-		}
+		actions := sets.New(vp.Spec.ValidationActions()...)
 		compiled = append(compiled, CompiledValidatingPolicy{
 			Actions:        actions,
 			Policy:         vp,
@@ -212,10 +209,7 @@ func (r *policyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	actions := sets.New(policy.Spec.ValidationAction...)
-	if len(actions) == 0 {
-		actions.Insert(admissionregistrationv1.Deny)
-	}
+	actions := sets.New(policy.Spec.ValidationActions()...)
 	r.policies[req.NamespacedName.String()] = CompiledValidatingPolicy{
 		Actions:        actions,
 		Policy:         policy,
@@ -289,10 +283,7 @@ func (r *ivpolpolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	actions := sets.New(policy.Spec.ValidationAction...)
-	if len(actions) == 0 {
-		actions.Insert(admissionregistrationv1.Deny)
-	}
+	actions := sets.New(policy.Spec.ValidationActions()...)
 	r.policies[req.NamespacedName.String()] = CompiledImageValidatingPolicy{
 		Policy:     &policy,
 		Exceptions: exceptions,

--- a/test/conformance/chainsaw/image-validating-policies/validation-checks/invalid-action/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-checks/invalid-action/chainsaw-test.yaml
@@ -1,0 +1,15 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: missing-action
+spec:
+  steps:
+  - name: Apply the policy
+    try:
+    - script:
+        content: kubectl apply -f policy.yaml
+        check:
+          ($error != null): true
+          # This check ensures the contents of stderr are exactly as shown.  
+          (trim_space($stderr)): |-
+            The ImageValidatingPolicy "ivpol-sample" is invalid: spec.validationActions[0]: Unsupported value: "test": supported values: "Deny", "Audit", "Warn"

--- a/test/conformance/chainsaw/image-validating-policies/validation-checks/invalid-action/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-checks/invalid-action/policy.yaml
@@ -1,0 +1,58 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ImageValidatingPolicy
+metadata:
+  name: ivpol-sample
+spec:
+  failurePolicy: Ignore
+  validationActions:
+  - test
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+  matchConditions:
+    - name: "check-prod-label"  
+      expression: >- 
+        has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
+  imageRules:
+    - glob: ghcr.io/*
+  attestors:
+    - name: notary
+      notary:
+        certs: |-
+          -----BEGIN CERTIFICATE-----
+          MIIDTTCCAjWgAwIBAgIJAPI+zAzn4s0xMA0GCSqGSIb3DQEBCwUAMEwxCzAJBgNV
+          BAYTAlVTMQswCQYDVQQIDAJXQTEQMA4GA1UEBwwHU2VhdHRsZTEPMA0GA1UECgwG
+          Tm90YXJ5MQ0wCwYDVQQDDAR0ZXN0MB4XDTIzMDUyMjIxMTUxOFoXDTMzMDUxOTIx
+          MTUxOFowTDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMRAwDgYDVQQHDAdTZWF0
+          dGxlMQ8wDQYDVQQKDAZOb3RhcnkxDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3
+          DQEBAQUAA4IBDwAwggEKAoIBAQDNhTwv+QMk7jEHufFfIFlBjn2NiJaYPgL4eBS+
+          b+o37ve5Zn9nzRppV6kGsa161r9s2KkLXmJrojNy6vo9a6g6RtZ3F6xKiWLUmbAL
+          hVTCfYw/2n7xNlVMjyyUpE+7e193PF8HfQrfDFxe2JnX5LHtGe+X9vdvo2l41R6m
+          Iia04DvpMdG4+da2tKPzXIuLUz/FDb6IODO3+qsqQLwEKmmUee+KX+3yw8I6G1y0
+          Vp0mnHfsfutlHeG8gazCDlzEsuD4QJ9BKeRf2Vrb0ywqNLkGCbcCWF2H5Q80Iq/f
+          ETVO9z88R7WheVdEjUB8UrY7ZMLdADM14IPhY2Y+tLaSzEVZAgMBAAGjMjAwMAkG
+          A1UdEwQCMAAwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMDMA0G
+          CSqGSIb3DQEBCwUAA4IBAQBX7x4Ucre8AIUmXZ5PUK/zUBVOrZZzR1YE8w86J4X9
+          kYeTtlijf9i2LTZMfGuG0dEVFN4ae3CCpBst+ilhIndnoxTyzP+sNy4RCRQ2Y/k8
+          Zq235KIh7uucq96PL0qsF9s2RpTKXxyOGdtp9+HO0Ty5txJE2txtLDUIVPK5WNDF
+          ByCEQNhtHgN6V20b8KU2oLBZ9vyB8V010dQz0NRTDLhkcvJig00535/LUylECYAJ
+          5/jn6XKt6UYCQJbVNzBg/YPGc1RF4xdsGVDBben/JXpeGEmkdmXPILTKd9tZ5TC0
+          uOKpF5rWAruB5PCIrquamOejpXV9aQA/K2JQDuc0mcKz
+          -----END CERTIFICATE-----
+  attestations:
+    - name: sbom
+      referrer:
+        type: sbom/cyclone-dx
+  validations:
+    - expression: >-
+        images.containers.map(image, verifyImageSignatures(image, [attestors.notary])).all(e, e > 0)
+      message: failed to verify image with notary cert
+    - expression: >-
+        images.containers.map(image, verifyAttestationSignatures(image, attestations.sbom ,[attestors.notary])).all(e, e > 0)
+      message: failed to verify attestation with notary cer
+    - expression: >-
+        images.containers.map(image, payload(image, attestations.sbom).bomFormat == 'CycloneDX').all(e, e)
+      message: sbom is not a cyclone dx sbom


### PR DESCRIPTION
## Explanation
This PR restricts the validationActions field in IVPOLs to be either Deny, Audit or Warn.