### PR TITLE
Fix: pass userInfo to admission.NewAttributesRecord instead of nil

### DIFF
--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -349,7 +349,7 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 					policyData.AddBinding(binding)
 				}
 			}
-			validateResponse, _ := admissionpolicy.Validate(policyData, resource, gvk, gvr, p.NamespaceSelectorMap, p.Client, !p.Cluster)
+			validateResponse, _ := admissionpolicy.Validate(policyData, resource, gvk, gvr, p.NamespaceSelectorMap, p.Client, !p.Cluster, &p.UserInfo.AdmissionUserInfo)
 			vapResponses = append(vapResponses, validateResponse)
 			p.Rc.addValidatingAdmissionResponse(validateResponse)
 		}

--- a/pkg/admissionpolicy/userinfo.go
+++ b/pkg/admissionpolicy/userinfo.go
@@ -1,0 +1,28 @@
+package admissionpolicy
+
+import authenticationv1 "k8s.io/api/authentication/v1"
+
+// UserInfo wraps authenticationv1.UserInfo to implement user.Info interface
+type UserInfo struct {
+	userInfo authenticationv1.UserInfo
+}
+
+func (u *UserInfo) GetName() string {
+	return u.userInfo.Username
+}
+
+func (u *UserInfo) GetUID() string {
+	return u.userInfo.UID
+}
+
+func (u *UserInfo) GetGroups() []string {
+	return u.userInfo.Groups
+}
+
+func (u *UserInfo) GetExtra() map[string][]string {
+	extra := make(map[string][]string)
+	for key, values := range u.userInfo.Extra {
+		extra[key] = []string(values)
+	}
+	return extra
+}

--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -338,7 +338,7 @@ func (s *scanner) ScanResource(
 					policyData.AddBinding(binding)
 				}
 			}
-			res, err := admissionpolicy.Validate(policyData, resource, resource.GroupVersionKind(), gvr, map[string]map[string]string{}, s.client, false)
+			res, err := admissionpolicy.Validate(policyData, resource, resource.GroupVersionKind(), gvr, map[string]map[string]string{}, s.client, false, nil)
 			results[&vaps[i]] = ScanResult{&res, err}
 		}
 	}


### PR DESCRIPTION
## Explanation

This PR fixes #13829 

Without this, any ValidatingAdmissinPolicy with a CEL expression that checks `request.userInfo` will not be tested correctly by kyverno CLI `test` command.

The reason is the userInfo data passed into the `admission.NewAttributesRecord` call is nil.

This change ensures the correct userInfo data is pass in.

## Related issue

Closes #13829 

## What type of PR is this

/kind bug

## Further Comments

Thanks for building this tool, it's very helpful! Please let me know if I can provide any further info or make any changes to help get this merged.