### PR TITLE
fix: Use prometheus webserver of controller-runtime instead

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -675,7 +675,7 @@ func main() {
 				// if prometheus metrics provider is used, bind address is set to the metrics manager address
 				ctrlMetricsBindAddress = setup.MetricsManager.MetricsAddress()
 				if controllerRuntimeMetricsAddress != "" && ctrlMetricsBindAddress != "" {
-					setup.Logger.Error(errors.New("controllerRuntimeMetricsAddress is not supported when using prometheus metrics provider"), "controllerRuntimeMetricsAddress is not supported when using prometheus metrics provider")
+					setup.Logger.Error(errors.New("controllerRuntimeMetricsAddress is not supported when using prometheus metrics provider"), "conflicting metrics addresses")
 					os.Exit(1)
 				}
 			}

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -670,10 +670,19 @@ func main() {
 				setup.Logger.Error(err, "failed to initialize scheme")
 				os.Exit(1)
 			}
+			ctrlMetricsBindAddress := controllerRuntimeMetricsAddress
+			if setup.MetricsManager.MetricsProviderMode() == "prometheus" {
+				// if prometheus metrics provider is used, bind address is set to the metrics manager address
+				ctrlMetricsBindAddress = setup.MetricsManager.MetricsAddress()
+				if controllerRuntimeMetricsAddress != "" && ctrlMetricsBindAddress != "" {
+					setup.Logger.Error(errors.New("controllerRuntimeMetricsAddress is not supported when using prometheus metrics provider"), "controllerRuntimeMetricsAddress is not supported when using prometheus metrics provider")
+					os.Exit(1)
+				}
+			}
 			mgr, err := ctrl.NewManager(setup.RestConfig, ctrl.Options{
 				Scheme: scheme,
 				Metrics: server.Options{
-					BindAddress: controllerRuntimeMetricsAddress,
+					BindAddress: ctrlMetricsBindAddress,
 				},
 			})
 			if err != nil {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -2,21 +2,20 @@ package metrics
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/kyverno/kyverno/pkg/config"
 	kconfig "github.com/kyverno/kyverno/pkg/config"
 	tlsutils "github.com/kyverno/kyverno/pkg/utils/tls"
 	"github.com/kyverno/kyverno/pkg/version"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/prometheus"
-	"go.opentelemetry.io/otel/metric"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	internalmetric "go.opentelemetry.io/otel/metric"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"k8s.io/client-go/kubernetes"
@@ -28,40 +27,51 @@ const (
 
 type MetricsConfig struct {
 	// instruments
-	policyChangesMetric metric.Int64Counter
-	clientQueriesMetric metric.Int64Counter
-	kyvernoInfoMetric   metric.Int64Gauge
+	policyChangesMetric internalmetric.Int64Counter
+	clientQueriesMetric internalmetric.Int64Counter
+	kyvernoInfoMetric   internalmetric.Int64Gauge
 
 	// config
-	config kconfig.MetricsConfiguration
-	Log    logr.Logger
+	metricsAddress string
+	otelProvider   string // prometheus, grpc
+	config         kconfig.MetricsConfiguration
+	Log            logr.Logger
 }
 
 type MetricsConfigManager interface {
 	Config() kconfig.MetricsConfiguration
 	RecordPolicyChanges(ctx context.Context, policyValidationMode PolicyValidationMode, policyType PolicyType, policyBackgroundMode PolicyBackgroundMode, policyNamespace string, policyName string, policyChangeType string)
 	RecordClientQueries(ctx context.Context, clientQueryOperation ClientQueryOperation, clientType ClientType, resourceKind string, resourceNamespace string)
+	MetricsProviderMode() string
+	MetricsAddress() string
 }
 
 func (m *MetricsConfig) Config() kconfig.MetricsConfiguration {
 	return m.config
 }
 
-func (m *MetricsConfig) initializeMetrics(meterProvider metric.MeterProvider) error {
+func (m *MetricsConfig) MetricsProviderMode() string {
+	return m.otelProvider
+}
+func (m *MetricsConfig) MetricsAddress() string {
+	return m.metricsAddress
+}
+
+func (m *MetricsConfig) initializeMetrics(meterProvider internalmetric.MeterProvider) error {
 	var err error
 	meter := meterProvider.Meter(MeterName)
-	m.policyChangesMetric, err = meter.Int64Counter("kyverno_policy_changes", metric.WithDescription("can be used to track all the changes associated with the Kyverno policies present on the cluster such as creation, updates and deletions"))
+	m.policyChangesMetric, err = meter.Int64Counter("kyverno_policy_changes", internalmetric.WithDescription("can be used to track all the changes associated with the Kyverno policies present on the cluster such as creation, updates and deletions"))
 	if err != nil {
 		m.Log.Error(err, "Failed to create instrument, kyverno_policy_changes")
 		return err
 	}
-	m.clientQueriesMetric, err = meter.Int64Counter("kyverno_client_queries", metric.WithDescription("can be used to track the number of client queries sent from Kyverno to the API-server"))
+	m.clientQueriesMetric, err = meter.Int64Counter("kyverno_client_queries", internalmetric.WithDescription("can be used to track the number of client queries sent from Kyverno to the API-server"))
 	if err != nil {
 		m.Log.Error(err, "Failed to create instrument, kyverno_client_queries")
 		return err
 	}
 	m.kyvernoInfoMetric, err = meter.Int64Gauge("kyverno_info",
-		metric.WithDescription("Kyverno version information"),
+		internalmetric.WithDescription("Kyverno version information"),
 	)
 	if err != nil {
 		m.Log.Error(err, "Failed to create instrument, kyverno_info")
@@ -71,7 +81,7 @@ func (m *MetricsConfig) initializeMetrics(meterProvider metric.MeterProvider) er
 	return nil
 }
 
-func ShutDownController(ctx context.Context, pusher *sdkmetric.MeterProvider) {
+func ShutDownController(ctx context.Context, pusher *metric.MeterProvider) {
 	if pusher != nil {
 		// pushes any last exports to the receiver
 		if err := pusher.Shutdown(ctx); err != nil {
@@ -80,21 +90,21 @@ func ShutDownController(ctx context.Context, pusher *sdkmetric.MeterProvider) {
 	}
 }
 
-func aggregationSelector(metricsConfiguration kconfig.MetricsConfiguration) func(ik sdkmetric.InstrumentKind) sdkmetric.Aggregation {
-	return func(ik sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+func aggregationSelector(metricsConfiguration kconfig.MetricsConfiguration) func(ik metric.InstrumentKind) metric.Aggregation {
+	return func(ik metric.InstrumentKind) metric.Aggregation {
 		switch ik {
-		case sdkmetric.InstrumentKindHistogram:
-			return sdkmetric.AggregationExplicitBucketHistogram{
+		case metric.InstrumentKindHistogram:
+			return metric.AggregationExplicitBucketHistogram{
 				Boundaries: metricsConfiguration.GetBucketBoundaries(),
 				NoMinMax:   false,
 			}
 		default:
-			return sdkmetric.DefaultAggregationSelector(ik)
+			return metric.DefaultAggregationSelector(ik)
 		}
 	}
 }
 
-func NewOTLPGRPCConfig(ctx context.Context, endpoint string, certs string, kubeClient kubernetes.Interface, log logr.Logger, configuration kconfig.MetricsConfiguration) (metric.MeterProvider, error) {
+func NewOTLPGRPCConfig(ctx context.Context, endpoint string, certs string, kubeClient kubernetes.Interface, log logr.Logger, configuration kconfig.MetricsConfiguration) (*metric.MeterProvider, error) {
 	options := []otlpmetricgrpc.Option{otlpmetricgrpc.WithEndpoint(endpoint), otlpmetricgrpc.WithAggregationSelector(aggregationSelector(configuration))}
 	if certs != "" {
 		// here the certificates are stored as configmaps
@@ -124,20 +134,20 @@ func NewOTLPGRPCConfig(ctx context.Context, endpoint string, certs string, kubeC
 		log.Error(err, "failed creating resource")
 		return nil, err
 	}
-	reader := sdkmetric.NewPeriodicReader(
+	reader := metric.NewPeriodicReader(
 		exporter,
-		sdkmetric.WithInterval(2*time.Second),
+		metric.WithInterval(2*time.Second),
 	)
 	// create controller and bind the exporter with it
-	provider := sdkmetric.NewMeterProvider(
-		sdkmetric.WithReader(reader),
-		sdkmetric.WithResource(res),
-		sdkmetric.WithView(configuration.BuildMeterProviderViews()...),
+	provider := metric.NewMeterProvider(
+		metric.WithReader(reader),
+		metric.WithResource(res),
+		metric.WithView(configuration.BuildMeterProviderViews()...),
 	)
 	return provider, nil
 }
 
-func NewPrometheusConfig(ctx context.Context, log logr.Logger, configuration kconfig.MetricsConfiguration) (metric.MeterProvider, *http.ServeMux, error) {
+func NewPrometheusConfig(ctx context.Context, log logr.Logger, configuration kconfig.MetricsConfiguration) (*metric.MeterProvider, error) {
 	res, err := resource.Merge(
 		resource.Default(),
 		resource.NewSchemaless(
@@ -148,25 +158,25 @@ func NewPrometheusConfig(ctx context.Context, log logr.Logger, configuration kco
 	)
 	if err != nil {
 		log.Error(err, "failed creating resource")
-		return nil, nil, err
+		return nil, err
 	}
 	exporter, err := prometheus.New(
+		// use the registry from controller-runtime metrics
+		prometheus.WithRegisterer(metrics.Registry),
 		prometheus.WithoutUnits(),
 		prometheus.WithoutTargetInfo(),
 		prometheus.WithAggregationSelector(aggregationSelector(configuration)),
 	)
 	if err != nil {
 		log.Error(err, "failed to initialize prometheus exporter")
-		return nil, nil, err
+		return nil, err
 	}
-	provider := sdkmetric.NewMeterProvider(
-		sdkmetric.WithReader(exporter),
-		sdkmetric.WithResource(res),
-		sdkmetric.WithView(configuration.BuildMeterProviderViews()...),
+	provider := metric.NewMeterProvider(
+		metric.WithReader(exporter),
+		metric.WithResource(res),
+		metric.WithView(configuration.BuildMeterProviderViews()...),
 	)
-	metricsServerMux := http.NewServeMux()
-	metricsServerMux.Handle(config.MetricsPath, promhttp.Handler())
-	return provider, metricsServerMux, nil
+	return provider, nil
 }
 
 func (m *MetricsConfig) RecordPolicyChanges(ctx context.Context, policyValidationMode PolicyValidationMode, policyType PolicyType, policyBackgroundMode PolicyBackgroundMode, policyNamespace string, policyName string, policyChangeType string) {
@@ -178,7 +188,7 @@ func (m *MetricsConfig) RecordPolicyChanges(ctx context.Context, policyValidatio
 		attribute.String("policy_name", policyName),
 		attribute.String("policy_change_type", policyChangeType),
 	}
-	m.policyChangesMetric.Add(ctx, 1, metric.WithAttributes(commonLabels...))
+	m.policyChangesMetric.Add(ctx, 1, internalmetric.WithAttributes(commonLabels...))
 }
 
 func (m *MetricsConfig) RecordClientQueries(ctx context.Context, clientQueryOperation ClientQueryOperation, clientType ClientType, resourceKind string, resourceNamespace string) {
@@ -188,7 +198,7 @@ func (m *MetricsConfig) RecordClientQueries(ctx context.Context, clientQueryOper
 		attribute.String("resource_kind", resourceKind),
 		attribute.String("resource_namespace", resourceNamespace),
 	}
-	m.clientQueriesMetric.Add(ctx, 1, metric.WithAttributes(commonLabels...))
+	m.clientQueriesMetric.Add(ctx, 1, internalmetric.WithAttributes(commonLabels...))
 }
 
 func initKyvernoInfoMetric(m *MetricsConfig) {
@@ -196,5 +206,5 @@ func initKyvernoInfoMetric(m *MetricsConfig) {
 	commonLabels := []attribute.KeyValue{
 		attribute.String("version", info.Version),
 	}
-	m.kyvernoInfoMetric.Record(context.Background(), 1, metric.WithAttributes(commonLabels...))
+	m.kyvernoInfoMetric.Record(context.Background(), 1, internalmetric.WithAttributes(commonLabels...))
 }


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

Due to the Pull Request #12008, a call to `ctrl.NewManager` was introduced, which ships by default its own web server to host `/metrics` under port `8080`.

```bash
$~ netstat -tlpen | grep 80
tcp6       0      0 :::8000                 :::*                    LISTEN      65532      44938      7543/kyverno # correct 
tcp6       0      0 :::8080                 :::*                    LISTEN      65532      47270      7543/kyverno
```



## Related Pull Requests
* https://github.com/kyverno/kyverno/pull/12008
* Other Pull Request suggesting a hotfix: https://github.com/kyverno/kyverno/pull/13220
* FIxing Pull Request: https://github.com/kyverno/kyverno/pull/13423

## Related Issues
* fixes: https://github.com/kyverno/kyverno/issues/13269

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

/kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

As kyverno already has these metrics under `8000` I merged both webservers into one and removed the additional `http.Server`.
The webserver of `controller-runtime` now listens on the `metricsPort` flag.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

I don't know if there are any tests for the `grpc` or `prometheus` otel metrics code path.
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
