### PR TITLE
Remove external service

### DIFF
--- a/pkg/cel/policies/dpol/engine/fetch.go
+++ b/pkg/cel/policies/dpol/engine/fetch.go
@@ -32,6 +32,9 @@ func NewFetchProvider(
 
 func (r *fetchProvider) Get(ctx context.Context, name string) (Policy, error) {
 	policy, err := r.dpolLister.Get(name)
+	if err != nil {
+		return Policy{}, err
+	}
 	// get exceptions that match the policy
 	var exceptions []*policiesv1alpha1.PolicyException
 	if r.polexEnabled {

--- a/test/conformance/chainsaw/deleting-policies/cel-lib/http-lib/README.md
+++ b/test/conformance/chainsaw/deleting-policies/cel-lib/http-lib/README.md
@@ -11,4 +11,5 @@ Delete a `Pod` only if an HTTP GET request to a remote URL returns a matching va
 Specifically, the policy deletes the pod **only if**:
 
 ```cel
-http.Get("https://httpbin.org/json").slideshow.author == "Yours Truly"
+http.Get("http://test-api-service.default.svc.cluster.local:80").metadata.labels.app == "test"
+```

--- a/test/conformance/chainsaw/deleting-policies/cel-lib/http-lib/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/deleting-policies/cel-lib/http-lib/chainsaw-test.yaml
@@ -8,7 +8,10 @@ spec:
       try: 
         - apply:
             file: rbac.yaml
-
+        - apply:
+            file: http-pod.yaml
+        - apply:
+            file: service.yaml
     - name: step-02
       try:
         - apply:

--- a/test/conformance/chainsaw/deleting-policies/cel-lib/http-lib/http-pod.yaml
+++ b/test/conformance/chainsaw/deleting-policies/cel-lib/http-lib/http-pod.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+  name: test-api
+  labels:
+    app: test-api
+spec:
+  containers:
+  - name: test-api
+    image: python:3.9-slim
+    command: ["sh", "-c"]
+    args:
+    - |
+      pip install flask &&
+      echo 'from flask import Flask, jsonify
+      app = Flask(__name__)
+      @app.route("/")
+      def json_api():
+          return jsonify({"metadata": {"labels": {"app": "test"}}})
+      if __name__ == "__main__":
+          app.run(host="0.0.0.0", port=5000)' > app.py &&
+      python app.py
+    ports:
+    - containerPort: 5000
+    readinessProbe:
+      httpGet:
+        path: /
+        port: 5000
+      initialDelaySeconds: 15
+      periodSeconds: 5
+      timeoutSeconds: 3
+      successThreshold: 1
+      failureThreshold: 3
+    livenessProbe:
+      httpGet:
+        path: /
+        port: 5000
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3 

--- a/test/conformance/chainsaw/deleting-policies/cel-lib/http-lib/policy.yaml
+++ b/test/conformance/chainsaw/deleting-policies/cel-lib/http-lib/policy.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   conditions:
   - name: http-200-check
-    expression: http.Get("https://httpbin.org/json").slideshow.author == "Yours Truly"
+    expression: >
+      http.Get("http://test-api-service.default.svc.cluster.local:80").metadata.labels.app == "test"
   matchConstraints:
     resourceRules:
     - apiGroups: [""]

--- a/test/conformance/chainsaw/deleting-policies/cel-lib/http-lib/service.yaml
+++ b/test/conformance/chainsaw/deleting-policies/cel-lib/http-lib/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: default
+  name: test-api-service
+spec:
+  selector:
+    app: test-api
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 5000 


### PR DESCRIPTION
## Explanation

Remove external service call and fix error case in dpol fetcher

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
