### PR TITLE
Add podAnnotations to test pods

### DIFF
--- a/charts/kyverno/templates/tests/_helpers.tpl
+++ b/charts/kyverno/templates/tests/_helpers.tpl
@@ -15,7 +15,11 @@
 {{- end -}}
 
 {{- define "kyverno.test.annotations" -}}
-helm.sh/hook: test
+{{- $annotations := dict "helm.sh/hook" "test" -}}
+{{- with .Values.test.podAnnotations -}}
+{{- $annotations = merge $annotations . -}}
+{{- end -}}
+{{- toYaml $annotations -}}
 {{- end -}}
 
 {{- define "kyverno.test.image" -}}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -522,6 +522,9 @@ test:
   # -- Node labels for pod assignment
   nodeSelector: {}
 
+   # -- Additional Pod annotations
+  podAnnotations: {}
+
   # -- List of node taints to tolerate
   tolerations: []
 


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->
This pull request is an addition to the Kyverno Helm chart. It addresses the lack of a configurable way to add custom annotations to the Pods used during the chart's post-installation tests. By introducing a new podAnnotations option in the values.yaml file, this change allows users to apply specific metadata to their test Pods, which is crucial for verifying policies that depend on Pod annotations in a live cluster.


## Related issue

Closes [#13705](https://github.com/kyverno/kyverno/issues/13705)
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

<!-- My PR contains new or altered behavior to Kyverno. -->
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
-->
> /kind feature
## Proposed Changes
This pull request introduces a new `podAnnotations` field within the test section of the Kyverno Helm chart's `values.yaml` file. This new field allows users to specify custom annotations to be added to the Pods created during the chart's post-installation test phase.

The change involves two key modifications:

`charts/kyverno/values.yaml`: The test section is updated to include podAnnotations: {}.

`charts/kyverno/_helpers.tpl`: The kyverno.test.annotations template is modified to merge the hardcoded helm.sh/hook: test annotation with the user-provided podAnnotations, ensuring both are applied correctly to the test Pods.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

Output of `helm template . --set "test.podAnnotations.my-test-annotation=true" | yq 'select(.kind == "Pod" and .metadata.name | test("admission-controller-liveness"))'`

```
# Source: kyverno/templates/tests/admission-controller-metrics.yaml
apiVersion: v1
kind: Pod
metadata:
  name: release-name-kyverno-admission-controller-metrics
  namespace: default
  labels:
    app.kubernetes.io/component: test
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: release-name-kyverno
    app.kubernetes.io/version: v0.0.0
    helm.sh/chart: kyverno-v0.0.0
  annotations:
    helm.sh/hook: test
    my-test-annotation: true
```
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
