### PR TITLE
chore(gpol): remove background from the API

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/generating_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/generating_policy.go
@@ -141,22 +141,10 @@ func (s GeneratingPolicySpec) AdmissionEnabled() bool {
 	return *s.EvaluationConfiguration.Admission.Enabled
 }
 
-// BackgroundEnabled checks if background is set to true
-func (s GeneratingPolicySpec) BackgroundEnabled() bool {
-	if s.EvaluationConfiguration == nil || s.EvaluationConfiguration.Background == nil || s.EvaluationConfiguration.Background.Enabled == nil {
-		return true
-	}
-	return *s.EvaluationConfiguration.Background.Enabled
-}
-
 type GeneratingPolicyEvaluationConfiguration struct {
 	// Admission controls policy evaluation during admission.
 	// +optional
 	Admission *AdmissionConfiguration `json:"admission,omitempty"`
-
-	// Background  controls policy evaluation during background scan.
-	// +optional
-	Background *BackgroundConfiguration `json:"background,omitempty"`
 
 	// GenerateExisting defines the configuration for generating resources for existing triggeres.
 	// +optional

--- a/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
+++ b/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
@@ -470,11 +470,6 @@ func (in *GeneratingPolicyEvaluationConfiguration) DeepCopyInto(out *GeneratingP
 		*out = new(AdmissionConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.Background != nil {
-		in, out := &in.Background, &out.Background
-		*out = new(BackgroundConfiguration)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.GenerateExistingConfiguration != nil {
 		in, out := &in.GenerateExistingConfiguration, &out.GenerateExistingConfiguration
 		*out = new(GenerateExistingConfiguration)

--- a/charts/kyverno/charts/crds/templates/policies.kyverno.io/policies.kyverno.io_generatingpolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/policies.kyverno.io/policies.kyverno.io_generatingpolicies.yaml
@@ -67,18 +67,6 @@ spec:
                           Optional. Default value is "true".
                         type: boolean
                     type: object
-                  background:
-                    description: Background  controls policy evaluation during background
-                      scan.
-                    properties:
-                      enabled:
-                        default: true
-                        description: |-
-                          Enabled controls if rules are applied to existing resources during a background scan.
-                          Optional. Default value is "true". The value must be set to "false" if the policy rule
-                          uses variables that are only available in the admission review request (e.g. user name).
-                        type: boolean
-                    type: object
                   generateExisting:
                     description: GenerateExisting defines the configuration for generating
                       resources for existing triggeres.

--- a/cmd/cli/kubectl-kyverno/data/crds/policies.kyverno.io_generatingpolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/policies.kyverno.io_generatingpolicies.yaml
@@ -61,18 +61,6 @@ spec:
                           Optional. Default value is "true".
                         type: boolean
                     type: object
-                  background:
-                    description: Background  controls policy evaluation during background
-                      scan.
-                    properties:
-                      enabled:
-                        default: true
-                        description: |-
-                          Enabled controls if rules are applied to existing resources during a background scan.
-                          Optional. Default value is "true". The value must be set to "false" if the policy rule
-                          uses variables that are only available in the admission review request (e.g. user name).
-                        type: boolean
-                    type: object
                   generateExisting:
                     description: GenerateExisting defines the configuration for generating
                       resources for existing triggeres.

--- a/config/crds/policies.kyverno.io/policies.kyverno.io_generatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io/policies.kyverno.io_generatingpolicies.yaml
@@ -61,18 +61,6 @@ spec:
                           Optional. Default value is "true".
                         type: boolean
                     type: object
-                  background:
-                    description: Background  controls policy evaluation during background
-                      scan.
-                    properties:
-                      enabled:
-                        default: true
-                        description: |-
-                          Enabled controls if rules are applied to existing resources during a background scan.
-                          Optional. Default value is "true". The value must be set to "false" if the policy rule
-                          uses variables that are only available in the admission review request (e.g. user name).
-                        type: boolean
-                    type: object
                   generateExisting:
                     description: GenerateExisting defines the configuration for generating
                       resources for existing triggeres.

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -49136,18 +49136,6 @@ spec:
                           Optional. Default value is "true".
                         type: boolean
                     type: object
-                  background:
-                    description: Background  controls policy evaluation during background
-                      scan.
-                    properties:
-                      enabled:
-                        default: true
-                        description: |-
-                          Enabled controls if rules are applied to existing resources during a background scan.
-                          Optional. Default value is "true". The value must be set to "false" if the policy rule
-                          uses variables that are only available in the admission review request (e.g. user name).
-                        type: boolean
-                    type: object
                   generateExisting:
                     description: GenerateExisting defines the configuration for generating
                       resources for existing triggeres.

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -11569,8 +11569,7 @@ Notary
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#policies.kyverno.io/v1alpha1.EvaluationConfiguration">EvaluationConfiguration</a>, 
-<a href="#policies.kyverno.io/v1alpha1.GeneratingPolicyEvaluationConfiguration">GeneratingPolicyEvaluationConfiguration</a>)
+<a href="#policies.kyverno.io/v1alpha1.EvaluationConfiguration">EvaluationConfiguration</a>)
 </p>
 <p>
 </p>
@@ -12275,20 +12274,6 @@ AdmissionConfiguration
 <td>
 <em>(Optional)</em>
 <p>Admission controls policy evaluation during admission.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>background</code><br/>
-<em>
-<a href="#policies.kyverno.io/v1alpha1.BackgroundConfiguration">
-BackgroundConfiguration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Background  controls policy evaluation during background scan.</p>
 </td>
 </tr>
 <tr>

--- a/docs/user/crd/kyverno_cel_policies.v1alpha1.html
+++ b/docs/user/crd/kyverno_cel_policies.v1alpha1.html
@@ -2703,8 +2703,7 @@ Optional. Default value is &quot;true&quot;.</p>
   
     <p>
       (<em>Appears in:</em>
-        <a href="#policies-kyverno-io-v1alpha1-EvaluationConfiguration">EvaluationConfiguration</a>, 
-        <a href="#policies-kyverno-io-v1alpha1-GeneratingPolicyEvaluationConfiguration">GeneratingPolicyEvaluationConfiguration</a>)
+        <a href="#policies-kyverno-io-v1alpha1-EvaluationConfiguration">EvaluationConfiguration</a>)
     </p>
   
 
@@ -4094,35 +4093,6 @@ Optional. Defaults to &quot;false&quot; if not specified.</p>
           
 
           <p>Admission controls policy evaluation during admission.</p>
-
-
-          
-
-          
-        </td>
-      </tr>
-    
-  
-    
-    
-      <tr>
-        <td><code>background</code>
-          
-          </br>
-
-          
-          
-            
-              <a href="#policies-kyverno-io-v1alpha1-BackgroundConfiguration">
-                <span style="font-family: monospace">BackgroundConfiguration</span>
-              </a>
-            
-          
-        </td>
-        <td>
-          
-
-          <p>Background  controls policy evaluation during background scan.</p>
 
 
           

--- a/pkg/controllers/policystatus/controller.go
+++ b/pkg/controllers/policystatus/controller.go
@@ -223,7 +223,6 @@ func (c controller) reconcileConditions(ctx context.Context, policy engineapi.Ge
 	case webhook.GeneratingPolicyType:
 		key = webhook.BuildRecorderKey(webhook.GeneratingPolicyType, policy.GetName())
 		matchConstraints = policy.AsGeneratingPolicy().GetMatchConstraints()
-		backgroundOnly = (!policy.AsGeneratingPolicy().GetSpec().AdmissionEnabled() && policy.AsGeneratingPolicy().GetSpec().BackgroundEnabled())
 	}
 
 	if !backgroundOnly {


### PR DESCRIPTION
## Explanation
This PR removes the `background` field from the GPOL API.