### PR TITLE
WIP fix(controllers): clamp negative requeues

### DIFF
--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -338,10 +338,15 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 		nextExecutionTime = executionTime
 	}
 
-	// calculate the remaining time until deletion.
-	timeRemaining := time.Until(*nextExecutionTime)
-	// add the item back to the queue after the remaining time.
-	c.queue.AddAfter(key, timeRemaining)
+	// calculate the remaining time until deletion and clamp to a sane minimum
+	// to avoid immediate hot-loops when nextExecutionTime is in the past or now.
+	const minRequeueDelay = 5 * time.Second
+	delay := time.Until(*nextExecutionTime)
+	if delay <= 0 {
+		delay = minRequeueDelay
+	}
+	// add the item back to the queue after the delay
+	c.queue.AddAfter(key, delay)
 	return nil
 }
 

--- a/pkg/controllers/cleanup/controller_test.go
+++ b/pkg/controllers/cleanup/controller_test.go
@@ -1,13 +1,24 @@
 package cleanup
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
+	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	versionedfake "github.com/kyverno/kyverno/pkg/client/clientset/versioned/fake"
+	v2listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v2"
+	configpkg "github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/config/mocks"
+	"github.com/kyverno/kyverno/pkg/engine/jmespath"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 )
 
 func Test_SkipResourceDueToFilter(t *testing.T) {
@@ -41,4 +52,82 @@ func Test_SkipResourceDueToFilter(t *testing.T) {
 	)
 
 	assert.True(t, filtered, "Expected resource to be filtered and skipped")
+}
+
+// captureQueue wraps a real typed queue but captures the last AddAfter delay used by the controller.
+type captureQueue struct {
+	workqueue.TypedRateLimitingInterface[any]
+	lastDelay time.Duration
+	lastKey   any
+}
+
+func (c *captureQueue) AddAfter(item any, delay time.Duration) {
+	c.lastDelay = delay
+	c.lastKey = item
+	c.TypedRateLimitingInterface.AddAfter(item, delay)
+}
+
+// Test that reconcile clamps the requeue delay when the next execution time
+// (derived from a very old lastExecutionTime) is in the past.
+func TestReconcile_ClampPastNextExecution(t *testing.T) {
+	// Build a CleanupPolicy with an ancient lastExecutionTime and a frequent schedule.
+	pol := &kyvernov2.CleanupPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kyverno.io/v2",
+			Kind:       "CleanupPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pol",
+			Namespace: "ns1",
+		},
+		Spec: kyvernov2.CleanupPolicySpec{
+			Schedule: "* * * * *",
+		},
+		Status: kyvernov2.CleanupPolicyStatus{
+			LastExecutionTime: metav1.Time{
+				Time: time.Date(1901, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	fakeClient := versionedfake.NewSimpleClientset(pol.DeepCopy())
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc,
+		cache.Indexers{
+			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		},
+	)
+	if err := indexer.Add(pol.DeepCopy()); err != nil {
+		t.Fatalf("indexer add failed: %v", err)
+	}
+	polLister := v2listers.NewCleanupPolicyLister(indexer)
+
+	baseQ := workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.DefaultTypedControllerRateLimiter[any](),
+		workqueue.TypedRateLimitingQueueConfig[any]{
+			Name: "test-cleanup",
+		},
+	)
+	cq := &captureQueue{TypedRateLimitingInterface: baseQ}
+
+	ctrl := &controller{
+		kyvernoClient: fakeClient,
+		polLister:     polLister,
+		queue:         cq,
+		jp:            jmespath.New(configpkg.NewDefaultConfiguration(false)),
+	}
+
+	if err := ctrl.reconcile(
+		context.Background(),
+		logr.Discard(),
+		"ns1/test-pol",
+		"ns1",
+		"test-pol",
+	); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	if cq.lastDelay != 5*time.Second {
+		t.Fatalf("expected clamped delay to be 5s, got %q", cq.lastDelay)
+	}
 }

--- a/pkg/controllers/deleting/controller.go
+++ b/pkg/controllers/deleting/controller.go
@@ -246,9 +246,14 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 		nextExecutionTime = executionTime
 	}
 	// calculate the remaining time until deletion.
-	timeRemaining := time.Until(*nextExecutionTime)
-	// add the item back to the queue after the remaining time.
-	c.queue.AddAfter(key, timeRemaining)
+	// clamp to a sane minimum to avoid immediate hot-loops when nextExecutionTime is past/now
+	const minRequeueDelay = 5 * time.Second
+	delay := time.Until(*nextExecutionTime)
+	if delay <= 0 {
+		delay = minRequeueDelay
+	}
+	// add the item back to the queue after the delay
+	c.queue.AddAfter(key, delay)
 	return nil
 }
 

--- a/pkg/controllers/deleting/controller_test.go
+++ b/pkg/controllers/deleting/controller_test.go
@@ -1,13 +1,24 @@
 package deleting
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
+	policiesv1alpha1 "github.com/kyverno/kyverno/api/policies.kyverno.io/v1alpha1"
+	enginecompiler "github.com/kyverno/kyverno/pkg/cel/policies/dpol/compiler"
+	dpolengine "github.com/kyverno/kyverno/pkg/cel/policies/dpol/engine"
+	versionedfake "github.com/kyverno/kyverno/pkg/client/clientset/versioned/fake"
 	"github.com/kyverno/kyverno/pkg/config/mocks"
 	"github.com/stretchr/testify/assert"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/workqueue"
 )
 
 func Test_SkipResourceDueToFilter(t *testing.T) {
@@ -41,4 +52,93 @@ func Test_SkipResourceDueToFilter(t *testing.T) {
 	)
 
 	assert.True(t, filtered, "Expected resource to be filtered and skipped")
+}
+
+// captureQueue wraps a real typed queue but captures the last AddAfter delay used by the controller.
+type captureQueue struct {
+	workqueue.TypedRateLimitingInterface[any]
+	lastDelay time.Duration
+}
+
+func (c *captureQueue) AddAfter(item any, delay time.Duration) {
+	c.lastDelay = delay
+	c.TypedRateLimitingInterface.AddAfter(item, delay)
+}
+
+// Test that deleting controller reconcile clamps the requeue delay when the next execution
+// time is in the past (due to an old LastExecutionTime).
+func TestReconcile_ClampPastNextExecution_Deleting(t *testing.T) {
+	pol := policiesv1alpha1.DeletingPolicy{
+		Spec: policiesv1alpha1.DeletingPolicySpec{
+			Schedule: "* * * * *",
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{"CREATE"},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{""},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"globalcontextentries"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: policiesv1alpha1.DeletingPolicyStatus{
+			LastExecutionTime: metav1.NewTime(
+				time.Date(1901, 1, 1, 0, 0, 0, 0, time.UTC),
+			),
+		},
+	}
+	pol.Name = "dpol"
+
+	fakeClient := versionedfake.NewSimpleClientset(&pol)
+
+	baseQ := workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.DefaultTypedControllerRateLimiter[any](),
+		workqueue.TypedRateLimitingQueueConfig[any]{
+			Name: "test-deleting",
+		},
+	)
+	cq := &captureQueue{TypedRateLimitingInterface: baseQ}
+
+	compiler := enginecompiler.NewCompiler()
+	provFunc, err := dpolengine.NewProvider(compiler, []policiesv1alpha1.DeletingPolicy{pol}, nil)
+	if err != nil {
+		t.Fatalf("provider init failed: %v", err)
+	}
+	provider := providerAdapter{fetch: provFunc, name: pol.Name}
+
+	ctrl := &controller{
+		kyvernoClient: fakeClient,
+		queue:         cq,
+		provider:      provider,
+	}
+
+	if err := ctrl.reconcile(context.Background(), logr.Discard(), "dpol", "", "dpol"); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+	if cq.lastDelay != 5*time.Second {
+		t.Fatalf("expected 5s clamp, got %v", cq.lastDelay)
+	}
+}
+
+type providerAdapter struct {
+	fetch dpolengine.ProviderFunc
+	name  string
+}
+
+func (p providerAdapter) Get(ctx context.Context, name string) (dpolengine.Policy, error) {
+	list, err := p.fetch.Fetch(ctx)
+	if err != nil {
+		return dpolengine.Policy{}, err
+	}
+	for _, it := range list {
+		if it.Policy.Name == name {
+			return it, nil
+		}
+	}
+	return dpolengine.Policy{}, fmt.Errorf("not found")
 }


### PR DESCRIPTION


## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

Prevent hot-loop requeues when `nextExecutionTime` is `<= now` by floor-clamping delay to 5s in cleanup and deleting controllers. Add unit tests with a pure delay clamp check and controller-level tests verifying the 5s requeue in this scenario. Improves stability under misconfigured schedules and reduces API/CPU pressure.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

None.

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change -->
/kind bug
<!--
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

At the moment, with backdated `status.lastExecutionTime` the `CleanupPolicy` and `DeletingPolicy` controllers compute a non-positive delay and requeue immediately, creating a tight loop (high CPU/API load). No behavior change for on-time schedules. Only prevents pathological immediate requeues when the next slot is in the past.

Includes tests validating the clamping in both controllers.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
