### PR TITLE
ci(chery-pick): reset cherry-pick branch if already exists

### DIFF
--- a/.github/actions/cherry-pick/action.yaml
+++ b/.github/actions/cherry-pick/action.yaml
@@ -55,17 +55,23 @@ runs:
         for target_branch in "${BRANCHES[@]}"; do
           echo "🔄 Cherry-picking to $target_branch..."
         
-          git fetch origin $target_branch
-          git checkout -b cherry-pick-${{ inputs.source-pr }}-${target_branch} origin/$target_branch
+          pr_branch_name=cherry-pick-${{ inputs.source-pr }}-${target_branch}
+        
+          git fetch --prune origin $target_branch
+          git checkout -B ${pr_branch_name} origin/$target_branch
         
           if git cherry-pick -m 1 ${{ inputs.merge-commit }}; then
-            git push origin cherry-pick-${{ inputs.source-pr }}-${target_branch}
+            git push --force-with-lease origin ${pr_branch_name}
         
-            gh pr create \
-              --title "${{ inputs.source-pr-title }} (Cherry-pick #${{ inputs.source-pr }})" \
-              --body "Cherry-pick #${{ inputs.source-pr }}" \
-              --base ${target_branch} \
-              --head cherry-pick-${{ inputs.source-pr }}-${target_branch}
+            if gh pr list --base "$target_branch" --head "$pr_branch_name" --state open --json number --jq '.[0].number' | grep -q .; then
+              echo "PR from '$pr_branch_name' to '$target_branch' already exists. Skipping creation"
+            else
+              gh pr create \
+                --title "${{ inputs.source-pr-title }} (Cherry-pick #${{ inputs.source-pr }})" \
+                --body "Cherry-pick #${{ inputs.source-pr }}" \
+                --base ${target_branch} \
+                --head cherry-pick-${{ inputs.source-pr }}-${target_branch}
+            fi
           else
             echo "❌ Error while cherry picking into ${target_branch}"
             git_logs+=$(git cherry-pick -m 1 ${{ inputs.merge-commit }} 2>&1)


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

Cherry-picking bot had issues whenever the PR was already created / a pull was needed. This PR aims at fixing the issue

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

/milestone 1.16.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [x] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind bug

## Proposed Changes

This PR updates the way the bot handles branch when cherry-picking:
- It uses `-B` to either create a new branch or reset it back to `target_branch`
- It cherry picks the commit
- It `force-pushes` the change (needed because remote will be different than the local branch)
- It creates the `PullRequest` only if it wasn't already created

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
