### PR TITLE
refactor: include vap bindings in the GenericPolicy

### DIFF
--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -217,7 +217,7 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 	// validating admission policies
 	vapResponses := make([]engineapi.EngineResponse, 0, len(p.ValidatingAdmissionPolicies))
 	for _, policy := range p.ValidatingAdmissionPolicies {
-		policyData := admissionpolicy.NewPolicyData(policy)
+		policyData := engineapi.NewValidatingAdmissionPolicyData(&policy)
 		for _, binding := range p.ValidatingAdmissionPolicyBindings {
 			if binding.Spec.PolicyName == policy.Name {
 				policyData.AddBinding(binding)

--- a/pkg/admissionpolicy/api.go
+++ b/pkg/admissionpolicy/api.go
@@ -4,37 +4,11 @@ import (
 	"context"
 
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
-
-// Everything someone might need to validate a single ValidatingPolicyDefinition
-// against all of its registered bindings.
-type PolicyData struct {
-	definition admissionregistrationv1.ValidatingAdmissionPolicy
-	bindings   []admissionregistrationv1.ValidatingAdmissionPolicyBinding
-}
-
-func (p *PolicyData) AddBinding(binding admissionregistrationv1.ValidatingAdmissionPolicyBinding) {
-	p.bindings = append(p.bindings, binding)
-}
-
-func (p *PolicyData) GetDefinition() admissionregistrationv1.ValidatingAdmissionPolicy {
-	return p.definition
-}
-
-func (p *PolicyData) GetBindings() []admissionregistrationv1.ValidatingAdmissionPolicyBinding {
-	return p.bindings
-}
-
-func NewPolicyData(policy admissionregistrationv1.ValidatingAdmissionPolicy) PolicyData {
-	return PolicyData{
-		definition: policy,
-	}
-}
 
 type CustomNamespaceLister struct {
 	dClient dclient.Interface

--- a/pkg/admissionpolicy/validate.go
+++ b/pkg/admissionpolicy/validate.go
@@ -68,15 +68,15 @@ func GetKinds(matchResources *admissionregistrationv1.MatchResources) []string {
 }
 
 func Validate(
-	policyData PolicyData,
+	policyData *engineapi.ValidatingAdmissionPolicyData,
 	resource unstructured.Unstructured,
 	namespaceSelectorMap map[string]map[string]string,
 	client dclient.Interface,
 ) (engineapi.EngineResponse, error) {
 	resPath := fmt.Sprintf("%s/%s/%s", resource.GetNamespace(), resource.GetKind(), resource.GetName())
-	policy := policyData.definition
-	bindings := policyData.bindings
-	engineResponse := engineapi.NewEngineResponse(resource, engineapi.NewValidatingAdmissionPolicy(&policy), nil)
+	policy := policyData.GetDefinition()
+	bindings := policyData.GetBindings()
+	engineResponse := engineapi.NewEngineResponse(resource, engineapi.NewValidatingAdmissionPolicy(policy), nil)
 
 	gvk := resource.GroupVersionKind()
 	gvr := schema.GroupVersionResource{
@@ -129,7 +129,7 @@ func Validate(
 
 		// check if policy matches the incoming resource
 		o := admission.NewObjectInterfacesFromScheme(runtime.NewScheme())
-		isMatch, _, _, err := matcher.DefinitionMatches(a, o, validating.NewValidatingAdmissionPolicyAccessor(&policy))
+		isMatch, _, _, err := matcher.DefinitionMatches(a, o, validating.NewValidatingAdmissionPolicyAccessor(policy))
 		if err != nil {
 			return engineResponse, err
 		}
@@ -174,7 +174,7 @@ func Validate(
 }
 
 func validateResource(
-	policy admissionregistrationv1.ValidatingAdmissionPolicy,
+	policy *admissionregistrationv1.ValidatingAdmissionPolicy,
 	binding *admissionregistrationv1.ValidatingAdmissionPolicyBinding,
 	resource unstructured.Unstructured,
 	namespace *corev1.Namespace,
@@ -182,7 +182,7 @@ func validateResource(
 ) (engineapi.EngineResponse, error) {
 	startTime := time.Now()
 
-	engineResponse := engineapi.NewEngineResponse(resource, engineapi.NewValidatingAdmissionPolicy(&policy), nil)
+	engineResponse := engineapi.NewEngineResponse(resource, engineapi.NewValidatingAdmissionPolicy(policy), nil)
 	policyResp := engineapi.NewPolicyResponse()
 	var ruleResp *engineapi.RuleResponse
 

--- a/pkg/controllers/report/background/controller.go
+++ b/pkg/controllers/report/background/controller.go
@@ -437,7 +437,7 @@ func (c *controller) reconcileReport(
 			if policy.AsKyvernoPolicy() != nil {
 				key = cache.MetaObjectToName(policy.AsKyvernoPolicy()).String()
 			} else if policy.AsValidatingAdmissionPolicy() != nil {
-				key = cache.MetaObjectToName(policy.AsValidatingAdmissionPolicy()).String()
+				key = cache.MetaObjectToName(policy.AsValidatingAdmissionPolicy().GetDefinition()).String()
 			} else if policy.AsValidatingPolicy() != nil {
 				key = cache.MetaObjectToName(policy.AsValidatingPolicy()).String()
 			} else if policy.AsImageValidatingPolicy() != nil {

--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -255,10 +255,9 @@ func (s *scanner) ScanResource(
 	}
 	// evaluate validating admission policies
 	for i, policy := range vaps {
-		if pol := policy.AsValidatingAdmissionPolicy(); pol != nil {
-			policyData := admissionpolicy.NewPolicyData(*pol)
+		if policyData := policy.AsValidatingAdmissionPolicy(); policyData != nil {
 			for _, binding := range bindings {
-				if binding.Spec.PolicyName == pol.Name {
+				if binding.Spec.PolicyName == policyData.GetDefinition().GetName() {
 					policyData.AddBinding(binding)
 				}
 			}

--- a/pkg/engine/api/policy.go
+++ b/pkg/engine/api/policy.go
@@ -8,6 +8,35 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Everything someone might need to validate a single ValidatingAdmissionPolicy
+// against all of its registered bindings.
+type ValidatingAdmissionPolicyData struct {
+	definition *admissionregistrationv1.ValidatingAdmissionPolicy
+	bindings   []admissionregistrationv1.ValidatingAdmissionPolicyBinding
+}
+
+func (p *ValidatingAdmissionPolicyData) AddBinding(binding admissionregistrationv1.ValidatingAdmissionPolicyBinding) {
+	p.bindings = append(p.bindings, binding)
+}
+
+func (p *ValidatingAdmissionPolicyData) GetDefinition() *admissionregistrationv1.ValidatingAdmissionPolicy {
+	return p.definition
+}
+
+func (p *ValidatingAdmissionPolicyData) GetBindings() []admissionregistrationv1.ValidatingAdmissionPolicyBinding {
+	return p.bindings
+}
+
+func NewValidatingAdmissionPolicyData(
+	policy *admissionregistrationv1.ValidatingAdmissionPolicy,
+	bindings ...admissionregistrationv1.ValidatingAdmissionPolicyBinding,
+) *ValidatingAdmissionPolicyData {
+	return &ValidatingAdmissionPolicyData{
+		definition: policy,
+		bindings:   bindings,
+	}
+}
+
 // GenericPolicy abstracts the policy type (ClusterPolicy/Policy, ValidatingPolicy, ValidatingAdmissionPolicy and MutatingAdmissionPolicy)
 // It is intended to be used in EngineResponse
 type GenericPolicy interface {
@@ -22,8 +51,8 @@ type GenericPolicy interface {
 	AsObject() any
 	// AsKyvernoPolicy returns the kyverno policy
 	AsKyvernoPolicy() kyvernov1.PolicyInterface
-	// AsValidatingAdmissionPolicy returns the validating admission policy
-	AsValidatingAdmissionPolicy() *admissionregistrationv1.ValidatingAdmissionPolicy
+	// AsValidatingAdmissionPolicy returns the validating admission policy with its bindings
+	AsValidatingAdmissionPolicy() *ValidatingAdmissionPolicyData
 	// AsValidatingPolicy returns the validating policy
 	AsValidatingPolicy() *policiesv1alpha1.ValidatingPolicy
 	// AsImageValidatingPolicy returns the imageverificationpolicy
@@ -33,7 +62,7 @@ type GenericPolicy interface {
 type genericPolicy struct {
 	metav1.Object
 	PolicyInterface           kyvernov1.PolicyInterface
-	ValidatingAdmissionPolicy *admissionregistrationv1.ValidatingAdmissionPolicy
+	ValidatingAdmissionPolicy *ValidatingAdmissionPolicyData
 	MutatingAdmissionPolicy   *admissionregistrationv1alpha1.MutatingAdmissionPolicy
 	ValidatingPolicy          *policiesv1alpha1.ValidatingPolicy
 	ImageValidatingPolicy     *policiesv1alpha1.ImageValidatingPolicy
@@ -47,7 +76,7 @@ func (p *genericPolicy) AsKyvernoPolicy() kyvernov1.PolicyInterface {
 	return p.PolicyInterface
 }
 
-func (p *genericPolicy) AsValidatingAdmissionPolicy() *admissionregistrationv1.ValidatingAdmissionPolicy {
+func (p *genericPolicy) AsValidatingAdmissionPolicy() *ValidatingAdmissionPolicyData {
 	return p.ValidatingAdmissionPolicy
 }
 
@@ -109,7 +138,14 @@ func NewKyvernoPolicy(pol kyvernov1.PolicyInterface) GenericPolicy {
 func NewValidatingAdmissionPolicy(pol *admissionregistrationv1.ValidatingAdmissionPolicy) GenericPolicy {
 	return &genericPolicy{
 		Object:                    pol,
-		ValidatingAdmissionPolicy: pol,
+		ValidatingAdmissionPolicy: NewValidatingAdmissionPolicyData(pol),
+	}
+}
+
+func NewValidatingAdmissionPolicyWithBindings(pol *admissionregistrationv1.ValidatingAdmissionPolicy, bindings ...admissionregistrationv1.ValidatingAdmissionPolicyBinding) GenericPolicy {
+	return &genericPolicy{
+		Object:                    pol,
+		ValidatingAdmissionPolicy: NewValidatingAdmissionPolicyData(pol, bindings...),
 	}
 }
 


### PR DESCRIPTION
## Explanation
This PR modifies the VAP in the GenericPolicy to include bindings too.