### PR TITLE
Fix: use the introduced testResult.patchResources field if provided

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -195,9 +195,15 @@ func checkResult(test v1alpha1.TestResult, fs billy.Filesystem, resoucePath stri
 	if expected == "" {
 		expected = test.Status
 	}
-	// fallback on deprecated field
-	if test.PatchedResource != "" {
-		equals, diff, err := getAndCompareResource(actualResource, fs, filepath.Join(resoucePath, test.PatchedResource))
+
+	expectedPatchResources := test.PatchedResources
+	if expectedPatchResources == "" {
+		// fallback on deprecated field
+		expectedPatchResources = test.PatchedResource
+	}
+
+	if expectedPatchResources != "" {
+		equals, diff, err := getAndCompareResource(actualResource, fs, filepath.Join(resoucePath, expectedPatchResources))
 		if err != nil {
 			return false, err.Error(), "Resource error"
 		}

--- a/test/cli/test-mutating-admission-policy/check-labels/expected-patched.yaml
+++ b/test/cli/test-mutating-admission-policy/check-labels/expected-patched.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:latest

--- a/test/cli/test-mutating-admission-policy/check-labels/resource1.yaml
+++ b/test/cli/test-mutating-admission-policy/check-labels/resource1.yaml
@@ -7,3 +7,4 @@ metadata:
 spec:
   containers:
   - name: nginx
+    image: nginx:latest


### PR DESCRIPTION
## Explanation

For the CLI test command a new field `testResult.patchResources` was introduced and the `testResult.patchResource` field deprecated.

Unfortunately is the new introduced `testResult.patchResources` never used. So all tests using the new field will pass even the patched resource does not have the expected patches.