### PR TITLE
fix: overlapping identifier for name 'variables'

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -703,7 +703,7 @@ func main() {
 					}
 					return ns
 				},
-				setup.KubeClient,
+				setup.KubeClient.Discovery().OpenAPIV3(),
 				matching.NewMatcher(),
 			)
 		}

--- a/pkg/cel/policies/mpol/compiler/compiler.go
+++ b/pkg/cel/policies/mpol/compiler/compiler.go
@@ -47,7 +47,6 @@ func (c *compilerImpl) Compile(policy *policiesv1alpha1.MutatingPolicy, exceptio
 				cel.Variable(compiler.ImageDataKey, imagedata.ContextType),
 				cel.Variable(compiler.ResourceKey, resource.ContextType),
 				// TODO(shuting): add variables provider
-				cel.Variable(compiler.VariablesKey, compiler.VariablesType),
 				cel.Types(compiler.NamespaceType.CelType()),
 				cel.Types(compiler.RequestType.CelType()),
 				globalcontext.Lib(),

--- a/pkg/cel/policies/mpol/engine/engine.go
+++ b/pkg/cel/policies/mpol/engine/engine.go
@@ -14,7 +14,7 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/openapi"
 )
 
 type Engine interface {
@@ -35,12 +35,12 @@ type Predicate = func(policiesv1alpha1.MutatingPolicy) bool
 
 type engineImpl struct {
 	provider   Provider
-	client     kubernetes.Interface
+	client     openapi.Client
 	nsResolver engine.NamespaceResolver
 	matcher    matching.Matcher
 }
 
-func NewEngine(provider Provider, nsResolver engine.NamespaceResolver, client kubernetes.Interface, matcher matching.Matcher) *engineImpl {
+func NewEngine(provider Provider, nsResolver engine.NamespaceResolver, client openapi.Client, matcher matching.Matcher) *engineImpl {
 	return &engineImpl{
 		provider:   provider,
 		nsResolver: nsResolver,
@@ -86,7 +86,7 @@ func (e *engineImpl) Handle(ctx context.Context, request engine.EngineRequest, p
 		namespace = e.nsResolver(ns)
 	}
 
-	typeConverter := patch.NewTypeConverterManager(nil, e.client.Discovery().OpenAPIV3())
+	typeConverter := patch.NewTypeConverterManager(nil, e.client)
 	for _, mpol := range mpols {
 		if predicate != nil && !predicate(mpol.Policy) {
 			continue


### PR DESCRIPTION
## Explanation

The following code in the mpol compiler:

```go
	compositedCompiler, err := plugincel.NewCompositedCompiler(extendedEnvSet)
	if err != nil {
		return nil, append(allErrs, field.InternalError(nil, err))
	}
```

adds an `variables` key as well. This leads to an overlapping identifier error.

---

Using the `openapi.Client` makes it easier to work with this code when no k8s client is available. E.g Playground or CLI
