### PR TITLE
feat(chart): Add Service trafficDistribution support for K8s 1.31+

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -443,11 +443,13 @@ The chart values are organised per component.
 | admissionController.service.type | string | `"ClusterIP"` | Service type. |
 | admissionController.service.nodePort | string | `nil` | Service node port. Only used if `type` is `NodePort`. |
 | admissionController.service.annotations | object | `{}` | Service annotations. |
+| admissionController.service.trafficDistribution | string | `nil` | Service traffic distribution policy. Set to `PreferClose` to route traffic to nearby endpoints, reducing latency and cross-zone costs. |
 | admissionController.metricsService.create | bool | `true` | Create service. |
 | admissionController.metricsService.port | int | `8000` | Service port. Kyverno's metrics server will be exposed at this port. |
 | admissionController.metricsService.type | string | `"ClusterIP"` | Service type. |
 | admissionController.metricsService.nodePort | string | `nil` | Service node port. Only used if `type` is `NodePort`. |
 | admissionController.metricsService.annotations | object | `{}` | Service annotations. |
+| admissionController.metricsService.trafficDistribution | string | `nil` | Service traffic distribution policy. Set to `PreferClose` to route traffic to nearby endpoints, reducing latency and cross-zone costs. |
 | admissionController.networkPolicy.enabled | bool | `false` | When true, use a NetworkPolicy to allow ingress to the webhook This is useful on clusters using Calico and/or native k8s network policies in a default-deny setup. |
 | admissionController.networkPolicy.ingressFrom | list | `[]` | A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies. |
 | admissionController.serviceMonitor.enabled | bool | `false` | Create a `ServiceMonitor` to collect Prometheus metrics. |
@@ -527,6 +529,7 @@ The chart values are organised per component.
 | backgroundController.metricsService.type | string | `"ClusterIP"` | Service type. |
 | backgroundController.metricsService.nodePort | string | `nil` | Service node port. Only used if `metricsService.type` is `NodePort`. |
 | backgroundController.metricsService.annotations | object | `{}` | Service annotations. |
+| backgroundController.metricsService.trafficDistribution | string | `nil` | Service traffic distribution policy. Set to `PreferClose` to route traffic to nearby endpoints, reducing latency and cross-zone costs. |
 | backgroundController.networkPolicy.enabled | bool | `false` | When true, use a NetworkPolicy to allow ingress to the webhook This is useful on clusters using Calico and/or native k8s network policies in a default-deny setup. |
 | backgroundController.networkPolicy.ingressFrom | list | `[]` | A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies. |
 | backgroundController.serviceMonitor.enabled | bool | `false` | Create a `ServiceMonitor` to collect Prometheus metrics. |
@@ -607,11 +610,13 @@ The chart values are organised per component.
 | cleanupController.service.type | string | `"ClusterIP"` | Service type. |
 | cleanupController.service.nodePort | string | `nil` | Service node port. Only used if `service.type` is `NodePort`. |
 | cleanupController.service.annotations | object | `{}` | Service annotations. |
+| cleanupController.service.trafficDistribution | string | `nil` | Service traffic distribution policy. Set to `PreferClose` to route traffic to nearby endpoints, reducing latency and cross-zone costs. |
 | cleanupController.metricsService.create | bool | `true` | Create service. |
 | cleanupController.metricsService.port | int | `8000` | Service port. Metrics server will be exposed at this port. |
 | cleanupController.metricsService.type | string | `"ClusterIP"` | Service type. |
 | cleanupController.metricsService.nodePort | string | `nil` | Service node port. Only used if `metricsService.type` is `NodePort`. |
 | cleanupController.metricsService.annotations | object | `{}` | Service annotations. |
+| cleanupController.metricsService.trafficDistribution | string | `nil` | Service traffic distribution policy. Set to `PreferClose` to route traffic to nearby endpoints, reducing latency and cross-zone costs. |
 | cleanupController.networkPolicy.enabled | bool | `false` | When true, use a NetworkPolicy to allow ingress to the webhook This is useful on clusters using Calico and/or native k8s network policies in a default-deny setup. |
 | cleanupController.networkPolicy.ingressFrom | list | `[]` | A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies. |
 | cleanupController.serviceMonitor.enabled | bool | `false` | Create a `ServiceMonitor` to collect Prometheus metrics. |
@@ -695,6 +700,7 @@ The chart values are organised per component.
 | reportsController.metricsService.type | string | `"ClusterIP"` | Service type. |
 | reportsController.metricsService.nodePort | string | `nil` | Service node port. Only used if `type` is `NodePort`. |
 | reportsController.metricsService.annotations | object | `{}` | Service annotations. |
+| reportsController.metricsService.trafficDistribution | string | `nil` | Service traffic distribution policy. Set to `PreferClose` to route traffic to nearby endpoints, reducing latency and cross-zone costs. |
 | reportsController.networkPolicy.enabled | bool | `false` | When true, use a NetworkPolicy to allow ingress to the webhook This is useful on clusters using Calico and/or native k8s network policies in a default-deny setup. |
 | reportsController.networkPolicy.ingressFrom | list | `[]` | A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies. |
 | reportsController.serviceMonitor.enabled | bool | `false` | Create a `ServiceMonitor` to collect Prometheus metrics. |

--- a/charts/kyverno/templates/admission-controller/service.yaml
+++ b/charts/kyverno/templates/admission-controller/service.yaml
@@ -22,6 +22,9 @@ spec:
   selector:
     {{- include "kyverno.admission-controller.matchLabels" . | nindent 4 }}
   type: {{ .Values.admissionController.service.type }}
+  {{- if .Values.admissionController.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.admissionController.service.trafficDistribution }}
+  {{- end }}
 {{- if .Values.admissionController.metricsService.create }}
 ---
 apiVersion: v1
@@ -46,6 +49,9 @@ spec:
   selector:
     {{- include "kyverno.admission-controller.matchLabels" . | nindent 4 }}
   type: {{ .Values.admissionController.metricsService.type }}
+  {{- if .Values.admissionController.metricsService.trafficDistribution }}
+  trafficDistribution: {{ .Values.admissionController.metricsService.trafficDistribution }}
+  {{- end }}
 {{- end -}}
 {{- if .Values.admissionController.profiling.enabled }}
 ---

--- a/charts/kyverno/templates/background-controller/service.yaml
+++ b/charts/kyverno/templates/background-controller/service.yaml
@@ -24,6 +24,9 @@ spec:
   selector:
     {{- include "kyverno.background-controller.matchLabels" . | nindent 4 }}
   type: {{ .Values.backgroundController.metricsService.type }}
+  {{- if .Values.backgroundController.metricsService.trafficDistribution }}
+  trafficDistribution: {{ .Values.backgroundController.metricsService.trafficDistribution }}
+  {{- end }}
 {{- end -}}
 {{- end -}}
 {{- if .Values.backgroundController.profiling.enabled }}

--- a/charts/kyverno/templates/cleanup-controller/service.yaml
+++ b/charts/kyverno/templates/cleanup-controller/service.yaml
@@ -24,6 +24,9 @@ spec:
   selector:
     {{- include "kyverno.cleanup-controller.matchLabels" . | nindent 4 }}
   type: {{ .Values.cleanupController.service.type }}
+  {{- if .Values.cleanupController.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.cleanupController.service.trafficDistribution }}
+  {{- end }}
 {{- if .Values.cleanupController.metricsService.create }}
 ---
 apiVersion: v1
@@ -49,6 +52,9 @@ spec:
   selector:
     {{- include "kyverno.cleanup-controller.matchLabels" . | nindent 4 }}
   type: {{ .Values.cleanupController.metricsService.type }}
+  {{- if .Values.cleanupController.metricsService.trafficDistribution }}
+  trafficDistribution: {{ .Values.cleanupController.metricsService.trafficDistribution }}
+  {{- end }}
 {{- end -}}
 {{- if .Values.cleanupController.profiling.enabled }}
 ---

--- a/charts/kyverno/templates/reports-controller/service.yaml
+++ b/charts/kyverno/templates/reports-controller/service.yaml
@@ -24,6 +24,9 @@ spec:
   selector:
     {{- include "kyverno.reports-controller.matchLabels" . | nindent 4 }}
   type: {{ .Values.reportsController.metricsService.type }}
+  {{- if .Values.reportsController.metricsService.trafficDistribution }}
+  trafficDistribution: {{ .Values.reportsController.metricsService.trafficDistribution }}
+  {{- end }}
 {{- end -}}
 {{- end -}}
 {{- if .Values.reportsController.profiling.enabled }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -1147,6 +1147,9 @@ admissionController:
     nodePort:
     # -- Service annotations.
     annotations: {}
+    # -- (string) Service traffic distribution policy.
+    # Set to `PreferClose` to route traffic to nearby endpoints, reducing latency and cross-zone costs.
+    trafficDistribution: ~
 
   metricsService:
     # -- Create service.
@@ -1161,6 +1164,9 @@ admissionController:
     nodePort:
     # -- Service annotations.
     annotations: {}
+    # -- (string) Service traffic distribution policy.
+    # Set to `PreferClose` to route traffic to nearby endpoints, reducing latency and cross-zone costs.
+    trafficDistribution: ~
 
   networkPolicy:
     # -- When true, use a NetworkPolicy to allow ingress to the webhook
@@ -1472,6 +1478,9 @@ backgroundController:
     nodePort:
     # -- Service annotations.
     annotations: {}
+    # -- (string) Service traffic distribution policy.
+    # Set to `PreferClose` to route traffic to nearby endpoints, reducing latency and cross-zone costs.
+    trafficDistribution: ~
 
   networkPolicy:
 
@@ -1786,6 +1795,9 @@ cleanupController:
     nodePort:
     # -- Service annotations.
     annotations: {}
+    # -- (string) Service traffic distribution policy.
+    # Set to `PreferClose` to route traffic to nearby endpoints, reducing latency and cross-zone costs.
+    trafficDistribution: ~
 
   metricsService:
     # -- Create service.
@@ -1800,6 +1812,9 @@ cleanupController:
     nodePort:
     # -- Service annotations.
     annotations: {}
+    # -- (string) Service traffic distribution policy.
+    # Set to `PreferClose` to route traffic to nearby endpoints, reducing latency and cross-zone costs.
+    trafficDistribution: ~
 
   networkPolicy:
 
@@ -2102,6 +2117,9 @@ reportsController:
     nodePort: ~
     # -- Service annotations.
     annotations: {}
+    # -- (string) Service traffic distribution policy.
+    # Set to `PreferClose` to route traffic to nearby endpoints, reducing latency and cross-zone costs.
+    trafficDistribution: ~
 
   networkPolicy:
 


### PR DESCRIPTION
## Explanation

Adds kubernetes service [trafficDistribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) configuration to all kyverno services for better performance and data transfer cost optimization.

This PR includes these changes:

- Added trafficDistribution option to values.yaml for all services
- Updated service templates to support the new field
- Added clear documentation with benefits

This gives cluster administrators control over traffic routing for better performance and lower cloud costs.

- Reduces network latency by routing traffic to nearby endpoints
- Cluster administrator can save costs by minimizing cross-zone traffic in cloud environments
- Improves performance in multi-zone clusters

Values example:

```yaml
# kyverno/values_example.yaml
admissionController:
  service:
    trafficDistribution: PreferClose
```

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind feature (relates to helm chart)

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

### Version compatibility

The Service [trafficDistribution](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) field became a Beta feature in Kubernetes 1.31 and is enabled by default. This allows routing traffic to topologically close endpoints to reduce latency and cross-zone costs. Clusters running Kubernetes versions prior to 1.31 will ignore this configuration.

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
