### PR TITLE
fix: Fix OpenSSF scorecard critical issue

### DIFF
--- a/.github/workflows/comment-commands.yaml
+++ b/.github/workflows/comment-commands.yaml
@@ -75,7 +75,28 @@ jobs:
       - name: Extract target branch
         if: fromJSON(steps.check-merged.outputs.result).merged == true
         id: extract-branch
-        run: echo "branch=$(echo '${{ github.event.comment.body }}' | awk '{print $2}')" >> $GITHUB_OUTPUT
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          
+          # Keep only the first line
+          first_line="$(printf '%s' "$COMMENT_BODY" | tr -d '\r' | head -n1)"
+          candidate="$(printf '%s' "$first_line" | awk '{print $2}')"
+          
+          if [ -z "${candidate:-}" ]; then
+            echo "No branch in comment (expected: /cherry-pick <branch>)" >&2
+            exit 1
+          fi
+          
+          # Validate branch format using git
+          if ! git check-ref-format --branch "$candidate"; then
+            echo "Invalid branch name: $candidate" >&2
+            exit 1
+          fi
+          
+          echo "branch=$candidate" >> "$GITHUB_OUTPUT"
+
 
       - name: Comment PR Unmerged
         if: ${{ fromJSON(steps.check-merged.outputs.result).merged == false && fromJSON(steps.check-merged.outputs.result).state != 'closed' }}


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

By looking at the [OpenSSF scorecard](https://scorecard.dev/viewer/?uri=github.com/kyverno/kyverno), it looks like the new bot added a `critical` allowing possible command execution via the <branch> part of `/cherry-pick <branch>`:

<img width="854" height="292" alt="Capture d’écran 2025-08-11 à 11 32 24" src="https://github.com/user-attachments/assets/9adab98a-c39b-48dc-91c0-eb86c51865c0" />

This PR aims at adding more control over the parameter to avoid miss-using this parameter

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

/milestone 1.16.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [x] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind bug

## Proposed Changes

Instead of getting the comment's and inserting it inside a shell, we:
- Set the comment as an env variable
- Select only the first line
- Check whether the branch name is valid

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.