### PR TITLE
Make sure that imagePullSecrets are properly formatted

### DIFF
--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -121,13 +121,17 @@
 {{/* Helper function to sort imagePullSecrets by name to ensure consistent ordering */}}
 {{- define "kyverno.sortedImagePullSecrets" -}}
 {{- if . -}}
-{{- $secrets := list -}}
+{{- $secrets := dict -}}
 {{- range . -}}
-{{- $secrets = append $secrets (toYaml .) -}}
+{{- $secrets = set $secrets (toYaml .) . -}}
+{{- end -}}
+{{- $sortedKeys := list -}}
+{{- if $secrets -}}
+{{- $sortedKeys = sortAlpha (keys $secrets) -}}
 {{- end -}}
 {{- $sortedSecrets := list -}}
-{{- if $secrets -}}
-{{- $sortedSecrets = sortAlpha $secrets -}}
+{{- range $sortedKeys -}}
+{{- $sortedSecrets = append $sortedSecrets (get $secrets .) -}}
 {{- end -}}
 {{- toYaml $sortedSecrets -}}
 {{- end -}}

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -123,7 +123,7 @@
 {{- if . -}}
 {{- $secrets := list -}}
 {{- range . -}}
-{{- $secrets = append $secrets . -}}
+{{- $secrets = append $secrets (toYaml .) -}}
 {{- end -}}
 {{- $sortedSecrets := list -}}
 {{- if $secrets -}}


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

Currently there is a formatting issue in Kyverno's Helm Chart, introduced by https://github.com/kyverno/kyverno/commit/385eef980e59a2965570a2ef91350e7440d08e84 which causes `imagePullSecrets` to be broken. This is a major issue if you are using a pull-through cache to fetch your Kyverno container image which is common in corporate environments.

[Here is a playground example demonstrating the issue](https://helm-playground.com/#t=N7C0AIHoCpwCQKYBsAOCBO4BmBXAdgMYAuAlgPZ7hFngDOZ6R4JAtgIYDmCACjkkgGUEBdAiK1wAIwCe4PGxYIqNBHlo5R4AhVolaRVUwYATDCTwdw0SAF8bAKBARTWc0oBEAa2kA3DHjIAOnpGBGMASXYuXn4hETFad3BQO0cwZixwQOTUp3AAElphUXFwAC4AXnAkPSYUhzz0NgslbPq0iELihPAqthQ0PGMCovjSttz01WH2vMKGA2M4kolK6tqchvSSTK6xiVn0%2BdCl7tKqkKIAQVQACzYRs4PJiGnNjuUATQUkEYWw5Y9Q6vIbvPJvdq0NAEMr2cBUBAsFBINgGWHw%2BFQ4TojHwgDE4AAKrc9MwJERbkoUKIfOQcBJtKY4bjmFEeHxBE8yuA8kRkeAABTUb4sX6BABqbCQOAQtECrE47NiTwAlAVwAAfOTmUx4JgADnAqRZ4AJ4T16DIxhwBDCzEotyIfNoZUgkA4JApOEkgW0LEg3j86ACAd8-jIkD9LE9kAAzPqAKwIBBYACc%2BoADAgE6m2AAmVMANgTCYA7Bn8ynUwBGWMJrOlgAsjYzxgz%2BoQ%2BsbzNxCuiHMB4m5vP5AvMBGlpnAXjDwaClzCkUVMU5%2BySEqlMrlfaVq5Wavymu1Q0M4ENdiAA&v=LQhQEsFsEMHMFMAKBXANqgyvAxgJ3gC4DOAXKAATnDkB20k8J5AZgPatA)  (Courtesy of @fernandezcuesta)

Notice the formatting of the output:
```yaml
      imagePullSecrets:
        - map[name:foo]
```

[Here is a playground showing the output with this change instead](https://helm-playground.com/#t=N7C0AIHoCpwCQKYBsAOCBO4BmBXAdgMYAuAlgPZ7hFngDOZ6R4JAtgIYDmCACjkkgGUEBdAiK1wAIwCe4PGxYIqNBHlo5R4AhVolaRVUwYATDCTwdw0SAF8bAKBARTWc0oBEAa2kA3DHjIAOnpGBGMASXYuXn4hETFad3BQO0cwZixwQOTUp3AAElphUXFwAC4AXnBjEmIchzz0NgslbJSG9MLihPAqoqYu%2BNKACmoATQUkLIBKLPq0iFVjebzChgNjAGkEaQlK8CQ9JnaFjIKioYkT1ZCN7d3eunWAQVQACzZwYc8diUGS2iza7pJYrTq3MJxAHlKqHfRgiBNFrndZhe5XXLg1HGKE9KpsFBoPDLNahHHdEZcAYXaGBIGYxbEhHKCYsKakja40rAxnLHngUEnWhoAhlezgKgIFgoJBsAxiiUS4XCBWKiUAYnAABU3npmBIiG8lChRD5yDgJNpTOK1cwojw%2BIIKbQyuA8kQZV9xpMsgA1NhIHAIWiBVicB2xZ2zfLgAA%2BcnMpjwTAAHOBUrbwJrwsn0GRjDgCGFmJQ3kQPS7IJAOCRDThJIFtCxIN4-OgAi3fP4yJAmyxa5AAMwpgCsCAQWAAnCmAAwIEeTtgAJknADYRyOAOwz5cTycARkHI7nm4ALKeZ8YZymECnTza1WHoo6uS63ekPVNhuYCIHTOAvC7dsgghCJ7RiJ1LiSQJ-UDYNQ3Al8owKOME2JQxwDTOwgA&v=LQhQEsFsEMHMFMAKBXANqgyvAxgJ3gC4DOAXKAATnDkB20k8J5AZgPatA)

```yaml
      imagePullSecrets:
        - name: foo
```

There might be a nicer way to implement this functionality, but this way is fairly straightforward.

## Related issue
Closes #13310
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
>
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind bug

## Proposed Changes

When using sortAlpha, it will convert its input list to a list of strings and return a sorted list of those strings. This is fine but it ruins the structural information so we really want to convert it back from a string to map. 

This can be done in multiple ways, I simply decided to store both the stringified version (as the keys) and the structural version (as the values) in a dictionary, then sort the keys and loop through the keys to lookup the corresponding maps.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

[Here is a playground showing the output with this change instead](https://helm-playground.com/#t=N7C0AIHoCpwCQKYBsAOCBO4BmBXAdgMYAuAlgPZ7hFngDOZ6R4JAtgIYDmCACjkkgGUEBdAiK1wAIwCe4PGxYIqNBHlo5R4AhVolaRVUwYATDCTwdw0SAF8bAKBARTWc0oBEAa2kA3DHjIAOnpGBGMASXYuXn4hETFad3BQO0cwZixwQOTUp3AAElphUXFwAC4AXnBjEmIchzz0NgslbJSG9MLihPAqoqYu%2BNKACmoATQUkLIBKLPq0iFVjebzChgNjAGkEaQlK8CQ9JnaFjIKioYkT1ZCN7d3eunWAQVQACzZwYc8diUGS2iza7pJYrTq3MJxAHlKqHfRgiBNFrndZhe5XXLg1HGKE9KpsFBoPDLNahHHdEZcAYXaGBIGYxbEhHKCYsKakja40rAxnLHngUEnWhoAhlezgKgIFgoJBsAxiiUS4XCBWKiUAYnAABU3npmBIiG8lChRD5yDgJNpTOK1cwojw%2BIIKbQyuA8kQZV9xpMsgA1NhIHAIWiBVicB2xZ2zfLgAA%2BcnMpjwTAAHOBUrbwJrwsn0GRjDgCGFmJQ3kQPS7IJAOCRDThJIFtCxIN4-OgAi3fP4yJAmyxa5AAMwpgCsCAQWAAnCmAAwIEeTtgAJknADYRyOAOwz5cTycARkHI7nm4ALKeZ8YZymECnTza1WHoo6uS63ekPVNhuYCIHTOAvC7dsgghCJ7RiJ1LiSQJ-UDYNQ3Al8owKOME2JQxwDTOwgA&v=LQhQEsFsEMHMFMAKBXANqgyvAxgJ3gC4DOAXKAATnDkB20k8J5AZgPatA)

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
