### PR TITLE
fix: remove the delete permission of exceptions

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -35,6 +35,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: fixed
       description: Ensure spec.template.metadata isn't null
+    - kind: removed
+      description: Remove the `delete` permission for policyexceptions in the admission controller
 dependencies:
   - name: grafana
     version: v0.0.0

--- a/charts/kyverno/templates/admission-controller/clusterrole.yaml
+++ b/charts/kyverno/templates/admission-controller/clusterrole.yaml
@@ -73,7 +73,33 @@ rules:
       - updaterequests/status
       - globalcontextentries
       - globalcontextentries/status
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - deletecollection
+  - apiGroups:
+      - kyverno.io
+    resources:
       - policyexceptions
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policies.kyverno.io
+    resources:
+      - validatingpolicies
+      - validatingpolicies/status
+      - imagevalidatingpolicies
+      - imagevalidatingpolicies/status
     verbs:
       - create
       - delete
@@ -86,20 +112,14 @@ rules:
   - apiGroups:
       - policies.kyverno.io
     resources:
-      - validatingpolicies
-      - validatingpolicies/status
       - policyexceptions
-      - imagevalidatingpolicies
-      - imagevalidatingpolicies/status
     verbs:
       - create
-      - delete
       - get
       - list
       - patch
       - update
       - watch
-      - deletecollection
   - apiGroups:
       - reports.kyverno.io
     resources:

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -53846,7 +53846,33 @@ rules:
       - updaterequests/status
       - globalcontextentries
       - globalcontextentries/status
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - deletecollection
+  - apiGroups:
+      - kyverno.io
+    resources:
       - policyexceptions
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policies.kyverno.io
+    resources:
+      - validatingpolicies
+      - validatingpolicies/status
+      - imagevalidatingpolicies
+      - imagevalidatingpolicies/status
     verbs:
       - create
       - delete
@@ -53859,20 +53885,14 @@ rules:
   - apiGroups:
       - policies.kyverno.io
     resources:
-      - validatingpolicies
-      - validatingpolicies/status
       - policyexceptions
-      - imagevalidatingpolicies
-      - imagevalidatingpolicies/status
     verbs:
       - create
-      - delete
       - get
       - list
       - patch
       - update
       - watch
-      - deletecollection
   - apiGroups:
       - reports.kyverno.io
     resources:


### PR DESCRIPTION
## Explanation
This PR removes the `delete` permission for exceptions in the admission controller.