### PR TITLE
Fix namespace selector handling for empty resources in background processing

### DIFF
--- a/pkg/engine/utils/match.go
+++ b/pkg/engine/utils/match.go
@@ -232,9 +232,7 @@ func MatchesResourceDescription(
 	operation kyvernov1.AdmissionOperation,
 ) error {
 	if resource.Object == nil {
-		// Allow namespace selector evaluation even for empty resources during background processing
 		if hasNamespaceSelector(rule) && len(namespaceLabels) > 0 {
-			// Continue with namespace selector evaluation
 		} else {
 			return fmt.Errorf("resource is empty")
 		}


### PR DESCRIPTION

fixes #13311

## Problem
Kyverno policies with namespace selectors were failing during background processing with the error ``` "resource is empty" ``` when processing Namespace resources, even when the namespace existed and had the required labels. This was particularly problematic for generate rules that needed to evaluate namespace selectors.

## Root Cause
The ``` MatchesResourceDescription ``` function in ``` match.go ``` was rejecting all resources with empty ``` Object ``` fields, even when:

- The rule had namespace selectors that could be evaluated
- Namespace labels were available for evaluation
- The policy evaluation could proceed based on namespace metadata alone


## Solution
This PR introduces targeted fixes to handle empty resources when namespace selectors are present:

1. **Enhanced Resource Validation Logic**

- Modified ``` MatchesResourceDescription ``` to allow empty resources when namespace selectors exist and namespace labels are available
- Prevents premature rejection of valid policy evaluations

2. **Added ``` hasNamespaceSelector ``` Helper Function**

- Comprehensive detection of namespace selectors across all rule configurations:

> ``` MatchResources.ResourceDescription.NamespaceSelector ```

> ``` MatchResources.Any[].ResourceDescription.NamespaceSelector ```

> ``` MatchResources.All[].ResourceDescription.NamespaceSelector ```

> ``` ExcludeResources.ResourceDescription.NamespaceSelector ```

> ``` ExcludeResources.Any[].ResourceDescription.NamespaceSelector ```

> ``` ExcludeResources.All[].ResourceDescription.NamespaceSelector ```

3. **Improved Namespace Selector Condition Logic**

- Added ``` || resource.Object == nil ``` to namespace selector evaluation conditions
- Allows namespace selector evaluation even with empty resource objects
