### PR TITLE
fix: correct spelling of 'received' in API call test

### DIFF
--- a/test/conformance/chainsaw/mutating-policies/context/api-call/http-post/http-pod.yaml
+++ b/test/conformance/chainsaw/mutating-policies/context/api-call/http-post/http-pod.yaml
@@ -19,7 +19,7 @@ spec:
       def post_data():
         json_data = request.get_json()
         data = json_data.get("labels")
-        return jsonify({"recieved": data})
+        return jsonify({"received": data})
       if __name__ == "__main__":
           app.run(host="0.0.0.0", port=5000)' > app.py &&
             python app.py

--- a/test/conformance/chainsaw/mutating-policies/context/api-call/http-post/policy.yaml
+++ b/test/conformance/chainsaw/mutating-policies/context/api-call/http-post/policy.yaml
@@ -17,7 +17,7 @@ spec:
         {"labels": object.metadata.labels.app},{"Content-Type": "application/json"})
     - name: envVariable
       expression: >-
-        has(variables.apiResponse) && has(variables.apiResponse.recieved) && 'recieved' in variables.apiResponse ? variables.apiResponse.recieved : 'unknown'
+        has(variables.apiResponse) && has(variables.apiResponse.received) && 'received' in variables.apiResponse ? variables.apiResponse.received : 'unknown'
   mutations:
     - patchType: ApplyConfiguration
       applyConfiguration:


### PR DESCRIPTION
## What this PR does / why we need it

This PR fixes a spelling error in the API call test files where "recieved" was incorrectly spelled instead of "received". The typo appears in both the test policy and the corresponding mock API response, affecting code readability and consistency.

## Changes made

- **Fixed spelling**: Changed "recieved" to "received" in 3 locations within the http-post test
- **Files modified**:
  - `test/conformance/chainsaw/mutating-policies/context/api-call/http-post/policy.yaml` (line 20)
  - `test/conformance/chainsaw/mutating-policies/context/api-call/http-post/http-pod.yaml` (line 22)

## Testing

- [x] Verified that the spelling correction maintains test functionality
- [x] Confirmed that both the policy and mock API response use consistent spelling
- [x] No functional changes - only improves code quality

## Which issue(s) this PR fixes

This PR addresses a code quality issue (spelling error) found in the codebase.

## Special notes for your reviewer

This is a simple typo fix that:
- Maintains existing test functionality
- Improves code readability and professionalism
- Ensures consistency between the policy expectations and API response
- Contains no breaking changes or logic modifications

The change affects only test files and does not impact any production code or user-facing functionality.

## Does this PR introduce a user-facing change?

```release-note
NONE
```

## Additional documentation

No additional documentation is required as this is a simple spelling correction in test files.

## Checklist

- [x] I have read the [contributor guidelines](https://github.com/kyverno/community/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed-off my commits using `git commit -s`
- [x] I have verified that my changes do not break existing functionality
- [x] This is a non-breaking change (spelling correction only)
- [x] No new tests are required as this maintains existing test behavior