### PR TITLE
fix: support subresources in PolicyException match (Pod/exec)

### DIFF
--- a/pkg/engine/utils/exceptions.go
+++ b/pkg/engine/utils/exceptions.go
@@ -13,6 +13,22 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// matchesResource returns true if the incoming request Kind/Subresource
+// matches any of the configured kinds (e.g. "Pod" or "Pod/exec").
+func matchesResource(kinds []string, reqKind, reqSubresource string) bool {
+	full := reqKind
+	if reqSubresource != "" {
+		full = reqKind + "/" + reqSubresource
+	}
+	for _, kind := range kinds {
+		// exact match on subresource ("Pod/exec") or base-kind ("Pod")
+		if kind == full || kind == reqKind {
+			return true
+		}
+	}
+	return false
+}
+
 // MatchesException takes a list of exceptions and checks if there is an exception applies to the incoming resource.
 // It returns the matched policy exception.
 func MatchesException(polexs []*kyvernov2.PolicyException, policyContext engineapi.PolicyContext, logger logr.Logger) []kyvernov2.PolicyException {
@@ -96,7 +112,7 @@ func checkResourceDescription(
 	subresource string,
 ) bool {
 	if len(conditionBlock.Kinds) > 0 {
-		if !matched.CheckKind(conditionBlock.Kinds, gvk, subresource, true) {
+		if !matchesResource(conditionBlock.Kinds, gvk.Kind, subresource) {
 			return false
 		}
 	}

--- a/pkg/engine/utils/exceptions_test.go
+++ b/pkg/engine/utils/exceptions_test.go
@@ -1,0 +1,31 @@
+package utils
+
+import "testing"
+
+func TestMatchesResource(t *testing.T) {
+    tests := []struct {
+        kinds       []string
+        reqKind     string
+        subresource string
+        want        bool
+    }{
+        // exact subresource match
+        {[]string{"Pod/exec"}, "Pod", "exec", true},
+        // wrong subresource
+        {[]string{"Pod/exec"}, "Pod", "attach", false},
+        // base-kind match on any subresource
+        {[]string{"Pod"}, "Pod", "exec", true},
+        // base-kind match on no subresource
+        {[]string{"Pod"}, "Pod", "", true},
+        // unrelated kind
+        {[]string{"Service"}, "Pod", "exec", false},
+    }
+
+    for _, tt := range tests {
+        got := matchesResource(tt.kinds, tt.reqKind, tt.subresource)
+        if got != tt.want {
+            t.Errorf("matchesResource(%v, %q, %q) = %v; want %v",
+                tt.kinds, tt.reqKind, tt.subresource, got, tt.want)
+        }
+    }
+}


### PR DESCRIPTION
## Explanation
This PR fixes a bug where PolicyExceptions did not apply to subresource requests (for example, Pod/exec). It updates the exception-matching logic in pkg/engine/utils/exceptions.go to correctly handle both plain resource kinds (e.g. Pod) and subresource kinds (e.g. Pod/exec), and adds unit tests to verify the behavior. This is a fix of existing behavior.
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #13086


<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind bug


<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
