### PR TITLE
add check for namespace

### DIFF
--- a/pkg/engine/utils/exceptions.go
+++ b/pkg/engine/utils/exceptions.go
@@ -30,12 +30,14 @@ func MatchesException(client engineapi.Client, polexs []*kyvernov2.PolicyExcepti
 	}
 	nsLabels := policyContext.NamespaceLabels()
 	if isCluster {
-		namespace, err := client.GetNamespace(context.TODO(), resource.GetNamespace(), metav1.GetOptions{})
-		if err != nil {
-			logger.Error(err, "failed to get namespace", "name", resource.GetNamespace())
-			return nil
+		if resource.GetNamespace() != "" {
+			namespace, err := client.GetNamespace(context.TODO(), resource.GetNamespace(), metav1.GetOptions{})
+			if err != nil {
+				logger.Error(err, "failed to get namespace", "name", resource.GetNamespace())
+				return nil
+			}
+			nsLabels = namespace.GetLabels()
 		}
-		nsLabels = namespace.GetLabels()
 	}
 	for _, polex := range polexs {
 		match := checkMatchesResources(


### PR DESCRIPTION
## Explanation

After upgrading Kyverno helm chart on DEV clusters from 3.5.1 to 3.5.2 we noticed that Kyverno policy reporter for the policies with a kinds: ClusterRole started evaluating Cluster Roles as Failed but should have skipped them since as we have a Policy Exception. As it turned out Kyverno "ignores" policy exceptions for policies - https://github.com/kyverno/policies/blob/main/other/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml, https://github.com/kyverno/policies/blob/main/other/restrict-wildcard-resources/restrict-wildcard-resources.yaml, https://github.com/kyverno/policies/blob/main/other/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml

## Related issue
closes https://github.com/kyverno/kyverno/issues/14079


## What type of PR is this

bug

## Proposed Changes

add conditional statement to check if `resource.GetNamespace != ""`  to prevent known error causing return.

### Proof Manifests


# Kubernetes resource

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: my-full-access      # This is listed in your PolicyException
rules:
  - apiGroups: [""]
    resources: ["pods"]
    verbs: ["*"]           # Wildcard triggers the policy

```

# Policy

https://github.com/kyverno/policies/blob/main/other/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml

## PolicyException

```yaml
apiVersion: kyverno.io/v2
kind: PolicyException
metadata:
  name: restrict-cluster-roles-wildcard-verbs
  namespace: kyverno
spec:
  exceptions:
    - policyName: restrict-wildcard-verbs
      ruleNames:
        - '*'
  match:
    all:
      - resources:
          kinds:
            - ClusterRole
          names:
            - my-full-access
            - crd-controller-flux-system
            - eks:cloud-controller-manager
            - prometheus-operator
            - system:kubelet-api-admin
          namespaces: 
            - '*'
```
## Result

should skip policy for resource `my-full-access `
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
