### PR TITLE
fix: replace invalid Prometheus label names http.method and http.url

### DIFF
--- a/pkg/webhooks/handlers/metrics.go
+++ b/pkg/webhooks/handlers/metrics.go
@@ -86,8 +86,8 @@ func (inner HttpHandler) withMetrics(logger logr.Logger, attrs ...attribute.KeyV
 		startTime := time.Now()
 		attributes := []attribute.KeyValue{
 			// semconv.HTTPHostKey.String(request.Host),
-			semconv.HTTPMethodKey.String(request.Method),
-			semconv.HTTPURLKey.String(request.RequestURI),
+			attribute.String("method", request.Method),
+    		attribute.String("url", request.RequestURI),
 		}
 		attributes = append(attributes, attrs...)
 		if requestsMetric != nil {


### PR DESCRIPTION
## Summary

This PR fixes invalid Prometheus label names used in the metric `kyverno_http_requests_duration_seconds`. 
The original label names `http.method` and `http.url` are not compatible with the Prometheus remote_write API 
due to the use of dots, which violates the expected label regex.

## Changes

- Replaced `http.method` → `method`
- Replaced `http.url` → `url`

Fixes: [https://github.com/kyverno/kyverno/issues/13115]