### PR TITLE
chore: create a dedicated cluster when generating api-group-resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -581,8 +581,12 @@ codegen-crds-all: codegen-crds-cli
 .PHONY: codegen-cli-api-group-resources
 codegen-cli-api-group-resources: ## Generate API group resources
 codegen-cli-api-group-resources: $(API_GROUP_RESOURCES)
+codegen-cli-api-group-resources: $(KIND)
 	@echo Generate API group resources... >&2
+	@$(KIND) delete cluster --name codegen-cli-api-group-resources || true
+	@$(KIND) create cluster --name codegen-cli-api-group-resources --image $(KIND_IMAGE) --config ./scripts/config/kind/codegen.yaml
 	@$(API_GROUP_RESOURCES) > cmd/cli/kubectl-kyverno/data/api-group-resources.json
+	@$(KIND) delete cluster --name codegen-cli-api-group-resources
 
 .PHONY: codegen-cli-crds
 codegen-cli-crds: ## Copy generated CRDs to embed in the CLI

--- a/scripts/config/kind/codegen.yaml
+++ b/scripts/config/kind/codegen.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker


### PR DESCRIPTION
## Explanation

Create a dedicated cluster when generating api-group-resources.
