### PR TITLE
feature: Split openreports CRD installation from controller flag enabling in the helm chart #13874

### DIFF
--- a/charts/kyverno/Chart.lock
+++ b/charts/kyverno/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: openreports
   repository: https://openreports.github.io/reports-api
   version: 0.1.0
-digest: sha256:c159d6120b9143d844e087a74ca406fb80bd17ca014e869f97b70a705c8104d2
-generated: "2025-07-09T14:58:12.948526+03:00"
+digest: sha256:67ca35821e96f24c58ac344228fd3641c727dd71cd09bd7ca24b4fbc3879e095
+generated: "2025-08-31T17:19:05.475432+05:30"

--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -51,4 +51,4 @@ dependencies:
   - name: openreports
     version: "0.1.0"
     repository: "https://openreports.github.io/reports-api"
-    condition: openreports.enabled
+    condition: openreports.installCrds

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -816,7 +816,8 @@ The chart values are organised per component.
 | namespaceOverride | string | `nil` | Override the namespace the chart deploys to |
 | upgrade.fromV2 | bool | `false` | Upgrading from v2 to v3 is not allowed by default, set this to true once changes have been reviewed. |
 | rbac.roles.aggregate | object | `{"admin":true,"view":true}` | Aggregate ClusterRoles to Kubernetes default user-facing roles. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) |
-| openreports.enabled | bool | `false` |  |
+| openreports.enabled | bool | `false` | Enable OpenReports feature in controllers |
+| openreports.installCrds | bool | `false` | Whether to install CRDs from the upstream OpenReports chart. Setting this to true requires enabled to also be true. |
 | imagePullSecrets | object | `{}` | Image pull secrets for image verification policies, this will define the `--imagePullSecrets` argument |
 | existingImagePullSecrets | list | `[]` | Existing Image pull secrets for image verification policies, this will define the `--imagePullSecrets` argument |
 | customLabels | object | `{}` | Additional labels |

--- a/charts/kyverno/ci/openreports-values.yaml
+++ b/charts/kyverno/ci/openreports-values.yaml
@@ -1,0 +1,19 @@
+openreports:
+  # Test case 1: OpenReports disabled
+  enabled: false
+  installCrds: false
+---
+openreports:
+  # Test case 2: OpenReports enabled but CRDs not installed
+  enabled: true
+  installCrds: false
+---
+openreports:
+  # Test case 3: OpenReports enabled with CRDs installed
+  enabled: true
+  installCrds: true
+---
+openreports:
+  # Test case 4: Invalid configuration - should fail validation
+  enabled: false
+  installCrds: true

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -1,5 +1,12 @@
 {{/* vim: set filetype=mustache: */}}
 
+{{/* Validate OpenReports configuration */}}
+{{- define "kyverno.validateOpenReports" -}}
+{{- if and (not .Values.openreports.enabled) .Values.openreports.installCrds -}}
+{{- fail "OpenReports CRD installation (openreports.installCrds) cannot be enabled when the feature (openreports.enabled) is disabled" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "kyverno.chartVersion" -}}
 {{- if .Values.templating.enabled -}}
   {{- required "templating.version is required when templating.enabled is true" .Values.templating.version | replace "+" "_" -}}

--- a/charts/kyverno/templates/reports-controller/deployment.yaml
+++ b/charts/kyverno/templates/reports-controller/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.reportsController.enabled -}}
+{{- include "kyverno.validateOpenReports" . -}}
 {{- if not .Values.templating.debug -}}
 {{- $automountSAToken := .Values.reportsController.rbac.serviceAccount.automountServiceAccountToken }}
 apiVersion: apps/v1

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -77,7 +77,10 @@ rbac:
 
 # Use openreports.io as the API group for reporting
 openreports:
+  # -- Enable OpenReports feature in controllers
   enabled: false
+  # -- Whether to install CRDs from the upstream OpenReports chart. Setting this to true requires enabled to also be true.
+  installCrds: false
 
 # CRDs configuration
 crds:


### PR DESCRIPTION
## Explanation

This PR introduces a new configuration option to split the OpenReports CRD installation from the controller enabling flag in the Helm chart. This change allows users to have more granular control over OpenReports feature enablement and CRD installation, making it easier to manage CRDs in environments where they are handled separately from application deployment. The PR also includes validation to prevent invalid configurations, ensuring users don't enable CRD installation without enabling the feature itself.

## Related issue

Closes #13874

## What type of PR is this

/kind feature

## Proposed Changes

- Added new `openreports.installCrds` value to control CRD installation independently
- Added validation in _helpers.tpl to prevent invalid configurations
- Updated Chart.yaml dependencies with proper conditions for OpenReports
- Added test cases to verify different OpenReports configuration scenarios
- Updated documentation with clear descriptions of the new parameters

### Proof Manifests

```yaml
# Test case 1: OpenReports disabled (valid)
openreports:
  enabled: false
  installCrds: false
---
# Test case 2: OpenReports enabled but CRDs not installed (valid)
openreports:
  enabled: true
  installCrds: false
---
# Test case 3: OpenReports enabled with CRDs installed (valid)
openreports:
  enabled: true
  installCrds: true
---
# Test case 4: Invalid configuration - will fail validation
openreports:
  enabled: false
  installCrds: true  # Cannot install CRDs when feature is disabled
  ```
  
  ## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

We might need to update the kyverno website for this change. The documentation should clearly explain:

- The separation between feature enablement and CRD installation
- Valid configuration combinations
- The validation that prevents invalid configurations