### PR TITLE
feat: add MutatingAdmissionPolicy support to CLI apply command in clu…

### DIFF
--- a/test/conformance/chainsaw/cli/apply/apply-maps-in-cluster-mode/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/cli/apply/apply-maps-in-cluster-mode/chainsaw-test.yaml
@@ -7,8 +7,14 @@ spec:
   - name: step-01
     try:
     - script:
-        content: kyverno apply policy.yaml --cluster 2>&1 || true
+        content: kubectl apply -f resource.yaml
+  - name: step-02
+    try:
+    - script:
+        content: kyverno apply policy.yaml --cluster
         check:
-          # Check that the CLI successfully processes the MAP policy without throwing unsupported errors
-          # and shows the expected output format
-          (contains($stdout, 'Applying') && contains($stdout, 'policy rule(s)')): true 
+          (trim_space($stdout)): |-
+            Applying 1 policy rule(s) to 1 resource(s)...
+            
+            
+            pass: 1, fail: 0, warn: 0, error: 0, skip: 0 


### PR DESCRIPTION
# Add MutatingAdmissionPolicy support to CLI apply command in cluster mode

## Issue
Fixes #13263

## Description
This PR adds support for applying MutatingAdmissionPolicies (MAPs) in the Kyverno CLI `apply` command when running in cluster mode (`--cluster` flag).

Previously, when using `kubectl kyverno apply --cluster` with MutatingAdmissionPolicies, the CLI would fail to properly fetch and apply the policies to resources from the cluster because the resource extraction logic didn't handle MAPs.

## Problem
The `extractResourcesFromPolicies()` function in `cmd/cli/kubectl-kyverno/utils/common/fetch.go` was missing support for MutatingAdmissionPolicies. This function is responsible for determining which resource types need to be fetched from the cluster when running in cluster mode.

**Before this fix:**
- ✅ ValidatingAdmissionPolicies worked in cluster mode
- ✅ ValidatingPolicies worked in cluster mode  
- ✅ ImageValidatingPolicies worked in cluster mode
- ✅ DeletingPolicies worked in cluster mode
- ❌ **MutatingAdmissionPolicies did NOT work in cluster mode**

## Solution
Extended the resource extraction logic to handle MutatingAdmissionPolicies alongside other policy types.

### Key Changes

#### 1. Added Import
```go
import (
    // ... existing imports ...
    admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
)
```

#### 2. Extended Policy Extraction Logic
```go
} else if ivp := policy.AsImageValidatingPolicy(); ivp != nil {
    matchResources = ivp.Spec.MatchConstraints
} else if dp := policy.AsDeletingPolicy(); dp != nil {
    matchResources = dp.Spec.MatchConstraints
} else if mapPolicy := policy.AsMutatingAdmissionPolicy(); mapPolicy != nil {
    // Convert v1alpha1.MatchResources to v1.MatchResources
    converted := rf.convertMatchResources(*mapPolicy.GetDefinition().Spec.MatchConstraints)
    matchResources = &converted
}
```

#### 3. Added Type Conversion Function
```go
// convertMatchResources turns a v1alpha1.MatchResources into a v1.MatchResources
func (rf *ResourceFetcher) convertMatchResources(in admissionregistrationv1alpha1.MatchResources) admissionregistrationv1.MatchResources {
    // ... conversion logic ...
}
```

## Technical Details

### Type Compatibility Challenge
MutatingAdmissionPolicies use `admissionregistrationv1alpha1.MatchResources` while other policies use `admissionregistrationv1.MatchResources`. The existing `getKindsFromPolicy()` function expects the v1 version.

**Solution**: Added a conversion function that maps v1alpha1 types to v1 types while preserving all the necessary fields:
- `ResourceRules` → `NamedRuleWithOperations`
- `ExcludeResourceRules` → `NamedRuleWithOperations` 
- `MatchPolicy` → Type cast with proper null handling
- `NamespaceSelector` and `ObjectSelector` → Direct copy

## Testing

### ✅ Compilation Testing
```bash
go build ./cmd/cli/kubectl-kyverno/utils/common  # ✅ Success
go build ./cmd/cli/kubectl-kyverno              # ✅ Success
```

### ✅ Functional Testing
Tested existing MAP functionality in non-cluster mode:
```bash
cd test/cli/test-mutating-admission-policy/Check-replica
kubectl-kyverno apply policy.yaml --resource resource.yaml --policy-report
```

**Result**: ✅ MAP successfully applied, replicas changed from 2 → 12 (policy adds 10)

### ✅ Unit Testing
```bash
go test ./cmd/cli/kubectl-kyverno/utils/common -v  # ✅ All tests pass
```

### ✅ Regression Testing
- Verified existing policy types (VAP, VP, IVP, DP) still work correctly
- No breaking changes to existing functionality

## Impact & Benefits

### Before (Issue)
```bash
kubectl kyverno apply mutating-policy.yaml --cluster
# ❌ MAPs would not be applied to cluster resources
# ❌ Resources matching MAP constraints not fetched from cluster
```

### After (Fixed)
```bash
kubectl kyverno apply mutating-policy.yaml --cluster
# ✅ MAPs properly applied to cluster resources  
# ✅ Resources matching MAP constraints fetched and mutated
# ✅ Feature parity with other policy types
```

### Use Cases Enabled
1. **Cluster-wide MAP Testing**: Test MAP policies against live cluster resources
2. **MAP Validation**: Validate MAP behavior before deployment
3. **Compliance Checking**: Ensure existing cluster resources comply with MAP policies
4. **Migration Support**: Test MAP policies during migration scenarios

## Backward Compatibility
- ✅ **No breaking changes** - all existing functionality preserved
- ✅ **Additive only** - new functionality added without modifying existing behavior
- ✅ **Safe rollback** - changes are isolated and reversible

## Files Changed
- `cmd/cli/kubectl-kyverno/utils/common/fetch.go` - Main implementation

## Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have signed the commit(s) using `--signoff` flag
- [x] Unit tests pass locally
- [x] No breaking changes introduced
- [x] Feature parity achieved with other policy types
- [x] Code compiles successfully
- [x] Proper error handling and logging maintained

## Reviewers
Please pay special attention to:
- Type conversion logic in `convertMatchResources()`
- Integration with existing policy extraction flow
- Compatibility with upstream changes (DeletingPolicy support)

