### PR TITLE
chore: add gpol assert in chainsaw tests

### DIFF
--- a/test/conformance/chainsaw/generating-policies/clone/nosync/generate-on-trigger-deletion/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/generate-on-trigger-deletion/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/generate-on-trigger-deletion/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/generate-on-trigger-deletion/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-networkpolicy
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/generate-secrets-and-networkpolicies/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/generate-secrets-and-networkpolicies/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/generate-secrets-and-networkpolicies/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/generate-secrets-and-networkpolicies/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-secrets-and-networkpolicies
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/generate-secrets/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/generate-secrets/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/generate-secrets/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/generate-secrets/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-secrets
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-create/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-create/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-create/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-create/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-secret
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-downstream/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-downstream/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-downstream/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-downstream/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-secret
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-policy/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-policy/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-policy/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-policy/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-secret
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-source/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-source/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-source/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-source/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-secret
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-trigger/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-trigger/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-trigger/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-delete-trigger/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-networkpolicy
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-modify-downstream/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-modify-downstream/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-modify-downstream/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-modify-downstream/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-networkpolicy
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-modify-source/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-modify-source/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-modify-source/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/nosync/nosync-modify-source/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-networkpolicy
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/sync/sync-delete-downstream/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/sync/sync-delete-downstream/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/sync/sync-delete-downstream/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/sync/sync-delete-downstream/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-secret
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/sync/sync-delete-source/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/sync/sync-delete-source/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/sync/sync-delete-source/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/sync/sync-delete-source/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-secret
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/sync/sync-delete-trigger/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/sync/sync-delete-trigger/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/sync/sync-delete-trigger/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/sync/sync-delete-trigger/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: sync-delete-trigger
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/sync/sync-modify-downstream/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/sync/sync-modify-downstream/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/sync/sync-modify-downstream/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/sync/sync-modify-downstream/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-secret
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/clone/sync/sync-modify-source/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/sync/sync-modify-source/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the source
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/clone/sync/sync-modify-source/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/clone/sync/sync-modify-source/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-secret
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/data/nosync/generate-cm/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/generate-cm/chainsaw-test.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   steps:
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create namespace
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/data/nosync/generate-cm/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/generate-cm/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: zk-kafka-address
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/data/nosync/generate-on-eviction-subresource-trigger/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/generate-on-eviction-subresource-trigger/chainsaw-test.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   steps:
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create namespace
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/data/nosync/generate-on-eviction-subresource-trigger/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/generate-on-eviction-subresource-trigger/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: zk-kafka-address
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/data/nosync/generate-on-subresource-trigger/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/generate-on-subresource-trigger/chainsaw-test.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   steps:
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create namespace
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/data/nosync/generate-on-subresource-trigger/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/generate-on-subresource-trigger/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: zk-kafka-address
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/data/nosync/generate-on-trigger-deletion/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/generate-on-trigger-deletion/chainsaw-test.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   steps:
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the trigger
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/data/nosync/generate-on-trigger-deletion/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/generate-on-trigger-deletion/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-networkpolicy
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/data/nosync/nosync-delete-downstream/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/nosync-delete-downstream/chainsaw-test.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   steps:
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create namespace
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/data/nosync/nosync-delete-downstream/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/nosync-delete-downstream/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: zk-kafka-address
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/data/nosync/nosync-delete-policy/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/nosync-delete-policy/chainsaw-test.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   steps:
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create namespace
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/data/nosync/nosync-delete-policy/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/nosync-delete-policy/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: zk-kafka-address
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/data/nosync/nosync-delete-trigger/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/nosync-delete-trigger/chainsaw-test.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   steps:
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the trigger
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/data/nosync/nosync-delete-trigger/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/nosync-delete-trigger/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-networkpolicy
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/data/nosync/nosync-modify-downstream/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/nosync-modify-downstream/chainsaw-test.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   steps:
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create namespace
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/data/nosync/nosync-modify-downstream/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/nosync-modify-downstream/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: zk-kafka-address
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/data/nosync/nosync-modify-policy/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/nosync-modify-policy/chainsaw-test.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   steps:
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create namespace
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/data/nosync/nosync-modify-policy/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/nosync/nosync-modify-policy/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: zk-kafka-address
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/data/sync/sync-delete-downstream/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/sync/sync-delete-downstream/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the trigger
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/data/sync/sync-delete-downstream/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/sync/sync-delete-downstream/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: zk-kafka-address
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/data/sync/sync-delete-policy/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/sync/sync-delete-policy/chainsaw-test.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   steps:
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create namespace
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/data/sync/sync-delete-policy/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/sync/sync-delete-policy/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: zk-kafka-address
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/data/sync/sync-delete-trigger/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/sync/sync-delete-trigger/chainsaw-test.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   steps:
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create the trigger
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/data/sync/sync-delete-trigger/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/sync/sync-delete-trigger/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: generate-networkpolicy
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/data/sync/sync-modify-downstream/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/sync/sync-modify-downstream/chainsaw-test.yaml
@@ -10,12 +10,11 @@ spec:
     - apply:
         file: permissions.yaml
   - name: create policy
-    use:
-      template: ../../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: create namespace
     try:
     - apply:

--- a/test/conformance/chainsaw/generating-policies/data/sync/sync-modify-downstream/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/sync/sync-modify-downstream/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: zk-kafka-address
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/webhook/match-conditions/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/webhook/match-conditions/chainsaw-test.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   steps:
   - name: create policy
-    use:
-      template: ../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: check webhooks
     try:
     - assert:

--- a/test/conformance/chainsaw/generating-policies/webhook/match-conditions/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/webhook/match-conditions/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: zk-kafka-address
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true

--- a/test/conformance/chainsaw/generating-policies/webhook/single/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/webhook/single/chainsaw-test.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   steps:
   - name: create policy
-    use:
-      template: ../../../_step-templates/create-policy.yaml
-      with:
-        bindings:
-        - name: file
-          value: policy.yaml
+    try:
+    - create:
+        file: policy.yaml
+    - assert:
+        file: policy-assert.yaml
   - name: check webhooks
     try:
     - assert:

--- a/test/conformance/chainsaw/generating-policies/webhook/single/policy-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/webhook/single/policy-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: zk-kafka-address
+status:
+  conditionStatus:
+    conditions:
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    message: ""
+    ready: true


### PR DESCRIPTION
## Explanation
This PR adds `policy-assert.yaml` in chainsaw tests for GeneratingPolicies since now we have the `status` field.
Related to #11638 