### PR TITLE
ci: update signature repository for manifests

### DIFF
--- a/.github/actions/publish-image/action.yaml
+++ b/.github/actions/publish-image/action.yaml
@@ -73,6 +73,7 @@ runs:
           -a "repo=${{ github.repository }}" \
           -a "workflow=${{ github.workflow }}" \
           -a "ref=${{ github.sha }}" \
+          -a "kind=image" \
           ${{ steps.ko-publish.outputs.digest }}
     - shell: bash
       env:

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -100,6 +100,8 @@ jobs:
           helm registry login --username ${GITHUB_ACTOR} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
       
       - name: Publish OCI Charts
+        env:
+          COSIGN_REPOSITORY: ghcr.io/${{ github.repository_owner }}/signatures
         run: |
           for dir in `find charts-tmp -maxdepth 1 -mindepth 1 -type d -print`; do
             chart=${dir##*/}
@@ -107,5 +109,10 @@ jobs:
             helm package charts-tmp/${chart} --destination .dist
             helm push .dist/${chart}-*.tgz oci://ghcr.io/${{ github.repository_owner }}/charts |& tee .digest
             cosign login --username ${GITHUB_ACTOR} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
-            cosign sign --yes ghcr.io/${{ github.repository_owner }}/charts/${chart}@$(cat .digest | awk -F "[, ]+" '/Digest/{print $NF}')
+            cosign sign --yes \
+              -a "repo=${{ github.repository }}" \
+              -a "workflow=${{ github.workflow }}" \
+              -a "ref=${{ github.sha }}" \
+              -a "kind=helm-chart" \
+              ghcr.io/${{ github.repository_owner }}/charts/${chart}@$(cat .digest | awk -F "[, ]+" '/Digest/{print $NF}')
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -309,8 +309,15 @@ jobs:
             --source="$(git config --get remote.origin.url)" \
             --revision="${{ github.ref_name }}/$(git rev-parse HEAD)"
       - name: Sign manifests in GHCR with Cosign
+        env:
+          COSIGN_REPOSITORY: ghcr.io/${{ github.repository_owner }}/signatures
         run: |
-          cosign sign --yes ghcr.io/${{ github.repository_owner }}/manifests/kyverno:${{ github.ref_name }}
+          cosign sign --yes \
+            -a "repo=${{ github.repository }}" \
+            -a "workflow=${{ github.workflow }}" \
+            -a "ref=${{ github.sha }}" \
+            -a "kind=manifest" \
+            ghcr.io/${{ github.repository_owner }}/manifests/kyverno:${{ github.ref_name }}
 
   release-cli-via-krew:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Explanation

We currently have multiple procedures to verify signatures for artifacts of a release:
 1. using `COSIGN_REPOSITORY=ghcr.io/kyverno/signatures` for everything image-related and attestations
 2. using colocated signatures (cosign's default behaviour) for k8s manifests and helm-charts.

🎯 This PR align all signing methods by leveraging the `ghcr.io/kyverno/signatures` for all of our resources.

🛑 This will **break existing signature check for manifests/helm-charts** for our clients. If we want to push this change, we'll need to make sure people are aware of this when migrating.


## Related issue

- Closes https://github.com/kyverno/kyverno/issues/13760

## Milestone of this PR

/milestone 1.16.0

## Documentation (required for features)

TODO: Add PR to website documentation `https://github.com/kyverno/website/pull/...` 

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind feature

## Proposed Changes

- Use `COSIGN_REPOSITORY` for all of our signing purposes (images, attestations, k8s manifests, helm charts)

### How it works

I used my fork to create deployments of images as example. This means we can use `COSIGN_REPOSITORY=ghcr.io/lucchmielowski/signatures` as store for verification for all of our signed artifacts


- Using the current documentation (image signing hasn't changed), signature verification for images **as well as k8s manifests** (which wasn't the case before) can be done via:

```shell
COSIGN_REPOSITORY=ghcr.io/lucchmielowski/signatures cosign verify <kyverno_repository> \
  --certificate-identity-regexp="https://github.com/lucchmielowski/kyverno/.github/workflows/release.yaml@refs/tags/*" \
  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" | jq
```

- Since helm-charts are using a different workflow (because of different lifecycle) they can now be verified via:

```shell
COSIGN_REPOSITORY=ghcr.io/lucchmielowski/signatures cosign verify ghcr.io/lucchmielowski/charts/kyverno:v0.0.0 \
  --certificate-identity-regexp="https://github.com/lucchmielowski/kyverno/.github/workflows/helm-release.yaml@refs/tags/*" \
  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" | jq
```



## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
