### PR TITLE
feat: Add namespace selectors to webhook configurations for namespaced policies

### DIFF
--- a/pkg/controllers/webhook/controller.go
+++ b/pkg/controllers/webhook/controller.go
@@ -1038,6 +1038,12 @@ func (c *controller) buildResourceMutatingWebhookRules(caBundle []byte, webhookC
 		failurePolicy := webhook.failurePolicy
 		timeout := capTimeout(webhook.maxWebhookTimeout)
 		name, path := webhookNameAndPath(*webhook, config.MutatingWebhookName, config.MutatingWebhookServicePath)
+		// Use webhook-specific namespace selector if available (for namespaced policies),
+		// otherwise use global configuration
+		namespaceSelector := webhookCfg.NamespaceSelector
+		if webhook.namespaceSelector != nil {
+			namespaceSelector = webhook.namespaceSelector
+		}
 		mutatingWebhooks = append(
 			mutatingWebhooks,
 			admissionregistrationv1.MutatingWebhook{
@@ -1047,7 +1053,7 @@ func (c *controller) buildResourceMutatingWebhookRules(caBundle []byte, webhookC
 				FailurePolicy:           &failurePolicy,
 				SideEffects:             sideEffects,
 				AdmissionReviewVersions: []string{"v1"},
-				NamespaceSelector:       webhookCfg.NamespaceSelector,
+				NamespaceSelector:       namespaceSelector,
 				ObjectSelector:          objectSelector,
 				TimeoutSeconds:          &timeout,
 				ReinvocationPolicy:      &ifNeeded,
@@ -1250,6 +1256,12 @@ func (c *controller) buildResourceValidatingWebhookRules(caBundle []byte, webhoo
 		timeout := capTimeout(webhook.maxWebhookTimeout)
 		name, path := webhookNameAndPath(*webhook, config.ValidatingWebhookName, config.ValidatingWebhookServicePath)
 		failurePolicy := webhook.failurePolicy
+		// Use webhook-specific namespace selector if available (for namespaced policies),
+		// otherwise use global configuration
+		namespaceSelector := webhookCfg.NamespaceSelector
+		if webhook.namespaceSelector != nil {
+			namespaceSelector = webhook.namespaceSelector
+		}
 		validatingWebhooks = append(
 			validatingWebhooks,
 			admissionregistrationv1.ValidatingWebhook{
@@ -1259,7 +1271,7 @@ func (c *controller) buildResourceValidatingWebhookRules(caBundle []byte, webhoo
 				FailurePolicy:           &failurePolicy,
 				SideEffects:             sideEffects,
 				AdmissionReviewVersions: []string{"v1"},
-				NamespaceSelector:       webhookCfg.NamespaceSelector,
+				NamespaceSelector:       namespaceSelector,
 				ObjectSelector:          objectSelector,
 				TimeoutSeconds:          &timeout,
 				MatchConditions:         webhook.matchConditions,


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->
This PR implements namespace selectors for Kyverno webhook configurations to reduce unnecessary webhook calls for namespaced policies. When a Policy (not ClusterPolicy) is created in a specific namespace, the corresponding webhook configuration will include a namespaceSelector that targets only that namespace using the Kubernetes standard label kubernetes.io/metadata.name. This optimization ensures that admission webhooks are only triggered for resources in the policy's target namespace, significantly reducing webhook overhead in multi-namespace clusters.
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->
#10623 
## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
`/1.16.0`
## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind feature
## Proposed Changes
The following changes were made to implement namespace selectors for webhook configurations:

pkg/controllers/webhook/utils_webhook.go:

Enhanced newWebhookPerPolicy function to automatically add namespace selectors for namespaced policies
Uses the Kubernetes standard label kubernetes.io/metadata.name to target specific namespaces
Maintains backward compatibility - cluster policies remain unaffected

pkg/controllers/webhook/controller.go:

Updated buildResourceMutatingWebhookRules to use webhook-specific namespace selectors when available
Updated buildResourceValidatingWebhookRules with similar namespace selector logic
Falls back to global configuration namespace selector when webhook-specific selector is not set
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->
Testing Performed:

Tests were conducted to verify the namespace selector implementation:

Unit Tests:

go test ./pkg/controllers/webhook/... -v
=== RUN   TestNamespaceSelectorFeature
=== RUN   TestNamespaceSelectorFeature/namespaced-policy-has-namespace-selector ✅
=== RUN   TestNamespaceSelectorFeature/cluster-policy-no-namespace-selector ✅
=== RUN   TestNamespaceSelectorFeature/validation-policy-has-namespace-selector ✅
=== RUN   TestNamespaceSelectorFeature/empty-namespace-no-selector ✅
--- PASS: TestNamespaceSelectorFeature (0.00s)

Build Verification:

make build-all
Build successful with no compilation errors


<img width="1201" height="882" alt="Screenshot from 2025-08-08 23-52-22" src="https://github.com/user-attachments/assets/2e447abc-0551-4d09-a359-44f085a620a9" />


<img width="1201" height="289" alt="Screenshot from 2025-08-08 23-53-17-1" src="https://github.com/user-attachments/assets/24532211-185d-465c-b4b9-afad737307b1" />


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
