### PR TITLE
fix: Kyverno 1.14.0 cannot map gvk to gvr for custom resources

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -439,11 +439,13 @@ func (c *ApplyCommandConfig) applyImageValidatingPolicies(
 	rc *processor.ResultCounts,
 	dclient dclient.Interface,
 ) ([]engineapi.EngineResponse, error) {
+	if len(ivps) == 0 {
+		return nil, nil
+	}
 	provider, err := ivpolengine.NewProvider(ivps, celExceptions)
 	if err != nil {
 		return nil, err
 	}
-
 	var lister k8scorev1.SecretInterface
 	if dclient != nil {
 		lister = dclient.GetKubeClient().CoreV1().Secrets("")


### PR DESCRIPTION
## Explanation

Fix Kyverno 1.14.0 cannot map gvk to gvr for custom resources.

## Related issue

Fixes #12916
