### PR TITLE
pass the obtained kind from the top level api description to the gvk/gvr map

### DIFF
--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -452,7 +452,7 @@ func (c *controller) addGVKToGVRMapping(group, version, kind, subresource string
 	} else {
 		for gvrs, api := range gvrss {
 			if gvrs.SubResource == "" {
-				gvk := schema.GroupVersionKind{Group: gvrs.Group, Version: gvrs.Version, Kind: kind}
+				gvk := schema.GroupVersionKind{Group: gvrs.Group, Version: gvrs.Version, Kind: gvrs.Kind}
 				if !reportutils.IsGvkSupported(gvk) {
 					logger.V(2).Info("kind is not supported", "gvk", gvk)
 				} else {


### PR DESCRIPTION
## Explanation

When a policy has a wildcard for a target, we use the discovery client to discover available resources and then build a gvk map which is later used in the dynamic watcher, and is used in notifying the background controller about resource changes. when the kind is erroneously set to '*', this leads to failure in `getGroupVersionMapper` during kind and apiversion parsing
```golang
	gv, err := schema.ParseGroupVersion(apiVersion)
	if err != nil {
		return schema.GroupVersionResource{}
	}
	gvr, err := c.disco.GetGVRFromGVK(gv.WithKind(kind))
	if err != nil {
		return schema.GroupVersionResource{}
	}
```
which gets called as a part of the background report controller while loading the target resource

```golang
	// load target resource
	target, err := c.client.GetResource(ctx, gvk.GroupVersion().String(), gvk.Kind, resource.Namespace, resource.Name)
	if err != nil {
		return err
	}
```
leading to report updating to fail.

This PR sets the kind to the kind fetched from the apiserver rather than whats passed in the function for discovery

## Related issue

Closes: https://github.com/kyverno/kyverno/issues/12738
Closes: https://github.com/kyverno/kyverno/issues/11326

## Milestone of this PR


## What type of PR is this

/kind bug

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

