### PR TITLE
fix: rewrite cel/matching package with upstream code (cherry-pick #12929)

### DIFF
--- a/pkg/cel/matching/matcher.go
+++ b/pkg/cel/matching/matcher.go
@@ -1,19 +1,17 @@
 package matching
 
 import (
+	"github.com/kyverno/kyverno/pkg/cel/matching/predicates/namespace"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/matching"
-	"k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/namespace"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/object"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/rules"
 )
 
 type Matcher interface {
-	Match(criteria matching.MatchCriteria, attr admission.Attributes, namespace runtime.Object) (bool, error)
+	Match(matching.MatchCriteria, admission.Attributes, runtime.Object) (bool, error)
 }
 
 type matcher struct {
@@ -26,21 +24,27 @@ func NewMatcher() Matcher {
 	}
 }
 
-func (m *matcher) Match(criteria matching.MatchCriteria, attr admission.Attributes, namespace runtime.Object) (bool, error) {
-	matches, matchNsErr := matchNamespace(criteria, namespace)
+func (m *matcher) Match(criteria matching.MatchCriteria, attr admission.Attributes, ns runtime.Object) (bool, error) {
+	nsMatcher := namespace.Matcher{
+		Namespace: ns,
+	}
+	matches, matchNsErr := nsMatcher.MatchNamespaceSelector(criteria, attr)
 	// Should not return an error here for policy which do not apply to the request, even if err is an unexpected scenario.
 	if !matches && matchNsErr == nil {
 		return false, nil
 	}
+
 	matches, matchObjErr := m.objectMatcher.MatchObjectSelector(criteria, attr)
 	// Should not return an error here for policy which do not apply to the request, even if err is an unexpected scenario.
 	if !matches && matchObjErr == nil {
 		return false, nil
 	}
+
 	matchResources := criteria.GetMatchResources()
 	if isExcluded, err := matchesResourceRules(matchResources.ExcludeResourceRules, attr); isExcluded || err != nil {
 		return false, err
 	}
+
 	var (
 		isMatch  bool
 		matchErr error
@@ -56,6 +60,7 @@ func (m *matcher) Match(criteria matching.MatchCriteria, attr admission.Attribut
 	if !isMatch {
 		return false, nil
 	}
+
 	// now that we know this applies to this request otherwise, if there were selector errors, return them
 	if matchNsErr != nil {
 		return false, matchNsErr
@@ -63,33 +68,15 @@ func (m *matcher) Match(criteria matching.MatchCriteria, attr admission.Attribut
 	if matchObjErr != nil {
 		return false, matchObjErr
 	}
-	return true, nil
-}
 
-func matchNamespace(provider namespace.NamespaceSelectorProvider, namespace runtime.Object) (bool, error) {
-	selector, err := provider.GetParsedNamespaceSelector()
-	if err != nil {
-		return false, err
-	}
-	if selector.Empty() {
-		return true, nil
-	}
-	if namespace == nil {
-		// If the request is about a cluster scoped resource, and it is not a
-		// namespace, it is never exempted.
-		return true, nil
-	}
-	accessor, err := meta.Accessor(namespace)
-	if err != nil {
-		return false, err
-	}
-	return selector.Matches(labels.Set(accessor.GetLabels())), nil
+	return true, nil
 }
 
 func matchesResourceRules(namedRules []admissionregistrationv1.NamedRuleWithOperations, attr admission.Attributes) (bool, error) {
 	for _, namedRule := range namedRules {
+		rule := namedRule.RuleWithOperations
 		ruleMatcher := rules.Matcher{
-			Rule: namedRule.RuleWithOperations,
+			Rule: rule,
 			Attr: attr,
 		}
 		if !ruleMatcher.Matches() {

--- a/pkg/cel/matching/predicates/namespace/matcher.go
+++ b/pkg/cel/matching/predicates/namespace/matcher.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+type NamespaceSelectorProvider interface {
+	// GetNamespaceSelector gets the webhook NamespaceSelector field.
+	GetParsedNamespaceSelector() (labels.Selector, error)
+}
+
+// Matcher decides if a request is exempted by the NamespaceSelector of a
+// webhook configuration.
+type Matcher struct {
+	Namespace runtime.Object
+}
+
+func (m *Matcher) GetNamespace(name string) (metav1.Object, error) {
+	if m.Namespace == nil {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "v1", Resource: "namesapces"}, name)
+	}
+	accessor, err := meta.Accessor(m.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	if accessor.GetName() != name {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "v1", Resource: "namesapces"}, name)
+	}
+	return accessor, nil
+}
+
+// Validate checks if the Matcher has a NamespaceLister and Client.
+func (m *Matcher) Validate() error {
+	var errs []error
+	if m.Namespace == nil {
+		errs = append(errs, fmt.Errorf("the namespace matcher requires a namespace"))
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+// GetNamespaceLabels gets the labels of the namespace related to the attr.
+func (m *Matcher) GetNamespaceLabels(attr admission.Attributes) (map[string]string, error) {
+	// If the request itself is creating or updating a namespace, then get the
+	// labels from attr.Object, because namespaceLister doesn't have the latest
+	// namespace yet.
+	//
+	// However, if the request is deleting a namespace, then get the label from
+	// the namespace in the namespaceLister, because a delete request is not
+	// going to change the object, and attr.Object will be a DeleteOptions
+	// rather than a namespace object.
+	if attr.GetResource().Resource == "namespaces" &&
+		len(attr.GetSubresource()) == 0 &&
+		(attr.GetOperation() == admission.Create || attr.GetOperation() == admission.Update) {
+		accessor, err := meta.Accessor(attr.GetObject())
+		if err != nil {
+			return nil, err
+		}
+		return accessor.GetLabels(), nil
+	}
+
+	namespace, err := m.GetNamespace(attr.GetNamespace())
+	if err != nil {
+		return nil, err
+	}
+	return namespace.GetLabels(), nil
+}
+
+// MatchNamespaceSelector decideds whether the request matches the
+// namespaceSelctor of the webhook. Only when they match, the webhook is called.
+func (m *Matcher) MatchNamespaceSelector(p NamespaceSelectorProvider, attr admission.Attributes) (bool, *apierrors.StatusError) {
+	namespaceName := attr.GetNamespace()
+	if len(namespaceName) == 0 && attr.GetResource().Resource != "namespaces" {
+		// If the request is about a cluster scoped resource, and it is not a
+		// namespace, it is never exempted.
+		// TODO: figure out a way selective exempt cluster scoped resources.
+		// Also update the comment in types.go
+		return true, nil
+	}
+	selector, err := p.GetParsedNamespaceSelector()
+	if err != nil {
+		return false, apierrors.NewInternalError(err)
+	}
+	if selector.Empty() {
+		return true, nil
+	}
+
+	namespaceLabels, err := m.GetNamespaceLabels(attr)
+	// this means the namespace is not found, for backwards compatibility,
+	// return a 404
+	if apierrors.IsNotFound(err) {
+		status, ok := err.(apierrors.APIStatus)
+		if !ok {
+			return false, apierrors.NewInternalError(err)
+		}
+		return false, &apierrors.StatusError{ErrStatus: status.Status()}
+	}
+	if err != nil {
+		return false, apierrors.NewInternalError(err)
+	}
+	return selector.Matches(labels.Set(namespaceLabels)), nil
+}

--- a/pkg/cel/matching/predicates/namespace/matcher_test.go
+++ b/pkg/cel/matching/predicates/namespace/matcher_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kyverno/kyverno/pkg/cel/matching/predicates/namespace"
+	registrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook"
+)
+
+func TestGetNamespaceLabels(t *testing.T) {
+	namespace1Labels := map[string]string{
+		"runlevel": "1",
+	}
+	namespace1 := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "1",
+			Labels: namespace1Labels,
+		},
+	}
+	namespace2Labels := map[string]string{
+		"runlevel": "2",
+	}
+	namespace2 := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "2",
+			Labels: namespace2Labels,
+		},
+	}
+
+	tests := []struct {
+		name           string
+		attr           admission.Attributes
+		expectedLabels map[string]string
+	}{
+		{
+			name:           "request is for creating namespace, the labels should be from the object itself",
+			attr:           admission.NewAttributesRecord(&namespace2, nil, schema.GroupVersionKind{}, "", namespace2.Name, schema.GroupVersionResource{Resource: "namespaces"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
+			expectedLabels: namespace2Labels,
+		},
+		{
+			name:           "request is for updating namespace, the labels should be from the new object",
+			attr:           admission.NewAttributesRecord(&namespace2, nil, schema.GroupVersionKind{}, namespace2.Name, namespace2.Name, schema.GroupVersionResource{Resource: "namespaces"}, "", admission.Update, &metav1.UpdateOptions{}, false, nil),
+			expectedLabels: namespace2Labels,
+		},
+		{
+			name:           "request is for deleting namespace, the labels should be from the cache",
+			attr:           admission.NewAttributesRecord(&namespace2, nil, schema.GroupVersionKind{}, namespace1.Name, namespace1.Name, schema.GroupVersionResource{Resource: "namespaces"}, "", admission.Delete, &metav1.DeleteOptions{}, false, nil),
+			expectedLabels: namespace1Labels,
+		},
+		{
+			name:           "request is for namespace/finalizer",
+			attr:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{}, namespace1.Name, "mock-name", schema.GroupVersionResource{Resource: "namespaces"}, "finalizers", admission.Create, &metav1.CreateOptions{}, false, nil),
+			expectedLabels: namespace1Labels,
+		},
+		{
+			name:           "request is for pod",
+			attr:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{}, namespace1.Name, "mock-name", schema.GroupVersionResource{Resource: "pods"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
+			expectedLabels: namespace1Labels,
+		},
+	}
+	matcher := namespace.Matcher{
+		Namespace: &namespace1,
+	}
+	for _, tt := range tests {
+		actualLabels, err := matcher.GetNamespaceLabels(tt.attr)
+		if err != nil {
+			t.Error(err)
+		}
+		if !reflect.DeepEqual(actualLabels, tt.expectedLabels) {
+			t.Errorf("expected labels to be %#v, got %#v", tt.expectedLabels, actualLabels)
+		}
+	}
+}
+
+func TestNotExemptClusterScopedResource(t *testing.T) {
+	hook := &registrationv1.ValidatingWebhook{
+		NamespaceSelector: &metav1.LabelSelector{},
+	}
+	attr := admission.NewAttributesRecord(
+		nil,
+		nil,
+		schema.GroupVersionKind{},
+		"",
+		"mock-name",
+		schema.GroupVersionResource{Version: "v1", Resource: "nodes"},
+		"",
+		admission.Create,
+		&metav1.CreateOptions{},
+		false,
+		nil,
+	)
+	matcher := namespace.Matcher{}
+	matches, err := matcher.MatchNamespaceSelector(webhook.NewValidatingWebhookAccessor("mock-hook", "mock-cfg", hook), attr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !matches {
+		t.Errorf("cluster scoped resources (but not a namespace) should not be exempted from webhooks")
+	}
+}


### PR DESCRIPTION
## Explanation

fix: rewrite cel/matching package with upstream code (cherry-pick #12929)