### PR TITLE
fix(helm-hook): fix job for cleaning reports after Helm upgrade with Kyverno >=1.11.0 new naming convention

### DIFF
--- a/charts/kyverno/templates/hooks/post-upgrade-clean-reports.yaml
+++ b/charts/kyverno/templates/hooks/post-upgrade-clean-reports.yaml
@@ -46,21 +46,21 @@ spec:
 
               for ns in ${NAMESPACES[@]};
               do
-                COUNT=$(kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true | awk '/pol/{print $1}' | wc -l)
+                COUNT=$(kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true | awk '{print $1}' | wc -l)
 
                 if [ $COUNT -gt 0 ]; then
                   echo "deleting $COUNT policyreports in namespace $ns"
-                  kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true | awk '/pol/{print $1}' | xargs kubectl delete -n $ns policyreports.wgpolicyk8s.io
+                  kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true | awk '{print $1}' | xargs kubectl delete -n $ns policyreports.wgpolicyk8s.io
                 else
                   echo "no policyreports in namespace $ns"
                 fi
               done
 
-              COUNT=$(kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true | awk '/pol/{print $1}' | wc -l)
+              COUNT=$(kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true | awk '{print $1}' | wc -l)
 
               if [ $COUNT -gt 0 ]; then
                 echo "deleting $COUNT clusterpolicyreports"
-                kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true | awk '/pol/{print $1}' | xargs kubectl delete clusterpolicyreports.wgpolicyk8s.io
+                kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true | awk '{print $1}' | xargs kubectl delete clusterpolicyreports.wgpolicyk8s.io
               else
                 echo "no clusterpolicyreports"
               fi

--- a/test/conformance/chainsaw/hooks/post-upgrade/clean-reports/README.md
+++ b/test/conformance/chainsaw/hooks/post-upgrade/clean-reports/README.md
@@ -1,0 +1,9 @@
+## Description
+
+This test creates a policy with two rules.
+The rules are respectively namespace and cluster scoped.
+The test checks if, after a helm upgrade of kyverno, the post-hook clean-reports job runs correctly and deletes all the ClusterPolicyReports/PolicyReports objects.
+
+## Related issue
+
+No issue was found.

--- a/test/conformance/chainsaw/hooks/post-upgrade/clean-reports/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/hooks/post-upgrade/clean-reports/chainsaw-test.yaml
@@ -1,0 +1,109 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: concurrent-policy-execution
+spec:
+  steps:
+  - name: install-kyverno
+    try:
+      - script:
+          content: |
+            #!/bin/bash
+            set -eu
+            helm repo add kyverno https://kyverno.github.io/kyverno
+            helm repo add openreports https://openreports.github.io/reports-api
+            helm repo update
+            helm dependency build ../../../../../../charts/kyverno
+            helm install kyverno ../../../../../../charts/kyverno --namespace kyverno --create-namespace --wait
+  - name: create policy
+    use:
+      template: ../../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait policy ready
+    use:
+      template: ../../../_step-templates/cluster-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: validate
+  - name: create test-namespace
+    try:
+    - apply:
+        file: ns.yaml
+  - name: create-test-pods
+    try:
+      - apply:
+          file: pod.yaml
+  - name: create crd
+    try:
+      - apply:
+          file: crd.yaml
+  - name: wait-for-policy-reports
+    try:
+      - sleep:
+          duration: 1m
+  - name: check-policy-reports
+    try:
+      - script:
+          content: |
+            kubectl get polr -n test -o json | jq '{count: (.items | length | tostring) }'
+          outputs:
+            - name: result
+              value: (json_parse($stdout))
+      - assert:
+          resource: 
+            ($result):
+              (count != '0'): true
+  - name: check-cluster-policy-reports
+    try:
+      - script:
+          content: |
+            kubectl get cpolr -o json | jq '{count: (.items | length | tostring) }'
+          outputs:
+          - name: result
+            value: (json_parse($stdout))
+      - assert:
+          resource: 
+            ($result):
+              (count != '0'): true
+  - name: update-kyverno
+    try:
+      - script:
+          content: |
+            #!/bin/bash
+            set -eu
+            helm -n kyverno upgrade kyverno ../../../../../../charts/kyverno --wait
+  - name: check-policy-reports
+    try:
+      - script:
+          content: |
+            kubectl get polr -n test -o json | jq '{count: (.items | length | tostring) }'
+          outputs:
+            - name: result
+              value: (json_parse($stdout))
+      - assert:
+          resource: 
+            ($result):
+              (count == '0'): true
+  - name: check-cluster-policy-reports
+    try:
+      - script:
+          content: |
+            kubectl get cpolr -o json | jq '{count: (.items | length | tostring) }'
+          outputs:
+          - name: result
+            value: (json_parse($stdout))
+      - assert:
+          resource: 
+            ($result):
+              (count == '0'): true
+  - name: uninstall-kyverno
+    try:
+      - script:
+          content: |
+            #!/bin/bash
+            set -eu
+            helm uninstall kyverno -n kyverno

--- a/test/conformance/chainsaw/hooks/post-upgrade/clean-reports/crd.yaml
+++ b/test/conformance/chainsaw/hooks/post-upgrade/clean-reports/crd.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.example.com
+spec:
+  group: example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                message:
+                  type: string
+  scope: Cluster
+  names:
+    plural: foos
+    singular: foo
+    kind: Foo
+    shortNames:
+      - f

--- a/test/conformance/chainsaw/hooks/post-upgrade/clean-reports/ns.yaml
+++ b/test/conformance/chainsaw/hooks/post-upgrade/clean-reports/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test

--- a/test/conformance/chainsaw/hooks/post-upgrade/clean-reports/pod.yaml
+++ b/test/conformance/chainsaw/hooks/post-upgrade/clean-reports/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: test
+spec:
+  containers:
+  - name: test
+    image: busybox

--- a/test/conformance/chainsaw/hooks/post-upgrade/clean-reports/policy.yaml
+++ b/test/conformance/chainsaw/hooks/post-upgrade/clean-reports/policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate
+spec:
+  admission: true
+  rules:
+  - name: validate-namespace-scoped
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      failureAction: Audit
+      deny: {}
+  - name: validate-cluster-scoped
+    match:
+      any:
+      - resources:
+          kinds:
+          - CustomResourceDefinition
+    validate:
+      failureAction: Audit
+      deny: {}


### PR DESCRIPTION
## Explanation

This PR updates the clean-reports post-upgrade Helm hook job to handle the naming convention introduced in Kyverno 1.11.0.

Before v1.11.0, `ClusterPolicyReports` and `PolicyReports` names were based on the associated policy and included prefixes like `cpol-` or `pol-`.

Starting from [v1.11.0](https://github.com/kyverno/kyverno/releases/tag/v1.11.0) 

> Policy Reports are now created on a per-resource basis and using a UID as the name rather than the previous behavior of per-policy

so the existing clean-up logic no longer matched the new report names and left stale reports after an upgrade.

The updated job accounts for the new naming pattern to ensure proper cleanup.

Chainsaw tests have been added to validate the updated behavior (even though this might be more for completeness than strictly necessary).

## Related issue

No issue at the time

## Milestone of this PR

## What type of PR is this

/kind bug

## Proposed Changes

- Fix the `post-upgrade-clean-reports.yaml` post-upgrade Helm hook job to avoid stale reports
- Add Chainsaw tests related to the job

### Proof Manifests

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

I'm not sure if this pr needs to address both naming conventions (< v1.11.0 and >= v1.11.0) or not.