### PR TITLE
fix: skip chainsaw test based on deleted image

### DIFF
--- a/test/conformance/chainsaw/verifyImages/clusterpolicy/standard/update-multi-containers/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/verifyImages/clusterpolicy/standard/update-multi-containers/chainsaw-test.yaml
@@ -3,6 +3,7 @@ kind: Test
 metadata:
   name: update-multi-containers
 spec:
+  skip: true
   steps:
   - name: create policy
     use:


### PR DESCRIPTION
## Explanation

Skip chainsaw test based on deleted image.
