### PR TITLE
init apiserver client in kyverno pre

### DIFF
--- a/cmd/kyverno-init/main.go
+++ b/cmd/kyverno-init/main.go
@@ -38,6 +38,7 @@ func main() {
 		internal.WithDynamicClient(),
 		internal.WithKyvernoDynamicClient(),
 		internal.WithOpenreports(),
+		internal.WithApiServerClient(),
 	)
 	// parse flags
 	internal.ParseFlags(appConfig)


### PR DESCRIPTION
API server client is needed for checking if CRDs (wgpolicy) are installed in kyvernopre before deleting them