### PR TITLE
add matchLabels in buildwebhookRules() for fine-grained webhook

### DIFF
--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/default/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/default/validatingwebhookconfiguration.yaml
@@ -16,7 +16,16 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: vpol.validate.kyverno.svc-fail
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:

--- a/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/disabled/validatingwebhookconfiguration.yaml
+++ b/test/conformance/chainsaw/generate-validating-admission-policy/validatingpolicy/generation-config/disabled/validatingwebhookconfiguration.yaml
@@ -16,7 +16,16 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: vpol.validate.kyverno.svc-fail
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:

--- a/test/conformance/chainsaw/generating-policies/webhook/match-conditions/webhooks.yaml
+++ b/test/conformance/chainsaw/generating-policies/webhook/match-conditions/webhooks.yaml
@@ -19,7 +19,16 @@ webhooks:
     name: check-red-label
   matchPolicy: Equivalent
   name:  gpol.validate.kyverno.svc-ignore-finegrained-zk-kafka-address
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:

--- a/test/conformance/chainsaw/generating-policies/webhook/single/webhooks.yaml
+++ b/test/conformance/chainsaw/generating-policies/webhook/single/webhooks.yaml
@@ -16,7 +16,16 @@ webhooks:
   failurePolicy: Ignore
   matchPolicy: Equivalent
   name:  gpol.validate.kyverno.svc-ignore
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:

--- a/test/conformance/chainsaw/image-validating-policies/webhook-configuration/combined/webhooks.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/webhook-configuration/combined/webhooks.yaml
@@ -33,7 +33,16 @@ webhooks:
     name: autogen-defaults-check-prod-label
   matchPolicy: Equivalent
   name: ivpol.validate.kyverno.svc-fail-finegrained-check-signed-images-finegrained
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:
@@ -179,7 +188,16 @@ webhooks:
     name: autogen-defaults-check-prod-label
   matchPolicy: Equivalent
   name: ivpol.mutate.kyverno.svc-fail-finegrained-check-signed-images-finegrained
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   reinvocationPolicy: Never
   rules:

--- a/test/conformance/chainsaw/image-validating-policies/webhook-configuration/fine-grained/match-conditions/webhooks.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/webhook-configuration/fine-grained/match-conditions/webhooks.yaml
@@ -33,7 +33,16 @@ webhooks:
     name: autogen-defaults-check-prod-label
   matchPolicy: Equivalent
   name: ivpol.mutate.kyverno.svc-fail-finegrained-check-signed-images
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   reinvocationPolicy: Never
   rules:
@@ -116,7 +125,16 @@ webhooks:
     name: autogen-defaults-check-prod-label
   matchPolicy: Equivalent
   name: ivpol.validate.kyverno.svc-fail-finegrained-check-signed-images
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:

--- a/test/conformance/chainsaw/image-validating-policies/webhook-configuration/fine-grained/match-constraints/webhooks.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/webhook-configuration/fine-grained/match-constraints/webhooks.yaml
@@ -18,7 +18,16 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: ivpol.mutate.kyverno.svc-fail-finegrained-check-signed-images
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   reinvocationPolicy: Never
   rules:
@@ -86,7 +95,16 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Exact
   name: ivpol.validate.kyverno.svc-fail-finegrained-check-signed-images
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:

--- a/test/conformance/chainsaw/image-validating-policies/webhook-configuration/fine-grained/timeout/webhooks.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/webhook-configuration/fine-grained/timeout/webhooks.yaml
@@ -18,7 +18,16 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: ivpol.mutate.kyverno.svc-fail-finegrained-check-signed-images
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   reinvocationPolicy: Never
   rules:
@@ -85,7 +94,16 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: ivpol.validate.kyverno.svc-fail-finegrained-check-signed-images
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:

--- a/test/conformance/chainsaw/validating-policies/webhook-configuration/basic/multiple/webhooks.yaml
+++ b/test/conformance/chainsaw/validating-policies/webhook-configuration/basic/multiple/webhooks.yaml
@@ -16,7 +16,16 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: vpol.validate.kyverno.svc-fail
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:

--- a/test/conformance/chainsaw/validating-policies/webhook-configuration/basic/single/webhooks.yaml
+++ b/test/conformance/chainsaw/validating-policies/webhook-configuration/basic/single/webhooks.yaml
@@ -16,7 +16,16 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: vpol.validate.kyverno.svc-fail
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:

--- a/test/conformance/chainsaw/validating-policies/webhook-configuration/combined/webhooks.yaml
+++ b/test/conformance/chainsaw/validating-policies/webhook-configuration/combined/webhooks.yaml
@@ -33,7 +33,16 @@ webhooks:
     name: autogen-defaults-check-prod-label
   matchPolicy: Equivalent
   name: vpol.validate.kyverno.svc-fail-finegrained-disallow-privilege-escalation
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:

--- a/test/conformance/chainsaw/validating-policies/webhook-configuration/fine-grained-tests/match-conditions/output.yaml
+++ b/test/conformance/chainsaw/validating-policies/webhook-configuration/fine-grained-tests/match-conditions/output.yaml
@@ -1,0 +1,93 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    admissions.enforcer/disabled: "true"
+  creationTimestamp: "2025-08-24T17:47:43Z"
+  generation: 4
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg
+  resourceVersion: "2194"
+  uid: 6bc261a7-ce27-4075-9eaf-cefba4b14e36
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM3VENDQWRXZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFZTVJZd0ZBWURWUVFEREEwcUxtdDUKZG1WeWJtOHVjM1pqTUI0WERUSTFNRGd5TkRFMk5EYzBNMW9YRFRJMk1EZ3lOREUzTkRjME0xb3dHREVXTUJRRwpBMVVFQXd3TktpNXJlWFpsY201dkxuTjJZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBTWltVnd5VkFOOXozNTcxM1VUY0p0NkNKU2lqWWFDZDdmWW1waHV3dlRNcURWeWxlRDRwNWlrb1llWlkKMEJTWjZHRitweDA3VjV2RUVkWkZsMERNRHJ4S0MrQ3FuTUFpR3JXY3FkaGVKQVhxNXdjRHV6RkpxcmR1ZE11YwpuKzNnWmd2YlQxd0dRelNtU3pFUXRPZk92eTRMSEpxanNBZmRQS24zaFVzVWxmZkRRWldrdVd3bGxkUHJUNU0vCjY4dVozYU8vcnNUTHlwbmgxOGtueURLWGV1Z1VycXF4OXQxWHVOT3VaUGxzWE5LU09kRkkrL0ptTVYxZ24xUjEKS3BhOGJrTGFZYXlnRU1Vc2hXOFlFaWJJYnh5NkwrWk5NbDlOcGFIZUkyeVdXUTcrbm41T1hyU09mUjdWcnJwTApVVytZNWVMN3FtMUtqemFBVnRtUm5XQ0dmTmNDQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHCkExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkpBcURaZ0djTE1kakU0RXJzbVVWdjEzZXFmT01BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJEeFpqeHMzZkxkR2pMSVVxcis5Q3JabTZLVExaUkhzOU9QaThtWU1VSgp0YkZtTEZiWExCaWFaTDVZbStzTnVhZjBBV1dqd0VoNXhpVnFSNWs4RG9xYXFKMjhCRW1nbnArQVNEVGhyNFZuCnVNUnVuQ2o3WFFOQ2RMTGU4U3l2bEhyaXF1dzZFMDVxZmNITE9iM3o1bCsyR1ZqS0U2R2t3T21hOFN2NlV4cysKSzhEdzRqd0xwWnBlSlArTVlpM0RORklOdmF2UWsrU2JacU5vSTJ3Qi83RkxKcVk3UzhSY0JwSXlXUkFZQnd5ZApUUzQ2K3FPVnlMYVRsMmZvczUvU0crc0JEd1lvUDcrQWMyLzVUWDAzVE15YWV0RUFGWXQ1QXdhWU10SEErTzhxClpXcU9BdjZlajBWVkQxYWJyV2NrbFdxaW1Ham5PcW9uNVNoL1JtazBDejV1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: kyverno-svc
+      namespace: kyverno
+      path: /vpol/disallow-privilege-escalation-b
+      port: 443
+  failurePolicy: Fail
+  matchConditions:
+  - expression: has(object.metadata.labels) && has(object.metadata.labels.prod) &&
+      object.metadata.labels.prod == 'true'
+    name: check-prod-label
+  matchPolicy: Equivalent
+  name: vpol.validate.kyverno.svc-fail-finegrained-disallow-privilege-escalation-b
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
+    matchLabels:
+      key: environment
+      operator: In
+      values: staging
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+    scope: '*'
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM3VENDQWRXZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFZTVJZd0ZBWURWUVFEREEwcUxtdDUKZG1WeWJtOHVjM1pqTUI0WERUSTFNRGd5TkRFMk5EYzBNMW9YRFRJMk1EZ3lOREUzTkRjME0xb3dHREVXTUJRRwpBMVVFQXd3TktpNXJlWFpsY201dkxuTjJZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBTWltVnd5VkFOOXozNTcxM1VUY0p0NkNKU2lqWWFDZDdmWW1waHV3dlRNcURWeWxlRDRwNWlrb1llWlkKMEJTWjZHRitweDA3VjV2RUVkWkZsMERNRHJ4S0MrQ3FuTUFpR3JXY3FkaGVKQVhxNXdjRHV6RkpxcmR1ZE11YwpuKzNnWmd2YlQxd0dRelNtU3pFUXRPZk92eTRMSEpxanNBZmRQS24zaFVzVWxmZkRRWldrdVd3bGxkUHJUNU0vCjY4dVozYU8vcnNUTHlwbmgxOGtueURLWGV1Z1VycXF4OXQxWHVOT3VaUGxzWE5LU09kRkkrL0ptTVYxZ24xUjEKS3BhOGJrTGFZYXlnRU1Vc2hXOFlFaWJJYnh5NkwrWk5NbDlOcGFIZUkyeVdXUTcrbm41T1hyU09mUjdWcnJwTApVVytZNWVMN3FtMUtqemFBVnRtUm5XQ0dmTmNDQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHCkExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkpBcURaZ0djTE1kakU0RXJzbVVWdjEzZXFmT01BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJEeFpqeHMzZkxkR2pMSVVxcis5Q3JabTZLVExaUkhzOU9QaThtWU1VSgp0YkZtTEZiWExCaWFaTDVZbStzTnVhZjBBV1dqd0VoNXhpVnFSNWs4RG9xYXFKMjhCRW1nbnArQVNEVGhyNFZuCnVNUnVuQ2o3WFFOQ2RMTGU4U3l2bEhyaXF1dzZFMDVxZmNITE9iM3o1bCsyR1ZqS0U2R2t3T21hOFN2NlV4cysKSzhEdzRqd0xwWnBlSlArTVlpM0RORklOdmF2UWsrU2JacU5vSTJ3Qi83RkxKcVk3UzhSY0JwSXlXUkFZQnd5ZApUUzQ2K3FPVnlMYVRsMmZvczUvU0crc0JEd1lvUDcrQWMyLzVUWDAzVE15YWV0RUFGWXQ1QXdhWU10SEErTzhxClpXcU9BdjZlajBWVkQxYWJyV2NrbFdxaW1Ham5PcW9uNVNoL1JtazBDejV1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: kyverno-svc
+      namespace: kyverno
+      path: /vpol/disallow-privilege-escalation
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vpol.validate.kyverno.svc-fail
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+    scope: '*'
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10

--- a/test/conformance/chainsaw/validating-policies/webhook-configuration/fine-grained-tests/match-conditions/policy.yaml
+++ b/test/conformance/chainsaw/validating-policies/webhook-configuration/fine-grained-tests/match-conditions/policy.yaml
@@ -3,7 +3,43 @@ kind: ValidatingPolicy
 metadata:
   name: disallow-privilege-escalation
 spec:
+  validationActions: ["Deny"]
   matchConstraints:
+    namespaceSelector:
+      matchExpressions:
+        - key: environment
+          operator: In
+          values: ["prod", "staging"]
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: [v1]
+      operations:  [CREATE, UPDATE]
+      resources:   ["pods"]
+  # matchConditions:
+  #   - name: check-prod-label
+  #     expression: >- 
+  #       has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
+  validations:
+    - expression: >- 
+        object.spec.containers.all(container, has(container.securityContext) &&
+        has(container.securityContext.allowPrivilegeEscalation) &&
+        container.securityContext.allowPrivilegeEscalation == false)
+      message: >-
+        Privilege escalation is disallowed. The field
+        spec.containers[*].securityContext.allowPrivilegeEscalation must be set to `false`.
+---
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: disallow-privilege-escalation-b
+spec:
+  validationActions: ["Deny"]
+  matchConstraints:
+    namespaceSelector:
+      matchLabels:
+          key: environment
+          operator: In
+          values:  "staging"
     resourceRules:
     - apiGroups:   [""]
       apiVersions: [v1]

--- a/test/conformance/chainsaw/validating-policies/webhook-configuration/fine-grained-tests/match-conditions/webhooks.yaml
+++ b/test/conformance/chainsaw/validating-policies/webhook-configuration/fine-grained-tests/match-conditions/webhooks.yaml
@@ -31,7 +31,16 @@ webhooks:
     name: autogen-defaults-check-prod-label
   matchPolicy: Equivalent
   name: vpol.validate.kyverno.svc-fail-finegrained-disallow-privilege-escalation
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:

--- a/test/conformance/chainsaw/validating-policies/webhook-configuration/fine-grained-tests/match-constraints/webhooks.yaml
+++ b/test/conformance/chainsaw/validating-policies/webhook-configuration/fine-grained-tests/match-constraints/webhooks.yaml
@@ -18,7 +18,16 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Exact
   name: vpol.validate.kyverno.svc-fail-finegrained-check-deployment-labels
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:

--- a/test/conformance/chainsaw/validating-policies/webhook-configuration/fine-grained-tests/timeout/webhooks.yaml
+++ b/test/conformance/chainsaw/validating-policies/webhook-configuration/fine-grained-tests/timeout/webhooks.yaml
@@ -18,7 +18,16 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: vpol.validate.kyverno.svc-fail-finegrained-check-deployment-labels
-  namespaceSelector: {}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kyverno
   objectSelector: {}
   rules:
   - apiGroups:


### PR DESCRIPTION
## Explanation

Expose `namespaceSelector` and `objectSelector` in webhook rules.
This PR updates `buildWebhookRules()` so that matchLabels from both policies and Kyverno’s configuration are included in the webhook definition, enabling fine-grained webhook visibility and filtering

## Related issue

closes https://github.com/kyverno/kyverno/issues/13336




## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->



### Proof Manifests

## policy

```yaml
apiVersion: policies.kyverno.io/v1alpha1
kind: ValidatingPolicy
metadata:
  name: disallow-privilege-escalation
spec:
  validationActions: ["Deny"]
  matchConstraints:
    resourceRules:
    - apiGroups:   [""]
      apiVersions: [v1]
      operations:  [CREATE, UPDATE]
      resources:   ["pods"]
  validations:
    - expression: >- 
        object.spec.containers.all(container, has(container.securityContext) &&
        has(container.securityContext.allowPrivilegeEscalation) &&
        container.securityContext.allowPrivilegeEscalation == false)
      message: >-
        Privilege escalation is disallowed. The field
        spec.containers[*].securityContext.allowPrivilegeEscalation must be set to `false`.
---
apiVersion: policies.kyverno.io/v1alpha1
kind: ValidatingPolicy
metadata:
  name: disallow-privilege-escalation-b
spec:
  validationActions: ["Deny"]
  matchConstraints:
    namespaceSelector:
      matchLabels:
          key: environment
          operator: In
          values:  "staging"
    resourceRules:
    - apiGroups:   [""]
      apiVersions: [v1]
      operations:  [CREATE, UPDATE]
      resources:   ["pods"]
  matchConditions:
    - name: check-prod-label
      expression: >- 
        has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
  validations:
    - expression: >- 
        object.spec.containers.all(container, has(container.securityContext) &&
        has(container.securityContext.allowPrivilegeEscalation) &&
        container.securityContext.allowPrivilegeEscalation == false)
      message: >-
        Privilege escalation is disallowed. The field
        spec.containers[*].securityContext.allowPrivilegeEscalation must be set to `false`.
```


# webhook

```yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  annotations:
    admissions.enforcer/disabled: "true"
  creationTimestamp: "2025-08-24T17:47:43Z"
  generation: 5
  labels:
    webhook.kyverno.io/managed-by: kyverno
  name: kyverno-resource-validating-webhook-cfg
  resourceVersion: "8373"
  uid: 6bc261a7-ce27-4075-9eaf-cefba4b14e36
webhooks:
- admissionReviewVersions:
  - v1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM3VENDQWRXZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFZTVJZd0ZBWURWUVFEREEwcUxtdDUKZG1WeWJtOHVjM1pqTUI0WERUSTFNRGd5TkRFMk5EYzBNMW9YRFRJMk1EZ3lOREUzTkRjME0xb3dHREVXTUJRRwpBMVVFQXd3TktpNXJlWFpsY201dkxuTjJZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBTWltVnd5VkFOOXozNTcxM1VUY0p0NkNKU2lqWWFDZDdmWW1waHV3dlRNcURWeWxlRDRwNWlrb1llWlkKMEJTWjZHRitweDA3VjV2RUVkWkZsMERNRHJ4S0MrQ3FuTUFpR3JXY3FkaGVKQVhxNXdjRHV6RkpxcmR1ZE11YwpuKzNnWmd2YlQxd0dRelNtU3pFUXRPZk92eTRMSEpxanNBZmRQS24zaFVzVWxmZkRRWldrdVd3bGxkUHJUNU0vCjY4dVozYU8vcnNUTHlwbmgxOGtueURLWGV1Z1VycXF4OXQxWHVOT3VaUGxzWE5LU09kRkkrL0ptTVYxZ24xUjEKS3BhOGJrTGFZYXlnRU1Vc2hXOFlFaWJJYnh5NkwrWk5NbDlOcGFIZUkyeVdXUTcrbm41T1hyU09mUjdWcnJwTApVVytZNWVMN3FtMUtqemFBVnRtUm5XQ0dmTmNDQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHCkExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkpBcURaZ0djTE1kakU0RXJzbVVWdjEzZXFmT01BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJEeFpqeHMzZkxkR2pMSVVxcis5Q3JabTZLVExaUkhzOU9QaThtWU1VSgp0YkZtTEZiWExCaWFaTDVZbStzTnVhZjBBV1dqd0VoNXhpVnFSNWs4RG9xYXFKMjhCRW1nbnArQVNEVGhyNFZuCnVNUnVuQ2o3WFFOQ2RMTGU4U3l2bEhyaXF1dzZFMDVxZmNITE9iM3o1bCsyR1ZqS0U2R2t3T21hOFN2NlV4cysKSzhEdzRqd0xwWnBlSlArTVlpM0RORklOdmF2UWsrU2JacU5vSTJ3Qi83RkxKcVk3UzhSY0JwSXlXUkFZQnd5ZApUUzQ2K3FPVnlMYVRsMmZvczUvU0crc0JEd1lvUDcrQWMyLzVUWDAzVE15YWV0RUFGWXQ1QXdhWU10SEErTzhxClpXcU9BdjZlajBWVkQxYWJyV2NrbFdxaW1Ham5PcW9uNVNoL1JtazBDejV1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    service:
      name: kyverno-svc
      namespace: kyverno
      path: /vpol/disallow-privilege-escalation-b
      port: 443
  failurePolicy: Fail
  matchConditions:
  - expression: has(object.metadata.labels) && has(object.metadata.labels.prod) &&
      object.metadata.labels.prod == 'true'
    name: check-prod-label
  matchPolicy: Equivalent
  name: vpol.validate.kyverno.svc-fail-finegrained-disallow-privilege-escalation-b
  namespaceSelector:
    matchExpressions:
    - key: kubernetes.io/metadata.name
      operator: NotIn
      values:
      - kube-system
    - key: kubernetes.io/metadata.name
      operator: NotIn
      values:
      - kyverno
    matchLabels:
      key: environment
      operator: In
      values: staging
  objectSelector: {}
  rules:
  - apiGroups:
    - ""
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    resources:
    - pods
    scope: '*'
  sideEffects: NoneOnDryRun
  timeoutSeconds: 10
- admissionReviewVersions:
  - v1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM3VENDQWRXZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFZTVJZd0ZBWURWUVFEREEwcUxtdDUKZG1WeWJtOHVjM1pqTUI0WERUSTFNRGd5TkRFMk5EYzBNMW9YRFRJMk1EZ3lOREUzTkRjME0xb3dHREVXTUJRRwpBMVVFQXd3TktpNXJlWFpsY201dkxuTjJZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBTWltVnd5VkFOOXozNTcxM1VUY0p0NkNKU2lqWWFDZDdmWW1waHV3dlRNcURWeWxlRDRwNWlrb1llWlkKMEJTWjZHRitweDA3VjV2RUVkWkZsMERNRHJ4S0MrQ3FuTUFpR3JXY3FkaGVKQVhxNXdjRHV6RkpxcmR1ZE11YwpuKzNnWmd2YlQxd0dRelNtU3pFUXRPZk92eTRMSEpxanNBZmRQS24zaFVzVWxmZkRRWldrdVd3bGxkUHJUNU0vCjY4dVozYU8vcnNUTHlwbmgxOGtueURLWGV1Z1VycXF4OXQxWHVOT3VaUGxzWE5LU09kRkkrL0ptTVYxZ24xUjEKS3BhOGJrTGFZYXlnRU1Vc2hXOFlFaWJJYnh5NkwrWk5NbDlOcGFIZUkyeVdXUTcrbm41T1hyU09mUjdWcnJwTApVVytZNWVMN3FtMUtqemFBVnRtUm5XQ0dmTmNDQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHCkExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkpBcURaZ0djTE1kakU0RXJzbVVWdjEzZXFmT01BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJEeFpqeHMzZkxkR2pMSVVxcis5Q3JabTZLVExaUkhzOU9QaThtWU1VSgp0YkZtTEZiWExCaWFaTDVZbStzTnVhZjBBV1dqd0VoNXhpVnFSNWs4RG9xYXFKMjhCRW1nbnArQVNEVGhyNFZuCnVNUnVuQ2o3WFFOQ2RMTGU4U3l2bEhyaXF1dzZFMDVxZmNITE9iM3o1bCsyR1ZqS0U2R2t3T21hOFN2NlV4cysKSzhEdzRqd0xwWnBlSlArTVlpM0RORklOdmF2UWsrU2JacU5vSTJ3Qi83RkxKcVk3UzhSY0JwSXlXUkFZQnd5ZApUUzQ2K3FPVnlMYVRsMmZvczUvU0crc0JEd1lvUDcrQWMyLzVUWDAzVE15YWV0RUFGWXQ1QXdhWU10SEErTzhxClpXcU9BdjZlajBWVkQxYWJyV2NrbFdxaW1Ham5PcW9uNVNoL1JtazBDejV1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    service:
      name: kyverno-svc
      namespace: kyverno
      path: /vpol/disallow-privilege-escalation
      port: 443
  failurePolicy: Fail
  matchPolicy: Equivalent
  name: vpol.validate.kyverno.svc-fail
  namespaceSelector:
    matchExpressions:
    - key: kubernetes.io/metadata.name
      operator: NotIn
      values:
      - kube-system
    - key: kubernetes.io/metadata.name
      operator: NotIn
      values:
      - kyverno
  objectSelector: {}
  rules:
  - apiGroups:
    - batch
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    resources:
    - cronjobs
    scope: '*'
  - apiGroups:
    - apps
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    resources:
    - daemonsets
    - deployments
    - replicasets
    - statefulsets
    scope: '*'
  - apiGroups:
    - batch
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    resources:
    - jobs
    scope: '*'
  - apiGroups:
    - ""
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    resources:
    - pods
    scope: '*'
  sideEffects: NoneOnDryRun
  timeoutSeconds: 10

```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
