### PR TITLE
fix: Fix repository for helm webhooks

### DIFF
--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -542,9 +542,9 @@ webhooksCleanup:
 
   image:
     # -- (string) Image registry
-    registry: ~
+    registry: registry.k8s.io
     # -- Image repository
-    repository: registry.k8s.io/kubectl
+    repository: kubectl
     # -- Image tag
     # Defaults to `latest` if omitted
     tag: 'v1.32.7'


### PR DESCRIPTION
## Explanation

This fixes issue where people would set `repository: myCustomRepo` and the cleanup image would look like : `image: myCustomRepo/registry.k8s.io/kubectl` 

## Related issue

- Fixes #13929 


## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

/milestone 1.15.2


## What type of PR is this

/kind bug

## Proposed Changes

Fixes the issue by moving the registry part to the `webhooksCleanup.image.registry`.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
- [ ] CLI support should be added and my PR doesn't contain that functionality.
