### PR TITLE
add support for auditAnnotations in ivpols

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/imagevalidating_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/imagevalidating_policy.go
@@ -141,6 +141,14 @@ type ImageValidatingPolicySpec struct {
 	// +kubebuilder:validation:Enum=Ignore;Fail
 	FailurePolicy *admissionregistrationv1.FailurePolicyType `json:"failurePolicy"`
 
+	// auditAnnotations contains CEL expressions which are used to produce audit
+	// annotations for the audit event of the API request.
+	// validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is
+	// required.
+	// +listType=atomic
+	// +optional
+	AuditAnnotations []admissionregistrationv1.AuditAnnotation `json:"auditAnnotations,omitempty"`
+
 	// ValidationAction specifies the action to be taken when the matched resource violates the policy.
 	// Required.
 	// +listType=set

--- a/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
+++ b/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
@@ -468,6 +468,11 @@ func (in *ImageValidatingPolicySpec) DeepCopyInto(out *ImageValidatingPolicySpec
 		*out = new(admissionregistrationv1.FailurePolicyType)
 		**out = **in
 	}
+	if in.AuditAnnotations != nil {
+		in, out := &in.AuditAnnotations, &out.AuditAnnotations
+		*out = make([]admissionregistrationv1.AuditAnnotation, len(*in))
+		copy(*out, *in)
+	}
 	if in.ValidationAction != nil {
 		in, out := &in.ValidationAction, &out.ValidationAction
 		*out = make([]admissionregistrationv1.ValidationAction, len(*in))

--- a/charts/kyverno/charts/crds/templates/policies.kyverno.io/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/policies.kyverno.io/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -351,6 +351,58 @@ spec:
                   - name
                   type: object
                 type: array
+              auditAnnotations:
+                description: |-
+                  auditAnnotations contains CEL expressions which are used to produce audit
+                  annotations for the audit event of the API request.
+                  validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is
+                  required.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -1348,6 +1400,58 @@ spec:
                                 - name
                                 type: object
                               type: array
+                            auditAnnotations:
+                              description: |-
+                                auditAnnotations contains CEL expressions which are used to produce audit
+                                annotations for the audit event of the API request.
+                                validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is
+                                required.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.

--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -581,7 +581,7 @@ func (c *ApplyCommandConfig) applyImageValidatingPolicies(
 				}
 			} else {
 				resp.PolicyResponse.Rules = []engineapi.RuleResponse{
-					*engineapi.RuleFail(p, engineapi.ImageVerify, rslt.Message, nil),
+					*engineapi.RuleFail(p, engineapi.ImageVerify, rslt.Message, rslt.AuditAnnotations),
 				}
 			}
 			resp = resp.WithPolicy(engineapi.NewImageValidatingPolicy(pMap[p]))

--- a/cmd/cli/kubectl-kyverno/data/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -345,6 +345,58 @@ spec:
                   - name
                   type: object
                 type: array
+              auditAnnotations:
+                description: |-
+                  auditAnnotations contains CEL expressions which are used to produce audit
+                  annotations for the audit event of the API request.
+                  validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is
+                  required.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -1342,6 +1394,58 @@ spec:
                                 - name
                                 type: object
                               type: array
+                            auditAnnotations:
+                              description: |-
+                                auditAnnotations contains CEL expressions which are used to produce audit
+                                annotations for the audit event of the API request.
+                                validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is
+                                required.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.

--- a/config/crds/policies.kyverno.io/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -345,6 +345,58 @@ spec:
                   - name
                   type: object
                 type: array
+              auditAnnotations:
+                description: |-
+                  auditAnnotations contains CEL expressions which are used to produce audit
+                  annotations for the audit event of the API request.
+                  validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is
+                  required.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -1342,6 +1394,58 @@ spec:
                                 - name
                                 type: object
                               type: array
+                            auditAnnotations:
+                              description: |-
+                                auditAnnotations contains CEL expressions which are used to produce audit
+                                annotations for the audit event of the API request.
+                                validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is
+                                required.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -48833,6 +48833,58 @@ spec:
                   - name
                   type: object
                 type: array
+              auditAnnotations:
+                description: |-
+                  auditAnnotations contains CEL expressions which are used to produce audit
+                  annotations for the audit event of the API request.
+                  validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is
+                  required.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -49830,6 +49882,58 @@ spec:
                                 - name
                                 type: object
                               type: array
+                            auditAnnotations:
+                              description: |-
+                                auditAnnotations contains CEL expressions which are used to produce audit
+                                annotations for the audit event of the API request.
+                                validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is
+                                required.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -10269,6 +10269,23 @@ or mis-configured policy definitions or bindings.</p>
 </tr>
 <tr>
 <td>
+<code>auditAnnotations</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#auditannotation-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.AuditAnnotation
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>auditAnnotations contains CEL expressions which are used to produce audit
+annotations for the audit event of the API request.
+validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is
+required.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>validationActions</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#validationaction-v1-admissionregistration">
@@ -11714,6 +11731,23 @@ Kubernetes admissionregistration/v1.FailurePolicyType
 <p>FailurePolicy defines how to handle failures for the admission policy. Failures can
 occur from CEL expression parse errors, type check errors, runtime errors and invalid
 or mis-configured policy definitions or bindings.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>auditAnnotations</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#auditannotation-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.AuditAnnotation
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>auditAnnotations contains CEL expressions which are used to produce audit
+annotations for the audit event of the API request.
+validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is
+required.</p>
 </td>
 </tr>
 <tr>

--- a/docs/user/crd/kyverno_cel_policies.v1alpha1.html
+++ b/docs/user/crd/kyverno_cel_policies.v1alpha1.html
@@ -194,6 +194,36 @@ or mis-configured policy definitions or bindings.</p>
     
     
       <tr>
+        <td><code>auditAnnotations</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]admissionregistration/v1.AuditAnnotation</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>auditAnnotations contains CEL expressions which are used to produce audit
+annotations for the audit event of the API request.
+validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is
+required.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
         <td><code>validationActions</code>
           
           <span style="color:blue;"> *</span>
@@ -3076,6 +3106,36 @@ apply a regexp for matching.</p>
           <p>FailurePolicy defines how to handle failures for the admission policy. Failures can
 occur from CEL expression parse errors, type check errors, runtime errors and invalid
 or mis-configured policy definitions or bindings.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>auditAnnotations</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]admissionregistration/v1.AuditAnnotation</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>auditAnnotations contains CEL expressions which are used to produce audit
+annotations for the audit event of the API request.
+validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is
+required.</p>
 
 
           

--- a/pkg/cel/policies/ivpol/engine/engine.go
+++ b/pkg/cel/policies/ivpol/engine/engine.go
@@ -244,7 +244,7 @@ func (e *engineImpl) handleMutation(
 					} else if result.Result {
 						response.Result = *engineapi.RulePass(ruleName, engineapi.ImageVerify, "success", nil)
 					} else {
-						response.Result = *engineapi.RuleFail(ruleName, engineapi.ImageVerify, result.Message, nil)
+						response.Result = *engineapi.RuleFail(ruleName, engineapi.ImageVerify, result.Message, result.AuditAnnotations)
 					}
 				}
 			}

--- a/pkg/imageverification/evaluator/compiler.go
+++ b/pkg/imageverification/evaluator/compiler.go
@@ -130,7 +130,7 @@ func (c *compiler) Compile(ivpolicy *policiesv1alpha1.ImageValidatingPolicy, exc
 		}
 	}
 
-	verifications := make([]engine.Validation, 0, len(ivpolicy.Spec.Validations))
+	validations := make([]engine.Validation, 0, len(ivpolicy.Spec.Validations))
 	{
 		path := path.Child("validations")
 		for i, rule := range ivpolicy.Spec.Validations {
@@ -139,7 +139,20 @@ func (c *compiler) Compile(ivpolicy *policiesv1alpha1.ImageValidatingPolicy, exc
 			if errs != nil {
 				return nil, append(allErrs, errs...)
 			}
-			verifications = append(verifications, program)
+			validations = append(validations, program)
+		}
+	}
+
+	auditAnnotations := make(map[string]cel.Program, len(ivpolicy.Spec.AuditAnnotations))
+	{
+		path := path.Child("auditAnnotations")
+		for i, auditAnnotation := range ivpolicy.Spec.AuditAnnotations {
+			path := path.Index(i)
+			program, errs := engine.CompileAuditAnnotation(path, env, auditAnnotation)
+			if errs != nil {
+				return nil, append(allErrs, errs...)
+			}
+			auditAnnotations[auditAnnotation.Key] = program
 		}
 	}
 
@@ -163,7 +176,8 @@ func (c *compiler) Compile(ivpolicy *policiesv1alpha1.ImageValidatingPolicy, exc
 		failurePolicy:        ivpolicy.GetFailurePolicy(),
 		matchConditions:      matchConditions,
 		matchImageReferences: matchImageReferences,
-		verifications:        verifications,
+		validations:          validations,
+		auditAnnotations:     auditAnnotations,
 		imageExtractors:      imageExtractors,
 		attestors:            compiledAttestors,
 		attestorList:         ivpolvar.GetAttestors(ivpolicy.Spec.Attestors),

--- a/test/conformance/chainsaw/image-validating-policies/report/admission/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/report/admission/policy.yaml
@@ -23,6 +23,10 @@ spec:
     - expression: >-
         images.containers.map(image, verifyImageSignatures(image, [attestors.notary])).all(e, e > 0)
       message: failed to verify image with notary cert
+  auditAnnotations:
+    - key: label
+      valueExpression: >-
+        has(object.metadata.labels) && 'env' in object.metadata.labels ? string(object.metadata.labels['env']) : ''
   webhookConfiguration:
     timeoutSeconds: 20
   failurePolicy: Ignore

--- a/test/conformance/chainsaw/image-validating-policies/report/admission/report.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/report/admission/report.yaml
@@ -17,6 +17,8 @@ results:
   result: fail
   scored: true
   source: KyvernoImageValidatingPolicy
+  properties:
+    label: prod
 summary:
   error: 0
   fail: 1


### PR DESCRIPTION
## Explanation

Support AuditAnnotations in ivpols

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
