### PR TITLE
fix: get kinds from vaps, vpols, and ivpols

### DIFF
--- a/pkg/admissionpolicy/validate_test.go
+++ b/pkg/admissionpolicy/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	utils "github.com/kyverno/kyverno/pkg/utils/restmapper"
 	yamlutils "github.com/kyverno/kyverno/pkg/utils/yaml"
 	"gotest.tools/assert"
 )
@@ -37,6 +38,26 @@ spec:
 			wantKinds: []string{"v1/Pod"},
 		},
 		{
+			name: "Matching subresource",
+			policy: []byte(`
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "policy-1"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   [""]
+        apiVersions: ["v1"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["pods/log"]
+  validations:
+    - expression: "object.metadata.name.matches('nginx')"
+`),
+			wantKinds: []string{"v1/Pod/log"},
+		},
+		{
 			name: "Matching deployments, replicasets, daemonsets and statefulsets",
 			policy: []byte(`
 apiVersion: admissionregistration.k8s.io/v1
@@ -54,7 +75,7 @@ spec:
   validations:
     - expression: "object.spec.replicas <= 5"
 `),
-			wantKinds: []string{"apps/v1/Deployment", "apps/v1/Replicaset", "apps/v1/Daemonset", "apps/v1/Statefulset"},
+			wantKinds: []string{"apps/v1/Deployment", "apps/v1/ReplicaSet", "apps/v1/DaemonSet", "apps/v1/StatefulSet"},
 		},
 		{
 			name: "Matching deployments/scale",
@@ -94,7 +115,7 @@ spec:
   validations:
     - expression: "object.spec.jobTemplate.spec.template.spec.containers.all(container, has(container.securityContext) && has(container.securityContext.readOnlyRootFilesystem) &&  container.securityContext.readOnlyRootFilesystem == true)"
 `),
-			wantKinds: []string{"batch/v1/Job", "batch/v1/Cronjob"},
+			wantKinds: []string{"batch/v1/Job", "batch/v1/CronJob"},
 		},
 		{
 			name: "Multiple resource rules",
@@ -122,7 +143,7 @@ spec:
   validations:
     - expression: "object.spec.replicas <= 5"
 `),
-			wantKinds: []string{"v1/Pod", "apps/v1/Deployment", "apps/v1/Replicaset", "apps/v1/Daemonset", "apps/v1/Statefulset", "batch/v1/Job", "batch/v1/Cronjob"},
+			wantKinds: []string{"v1/Pod", "apps/v1/Deployment", "apps/v1/ReplicaSet", "apps/v1/DaemonSet", "apps/v1/StatefulSet", "batch/v1/Job", "batch/v1/CronJob"},
 		},
 		{
 			name: "skip incomplete resource rules",
@@ -150,7 +171,7 @@ spec:
   validations:
     - expression: "object.spec.replicas <= 5"
 `),
-			wantKinds: []string{"apps/v1/Deployment", "apps/v1/Replicaset", "apps/v1/Daemonset", "apps/v1/Statefulset"},
+			wantKinds: []string{"apps/v1/Deployment", "apps/v1/ReplicaSet", "apps/v1/DaemonSet", "apps/v1/StatefulSet"},
 		},
 		{
 			name: "No matchConstraints",
@@ -172,7 +193,10 @@ spec:
 		t.Run(tt.name, func(t *testing.T) {
 			_, policy, _, _, _, err := yamlutils.GetPolicy(tt.policy)
 			assert.NilError(t, err)
-			kinds := GetKinds(policy[0].Spec.MatchConstraints)
+			restMapper, err := utils.GetRESTMapper(nil, false)
+			assert.NilError(t, err)
+			kinds, err := GetKinds(policy[0].Spec.MatchConstraints, restMapper)
+			assert.NilError(t, err)
 			if !reflect.DeepEqual(kinds, tt.wantKinds) {
 				t.Errorf("Expected %v, got %v", tt.wantKinds, kinds)
 			}

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -19,6 +19,7 @@ import (
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
+	restmapper "github.com/kyverno/kyverno/pkg/utils/restmapper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -260,6 +261,10 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 		group, version, kind, subresource := kubeutils.ParseKindSelector(policyKind)
 		c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)
 	}
+	restMapper, err := restmapper.GetRESTMapper(c.client, false)
+	if err != nil {
+		return err
+	}
 	if c.vapLister != nil {
 		vapPolicies, err := utils.FetchValidatingAdmissionPolicies(c.vapLister)
 		if err != nil {
@@ -267,7 +272,10 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 		}
 		// fetch kinds from validating admission policies
 		for _, policy := range vapPolicies {
-			kinds := admissionpolicy.GetKinds(policy.Spec.MatchConstraints)
+			kinds, err := admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)
+			if err != nil {
+				return err
+			}
 			for _, kind := range kinds {
 				group, version, kind, subresource := kubeutils.ParseKindSelector(kind)
 				c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)
@@ -281,7 +289,10 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 		}
 		// fetch kinds from validating admission policies
 		for _, policy := range vpols {
-			kinds := admissionpolicy.GetKinds(policy.Spec.MatchConstraints)
+			kinds, err := admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)
+			if err != nil {
+				return err
+			}
 			for _, kind := range kinds {
 				group, version, kind, subresource := kubeutils.ParseKindSelector(kind)
 				c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)
@@ -295,7 +306,10 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 		}
 		// fetch kinds from image verification admission policies
 		for _, policy := range ivpols {
-			kinds := admissionpolicy.GetKinds(policy.Spec.MatchConstraints)
+			kinds, err := admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)
+			if err != nil {
+				return err
+			}
 			for _, kind := range kinds {
 				group, version, kind, subresource := kubeutils.ParseKindSelector(kind)
 				c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)


### PR DESCRIPTION
## Explanation
This PR fixes the [GetKinds()](https://github.com/kyverno/kyverno/blob/584d3b5a42386d49b991eb7321162a237853b054/pkg/admissionpolicy/validate.go#L31-L73) function. Its purpose is to fetch the resource rules from the policy (vap, vp, or ivpol) and convert it into kind. It is used in the CLI to fetch resources from cluster for VAPs, and it is also used in the scanner.