### PR TITLE
Add unit test for mpol

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/mutating_policy_test.go
+++ b/api/policies.kyverno.io/v1alpha1/mutating_policy_test.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +16,8 @@ func TestGetMatchConstraints(t *testing.T) {
 		}
 
 		result := mpol.GetMatchConstraints()
+
+		//assert.Equal(t, nil, result.NamespaceSelector, "expected empty MatchResources, got %+v", result)
 		if result.NamespaceSelector != nil || result.ObjectSelector != nil ||
 			len(result.ResourceRules) != 0 || len(result.ExcludeResourceRules) != 0 ||
 			result.MatchPolicy != nil {
@@ -35,9 +38,9 @@ func TestGetMatchConstraints(t *testing.T) {
 		}
 
 		result := mpol.GetMatchConstraints()
-		if result.MatchPolicy == nil || *result.MatchPolicy != mp {
-			t.Errorf("expected MatchPolicy %s, got %v", mp, result.MatchPolicy)
-		}
+
+		assert.NotEqual(t, result.MatchPolicy, nil, "expected MatchPolicy %s, got %v", mp, result.MatchPolicy)
+		assert.Equal(t, *result.MatchPolicy, mp, "expected MatchPolicy %s, got %v", mp, result.MatchPolicy)
 	})
 }
 
@@ -51,17 +54,15 @@ func TestGetMatchConditions(t *testing.T) {
 		},
 	}
 	result := mpol.GetMatchConditions()
-	if len(result) != 1 || result[0].Name != "test" {
-		t.Errorf("expected 1 match condition named 'test', got %+v", result)
-	}
+
+	assert.Equal(t, len(result), 1, "expected 1 match condition named 'test', got %+v", result)
+	assert.Equal(t, result[0].Name, "test", "expected 1 match condition named 'test', got %+v", result)
 }
 
 func TestGenerateMutatingAdmissionPolicyEnabled(t *testing.T) {
 	t.Run("returns default false if nil", func(t *testing.T) {
 		spec := MutatingPolicySpec{}
-		if spec.GenerateMutatingAdmissionPolicyEnabled() {
-			t.Errorf("expected false when configuration is nil")
-		}
+		assert.False(t, spec.GenerateMutatingAdmissionPolicyEnabled(), "expected false when configuration is nil")
 	})
 
 	t.Run("returns false when MutatingAdmissionPolicy is nil", func(t *testing.T) {
@@ -71,9 +72,7 @@ func TestGenerateMutatingAdmissionPolicyEnabled(t *testing.T) {
 			},
 		}
 
-		if spec.GenerateMutatingAdmissionPolicyEnabled() {
-			t.Errorf("expected false when MutatingAdmissionPolicy is nil")
-		}
+		assert.False(t, spec.GenerateMutatingAdmissionPolicyEnabled(), "expected false when MutatingAdmissionPolicy is nil")
 	})
 
 	t.Run("returns false when Enabled is nil", func(t *testing.T) {
@@ -85,9 +84,7 @@ func TestGenerateMutatingAdmissionPolicyEnabled(t *testing.T) {
 			},
 		}
 
-		if spec.GenerateMutatingAdmissionPolicyEnabled() {
-			t.Errorf("expected false when Enabled is nil")
-		}
+		assert.False(t, spec.GenerateMutatingAdmissionPolicyEnabled(), "expected false when Enabled is nil")
 	})
 
 	t.Run("returns true when explicitly enabled", func(t *testing.T) {
@@ -100,9 +97,7 @@ func TestGenerateMutatingAdmissionPolicyEnabled(t *testing.T) {
 			},
 		}
 
-		if !spec.GenerateMutatingAdmissionPolicyEnabled() {
-			t.Errorf("expected true when enabled is true")
-		}
+		assert.True(t, spec.GenerateMutatingAdmissionPolicyEnabled(), "expected true when enabled is true")
 	})
 }
 
@@ -112,36 +107,27 @@ func TestGetFailurePolicy(t *testing.T) {
 			Spec: MutatingPolicySpec{},
 		}
 
-		if mpol.GetFailurePolicy() != admissionregistrationv1.Fail {
-			t.Errorf("expected default failure policy 'Fail'")
-		}
+		assert.Equal(t, mpol.GetFailurePolicy(), admissionregistrationv1.Fail, "expected default failure policy 'Fail'")
 	})
 
 	t.Run("returns provided value", func(t *testing.T) {
 		val := admissionregistrationv1alpha1.Ignore
-		// Check it here once before push!!
-		val2 := admissionregistrationv1.FailurePolicyType(val)
+		valAlpha := admissionregistrationv1.FailurePolicyType(val)
 		mpol := MutatingPolicy{
 			Spec: MutatingPolicySpec{
-				FailurePolicy: (*admissionregistrationv1alpha1.FailurePolicyType)(&val2),
+				FailurePolicy: (*admissionregistrationv1alpha1.FailurePolicyType)(&valAlpha),
 			},
 		}
 
-		if mpol.GetFailurePolicy() != val2 {
-			t.Errorf("expected %s, got %s", val, mpol.GetFailurePolicy())
-		}
+		assert.Equal(t, mpol.GetFailurePolicy(), valAlpha, "expected %s, got %s", val, mpol.GetFailurePolicy())
 	})
 }
 
 func TestAdmissionAndBackgroundEnabled(t *testing.T) {
 	t.Run("defaults to true if nil", func(t *testing.T) {
 		spec := MutatingPolicySpec{}
-		if !spec.AdmissionEnabled() {
-			t.Errorf("expected AdmissionEnabled to default to  true")
-		}
-		if !spec.BackgroundEnabled() {
-			t.Errorf("expected BackgroundEnabled to default to true")
-		}
+		assert.True(t, spec.AdmissionEnabled(), "expected AdmissionEnabled to default to true")
+		assert.True(t, spec.BackgroundEnabled(), "expected BackgroundEnabled to default to true")
 	})
 
 	t.Run("returns set values", func(t *testing.T) {
@@ -161,12 +147,8 @@ func TestAdmissionAndBackgroundEnabled(t *testing.T) {
 			},
 		}
 
-		if spec.AdmissionEnabled() {
-			t.Errorf("expected AdmissionEnabled to be false")
-		}
-		if !spec.BackgroundEnabled() {
-			t.Errorf("expected BackgroundEnabled to be true")
-		}
+		assert.False(t, spec.AdmissionEnabled(), "expected AdmissionEnabled to be false")
+		assert.True(t, spec.BackgroundEnabled(), "expected BackgroundEnabled to be true")
 	})
 }
 
@@ -207,19 +189,16 @@ func TestGetAndSetMatchConstrainst(t *testing.T) {
 
 		var spec MutatingPolicySpec
 		spec.SetMatchConstraints(input)
-
 		result := spec.GetMatchConstraints()
-		if result.MatchPolicy == nil || *result.MatchPolicy != mp {
-			t.Errorf("expected MatchPolicy %s, got %+v", mp, result.MatchPolicy)
-		}
+
+		assert.NotEqual(t, nil, result.MatchPolicy, "expected MatchPolicy %s, got %+v", mp, result.MatchPolicy)
+		assert.Equal(t, *result.MatchPolicy, mp, "expected MatchPolicy %s, got %+v", mp, result.MatchPolicy)
 	})
 
 	t.Run("returns nil if no match constraints are provided", func(t *testing.T) {
 		var spec MutatingPolicySpec
 		result := spec.GetMatchConstraints()
-		if result.MatchPolicy != nil {
-			t.Errorf("expected nil MatchPolicy")
-		}
+		assert.Equal(t, nil, result.MatchPolicy, "expected nil MatchPolicy")
 	})
 }
 
@@ -231,9 +210,7 @@ func TestGetWebhookConfiguration(t *testing.T) {
 			},
 		}
 		result := policy.GetWebhookConfiguration()
-		if result != nil {
-			t.Errorf("expected nil, got %+v", result)
-		}
+		assert.Equal(t, nil, result, "expected nil, got %+v", result)
 	})
 
 	t.Run("returns non-nil WebhookConfiguration", func(t *testing.T) {
@@ -244,9 +221,7 @@ func TestGetWebhookConfiguration(t *testing.T) {
 			},
 		}
 		result := policy.GetWebhookConfiguration()
-		if result != cfg {
-			t.Errorf("expected %+v, got %+v", cfg, result)
-		}
+		assert.Equal(t, result, cfg, "expected %+v, got %+v", cfg, result)
 	})
 }
 
@@ -258,9 +233,7 @@ func TestGetVariables(t *testing.T) {
 			},
 		}
 		result := policy.GetVariables()
-		if len(result) != 0 {
-			t.Errorf("expected empty slice, got %v", result)
-		}
+		assert.Equal(t, 0, len(result), "expected empty slice, got %v", result)
 	})
 
 	t.Run("returns copied slice of variables", func(t *testing.T) {
@@ -278,12 +251,9 @@ func TestGetVariables(t *testing.T) {
 		}
 		result := policy.GetVariables()
 
-		if len(result) != 2 {
-			t.Fatalf("expected 2 variables, got %d", len(result))
-		}
-		if result[0].Name != "foo" || result[1].Name != "bar" {
-			t.Errorf("unexpected values: %+v", result)
-		}
+		assert.Equal(t, len(result), 2, "expected 2 variables, got %d", len(result))
+		assert.Equal(t, "foo", result[0].Name, "unexpected values: %+v", result)
+		assert.Equal(t, "bar", result[1].Name, "unexpected values: %+v", result)
 	})
 }
 
@@ -294,9 +264,7 @@ func TestGetReinvocationPolicy(t *testing.T) {
 		}
 		expected := admissionregistrationv1alpha1.NeverReinvocationPolicy
 		result := spec.GetReinvocationPolicy()
-		if result != expected {
-			t.Errorf("expected %s, got %s", expected, result)
-		}
+		assert.Equal(t, result, expected, "expected %s, got %s", expected, result)
 	})
 
 	t.Run("returns explicitly set ReinvocationPolicy", func(t *testing.T) {
@@ -305,9 +273,7 @@ func TestGetReinvocationPolicy(t *testing.T) {
 			ReinvocationPolicy: expected,
 		}
 		result := spec.GetReinvocationPolicy()
-		if result != expected {
-			t.Errorf("expected %s, got %s", expected, result)
-		}
+		assert.Equal(t, result, expected, "expected %s, got %s", expected, result)
 	})
 }
 
@@ -323,21 +289,16 @@ func TestMutatingPolicy_Getters(t *testing.T) {
 			Status: expected,
 		}
 		result := policy.GetStatus()
-		if result == nil {
-			t.Fatal("expected non-nil status")
-		}
-		if result.ConditionStatus.Ready != &val {
-			t.Errorf("expected Ready=true, got %+v", result.ConditionStatus.Ready)
-		}
+		assert.NotEqual(t, nil, result, "expected non-nil status")
+		assert.Equal(t, result.ConditionStatus.Ready, &val, "expected Ready-true, got %+v", result.ConditionStatus.Ready)
 	})
 
 	t.Run("GetKind returns 'MutatingPolicy'", func(t *testing.T) {
 		policy := MutatingPolicy{}
 		result := policy.GetKind()
 		expected := "MutatingPolicy"
-		if result != expected {
-			t.Errorf("expected kind %q, got %q", expected, result)
-		}
+
+		assert.Equal(t, expected, result, "expected kind %q, got %q", expected, result)
 	})
 
 	t.Run("GetSpec returns pointer to Spec field", func(t *testing.T) {
@@ -348,12 +309,9 @@ func TestMutatingPolicy_Getters(t *testing.T) {
 			Spec: expected,
 		}
 		result := policy.GetSpec()
-		if result == nil {
-			t.Fatal("expected non-nil spec")
-		}
-		if result.ReinvocationPolicy != "IfNeeded" {
-			t.Errorf("expected ReinvocationPolicy 'IfNeeded', got %s", result.ReinvocationPolicy)
-		}
+
+		assert.NotEqual(t, result, nil, "expected non-nil spec")
+		assert.Equal(t, "IfNeeded", result.ReinvocationPolicy, "expected ReinvocationPolicy 'IfNeeded', got %s", result.ReinvocationPolicy)
 	})
 
 	t.Run("GetConditionStatus returns pointer to embedded ConditionStatus", func(t *testing.T) {
@@ -364,11 +322,8 @@ func TestMutatingPolicy_Getters(t *testing.T) {
 			},
 		}
 		result := status.GetConditionStatus()
-		if result == nil {
-			t.Fatal("expected non-nil ConditionStatus")
-		}
-		if result.Ready != &val {
-			t.Errorf("expected Ready=true, got %v", result.Ready)
-		}
+
+		assert.NotEqual(t, result, nil, "expected non-nil ConditionStatus")
+		assert.Equal(t, result.Ready, &val, "expected Ready=true, got %v", result.Ready)
 	})
 }

--- a/api/policies.kyverno.io/v1alpha1/mutating_policy_test.go
+++ b/api/policies.kyverno.io/v1alpha1/mutating_policy_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -308,7 +309,7 @@ func TestMutatingPolicy_Getters(t *testing.T) {
 		result := policy.GetSpec()
 
 		assert.NotEqual(t, result, nil, "expected non-nil spec")
-		assert.Equal(t, "IfNeeded", result.ReinvocationPolicy, "expected ReinvocationPolicy 'IfNeeded', got %s", result.ReinvocationPolicy)
+		assert.Equal(t, v1.ReinvocationPolicyType("IfNeeded"), result.ReinvocationPolicy, "expected ReinvocationPolicy 'IfNeeded', got %s", result.ReinvocationPolicy)
 	})
 
 	t.Run("GetConditionStatus returns pointer to embedded ConditionStatus", func(t *testing.T) {

--- a/api/policies.kyverno.io/v1alpha1/mutating_policy_test.go
+++ b/api/policies.kyverno.io/v1alpha1/mutating_policy_test.go
@@ -1,0 +1,374 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetMatchConstraints(t *testing.T) {
+	t.Run("returns empty when MatchConstraints is nil", func(t *testing.T) {
+		mpol := MutatingPolicy{
+			Spec: MutatingPolicySpec{},
+		}
+
+		result := mpol.GetMatchConstraints()
+		if result.NamespaceSelector != nil || result.ObjectSelector != nil ||
+			len(result.ResourceRules) != 0 || len(result.ExcludeResourceRules) != 0 ||
+			result.MatchPolicy != nil {
+			t.Errorf("expected empty MatchResources, got %+v", result)
+		}
+	})
+
+	t.Run("returns copied MatchConstraints", func(t *testing.T) {
+		mpAlpha := admissionregistrationv1alpha1.Equivalent
+		mp := admissionregistrationv1.MatchPolicyType(mpAlpha)
+
+		mpol := MutatingPolicy{
+			Spec: MutatingPolicySpec{
+				MatchConstraints: &admissionregistrationv1alpha1.MatchResources{
+					MatchPolicy: &mpAlpha,
+				},
+			},
+		}
+
+		result := mpol.GetMatchConstraints()
+		if result.MatchPolicy == nil || *result.MatchPolicy != mp {
+			t.Errorf("expected MatchPolicy %s, got %v", mp, result.MatchPolicy)
+		}
+	})
+}
+
+func TestGetMatchConditions(t *testing.T) {
+	condition := admissionregistrationv1alpha1.MatchCondition{
+		Name: "test",
+	}
+	mpol := MutatingPolicy{
+		Spec: MutatingPolicySpec{
+			MatchConditions: []admissionregistrationv1alpha1.MatchCondition{condition},
+		},
+	}
+	result := mpol.GetMatchConditions()
+	if len(result) != 1 || result[0].Name != "test" {
+		t.Errorf("expected 1 match condition named 'test', got %+v", result)
+	}
+}
+
+func TestGenerateMutatingAdmissionPolicyEnabled(t *testing.T) {
+	t.Run("returns default false if nil", func(t *testing.T) {
+		spec := MutatingPolicySpec{}
+		if spec.GenerateMutatingAdmissionPolicyEnabled() {
+			t.Errorf("expected false when configuration is nil")
+		}
+	})
+
+	t.Run("returns false when MutatingAdmissionPolicy is nil", func(t *testing.T) {
+		spec := MutatingPolicySpec{
+			AutogenConfiguration: &MutatingPolicyAutogenConfiguration{
+				MutatingAdmissionPolicy: nil,
+			},
+		}
+
+		if spec.GenerateMutatingAdmissionPolicyEnabled() {
+			t.Errorf("expected false when MutatingAdmissionPolicy is nil")
+		}
+	})
+
+	t.Run("returns false when Enabled is nil", func(t *testing.T) {
+		spec := MutatingPolicySpec{
+			AutogenConfiguration: &MutatingPolicyAutogenConfiguration{
+				MutatingAdmissionPolicy: &MAPGenerationConfiguration{
+					Enabled: nil,
+				},
+			},
+		}
+
+		if spec.GenerateMutatingAdmissionPolicyEnabled() {
+			t.Errorf("expected false when Enabled is nil")
+		}
+	})
+
+	t.Run("returns true when explicitly enabled", func(t *testing.T) {
+		val := true
+		spec := MutatingPolicySpec{
+			AutogenConfiguration: &MutatingPolicyAutogenConfiguration{
+				MutatingAdmissionPolicy: &MAPGenerationConfiguration{
+					Enabled: &val,
+				},
+			},
+		}
+
+		if !spec.GenerateMutatingAdmissionPolicyEnabled() {
+			t.Errorf("expected true when enabled is true")
+		}
+	})
+}
+
+func TestGetFailurePolicy(t *testing.T) {
+	t.Run("returns default Fail if  nil", func(t *testing.T) {
+		mpol := MutatingPolicy{
+			Spec: MutatingPolicySpec{},
+		}
+
+		if mpol.GetFailurePolicy() != admissionregistrationv1.Fail {
+			t.Errorf("expected default failure policy 'Fail'")
+		}
+	})
+
+	t.Run("returns provided value", func(t *testing.T) {
+		val := admissionregistrationv1alpha1.Ignore
+		// Check it here once before push!!
+		val2 := admissionregistrationv1.FailurePolicyType(val)
+		mpol := MutatingPolicy{
+			Spec: MutatingPolicySpec{
+				FailurePolicy: (*admissionregistrationv1alpha1.FailurePolicyType)(&val2),
+			},
+		}
+
+		if mpol.GetFailurePolicy() != val2 {
+			t.Errorf("expected %s, got %s", val, mpol.GetFailurePolicy())
+		}
+	})
+}
+
+func TestAdmissionAndBackgroundEnabled(t *testing.T) {
+	t.Run("defaults to true if nil", func(t *testing.T) {
+		spec := MutatingPolicySpec{}
+		if !spec.AdmissionEnabled() {
+			t.Errorf("expected AdmissionEnabled to default to  true")
+		}
+		if !spec.BackgroundEnabled() {
+			t.Errorf("expected BackgroundEnabled to default to true")
+		}
+	})
+
+	t.Run("returns set values", func(t *testing.T) {
+		admit := false
+		bg := true
+
+		spec := MutatingPolicySpec{
+			EvaluationConfiguration: &MutatingPolicyEvaluationConfiguration{
+				EvaluationConfiguration: EvaluationConfiguration{
+					Admission: &AdmissionConfiguration{
+						Enabled: &admit,
+					},
+					Background: &BackgroundConfiguration{
+						Enabled: &bg,
+					},
+				},
+			},
+		}
+
+		if spec.AdmissionEnabled() {
+			t.Errorf("expected AdmissionEnabled to be false")
+		}
+		if !spec.BackgroundEnabled() {
+			t.Errorf("expected BackgroundEnabled to be true")
+		}
+	})
+}
+
+func TestGetAndSetMatchConstrainst(t *testing.T) {
+	t.Run("returns expected match constraints", func(t *testing.T) {
+		mp := admissionregistrationv1.Equivalent
+		nsSelector := &metav1.LabelSelector{
+			MatchLabels: map[string]string{"env": "prod"},
+		}
+
+		objSelector := &metav1.LabelSelector{
+			MatchLabels: map[string]string{"app": "nginx"},
+		}
+
+		input := admissionregistrationv1.MatchResources{
+			NamespaceSelector: nsSelector,
+			ObjectSelector:    objSelector,
+			MatchPolicy:       &mp,
+			ExcludeResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+				{
+					ResourceNames: []string{"foo"},
+					RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+						Operations: []admissionregistrationv1.OperationType{"CREATE"},
+						Rule:       admissionregistrationv1.Rule{},
+					},
+				},
+			},
+			ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+				{
+					ResourceNames: []string{"bar"},
+					RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+						Operations: []admissionregistrationv1.OperationType{"UPDATE"},
+						Rule:       admissionregistrationv1.Rule{},
+					},
+				},
+			},
+		}
+
+		var spec MutatingPolicySpec
+		spec.SetMatchConstraints(input)
+
+		result := spec.GetMatchConstraints()
+		if result.MatchPolicy == nil || *result.MatchPolicy != mp {
+			t.Errorf("expected MatchPolicy %s, got %+v", mp, result.MatchPolicy)
+		}
+	})
+
+	t.Run("returns nil if no match constraints are provided", func(t *testing.T) {
+		var spec MutatingPolicySpec
+		result := spec.GetMatchConstraints()
+		if result.MatchPolicy != nil {
+			t.Errorf("expected nil MatchPolicy")
+		}
+	})
+}
+
+func TestGetWebhookConfiguration(t *testing.T) {
+	t.Run("returns nil when WebhookConfiguration is nil", func(t *testing.T) {
+		policy := MutatingPolicy{
+			Spec: MutatingPolicySpec{
+				WebhookConfiguration: nil,
+			},
+		}
+		result := policy.GetWebhookConfiguration()
+		if result != nil {
+			t.Errorf("expected nil, got %+v", result)
+		}
+	})
+
+	t.Run("returns non-nil WebhookConfiguration", func(t *testing.T) {
+		cfg := &WebhookConfiguration{}
+		policy := MutatingPolicy{
+			Spec: MutatingPolicySpec{
+				WebhookConfiguration: cfg,
+			},
+		}
+		result := policy.GetWebhookConfiguration()
+		if result != cfg {
+			t.Errorf("expected %+v, got %+v", cfg, result)
+		}
+	})
+}
+
+func TestGetVariables(t *testing.T) {
+	t.Run("returns empty slice when Variables is nil", func(t *testing.T) {
+		policy := MutatingPolicy{
+			Spec: MutatingPolicySpec{
+				Variables: nil,
+			},
+		}
+		result := policy.GetVariables()
+		if len(result) != 0 {
+			t.Errorf("expected empty slice, got %v", result)
+		}
+	})
+
+	t.Run("returns copied slice of variables", func(t *testing.T) {
+		policy := MutatingPolicy{
+			Spec: MutatingPolicySpec{
+				Variables: []admissionregistrationv1alpha1.Variable{
+					{
+						Name: "foo",
+					},
+					{
+						Name: "bar",
+					},
+				},
+			},
+		}
+		result := policy.GetVariables()
+
+		if len(result) != 2 {
+			t.Fatalf("expected 2 variables, got %d", len(result))
+		}
+		if result[0].Name != "foo" || result[1].Name != "bar" {
+			t.Errorf("unexpected values: %+v", result)
+		}
+	})
+}
+
+func TestGetReinvocationPolicy(t *testing.T) {
+	t.Run("returns default when ReinvocationPolicy is empty", func(t *testing.T) {
+		spec := MutatingPolicySpec{
+			ReinvocationPolicy: "",
+		}
+		expected := admissionregistrationv1alpha1.NeverReinvocationPolicy
+		result := spec.GetReinvocationPolicy()
+		if result != expected {
+			t.Errorf("expected %s, got %s", expected, result)
+		}
+	})
+
+	t.Run("returns explicitly set ReinvocationPolicy", func(t *testing.T) {
+		expected := admissionregistrationv1alpha1.IfNeededReinvocationPolicy
+		spec := MutatingPolicySpec{
+			ReinvocationPolicy: expected,
+		}
+		result := spec.GetReinvocationPolicy()
+		if result != expected {
+			t.Errorf("expected %s, got %s", expected, result)
+		}
+	})
+}
+
+func TestMutatingPolicy_Getters(t *testing.T) {
+	t.Run("GetStatus returns pointer to Status field", func(t *testing.T) {
+		val := true
+		expected := MutatingPolicyStatus{
+			ConditionStatus: ConditionStatus{
+				Ready: &val,
+			},
+		}
+		policy := MutatingPolicy{
+			Status: expected,
+		}
+		result := policy.GetStatus()
+		if result == nil {
+			t.Fatal("expected non-nil status")
+		}
+		if result.ConditionStatus.Ready != &val {
+			t.Errorf("expected Ready=true, got %+v", result.ConditionStatus.Ready)
+		}
+	})
+
+	t.Run("GetKind returns 'MutatingPolicy'", func(t *testing.T) {
+		policy := MutatingPolicy{}
+		result := policy.GetKind()
+		expected := "MutatingPolicy"
+		if result != expected {
+			t.Errorf("expected kind %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("GetSpec returns pointer to Spec field", func(t *testing.T) {
+		expected := MutatingPolicySpec{
+			ReinvocationPolicy: "IfNeeded",
+		}
+		policy := MutatingPolicy{
+			Spec: expected,
+		}
+		result := policy.GetSpec()
+		if result == nil {
+			t.Fatal("expected non-nil spec")
+		}
+		if result.ReinvocationPolicy != "IfNeeded" {
+			t.Errorf("expected ReinvocationPolicy 'IfNeeded', got %s", result.ReinvocationPolicy)
+		}
+	})
+
+	t.Run("GetConditionStatus returns pointer to embedded ConditionStatus", func(t *testing.T) {
+		val := true
+		status := MutatingPolicyStatus{
+			ConditionStatus: ConditionStatus{
+				Ready: &val,
+			},
+		}
+		result := status.GetConditionStatus()
+		if result == nil {
+			t.Fatal("expected non-nil ConditionStatus")
+		}
+		if result.Ready != &val {
+			t.Errorf("expected Ready=true, got %v", result.Ready)
+		}
+	})
+}

--- a/api/policies.kyverno.io/v1alpha1/mutating_policy_test.go
+++ b/api/policies.kyverno.io/v1alpha1/mutating_policy_test.go
@@ -17,12 +17,11 @@ func TestGetMatchConstraints(t *testing.T) {
 
 		result := mpol.GetMatchConstraints()
 
-		//assert.Equal(t, nil, result.NamespaceSelector, "expected empty MatchResources, got %+v", result)
-		if result.NamespaceSelector != nil || result.ObjectSelector != nil ||
-			len(result.ResourceRules) != 0 || len(result.ExcludeResourceRules) != 0 ||
-			result.MatchPolicy != nil {
-			t.Errorf("expected empty MatchResources, got %+v", result)
-		}
+		assert.Nil(t, result.NamespaceSelector, "NamespaceSelector should be nil")
+		assert.Nil(t, result.ObjectSelector, "ObjectSelector should be nil")
+		assert.Nil(t, result.MatchPolicy, "MatchPolicy should be nil")
+		assert.Empty(t, result.ResourceRules, "ResourceRules should be empty")
+		assert.Empty(t, result.ExcludeResourceRules, "ExcludeResourceRules should be empty")
 	})
 
 	t.Run("returns copied MatchConstraints", func(t *testing.T) {
@@ -39,7 +38,7 @@ func TestGetMatchConstraints(t *testing.T) {
 
 		result := mpol.GetMatchConstraints()
 
-		assert.NotEqual(t, result.MatchPolicy, nil, "expected MatchPolicy %s, got %v", mp, result.MatchPolicy)
+		assert.NotNil(t, result.MatchPolicy, "expected MatchPolicy %s, got %v", mp, result.MatchPolicy)
 		assert.Equal(t, *result.MatchPolicy, mp, "expected MatchPolicy %s, got %v", mp, result.MatchPolicy)
 	})
 }
@@ -131,18 +130,16 @@ func TestAdmissionAndBackgroundEnabled(t *testing.T) {
 	})
 
 	t.Run("returns set values", func(t *testing.T) {
-		admit := false
-		bg := true
+		admission := false
+		existing := true
 
 		spec := MutatingPolicySpec{
 			EvaluationConfiguration: &MutatingPolicyEvaluationConfiguration{
-				EvaluationConfiguration: EvaluationConfiguration{
-					Admission: &AdmissionConfiguration{
-						Enabled: &admit,
-					},
-					Background: &BackgroundConfiguration{
-						Enabled: &bg,
-					},
+				Admission: &AdmissionConfiguration{
+					Enabled: &admission,
+				},
+				MutateExistingConfiguration: &MutateExistingConfiguration{
+					Enabled: &existing,
 				},
 			},
 		}
@@ -191,14 +188,14 @@ func TestGetAndSetMatchConstrainst(t *testing.T) {
 		spec.SetMatchConstraints(input)
 		result := spec.GetMatchConstraints()
 
-		assert.NotEqual(t, nil, result.MatchPolicy, "expected MatchPolicy %s, got %+v", mp, result.MatchPolicy)
+		assert.NotNil(t, result.MatchPolicy, "expected MatchPolicy %s, got %+v", mp, result.MatchPolicy)
 		assert.Equal(t, *result.MatchPolicy, mp, "expected MatchPolicy %s, got %+v", mp, result.MatchPolicy)
 	})
 
 	t.Run("returns nil if no match constraints are provided", func(t *testing.T) {
 		var spec MutatingPolicySpec
 		result := spec.GetMatchConstraints()
-		assert.Equal(t, nil, result.MatchPolicy, "expected nil MatchPolicy")
+		assert.Nil(t, result.MatchPolicy, "expected nil MatchPolicy")
 	})
 }
 
@@ -210,7 +207,7 @@ func TestGetWebhookConfiguration(t *testing.T) {
 			},
 		}
 		result := policy.GetWebhookConfiguration()
-		assert.Equal(t, nil, result, "expected nil, got %+v", result)
+		assert.Nil(t, result, "expected nil, got %+v", result)
 	})
 
 	t.Run("returns non-nil WebhookConfiguration", func(t *testing.T) {
@@ -233,7 +230,7 @@ func TestGetVariables(t *testing.T) {
 			},
 		}
 		result := policy.GetVariables()
-		assert.Equal(t, 0, len(result), "expected empty slice, got %v", result)
+		assert.Empty(t, result, "expected empty slice, got %v", result)
 	})
 
 	t.Run("returns copied slice of variables", func(t *testing.T) {
@@ -323,7 +320,7 @@ func TestMutatingPolicy_Getters(t *testing.T) {
 		}
 		result := status.GetConditionStatus()
 
-		assert.NotEqual(t, result, nil, "expected non-nil ConditionStatus")
+		assert.NotNil(t, result, "expected non-nil ConditionStatus")
 		assert.Equal(t, result.Ready, &val, "expected Ready=true, got %v", result.Ready)
 	})
 }

--- a/pkg/cel/policies/mpol/autogen/autogen_test.go
+++ b/pkg/cel/policies/mpol/autogen/autogen_test.go
@@ -431,6 +431,37 @@ func TestAutogenIntegration(t *testing.T) {
 		assert.Contains(t, convertedExpr, "jobTemplate.spec.template.spec.containers")
 		assert.NotContains(t, convertedExpr, "object.spec.containers")
 	})
+
+	t.Run("nil-policy", func(t *testing.T) {
+		result, err := Autogen(nil)
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("non-autogenable match constraints", func(t *testing.T) {
+		pol := &policiesv1alpha1.MutatingPolicy{
+			Spec: policiesv1alpha1.MutatingPolicySpec{
+				MatchConstraints: &admissionregistrationv1alpha1.MatchResources{
+					ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{
+						{
+							RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+								Rule: admissionregistrationv1.Rule{
+									APIGroups:   []string{"custom.group.io"},
+									APIVersions: []string{"v1"},
+									Resources:   []string{"customresources"},
+								},
+								Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Connect},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result, err := Autogen(pol)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
 }
 
 func TestMutationConversionEdgeCases(t *testing.T) {

--- a/pkg/cel/policies/mpol/compiler/compiler.go
+++ b/pkg/cel/policies/mpol/compiler/compiler.go
@@ -1,8 +1,6 @@
 package compiler
 
 import (
-	"fmt"
-
 	cel "github.com/google/cel-go/cel"
 	policiesv1alpha1 "github.com/kyverno/kyverno/api/policies.kyverno.io/v1alpha1"
 	compiler "github.com/kyverno/kyverno/pkg/cel/compiler"
@@ -92,8 +90,8 @@ func (c *compilerImpl) Compile(policy *policiesv1alpha1.MutatingPolicy, exceptio
 		for _, err := range evaluator.CompilationErrors() {
 			allErrs = append(allErrs, field.Invalid(
 				field.NewPath("spec").Child("matchConditions"),
-				nil,
-				fmt.Sprintf("failed to compile CEL expressions: %v", err),
+				matchConditions[0].Expression,
+				err.Error(),
 			))
 		}
 

--- a/pkg/cel/policies/mpol/compiler/compiler.go
+++ b/pkg/cel/policies/mpol/compiler/compiler.go
@@ -89,10 +89,10 @@ func (c *compilerImpl) Compile(policy *policiesv1alpha1.MutatingPolicy, exceptio
 		_, err := compiler.CompileMatchConditions(field.NewPath("spec").Child("matchConditions"), extendedEnvSet.StoredExpressionsEnv(), policy.Spec.GetMatchConditions()...)
 		if err != nil {
 			allErrs = append(allErrs, err...)
-		} else {
-			failurePolicy := policy.GetFailurePolicy()
-			matcher = matchconditions.NewMatcher(compositedCompiler.CompileCondition(matchExpressionAccessors, optionsVars, environment.StoredExpressions), &failurePolicy, "policy", "validate", policy.Name)
 		}
+		failurePolicy := policy.GetFailurePolicy()
+		matcher = matchconditions.NewMatcher(compositedCompiler.CompileCondition(matchExpressionAccessors, optionsVars, environment.StoredExpressions), &failurePolicy, "policy", "validate", policy.Name)
+
 	}
 
 	compiledExceptions := make([]compiler.Exception, 0, len(exceptions))

--- a/pkg/cel/policies/mpol/compiler/compiler.go
+++ b/pkg/cel/policies/mpol/compiler/compiler.go
@@ -85,7 +85,7 @@ func (c *compilerImpl) Compile(policy *policiesv1alpha1.MutatingPolicy, exceptio
 		for i := range matchConditions {
 			matchExpressionAccessors[i] = (*matchconditions.MatchCondition)(&matchConditions[i])
 		}
-		// TODO (): Check if you can do something with this unused returned variable.
+		// TODO (): Check if you can do something with this unused returned
 		_, err := compiler.CompileMatchConditions(field.NewPath("spec").Child("matchConditions"), extendedEnvSet.StoredExpressionsEnv(), policy.Spec.GetMatchConditions()...)
 		if err != nil {
 			allErrs = append(allErrs, err...)

--- a/pkg/cel/policies/mpol/compiler/compiler_test.go
+++ b/pkg/cel/policies/mpol/compiler/compiler_test.go
@@ -1,0 +1,136 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/kyverno/kyverno/api/policies.kyverno.io/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+)
+
+func TestCompile(t *testing.T) {
+	tests := []struct {
+		name    string
+		pol     *v1alpha1.MutatingPolicy
+		polex   []*v1alpha1.PolicyException
+		wantErr bool
+	}{
+		{
+			name: "valid applyConfiguration mutation",
+			pol: &v1alpha1.MutatingPolicy{
+				Spec: v1alpha1.MutatingPolicySpec{
+					Mutations: []admissionregistrationv1alpha1.Mutation{
+						{
+							PatchType: admissionregistrationv1alpha1.PatchTypeApplyConfiguration,
+							ApplyConfiguration: &admissionregistrationv1alpha1.ApplyConfiguration{
+								Expression: `Object{spec: Object.spec{containers: [Object.spec.containers{name: "nginx"}]}}`,
+							},
+						},
+					},
+				},
+			},
+			polex:   nil,
+			wantErr: false,
+		},
+		{
+			name: "invalid-expression in exception",
+			pol: &v1alpha1.MutatingPolicy{
+				Spec: v1alpha1.MutatingPolicySpec{},
+			},
+			polex: []*v1alpha1.PolicyException{
+				{
+					Spec: v1alpha1.PolicyExceptionSpec{
+						MatchConditions: []admissionv1.MatchCondition{
+							{Expression: "invalid && expression"},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid jsonpatch mutation",
+			pol: &v1alpha1.MutatingPolicy{
+				Spec: v1alpha1.MutatingPolicySpec{
+					Mutations: []admissionregistrationv1alpha1.Mutation{
+						{
+							PatchType: admissionregistrationv1alpha1.PatchTypeJSONPatch,
+							JSONPatch: &admissionregistrationv1alpha1.JSONPatch{
+								Expression: `[{"op": "add", "path": "/spec/restartPolicy", "value": "Always"}]`,
+							},
+						},
+					},
+				},
+			},
+			polex:   nil,
+			wantErr: false,
+		},
+		{
+			name: "policy with variables",
+			pol: &v1alpha1.MutatingPolicy{
+				Spec: v1alpha1.MutatingPolicySpec{
+					Variables: []admissionregistrationv1alpha1.Variable{
+						{
+							Name:       "foo",
+							Expression: "object.metadata.name",
+						},
+					},
+					Mutations: []admissionregistrationv1alpha1.Mutation{
+						{
+							PatchType: admissionregistrationv1alpha1.PatchTypeApplyConfiguration,
+							ApplyConfiguration: &admissionregistrationv1alpha1.ApplyConfiguration{
+								Expression: `Object{}`,
+							},
+						},
+					},
+				},
+			},
+			polex:   nil,
+			wantErr: false,
+		},
+		{
+			name: "valid matchCondition expression",
+			pol: &v1alpha1.MutatingPolicy{
+				Spec: v1alpha1.MutatingPolicySpec{
+					MatchConditions: []admissionregistrationv1alpha1.MatchCondition{
+						{
+							Name:       "ns-is-test",
+							Expression: `true`,
+						},
+					},
+				},
+			},
+			polex:   nil,
+			wantErr: false,
+		},
+		{
+			name: "invalid matchCondition expression",
+			pol: &v1alpha1.MutatingPolicy{
+				Spec: v1alpha1.MutatingPolicySpec{
+					MatchConditions: []admissionregistrationv1alpha1.MatchCondition{
+						{
+							Name:       "ns-is-test",
+							Expression: `this is not a cel`,
+						},
+					},
+				},
+			},
+			polex:   nil,
+			wantErr: true,
+		},
+	}
+
+	compiler := NewCompiler()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compiled, errs := compiler.Compile(tt.pol, tt.polex)
+			if tt.wantErr {
+				assert.NotEmpty(t, errs, "expected error but got none")
+			} else {
+				assert.Empty(t, errs, "expected no error but got some: %v", errs)
+				assert.NotNil(t, compiled, "expected compiled policy but got nil")
+			}
+		})
+	}
+}

--- a/pkg/cel/policies/mpol/compiler/policy_test.go
+++ b/pkg/cel/policies/mpol/compiler/policy_test.go
@@ -1,0 +1,434 @@
+package compiler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	cel2 "github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	cel1 "k8s.io/apiserver/pkg/admission/plugin/cel"
+	"k8s.io/apiserver/pkg/admission/plugin/policy/mutating"
+	"k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/authentication/user"
+
+	celtypes "github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+)
+
+// mock Context
+type fakeContext struct{}
+
+func (f *fakeContext) GenerateResources(string, []map[string]any) error        { return nil }
+func (f *fakeContext) GetGlobalReference(name, projection string) (any, error) { return name, nil }
+func (f *fakeContext) GetImageData(image string) (map[string]any, error) {
+	return map[string]any{"test": image}, nil
+}
+func (f *fakeContext) GetResource(apiVersion, resource, namespace, name string) (*unstructured.Unstructured, error) {
+	return &unstructured.Unstructured{}, nil
+}
+func (f *fakeContext) ListResources(apiVersion, resource, namespace string) (*unstructured.UnstructuredList, error) {
+	return &unstructured.UnstructuredList{}, nil
+}
+func (f *fakeContext) GetGeneratedResources() []*unstructured.Unstructured { return nil }
+func (f *fakeContext) PostResource(apiVersion, resource, namespace string, data map[string]any) (*unstructured.Unstructured, error) {
+	return &unstructured.Unstructured{}, nil
+}
+func (f *fakeContext) ClearGeneratedResources()                                                {}
+func (f *fakeContext) SetPolicyName(name string)                                               {}
+func (f *fakeContext) SetTriggerMetadata(name, namespace, uid, apiVersion, group, kind string) {}
+
+type mockProgram struct {
+	retVal ref.Val
+	err    error
+}
+
+func (m *mockProgram) ContextEval(_ context.Context, _ any) (ref.Val, *cel2.EvalDetails, error) {
+	return m.retVal, nil, m.err
+}
+
+func (m *mockProgram) Eval(any) (ref.Val, *cel2.EvalDetails, error) {
+	return m.retVal, nil, m.err
+}
+
+func TestVariables(t *testing.T) {
+	t.Run("return lazyMap successfully", func(t *testing.T) {
+		ctx := context.TODO()
+
+		env, _ := cel2.NewEnv()
+		adapter := env.CELTypeAdapter()
+		value := types.NewStringStringMap(adapter, map[string]string{"foo": "bar"})
+
+		declType := apiservercel.NewSimpleTypeWithMinSize(
+			"map<string, dyn>",
+			celtypes.NewMapType(celtypes.StringType, celtypes.DynType),
+			value,
+			0,
+		)
+
+		prog := &mockProgram{retVal: types.String("value")}
+		evaluator := &mutating.PolicyEvaluator{
+			CompositionEnv: &cel1.CompositionEnv{
+				MapType: declType,
+				CompiledVariables: map[string]cel1.CompilationResult{
+					"foo": {
+						Program: prog,
+					},
+				},
+			},
+		}
+
+		cctx := &compositionContext{
+			ctx:             ctx,
+			evaluator:       evaluator,
+			contextProvider: &fakeContext{},
+		}
+
+		act := &fakeActivation{
+			vars: map[string]interface{}{
+				"object":    map[string]interface{}{"name": "obj"},
+				"oldObject": map[string]interface{}{"name": "old"},
+			},
+		}
+
+		val := cctx.Variables(act)
+		assert.NotNil(t, val)
+
+		// Access via traits.Mapper interface
+		mapVal, ok := val.(traits.Mapper)
+		assert.True(t, ok, "expected val to implement traits.Mapper")
+
+		fooVal := mapVal.Get(types.String("foo"))
+		assert.Equal(t, types.String("value"), fooVal)
+	})
+
+	t.Run("returns error", func(t *testing.T) {
+		ctx := context.TODO()
+
+		env, _ := cel2.NewEnv()
+		adapter := env.CELTypeAdapter()
+		value := types.NewStringStringMap(adapter, map[string]string{})
+
+		declType := apiservercel.NewSimpleTypeWithMinSize(
+			"map<string, dyn>",
+			celtypes.NewMapType(celtypes.StringType, celtypes.DynType),
+			value,
+			0,
+		)
+
+		mockErr := fmt.Errorf("simulated error")
+		prog := &mockProgram{
+			retVal: nil,
+			err:    mockErr,
+		}
+
+		evaluator := &mutating.PolicyEvaluator{
+			CompositionEnv: &cel1.CompositionEnv{
+				MapType: declType,
+				CompiledVariables: map[string]cel1.CompilationResult{
+					"errorVar": {
+						Program: prog,
+					},
+				},
+			},
+		}
+
+		cctx := &compositionContext{
+			ctx:             ctx,
+			evaluator:       evaluator,
+			contextProvider: &fakeContext{},
+		}
+
+		act := &fakeActivation{
+			vars: map[string]interface{}{
+				"object":    map[string]interface{}{"name": "obj"},
+				"oldObject": map[string]interface{}{"name": "old"},
+			},
+		}
+
+		val := cctx.Variables(act)
+		assert.NotNil(t, val)
+
+		mapVal, ok := val.(traits.Mapper)
+		assert.True(t, ok, "expected val to implement traits.Mapper")
+
+		result := mapVal.Get(types.String("errorVar"))
+		assert.NotNil(t, result)
+
+		// Should be a wrapped error
+		_, isErr := result.(*types.Err)
+		assert.True(t, isErr, "expected result to be *types.Err, got %T", result)
+	})
+
+}
+
+type fakeActivation struct {
+	vars map[string]interface{}
+}
+
+func (f *fakeActivation) ResolveName(name string) (interface{}, bool) {
+	v, ok := f.vars[name]
+	return v, ok
+}
+
+// FakeContextWithDeadline provides context with deadline and cancel
+func FakeContextWithDeadline(duration time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), duration)
+}
+
+func TestGetAndResetCost(t *testing.T) {
+	cctx := &compositionContext{
+		accumulatedCost: 42,
+	}
+
+	// First call should return 42 and reset to 0
+	cost := cctx.GetAndResetCost()
+	assert.Equal(t, int64(42), cost)
+	assert.Equal(t, int64(0), cctx.accumulatedCost)
+
+	// Second call should return 0
+	cost = cctx.GetAndResetCost()
+	assert.Equal(t, int64(0), cost)
+}
+
+func TestDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cctx := &compositionContext{
+		ctx: ctx,
+	}
+
+	deadline, ok := cctx.Deadline()
+	assert.True(t, ok, "Expected Deadline() to return true")
+	assert.WithinDuration(t, time.Now().Add(2*time.Second), deadline, time.Second)
+}
+
+func TestDoneAndErr(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cctx := &compositionContext{ctx: ctx}
+
+	// Not cancelled yet
+	select {
+	case <-cctx.Done():
+		t.Fatal("context should not be done")
+	default:
+		// expected
+	}
+
+	// Cancel and test
+	cancel()
+
+	select {
+	case <-cctx.Done():
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("context should be done after cancel")
+	}
+
+	assert.Equal(t, context.Canceled, cctx.Err())
+}
+
+func TestValue(t *testing.T) {
+	key := "testKey"
+	value := "testValue"
+
+	ctx := context.WithValue(context.Background(), key, value)
+	cctx := &compositionContext{ctx: ctx}
+
+	result := cctx.Value(key)
+	assert.Equal(t, value, result)
+
+	// Key not present
+	result = cctx.Value("nonexistent")
+	assert.Nil(t, result)
+}
+
+type fakeMatcher struct {
+	err     error
+	matches bool
+}
+
+func (f *fakeMatcher) Match(ctx context.Context, versionedAttr *admission.VersionedAttributes, versionedParams runtime.Object, authz authorizer.Authorizer) matchconditions.MatchResult {
+	return matchconditions.MatchResult{
+		Matches: f.matches,
+		Error:   f.err,
+	}
+}
+
+type fakeTCM struct{}
+
+func (f *fakeTCM) GetTypeConverter(_ schema.GroupVersionKind) managedfields.TypeConverter {
+	return managedfields.NewDeducedTypeConverter()
+}
+
+type mockAttributes struct{}
+
+func (m *mockAttributes) GetName() string      { return "" }
+func (m *mockAttributes) GetNamespace() string { return "default" }
+func (m *mockAttributes) GetResource() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+}
+func (m *mockAttributes) GetSubresource() string { return "" }
+func (m *mockAttributes) GetOperation() admission.Operation {
+	return admission.Create
+}
+func (m *mockAttributes) GetOperationOptions() runtime.Object { return nil }
+func (m *mockAttributes) IsDryRun() bool                      { return false }
+func (m *mockAttributes) GetObject() runtime.Object {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx",
+			Namespace: "default",
+			Labels:    map[string]string{},
+		},
+	}
+}
+func (m *mockAttributes) GetOldObject() runtime.Object { return nil }
+func (m *mockAttributes) GetKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+}
+func (m *mockAttributes) GetUserInfo() user.Info                { return &user.DefaultInfo{} }
+func (m *mockAttributes) AddAnnotation(key, value string) error { return nil }
+func (m *mockAttributes) AddAnnotationWithLevel(key, value string, level auditinternal.Level) error {
+	return nil
+}
+func (m *mockAttributes) GetReinvocationContext() admission.ReinvocationContext { return nil }
+
+type fakePatcher struct {
+	retVal runtime.Object
+	err    error
+}
+
+func (f *fakePatcher) Patch(ctx context.Context, request patch.Request, runtimeCELCostBudget int64) (runtime.Object, error) {
+	return f.retVal, f.err
+}
+
+func TestEvaluate(t *testing.T) {
+	ctx := context.TODO()
+	t.Run("error in matcher", func(t *testing.T) {
+		p := &Policy{
+			evaluator: mutating.PolicyEvaluator{
+				Matcher: &fakeMatcher{
+					err: errors.New("match error"),
+				},
+			},
+		}
+
+		res := p.Evaluate(ctx, &mockAttributes{}, &corev1.Namespace{}, &fakeTCM{}, &fakeContext{})
+		assert.NotNil(t, res)
+		assert.EqualError(t, res.Error, "match error")
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		p := &Policy{
+			evaluator: mutating.PolicyEvaluator{
+				Matcher: &fakeMatcher{
+					matches: false,
+				},
+			},
+		}
+
+		resp := p.Evaluate(ctx, &mockAttributes{}, &corev1.Namespace{}, &fakeTCM{}, &fakeContext{})
+		assert.Nil(t, resp)
+	})
+
+	t.Run("patch error", func(t *testing.T) {
+		p := Policy{
+			evaluator: mutating.PolicyEvaluator{
+				Matcher: &fakeMatcher{
+					matches: true,
+				},
+				Mutators: []patch.Patcher{
+					&fakePatcher{
+						retVal: nil,
+						err:    errors.New("patch failed"),
+					},
+				},
+			},
+		}
+
+		res := p.Evaluate(ctx, &mockAttributes{}, &corev1.Namespace{}, &fakeTCM{}, &fakeContext{})
+		assert.NotNil(t, res)
+		assert.EqualError(t, res.Error, "patch failed")
+	})
+
+	t.Run("successful evaluation", func(t *testing.T) {
+		patchedObj := &unstructured.Unstructured{}
+		p := &Policy{
+			evaluator: mutating.PolicyEvaluator{
+				Matcher: &fakeMatcher{
+					matches: true,
+				},
+				Mutators: []patch.Patcher{
+					&fakePatcher{
+						retVal: patchedObj,
+						err:    nil,
+					},
+				},
+			},
+		}
+
+		res := p.Evaluate(ctx, &mockAttributes{}, &corev1.Namespace{}, &fakeTCM{}, &fakeContext{})
+		assert.NotNil(t, res)
+		assert.Equal(t, patchedObj, res.PatchedResource)
+	})
+}
+
+func TestMatchesConditions(t *testing.T) {
+	ctx := context.TODO()
+	t.Run("no matcher", func(t *testing.T) {
+		p := Policy{}
+		res := p.MatchesConditions(ctx, &mockAttributes{}, &corev1.Namespace{})
+		assert.False(t, res)
+	})
+
+	t.Run("with error", func(t *testing.T) {
+		p := Policy{
+			evaluator: mutating.PolicyEvaluator{
+				Matcher: &fakeMatcher{
+					err: errors.New("match error"),
+				},
+			},
+		}
+
+		res := p.MatchesConditions(ctx, &mockAttributes{}, &corev1.Namespace{})
+		assert.False(t, res)
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		p := Policy{
+			evaluator: mutating.PolicyEvaluator{
+				Matcher: &fakeMatcher{matches: false},
+			},
+		}
+		res := p.MatchesConditions(ctx, &mockAttributes{}, &corev1.Namespace{})
+		assert.False(t, res)
+	})
+
+	t.Run("match successfully", func(t *testing.T) {
+		p := Policy{
+			evaluator: mutating.PolicyEvaluator{
+				Matcher: &fakeMatcher{matches: true},
+			},
+		}
+		res := p.MatchesConditions(ctx, &mockAttributes{}, &corev1.Namespace{})
+		assert.True(t, res)
+	})
+}

--- a/pkg/cel/policies/mpol/engine/engine.go
+++ b/pkg/cel/policies/mpol/engine/engine.go
@@ -78,6 +78,7 @@ func (e *engineImpl) Evaluate(ctx context.Context, attr admission.Attributes, pr
 	}
 
 	response := EngineResponse{}
+
 	for _, mpol := range mpols {
 		if predicate != nil && predicate(mpol.Policy) {
 			r, patched := e.handlePolicy(ctx, mpol, attr, nil)

--- a/pkg/cel/policies/mpol/engine/engine_test.go
+++ b/pkg/cel/policies/mpol/engine/engine_test.go
@@ -1,0 +1,524 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	policiesv1alpha1 "github.com/kyverno/kyverno/api/policies.kyverno.io/v1alpha1"
+	"github.com/kyverno/kyverno/pkg/cel/engine"
+	"github.com/kyverno/kyverno/pkg/cel/matching"
+	"github.com/kyverno/kyverno/pkg/cel/policies/mpol/compiler"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"k8s.io/apiserver/pkg/admission"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/openapi"
+	"k8s.io/client-go/rest"
+)
+
+func TestGetPatches(t *testing.T) {
+	t.Run("returns expected patch and policies when resource is mutated", func(t *testing.T) {
+		original := &unstructured.Unstructured{}
+		original.Object = map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "test-cm",
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{
+				"key1": "value1",
+			},
+		}
+
+		patched := original.DeepCopy()
+		data := patched.Object["data"].(map[string]interface{})
+		data["key2"] = "value2"
+
+		policy := &policiesv1alpha1.MutatingPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sample-policy",
+				Namespace: "default",
+			},
+		}
+
+		ruleResponse := engineapi.NewRuleResponse(
+			"add-key2",
+			engineapi.Mutation,
+			"added key2 to configmap",
+			engineapi.RuleStatusPass,
+			map[string]string{"source": "mutation"},
+		)
+
+		er := EngineResponse{
+			Resource:        original,
+			PatchedResource: patched,
+			Policies: []MutatingPolicyResponse{
+				{
+					Policy: policy,
+					Rules:  []engineapi.RuleResponse{*ruleResponse},
+				},
+			},
+		}
+
+		patches := er.GetPatches()
+
+		assert.NotNil(t, patches)
+		assert.Len(t, patches, 1)
+		assert.Equal(t, "add", patches[0].Operation)
+		assert.Equal(t, "/data/key2", patches[0].Path)
+		assert.Equal(t, "value2", patches[0].Value)
+
+		assert.Len(t, er.Policies, 1)
+		assert.Equal(t, "sample-policy", er.Policies[0].Policy.Name)
+		assert.Len(t, er.Policies[0].Rules, 1)
+	})
+
+	t.Run("returns nil when jsonpatch.CreatePatch fails due to invalid input", func(t *testing.T) {
+		badOriginal := &unstructured.Unstructured{}
+		badOriginal.Object = map[string]interface{}{
+			"key": json.RawMessage("invalid"),
+		}
+		badPatched := &unstructured.Unstructured{}
+		badPatched.Object = map[string]interface{}{
+			"key": func() {},
+		}
+
+		er := EngineResponse{
+			Resource:        badOriginal,
+			PatchedResource: badPatched,
+		}
+
+		patches := er.GetPatches()
+		assert.Nil(t, patches)
+	})
+
+	t.Run("returns nil when Resource.MarshalJSON fails", func(t *testing.T) {
+		res := &unstructured.Unstructured{}
+		res.Object = map[string]interface{}{
+			"noncodeable": func() {},
+		}
+
+		patched := &unstructured.Unstructured{}
+
+		er := EngineResponse{
+			Resource:        res,
+			PatchedResource: patched,
+		}
+		patches := er.GetPatches()
+		assert.Nil(t, patches)
+	})
+
+	t.Run("returns nil when PatchedResource.MarshalJSON fails", func(t *testing.T) {
+		res := &unstructured.Unstructured{}
+
+		patched := &unstructured.Unstructured{}
+		patched.Object = map[string]interface{}{
+			"noncodeable": func() {},
+		}
+
+		er := EngineResponse{
+			Resource:        res,
+			PatchedResource: patched,
+		}
+
+		patches := er.GetPatches()
+
+		assert.Nil(t, patches)
+	})
+}
+
+// mock Context
+type fakeContext struct{}
+
+func (f *fakeContext) GenerateResources(string, []map[string]any) error        { return nil }
+func (f *fakeContext) GetGlobalReference(name, projection string) (any, error) { return name, nil }
+func (f *fakeContext) GetImageData(image string) (map[string]any, error) {
+	return map[string]any{"test": image}, nil
+}
+func (f *fakeContext) GetResource(apiVersion, resource, namespace, name string) (*unstructured.Unstructured, error) {
+	return &unstructured.Unstructured{}, nil
+}
+func (f *fakeContext) ListResources(apiVersion, resource, namespace string) (*unstructured.UnstructuredList, error) {
+	return &unstructured.UnstructuredList{}, nil
+}
+func (f *fakeContext) GetGeneratedResources() []*unstructured.Unstructured { return nil }
+func (f *fakeContext) PostResource(apiVersion, resource, namespace string, data map[string]any) (*unstructured.Unstructured, error) {
+	return &unstructured.Unstructured{}, nil
+}
+func (f *fakeContext) ClearGeneratedResources()                                                {}
+func (f *fakeContext) SetPolicyName(name string)                                               {}
+func (f *fakeContext) SetTriggerMetadata(name, namespace, uid, apiVersion, group, kind string) {}
+
+type mockAttributes struct{}
+
+func (m *mockAttributes) GetName() string      { return "" }
+func (m *mockAttributes) GetNamespace() string { return "default" }
+func (m *mockAttributes) GetResource() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+}
+func (m *mockAttributes) GetSubresource() string { return "" }
+func (m *mockAttributes) GetOperation() admission.Operation {
+	return admission.Create
+}
+func (m *mockAttributes) GetOperationOptions() runtime.Object { return nil }
+func (m *mockAttributes) IsDryRun() bool                      { return false }
+func (m *mockAttributes) GetObject() runtime.Object {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx",
+			Namespace: "default",
+			Labels:    map[string]string{},
+		},
+	}
+}
+func (m *mockAttributes) GetOldObject() runtime.Object { return nil }
+func (m *mockAttributes) GetKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+}
+func (m *mockAttributes) GetUserInfo() user.Info                { return &user.DefaultInfo{} }
+func (m *mockAttributes) AddAnnotation(key, value string) error { return nil }
+func (m *mockAttributes) AddAnnotationWithLevel(key, value string, level auditinternal.Level) error {
+	return nil
+}
+func (m *mockAttributes) GetReinvocationContext() admission.ReinvocationContext { return nil }
+
+var (
+	mapper = meta.NewDefaultRESTMapper([]schema.GroupVersion{
+		{
+			Group:   "apps",
+			Version: "v1",
+		},
+	})
+
+	ctx        = context.Background()
+	res        = unstructured.Unstructured{}
+	matcher    = matching.NewMatcher()
+	nsResolver = func(ns string) *corev1.Namespace {
+		return nil
+	}
+	predicate     = func(p policiesv1alpha1.MutatingPolicy) bool { return true }
+	typeConverter = compiler.NewStaticTypeConverterManager(openapi.NewClient(&rest.RESTClient{}))
+)
+
+type mockFailingProvider struct{}
+
+func (m *mockFailingProvider) Fetch(ctx context.Context, mutate bool) ([]Policy, error) {
+	return nil, errors.New("fetch failed")
+}
+func (m *mockFailingProvider) MatchesMutateExisting(context.Context, admission.Attributes, *corev1.Namespace) []string {
+	return nil
+}
+
+type fakeTypeConverter struct{}
+
+func (f *fakeTypeConverter) GetTypeConverter(gvk schema.GroupVersionKind) managedfields.TypeConverter {
+	return managedfields.NewDeducedTypeConverter()
+}
+
+func TestEvaluate(t *testing.T) {
+	t.Run("no policies and no exceptions returns empty response without error", func(t *testing.T) {
+		pols := []policiesv1alpha1.MutatingPolicy{}
+		polexs := []*policiesv1alpha1.PolicyException{}
+
+		provider, err := NewProvider(compiler.NewCompiler(), pols, polexs)
+
+		assert.NoError(t, err)
+		engine := NewEngine(provider, nsResolver, matcher, typeConverter, &fakeContext{})
+		resp, err := engine.Evaluate(ctx, &mockAttributes{}, predicate)
+
+		assert.NotNil(t, resp)
+		assert.NoError(t, err)
+	})
+
+	t.Run("provider fetch failure returns error and empty response", func(t *testing.T) {
+		engine := NewEngine(&mockFailingProvider{}, nsResolver, matcher, typeConverter, &fakeContext{})
+		resp, err := engine.Evaluate(ctx, &mockAttributes{}, predicate)
+
+		assert.Error(t, err)
+		assert.Equal(t, EngineResponse{}, resp)
+	})
+
+	t.Run("successful match and mutation with mutateExisting enabled", func(t *testing.T) {
+		mutateExisting := true
+		mpol := policiesv1alpha1.MutatingPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "add-label",
+			},
+			Spec: policiesv1alpha1.MutatingPolicySpec{
+				EvaluationConfiguration: &policiesv1alpha1.MutatingPolicyEvaluationConfiguration{
+					MutateExistingConfiguration: &policiesv1alpha1.MutateExistingConfiguration{
+						Enabled: &mutateExisting,
+					},
+				},
+				MatchConstraints: &admissionregistrationv1alpha1.MatchResources{
+					ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{
+						{
+							RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+								Operations: []admissionregistrationv1.OperationType{"CREATE"},
+								Rule: admissionregistrationv1.Rule{
+									APIGroups:   []string{"apps"},
+									APIVersions: []string{"v1"},
+									Resources:   []string{"deployments"},
+								},
+							},
+						},
+					},
+				},
+				Mutations: []admissionregistrationv1alpha1.Mutation{
+					{
+						PatchType: admissionregistrationv1alpha1.PatchTypeApplyConfiguration,
+						ApplyConfiguration: &admissionregistrationv1alpha1.ApplyConfiguration{
+							Expression: `Object{metadata: Object.metadata{labels: {"env": "test"}}}`,
+						},
+					},
+				},
+			},
+		}
+
+		pols := []policiesv1alpha1.MutatingPolicy{mpol}
+
+		provider, err := NewProvider(compiler.NewCompiler(), pols, nil)
+
+		assert.NoError(t, err)
+		engine := NewEngine(
+			provider,
+			func(ns string) *corev1.Namespace {
+				return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+			}, matcher, &fakeTypeConverter{}, &fakeContext{})
+		resp, err := engine.Evaluate(ctx, &mockAttributes{}, predicate)
+
+		assert.NotNil(t, resp)
+		assert.NoError(t, err)
+	})
+}
+
+func TestHandle(t *testing.T) {
+	tests := []struct {
+		name           string
+		policies       []policiesv1alpha1.MutatingPolicy
+		requestObject  string
+		kind           string
+		matchNamespace string
+		predicate      Predicate
+		expectPolicies int
+		expectPatched  bool
+		expectLabel    string
+	}{
+		{
+			name: "Successful match and mutation",
+			policies: []policiesv1alpha1.MutatingPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "add-label",
+					},
+					Spec: policiesv1alpha1.MutatingPolicySpec{
+						MatchConstraints: &admissionregistrationv1alpha1.MatchResources{
+							ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{
+								{
+									RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+										Operations: []admissionregistrationv1.OperationType{"CREATE"},
+										Rule: admissionregistrationv1.Rule{
+											APIGroups:   []string{"apps"},
+											APIVersions: []string{"v1"},
+											Resources:   []string{"deployments"},
+										},
+									},
+								},
+							},
+						},
+						Mutations: []admissionregistrationv1alpha1.Mutation{
+							{
+								PatchType: admissionregistrationv1alpha1.PatchTypeApplyConfiguration,
+								ApplyConfiguration: &admissionregistrationv1alpha1.ApplyConfiguration{
+									Expression: `Object{metadata: Object.metadata{labels: {"env": "test"}}}`,
+								},
+							},
+						},
+					},
+				},
+			},
+			requestObject:  `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"nginx","namespace":"default"}}`,
+			kind:           "Deployment",
+			matchNamespace: "default",
+			predicate:      func(p policiesv1alpha1.MutatingPolicy) bool { return true },
+			expectPolicies: 1,
+			expectPatched:  true,
+			expectLabel:    "test",
+		},
+		{
+			name: "predicate returns false",
+			policies: []policiesv1alpha1.MutatingPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "skip-policy"},
+					Spec:       policiesv1alpha1.MutatingPolicySpec{},
+				},
+			},
+			requestObject:  `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"nginx","namespace":"default"}}`,
+			kind:           "Deployment",
+			matchNamespace: "default",
+			predicate:      func(p policiesv1alpha1.MutatingPolicy) bool { return false },
+			expectPolicies: 0,
+			expectPatched:  false,
+		},
+		{
+			name: "no mutation specified",
+			policies: []policiesv1alpha1.MutatingPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "no-mutation"},
+					Spec: policiesv1alpha1.MutatingPolicySpec{
+						MatchConstraints: &admissionregistrationv1alpha1.MatchResources{
+							ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{
+								{
+									ResourceNames: []string{"Deployment"},
+								},
+							},
+						},
+					},
+				},
+			},
+			requestObject:  `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"nginx","namespace":"default"}}`,
+			kind:           "Deployment",
+			matchNamespace: "default",
+			predicate:      func(p policiesv1alpha1.MutatingPolicy) bool { return true },
+			expectPolicies: 1,
+			expectPatched:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Compile policies
+			provider, err := NewProvider(
+				compiler.NewCompiler(),
+				tc.policies,
+				nil,
+			)
+			assert.NoError(t, err)
+
+			// Create engine
+			eng := NewEngine(
+				provider,
+				func(ns string) *corev1.Namespace {
+					return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+				},
+				matching.NewMatcher(),
+				&fakeTypeConverter{},
+				&fakeContext{},
+			)
+
+			dryRun := true
+
+			// Prepare admission request
+			req := engine.EngineRequest{
+				Request: admissionv1.AdmissionRequest{
+					Kind:      metav1.GroupVersionKind{Group: "apps", Version: "v1", Kind: tc.kind},
+					Resource:  metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+					Namespace: tc.matchNamespace,
+					Name:      "nginx",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: []byte(tc.requestObject),
+					},
+					OldObject: runtime.RawExtension{
+						Raw: []byte(tc.requestObject),
+					},
+					DryRun: &dryRun,
+				},
+			}
+
+			// Run Handle
+			resp, err := eng.Handle(context.Background(), req, tc.predicate)
+			assert.NoError(t, err)
+
+			// Assertions
+			assert.Len(t, resp.Policies, tc.expectPolicies)
+
+			if tc.expectPatched {
+				assert.NotNil(t, resp.PatchedResource)
+
+				if tc.expectLabel != "" {
+					labels, found, _ := unstructured.NestedMap(resp.PatchedResource.Object, "metadata", "labels")
+					assert.True(t, found)
+					assert.Equal(t, tc.expectLabel, labels["env"])
+				}
+			} else {
+				assert.Nil(t, resp.PatchedResource)
+			}
+		})
+	}
+}
+
+func TestMatchedMutateExistingPolicies(t *testing.T) {
+	t.Run("valid object raw", func(t *testing.T) {
+		dryRun := true
+		req := engine.EngineRequest{
+			Request: admissionv1.AdmissionRequest{
+				Kind:      metav1.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+				Resource:  metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+				Namespace: "default",
+				Name:      "test-deploy",
+				Operation: admissionv1.Create,
+				Object: runtime.RawExtension{
+					Raw: []byte(`{"apiVersion":"apps/v1","kind":"Deployment"}`),
+				},
+				OldObject: runtime.RawExtension{
+					Raw: []byte(`{"apiVersion":"apps/v1","kind":"Deployment"}`),
+				},
+				DryRun: &dryRun,
+			},
+		}
+
+		pols := []policiesv1alpha1.MutatingPolicy{}
+		polexs := []*policiesv1alpha1.PolicyException{}
+
+		provider, _ := NewProvider(compiler.NewCompiler(), pols, polexs)
+
+		eng := NewEngine(provider, nsResolver, matcher, typeConverter, &fakeContext{})
+
+		resp := eng.MatchedMutateExistingPolicies(ctx, req)
+
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("invalid object raw", func(t *testing.T) {
+		dryRun := true
+		req := engine.EngineRequest{
+			Request: admissionv1.AdmissionRequest{
+				Kind:      metav1.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+				Resource:  metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+				Namespace: "default",
+				Name:      "test-deploy",
+				Operation: admissionv1.Create,
+				Object: runtime.RawExtension{
+					Raw: []byte(`{invalid-json}`),
+				},
+				DryRun: &dryRun,
+			},
+		}
+
+		pols := []policiesv1alpha1.MutatingPolicy{}
+		polexs := []*policiesv1alpha1.PolicyException{}
+		provider, _ := NewProvider(compiler.NewCompiler(), pols, polexs)
+
+		eng := NewEngine(provider, nsResolver, matcher, typeConverter, &fakeContext{})
+
+		resp := eng.MatchedMutateExistingPolicies(ctx, req)
+
+		assert.Nil(t, resp)
+	})
+}

--- a/pkg/cel/policies/mpol/engine/predicate_test.go
+++ b/pkg/cel/policies/mpol/engine/predicate_test.go
@@ -1,0 +1,46 @@
+package engine
+
+import (
+	"testing"
+
+	policiesv1alpha1 "github.com/kyverno/kyverno/api/policies.kyverno.io/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMatchNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		names    []string
+		policies []policiesv1alpha1.MutatingPolicy
+		expected []bool
+	}{
+		{
+			name:     "no names provided - always match",
+			names:    []string{},
+			policies: []policiesv1alpha1.MutatingPolicy{{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}, {ObjectMeta: metav1.ObjectMeta{Name: "any"}}},
+			expected: []bool{true, true},
+		},
+		{
+			name:     "single name match",
+			names:    []string{"p1"},
+			policies: []policiesv1alpha1.MutatingPolicy{{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}, {ObjectMeta: metav1.ObjectMeta{Name: "p2"}}},
+			expected: []bool{true, false},
+		},
+		{
+			name:     "multiple name match",
+			names:    []string{"p1", "p3"},
+			policies: []policiesv1alpha1.MutatingPolicy{{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}, {ObjectMeta: metav1.ObjectMeta{Name: "p2"}}, {ObjectMeta: metav1.ObjectMeta{Name: "p3"}}},
+			expected: []bool{true, false, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predicate := MatchNames(tt.names...)
+			for i, policy := range tt.policies {
+				assert.Equal(t, tt.expected[i], predicate(policy), "policy name: %s", policy.Name)
+			}
+		})
+	}
+}

--- a/pkg/cel/policies/mpol/engine/provider_test.go
+++ b/pkg/cel/policies/mpol/engine/provider_test.go
@@ -1,0 +1,157 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	policiesv1alpha1 "github.com/kyverno/kyverno/api/policies.kyverno.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	admissionv1 "k8s.io/apiserver/pkg/admission"
+
+	"github.com/kyverno/kyverno/pkg/cel/policies/mpol/compiler"
+	"github.com/stretchr/testify/assert"
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type fakeCompiledPolicy struct{}
+
+func (f *fakeCompiledPolicy) MatchesConditions(_ context.Context, _ admissionv1.Attributes, _ *corev1.Namespace) bool {
+	return true
+}
+
+func TestNewProvider(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		pols          []policiesv1alpha1.MutatingPolicy
+		exceptions    []*policiesv1alpha1.PolicyException
+		expectErr     bool
+		expectedCount int
+	}{
+		{
+			name: "valid policy without exception",
+			pols: []policiesv1alpha1.MutatingPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "policy1"},
+				},
+			},
+			expectErr:     false,
+			expectedCount: 1, // includes autogen clone
+		},
+		{
+			name: "policy with matching exception",
+			pols: []policiesv1alpha1.MutatingPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "policy-exc"},
+				},
+			},
+			exceptions: []*policiesv1alpha1.PolicyException{
+				{
+					Spec: policiesv1alpha1.PolicyExceptionSpec{
+						PolicyRefs: []policiesv1alpha1.PolicyRef{
+							{
+								Name: "policy-exc",
+								Kind: "MutatingPolicy",
+							},
+						},
+					},
+				},
+			},
+			expectErr:     false,
+			expectedCount: 1, // includes autogen clone
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prov, err := NewProvider(compiler.NewCompiler(), tt.pols, tt.exceptions)
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, prov)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, prov)
+
+				pols, err := prov.Fetch(context.Background(), false)
+				assert.NoError(t, err)
+				assert.GreaterOrEqual(t, len(pols), tt.expectedCount)
+			}
+		})
+	}
+}
+
+func TestStaticProviderFetch(t *testing.T) {
+	trueBool := true
+	falseBool := false
+
+	policy1 := policiesv1alpha1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "enabled-policy"},
+		Spec: policiesv1alpha1.MutatingPolicySpec{
+			EvaluationConfiguration: &policiesv1alpha1.MutatingPolicyEvaluationConfiguration{
+				MutateExistingConfiguration: &policiesv1alpha1.MutateExistingConfiguration{
+					Enabled: &trueBool,
+				},
+			},
+		},
+	}
+	policy2 := policiesv1alpha1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "disabled-policy"},
+		Spec: policiesv1alpha1.MutatingPolicySpec{
+			EvaluationConfiguration: &policiesv1alpha1.MutatingPolicyEvaluationConfiguration{
+				MutateExistingConfiguration: &policiesv1alpha1.MutateExistingConfiguration{
+					Enabled: &falseBool,
+				},
+			},
+		},
+	}
+
+	provider := &staticProvider{
+		policies: []Policy{
+			{Policy: policy1},
+			{Policy: policy2},
+		},
+	}
+
+	t.Run("fetch mutateExisting == true", func(t *testing.T) {
+		res, err := provider.Fetch(context.TODO(), true)
+		assert.NoError(t, err)
+		assert.Len(t, res, 1)
+		assert.Equal(t, "enabled-policy", res[0].Policy.GetName())
+	})
+
+	t.Run("fetch mutateExisting == false", func(t *testing.T) {
+		res, err := provider.Fetch(context.TODO(), false)
+		assert.NoError(t, err)
+		assert.Len(t, res, 1)
+		assert.Equal(t, "disabled-policy", res[0].Policy.GetName())
+	})
+}
+
+func TestStaticProviderMatchesMutateExisting(t *testing.T) {
+	trueBool := true
+
+	provider := &staticProvider{
+		policies: []Policy{
+			{
+				Policy: policiesv1alpha1.MutatingPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: "match"},
+					Spec: policiesv1alpha1.MutatingPolicySpec{
+						EvaluationConfiguration: &policiesv1alpha1.MutatingPolicyEvaluationConfiguration{
+							MutateExistingConfiguration: &policiesv1alpha1.MutateExistingConfiguration{
+								Enabled: &trueBool,
+							},
+						},
+						MatchConstraints: &admissionregistrationv1alpha1.MatchResources{}, // match everything
+					},
+				},
+				CompiledPolicy: &compiler.Policy{},
+			},
+		},
+	}
+
+	t.Run("match all", func(t *testing.T) {
+		names := provider.MatchesMutateExisting(context.Background(), &mockAttributes{}, &corev1.Namespace{})
+		assert.Equal(t, []string{"match"}, names)
+	})
+}

--- a/pkg/cel/policies/mpol/engine/reconciler_test.go
+++ b/pkg/cel/policies/mpol/engine/reconciler_test.go
@@ -1,0 +1,269 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	policiesv1alpha1 "github.com/kyverno/kyverno/api/policies.kyverno.io/v1alpha1"
+	"github.com/kyverno/kyverno/pkg/cel/policies/mpol/compiler"
+	"github.com/stretchr/testify/assert"
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// Mocks
+
+type fakeClient struct {
+	client.Client
+	policy *policiesv1alpha1.MutatingPolicy
+	err    error
+}
+
+func (f *fakeClient) Get(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	if f.err != nil {
+		return f.err
+	}
+	*obj.(*policiesv1alpha1.MutatingPolicy) = *f.policy
+	return nil
+}
+
+func TestReconcile(t *testing.T) {
+	ctx := context.Background()
+	name := types.NamespacedName{Namespace: "default", Name: "test-policy"}
+
+	//t.Run("policy not found", func(t *testing.T) {
+	//	rec := newReconciler(
+	//		&fakeClient{err: errors.ErrUnsupported(policiesv1alpha1.Resource("mutatingpolicies"), "test-policy")},
+	//		compiler.NewCompiler(), nil, false,
+	///	)
+	//	res, err := rec.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+	//	assert.NoError(t, err)
+	//	assert.Equal(t, reconcile.Result{}, res)
+	//})
+
+	t.Run("successful reconciliation", func(t *testing.T) {
+		mp := &policiesv1alpha1.MutatingPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},
+		}
+		rec := newReconciler(
+			&fakeClient{policy: mp},
+			compiler.NewCompiler(),
+			nil, false,
+		)
+		res, err := rec.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+		assert.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+	})
+}
+
+func TestFetch(t *testing.T) {
+	trueBool := true
+	falseBool := false
+
+	tests := []struct {
+		name           string
+		mutateExisting bool
+		policyMap      map[string][]Policy
+		expectedNames  []string
+	}{
+		{
+			name:           "no policies",
+			mutateExisting: false,
+			policyMap:      map[string][]Policy{},
+			expectedNames:  []string{},
+		},
+		{
+			name:           "mutateExisting = false, return all policies",
+			mutateExisting: false,
+			policyMap: map[string][]Policy{
+				"ns1/policy1": {
+					{
+						Policy: policiesv1alpha1.MutatingPolicy{
+							ObjectMeta: metav1.ObjectMeta{Name: "policy1"},
+						},
+					},
+					{
+						Policy: policiesv1alpha1.MutatingPolicy{
+							ObjectMeta: metav1.ObjectMeta{Name: "policy2"},
+						},
+					},
+				},
+			},
+			expectedNames: []string{"policy1", "policy2"},
+		},
+		{
+			name:           "mutateExisting = true, only enabled ones returned",
+			mutateExisting: true,
+			policyMap: map[string][]Policy{
+				"ns1/policy1": {
+					{
+						Policy: policiesv1alpha1.MutatingPolicy{
+							ObjectMeta: metav1.ObjectMeta{Name: "policy1"},
+							Spec: policiesv1alpha1.MutatingPolicySpec{
+								EvaluationConfiguration: &policiesv1alpha1.MutatingPolicyEvaluationConfiguration{
+									MutateExistingConfiguration: &policiesv1alpha1.MutateExistingConfiguration{
+										Enabled: &trueBool,
+									},
+								},
+							},
+						},
+					},
+					{
+						Policy: policiesv1alpha1.MutatingPolicy{
+							ObjectMeta: metav1.ObjectMeta{Name: "policy2"},
+							Spec: policiesv1alpha1.MutatingPolicySpec{
+								EvaluationConfiguration: &policiesv1alpha1.MutatingPolicyEvaluationConfiguration{
+									MutateExistingConfiguration: &policiesv1alpha1.MutateExistingConfiguration{
+										Enabled: &falseBool,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNames: []string{"policy1"},
+		},
+		{
+			name:           "mutateExisting = true, all disabled",
+			mutateExisting: true,
+			policyMap: map[string][]Policy{
+				"ns1/policy2": {
+					{
+						Policy: policiesv1alpha1.MutatingPolicy{
+							ObjectMeta: metav1.ObjectMeta{Name: "policy2"},
+							Spec: policiesv1alpha1.MutatingPolicySpec{
+								EvaluationConfiguration: &policiesv1alpha1.MutatingPolicyEvaluationConfiguration{
+									MutateExistingConfiguration: &policiesv1alpha1.MutateExistingConfiguration{
+										Enabled: &falseBool,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNames: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &reconciler{
+				policies: tt.policyMap,
+				lock:     &sync.RWMutex{},
+			}
+
+			got, err := r.Fetch(context.Background(), tt.mutateExisting)
+
+			assert.NoError(t, err)
+
+			var gotNames []string
+			for _, p := range got {
+				gotNames = append(gotNames, p.Policy.GetName())
+			}
+			assert.ElementsMatch(t, tt.expectedNames, gotNames)
+		})
+	}
+}
+
+type fakeFetchWithError struct {
+	*reconciler
+}
+
+func (f *fakeFetchWithError) Fetch(ctx context.Context, mutateExisting bool) ([]Policy, error) {
+	return nil, fmt.Errorf("simulated fetch error")
+}
+
+func TestMatchesMutateExisting(t *testing.T) {
+	trueBool := true
+
+	tests := []struct {
+		name          string
+		policies      map[string][]Policy
+		expectedNames []string
+	}{
+		{
+			name: "single policy matches with conditions true",
+			policies: map[string][]Policy{
+				"test/policy1": {
+					{
+						Policy: policiesv1alpha1.MutatingPolicy{
+							ObjectMeta: metav1.ObjectMeta{Name: "policy1"},
+							Spec: policiesv1alpha1.MutatingPolicySpec{
+								EvaluationConfiguration: &policiesv1alpha1.MutatingPolicyEvaluationConfiguration{
+									MutateExistingConfiguration: &policiesv1alpha1.MutateExistingConfiguration{
+										Enabled: &trueBool,
+									},
+								},
+								MatchConstraints: &admissionregistrationv1alpha1.MatchResources{}, // empty constraints should match
+								MatchConditions:  nil,                                             // no conditions
+							},
+						},
+						CompiledPolicy: &compiler.Policy{},
+					},
+				},
+			},
+			expectedNames: []string{"policy1"},
+		},
+		{
+			name: "policy with conditions that fail",
+			policies: map[string][]Policy{
+				"test/policy2": {
+					{
+						Policy: policiesv1alpha1.MutatingPolicy{
+							ObjectMeta: metav1.ObjectMeta{Name: "policy2"},
+							Spec: policiesv1alpha1.MutatingPolicySpec{
+								EvaluationConfiguration: &policiesv1alpha1.MutatingPolicyEvaluationConfiguration{
+									MutateExistingConfiguration: &policiesv1alpha1.MutateExistingConfiguration{
+										Enabled: &trueBool,
+									},
+								},
+								MatchConstraints: &admissionregistrationv1alpha1.MatchResources{},
+								MatchConditions: []admissionregistrationv1alpha1.MatchCondition{
+									{
+										Expression: `request.object.metadata.labels.env == "dev"`,
+									},
+								},
+							},
+						},
+						CompiledPolicy: &compiler.Policy{},
+					},
+				},
+			},
+			expectedNames: []string{},
+		},
+		{
+			name: "no mutateExisting enabled, nothing matched",
+			policies: map[string][]Policy{
+				"test/policy3": {
+					{
+						Policy: policiesv1alpha1.MutatingPolicy{
+							ObjectMeta: metav1.ObjectMeta{Name: "policy3"},
+						},
+					},
+				},
+			},
+			expectedNames: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &reconciler{
+				lock:     &sync.RWMutex{},
+				policies: tt.policies,
+			}
+			attrs := &mockAttributes{}
+			namespace := &corev1.Namespace{}
+			got := r.MatchesMutateExisting(context.TODO(), attrs, namespace)
+			assert.ElementsMatch(t, tt.expectedNames, got)
+		})
+	}
+}

--- a/pkg/cel/policies/mpol/validate_test.go
+++ b/pkg/cel/policies/mpol/validate_test.go
@@ -1,0 +1,165 @@
+package mpol
+
+import (
+	"testing"
+
+	"github.com/kyverno/kyverno/api/policies.kyverno.io/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/admissionregistration/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		pol     *v1alpha1.MutatingPolicy
+		wantErr bool
+	}{
+		{
+			name: "valid policy",
+			pol: &v1alpha1.MutatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "valid-mpol",
+				},
+				Spec: v1alpha1.MutatingPolicySpec{
+					MatchConstraints: &v1.MatchResources{
+						ResourceRules: []v1.NamedRuleWithOperations{
+							{
+								RuleWithOperations: v1.RuleWithOperations{
+									Rule: v1.Rule{
+										APIGroups: []string{"apps"},
+										Resources: []string{"deployments"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing matchConstraints",
+			pol: &v1alpha1.MutatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "no-constraints",
+				},
+				Spec: v1alpha1.MutatingPolicySpec{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty resourceRules",
+			pol: &v1alpha1.MutatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "empty-rules",
+				},
+				Spec: v1alpha1.MutatingPolicySpec{
+					MatchConstraints: &v1.MatchResources{
+						ResourceRules: []v1.NamedRuleWithOperations{ /* empty config */ },
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "only ExcludeResourceRules present (should fail)",
+			pol: &v1alpha1.MutatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "exclude-only",
+				},
+				Spec: v1alpha1.MutatingPolicySpec{
+					MatchConstraints: &v1.MatchResources{
+						ExcludeResourceRules: []v1.NamedRuleWithOperations{
+							{
+								RuleWithOperations: v1.RuleWithOperations{
+									Rule: v1.Rule{
+										APIGroups: []string{"batch"},
+										Resources: []string{"jobs"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid policy",
+			pol: &v1alpha1.MutatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "invalid-policy",
+				},
+				Spec: v1alpha1.MutatingPolicySpec{
+					MatchConstraints: &v1.MatchResources{
+						ResourceRules: []v1.NamedRuleWithOperations{
+							{
+								RuleWithOperations: v1.RuleWithOperations{
+									Rule: v1.Rule{
+										APIGroups: []string{"apps"},
+										Resources: []string{"deployments"},
+									},
+								},
+							},
+						},
+					},
+					MatchConditions: []v1.MatchCondition{
+						{
+							Name:       "invalid-cel",
+							Expression: "this is not a CEL expression",
+						},
+					},
+					FailurePolicy: func() *v1.FailurePolicyType {
+						fp := v1.Fail
+						return &fp
+					}(),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid policy with match conditions",
+			pol: &v1alpha1.MutatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "valid-mpol-with-cel",
+				},
+				Spec: v1alpha1.MutatingPolicySpec{
+					MatchConstraints: &v1.MatchResources{
+						ResourceRules: []v1.NamedRuleWithOperations{
+							{
+								RuleWithOperations: v1.RuleWithOperations{
+									Rule: v1.Rule{
+										APIGroups: []string{""},
+										Resources: []string{"pods"},
+									},
+								},
+							},
+						},
+					},
+					MatchConditions: []v1.MatchCondition{
+						{
+							Name:       "isProd",
+							Expression: `object.metadata.labels["env"] == "prod"`,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings, err := Validate(tt.pol)
+
+			if tt.wantErr {
+				assert.Error(t, err, "expected error but got nil for test: %s", tt.name)
+				assert.NotEmpty(t, warnings, "expected warnings but got none")
+			} else {
+				assert.NoError(t, err, "expected no error but got %v", err)
+				assert.Empty(t, warnings, "expected no warnings but got %#v", warnings)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Explanation

Add unit test for mpol: 
1. api/mutating_policy.go
2. autogen.go
3. compiler.go 
4. policy.go
5. engine.go
6. predicate.go
7. provider.go
8. reconciler.go
9. validate.go


Resolves a bug : 
During compilation it was not checking if any CEL compilation error thrown for pols. It was checking for just PolicyExceptions.

## Related issue

#13011 

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
