### PR TITLE
deploy(kyverno-policies): add support for passing custom annotations to chart

### DIFF
--- a/charts/kyverno-policies/README.md
+++ b/charts/kyverno-policies/README.md
@@ -89,6 +89,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | policyPreconditions | object | `{}` | Add preconditions to individual policies. Policies with multiple rules can have individual rules excluded by using the name of the rule as the key in the `policyPreconditions` map. |
 | autogenControllers | string | `""` | Customize the target Pod controllers for the auto-generated rules. (Eg. `none`, `Deployment`, `DaemonSet,Deployment,StatefulSet`) For more info https://kyverno.io/docs/writing-policies/autogen/. |
 | nameOverride | string | `nil` | Name override. |
+| customAnnotations | object | `{}` | Additional Annotations. |
 | customLabels | object | `{}` | Additional labels. |
 | background | bool | `true` | Policies background mode |
 | skipBackgroundRequests | bool | `nil` | SkipBackgroundRequests bypasses admission requests that are sent by the background controller |

--- a/charts/kyverno-policies/ci/test-with-annotations.yaml
+++ b/charts/kyverno-policies/ci/test-with-annotations.yaml
@@ -1,0 +1,2 @@
+customAnnotations:
+  test: "annotation"

--- a/charts/kyverno-policies/templates/_helpers.tpl
+++ b/charts/kyverno-policies/templates/_helpers.tpl
@@ -94,7 +94,7 @@ helm.sh/chart: {{ template "kyverno-policies.chart" . }}
 
 {{/* Custom annotations */}}
 {{- define "kyverno-policies.customAnnotations" -}}
-{{- if .Values.customAnnotations }}
-{{ toYaml .Values.customAnnotations}}
-{{- end }}
+{{- with .Values.customAnnotations -}}
+{{- toYaml . -}}
+{{- end -}}
 {{- end -}}

--- a/charts/kyverno-policies/templates/_helpers.tpl
+++ b/charts/kyverno-policies/templates/_helpers.tpl
@@ -91,3 +91,10 @@ helm.sh/chart: {{ template "kyverno-policies.chart" . }}
   {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Custom annotations */}}
+{{- define "kyverno-policies.customAnnotations" -}}
+{{- if .Values.customAnnotations }}
+{{ toYaml .Values.customAnnotations}}
+{{- end }}
+{{- end -}}

--- a/charts/kyverno-policies/templates/baseline/disallow-capabilities.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-capabilities.yaml
@@ -20,6 +20,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Adding capabilities beyond those listed in the policy must be disallowed.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-capabilities.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-capabilities.yaml
@@ -20,7 +20,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Adding capabilities beyond those listed in the policy must be disallowed.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.yaml
@@ -21,6 +21,7 @@ metadata:
       network namespace) allow access to shared information and can be used to elevate
       privileges. Pods should not be allowed access to host namespaces. This policy ensures
       fields which make use of these host namespaces are unset or set to `false`.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.yaml
@@ -21,7 +21,7 @@ metadata:
       network namespace) allow access to shared information and can be used to elevate
       privileges. Pods should not be allowed access to host namespaces. This policy ensures
       fields which make use of these host namespaces are unset or set to `false`.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-host-path.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-path.yaml
@@ -20,6 +20,7 @@ metadata:
       HostPath volumes let Pods use host directories and volumes in containers.
       Using host resources can be used to access shared data or escalate privileges
       and should not be allowed. This policy ensures no hostPath volumes are in use.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-host-path.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-path.yaml
@@ -20,7 +20,7 @@ metadata:
       HostPath volumes let Pods use host directories and volumes in containers.
       Using host resources can be used to access shared data or escalate privileges
       and should not be allowed. This policy ensures no hostPath volumes are in use.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-host-ports.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-ports.yaml
@@ -20,6 +20,7 @@ metadata:
       Access to host ports allows potential snooping of network traffic and should not be
       allowed, or at minimum restricted to a known list. This policy ensures the `hostPort`
       field is unset or set to `0`.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-host-ports.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-ports.yaml
@@ -20,7 +20,7 @@ metadata:
       Access to host ports allows potential snooping of network traffic and should not be
       allowed, or at minimum restricted to a known list. This policy ensures the `hostPort`
       field is unset or set to `0`.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-host-process.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-process.yaml
@@ -21,7 +21,7 @@ metadata:
       access to the Windows node. Privileged access to the host is disallowed in the baseline
       policy. HostProcess pods are an alpha feature as of Kubernetes v1.22. This policy ensures
       the `hostProcess` field, if present, is set to `false`.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-host-process.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-process.yaml
@@ -21,6 +21,7 @@ metadata:
       access to the Windows node. Privileged access to the host is disallowed in the baseline
       policy. HostProcess pods are an alpha feature as of Kubernetes v1.22. This policy ensures
       the `hostProcess` field, if present, is set to `false`.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.yaml
@@ -19,7 +19,7 @@ metadata:
     policies.kyverno.io/description: >-
       Privileged mode disables most security mechanisms and must not be allowed. This policy
       ensures Pods do not call for privileged mode.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.yaml
@@ -19,6 +19,7 @@ metadata:
     policies.kyverno.io/description: >-
       Privileged mode disables most security mechanisms and must not be allowed. This policy
       ensures Pods do not call for privileged mode.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-proc-mount.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-proc-mount.yaml
@@ -21,7 +21,7 @@ metadata:
       ensures nothing but the default procMount can be specified. Note that in order for users
       to deviate from the `Default` procMount requires setting a feature gate at the API
       server.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-proc-mount.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-proc-mount.yaml
@@ -21,6 +21,7 @@ metadata:
       ensures nothing but the default procMount can be specified. Note that in order for users
       to deviate from the `Default` procMount requires setting a feature gate at the API
       server.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-selinux.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-selinux.yaml
@@ -19,7 +19,7 @@ metadata:
     policies.kyverno.io/description: >-
       SELinux options can be used to escalate privileges and should not be allowed. This policy
       ensures that the `seLinuxOptions` field is undefined.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/disallow-selinux.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-selinux.yaml
@@ -19,6 +19,7 @@ metadata:
     policies.kyverno.io/description: >-
       SELinux options can be used to escalate privileges and should not be allowed. This policy
       ensures that the `seLinuxOptions` field is undefined.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
@@ -22,6 +22,7 @@ metadata:
       The default policy should prevent overriding or disabling the policy, or restrict
       overrides to an allowed set of profiles. This policy ensures Pods do not
       specify any other AppArmor profiles than `runtime/default` or `localhost/*`.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.yaml
@@ -22,7 +22,7 @@ metadata:
       The default policy should prevent overriding or disabling the policy, or restrict
       overrides to an allowed set of profiles. This policy ensures Pods do not
       specify any other AppArmor profiles than `runtime/default` or `localhost/*`.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/restrict-seccomp.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-seccomp.yaml
@@ -20,7 +20,7 @@ metadata:
       The seccomp profile must not be explicitly set to Unconfined. This policy,
       requiring Kubernetes v1.19 or later, ensures that seccomp is unset or
       set to `RuntimeDefault` or `Localhost`.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/restrict-seccomp.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-seccomp.yaml
@@ -20,6 +20,7 @@ metadata:
       The seccomp profile must not be explicitly set to Unconfined. This policy,
       requiring Kubernetes v1.19 or later, ensures that seccomp is unset or
       set to `RuntimeDefault` or `Localhost`.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/restrict-sysctls.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-sysctls.yaml
@@ -23,6 +23,7 @@ metadata:
       Pod, and it is isolated from other Pods or processes on the same Node.
       This policy ensures that only those "safe" subsets can be specified in
       a Pod.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/baseline/restrict-sysctls.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-sysctls.yaml
@@ -23,7 +23,7 @@ metadata:
       Pod, and it is isolated from other Pods or processes on the same Node.
       This policy ensures that only those "safe" subsets can be specified in
       a Pod.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/other/require-non-root-groups.yaml
+++ b/charts/kyverno-policies/templates/other/require-non-root-groups.yaml
@@ -21,7 +21,7 @@ metadata:
       This policy ensures the `runAsGroup`, `supplementalGroups`, and `fsGroup` fields are set to a number
       greater than zero (i.e., non root). A known issue prevents a policy such as this
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/other/require-non-root-groups.yaml
+++ b/charts/kyverno-policies/templates/other/require-non-root-groups.yaml
@@ -21,6 +21,7 @@ metadata:
       This policy ensures the `runAsGroup`, `supplementalGroups`, and `fsGroup` fields are set to a number
       greater than zero (i.e., non root). A known issue prevents a policy such as this
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.yaml
@@ -21,6 +21,7 @@ metadata:
     policies.kyverno.io/description: >-
       Adding capabilities other than `NET_BIND_SERVICE` is disallowed. In addition,
       all containers must explicitly drop `ALL` capabilities.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.yaml
@@ -21,7 +21,7 @@ metadata:
     policies.kyverno.io/description: >-
       Adding capabilities other than `NET_BIND_SERVICE` is disallowed. In addition,
       all containers must explicitly drop `ALL` capabilities.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.yaml
@@ -19,7 +19,7 @@ metadata:
     policies.kyverno.io/description: >-
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
       This policy ensures the `allowPrivilegeEscalation` field is set to `false`.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.yaml
@@ -19,6 +19,7 @@ metadata:
     policies.kyverno.io/description: >-
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
       This policy ensures the `allowPrivilegeEscalation` field is set to `false`.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
@@ -19,7 +19,7 @@ metadata:
     policies.kyverno.io/description: >-
       Containers must be required to run as non-root users. This policy ensures
       `runAsUser` is either unset or set to a number greater than zero.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
@@ -19,6 +19,7 @@ metadata:
     policies.kyverno.io/description: >-
       Containers must be required to run as non-root users. This policy ensures
       `runAsUser` is either unset or set to a number greater than zero.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
@@ -20,6 +20,7 @@ metadata:
       Containers must be required to run as non-root users. This policy ensures
       `runAsNonRoot` is set to `true`. A known issue prevents a policy such as this
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
@@ -20,7 +20,7 @@ metadata:
       Containers must be required to run as non-root users. This policy ensures
       `runAsNonRoot` is set to `true`. A known issue prevents a policy such as this
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.yaml
@@ -22,7 +22,7 @@ metadata:
       requiring Kubernetes v1.19 or later, ensures that seccomp is
       set to `RuntimeDefault` or `Localhost`. A known issue prevents a policy such as this
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.yaml
@@ -22,6 +22,7 @@ metadata:
       requiring Kubernetes v1.19 or later, ensures that seccomp is
       set to `RuntimeDefault` or `Localhost`. A known issue prevents a policy such as this
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/restricted/restrict-volume-types.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-volume-types.yaml
@@ -22,7 +22,7 @@ metadata:
       In addition to restricting HostPath volumes, the restricted pod security profile
       limits usage of non-core volume types to those defined through PersistentVolumes.
       This policy blocks any other type of volume other than those in the allow list.
-    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
+    {{- include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/templates/restricted/restrict-volume-types.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-volume-types.yaml
@@ -22,6 +22,7 @@ metadata:
       In addition to restricting HostPath volumes, the restricted pod security profile
       limits usage of non-core volume types to those defined through PersistentVolumes.
       This policy blocks any other type of volume other than those in the allow list.
+    {{ include "kyverno-policies.customAnnotations" . | nindent 4 }}
   labels: {{ include "kyverno-policies.labels" . | nindent 4 }}
 spec:
   background: {{ .Values.background }}

--- a/charts/kyverno-policies/values.yaml
+++ b/charts/kyverno-policies/values.yaml
@@ -106,6 +106,9 @@ autogenControllers: ""
 # -- Name override.
 nameOverride:
 
+# -- Additional Annotations.
+customAnnotations: {}
+
 # -- Additional labels.
 customLabels: {}
 


### PR DESCRIPTION
## Explanation

Adds support for passing annotations to policies in `charts/kyverno-policies`. This resolves an issue where installing both `kyverno` and `kyverno-policies` as part of the same umbrella helm chart fails due to the default installation order of helm.

Allowing users to pass labels means that helm hooks can be used to apply the policies post installation of `kyverno` (i.e. after the CRDs have been created).

i.e.
```yaml
annotations:
  helm.sh/hook: post-install,post-upgrade
```

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue

Closes #13183 

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

Documentation for this change is not required in the kyverno website.

## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
Scope of bigger picture is detailed above, but in short this enables users to install all the charts in `/charts` as part of a single umbrella helm chart. 

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
I have not provided proof manifests, as in this case it does not seem appropriate given that this is a runtime issue only when installing as part of an umbrella chart in helm. 


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
