### PR TITLE
chore: Update go version to fix CVE-2025-47907

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,9 +7,9 @@ RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
 
 # Install Golang
 RUN ARCH="$(dpkg --print-architecture)"; \
-    curl -LO https://dl.google.com/go/go1.23.8.linux-$ARCH.tar.gz \
-    && tar -C /usr/local -xzf go1.23.8.linux-$ARCH.tar.gz \
-    && rm go1.23.8.linux-$ARCH.tar.gz \
+    curl -LO https://dl.google.com/go/go1.23.12.linux-$ARCH.tar.gz \
+    && tar -C /usr/local -xzf go1.23.12.linux-$ARCH.tar.gz \
+    && rm go1.23.12.linux-$ARCH.tar.gz \
     && echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile
 
 # Install Docker

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyverno/kyverno
 
-go 1.23.8
+go 1.23.12
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6

--- a/hack/api-group-resources/go.mod
+++ b/hack/api-group-resources/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyverno/kyverno/hack/api-group-resources
 
-go 1.23.4
+go 1.23.12
 
 require k8s.io/client-go v0.32.3
 

--- a/hack/controller-gen/go.mod
+++ b/hack/controller-gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyverno/kyverno/hack/controller-gen
 
-go 1.23.4
+go 1.23.12
 
 require (
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
## Explanation

This is a copy of: https://github.com/kyverno/kyverno/pull/13822

Created a new PR because 1.14 is using an older golang version and we want to ensure compatibility (`1.23.12` instead of `1.24.6`)

fixes https://github.com/kyverno/kyverno/issues/13831