### PR TITLE
chore: update chainsaw test to kube 1.30 - 1.33

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -137,7 +137,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -157,7 +157,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -197,7 +197,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -217,7 +217,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -237,7 +237,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
         shard-index: [0, 1]
     needs: [define-matrix, prepare-images]
@@ -260,7 +260,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -280,7 +280,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -300,7 +300,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
         shard-index: [0, 1, 2, 3, 4, 5, 6, 7]
     needs: [define-matrix, prepare-images]
@@ -323,7 +323,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.31.6, v1.32.2]
+        k8s-version: [v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -344,7 +344,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -364,7 +364,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -384,7 +384,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
         shard-index: [0, 1, 2]
     needs: [define-matrix, prepare-images]
@@ -407,7 +407,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -427,7 +427,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -447,9 +447,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kyverno-configs:
-          [standard, default, "standard,force-failure-policy-ignore"]
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        kyverno-configs: [standard, default, standard,force-failure-policy-ignore]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -469,7 +468,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
         shard-index: [0, 1]
     needs: [define-matrix, prepare-images]
@@ -492,7 +491,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -512,7 +511,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
         shard-index: [0, 1, 2, 3, 4, 5]
     needs: [define-matrix, prepare-images]
@@ -535,7 +534,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.30.4, v1.31.0]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -556,7 +555,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
         shard-index: [0, 1, 2]
     needs: [define-matrix, prepare-images]
@@ -579,7 +578,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
         shard-index: [0, 1, 2]
     needs: [define-matrix, prepare-images]
@@ -602,7 +601,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
         shard-index: [0, 1, 2]
     needs: [define-matrix, prepare-images]
@@ -625,7 +624,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
         shard-index: [0, 1, 2]
     needs: [define-matrix, prepare-images]
@@ -648,7 +647,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -668,7 +667,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -688,7 +687,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
         shard-index: [0, 1]
     needs: [define-matrix, prepare-images]
@@ -711,7 +710,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -731,7 +730,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -751,7 +750,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         upgrade: ${{ fromJSON(needs.define-matrix.outputs.upgrades) }}
     needs: [define-matrix, prepare-images]
     steps:
@@ -773,9 +772,10 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version:
-          - v1.28.x
-          - v1.29.x
           - v1.30.x
+          - v1.31.x
+          - v1.32.x
+          - v1.33.x
         tests:
           - custom-sigstore
     needs: prepare-images
@@ -854,7 +854,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         shard-index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
     needs:
       - prepare-images
@@ -1040,7 +1040,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.14, v1.30.10, v1.31.6, v1.32.2]
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
         kyverno-version: ["3.2"]
     needs: [prepare-images]
     steps:

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -796,7 +796,7 @@ jobs:
           verify: true
       # create cluster
       - name: Create kind cluster and setup Sigstore Scaffolding
-        uses: sigstore/scaffolding/actions/setup@7dd406abbfb07599b10ad048a397a4904d3e40cc
+        uses: sigstore/scaffolding/actions/setup@69aa90def82998ef06be9928840b71e66858d4d9
         with:
           version: main
           k8s-version: ${{ matrix.k8s-version }}


### PR DESCRIPTION
## Explanation

Update chainsaw test to kube 1.30 - 1.33
