### PR TITLE
support label selector in resource.List CEL lib

### DIFF
--- a/pkg/cel/libs/fake_context.go
+++ b/pkg/cel/libs/fake_context.go
@@ -60,7 +60,7 @@ func (cp *FakeContextProvider) ToGVR(apiVersion, kind string) (*schema.GroupVers
 	panic("not implemented")
 }
 
-func (cp *FakeContextProvider) ListResources(apiVersion, resource, namespace string) (*unstructured.UnstructuredList, error) {
+func (cp *FakeContextProvider) ListResources(apiVersion, resource, namespace string, labels map[string]string) (*unstructured.UnstructuredList, error) {
 	gv, err := schema.ParseGroupVersion(apiVersion)
 	if err != nil {
 		return nil, err

--- a/pkg/cel/libs/fake_context_test.go
+++ b/pkg/cel/libs/fake_context_test.go
@@ -88,22 +88,22 @@ func TestFakeContextProvider_AddResource(t *testing.T) {
 	}
 	// list
 	{
-		got, err := cp.ListResources("v1", "configmaps", "test-ns")
+		got, err := cp.ListResources("v1", "configmaps", "test-ns", nil)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(got.Items))
 	}
 	{
-		got, err := cp.ListResources("v1", "configmaps", "wrong-ns")
+		got, err := cp.ListResources("v1", "configmaps", "wrong-ns", nil)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(got.Items))
 	}
 	{
-		got, err := cp.ListResources("v1", "wrongs", "test-ns")
+		got, err := cp.ListResources("v1", "wrongs", "test-ns", nil)
 		assert.Error(t, err)
 		assert.Nil(t, got)
 	}
 	{
-		got, err := cp.ListResources("wrong", "configmaps", "test-ns")
+		got, err := cp.ListResources("wrong", "configmaps", "test-ns", nil)
 		assert.Error(t, err)
 		assert.Nil(t, got)
 	}

--- a/pkg/cel/libs/resource/impl.go
+++ b/pkg/cel/libs/resource/impl.go
@@ -25,7 +25,31 @@ func (c *impl) list_resources_string_string_string(args ...ref.Val) ref.Val {
 	} else if namespace, err := utils.GetArg[string](args, 3); err != nil {
 		return err
 	} else {
-		list, err := self.ListResources(apiVersion, resource, namespace)
+		list, err := self.ListResources(apiVersion, resource, namespace, nil)
+		if err != nil {
+			// Errors are not expected here since Parse is a more lenient parser than ParseRequestURI.
+			return types.NewErr("failed to list resource: %v", err)
+		}
+		return c.NativeToValue(list.UnstructuredContent())
+	}
+}
+
+func (c *impl) list_resources_string_string_string_map(args ...ref.Val) ref.Val {
+	if len(args) != 5 {
+		return types.NewErr("expected 5 arguments, got %d", len(args))
+	}
+	if self, err := utils.GetArg[Context](args, 0); err != nil {
+		return err
+	} else if apiVersion, err := utils.GetArg[string](args, 1); err != nil {
+		return err
+	} else if resource, err := utils.GetArg[string](args, 2); err != nil {
+		return err
+	} else if namespace, err := utils.GetArg[string](args, 3); err != nil {
+		return err
+	} else if labels, err := utils.GetArg[map[string]string](args, 4); err != nil {
+		return err
+	} else {
+		list, err := self.ListResources(apiVersion, resource, namespace, labels)
 		if err != nil {
 			// Errors are not expected here since Parse is a more lenient parser than ParseRequestURI.
 			return types.NewErr("failed to list resource: %v", err)
@@ -41,7 +65,18 @@ func (c *impl) list_resources_gvr_string(args ...ref.Val) ref.Val {
 	if gvr, err := utils.GetArg[*schema.GroupVersionResource](args, 1); err != nil {
 		return err
 	} else {
-		return c.post_resource_string_string_string_map(args[0], types.String(gvr.GroupVersion().String()), types.String(gvr.Resource), args[2])
+		return c.list_resources_string_string_string(args[0], types.String(gvr.GroupVersion().String()), types.String(gvr.Resource), args[2])
+	}
+}
+
+func (c *impl) list_resources_gvr_string_map(args ...ref.Val) ref.Val {
+	if len(args) != 4 {
+		return types.NewErr("expected 4 arguments, got %d", len(args))
+	}
+	if gvr, err := utils.GetArg[*schema.GroupVersionResource](args, 1); err != nil {
+		return err
+	} else {
+		return c.list_resources_string_string_string_map(args[0], types.String(gvr.GroupVersion().String()), types.String(gvr.Resource), args[2], args[3])
 	}
 }
 

--- a/pkg/cel/libs/resource/lib.go
+++ b/pkg/cel/libs/resource/lib.go
@@ -47,10 +47,22 @@ func (c *lib) extendEnv(env *cel.Env) (*cel.Env, error) {
 				cel.FunctionBinding(impl.list_resources_string_string_string),
 			),
 			cel.MemberOverload(
+				"resource_list_string_string_string_map",
+				[]*cel.Type{ContextType, types.StringType, types.StringType, types.StringType, types.NewMapType(types.StringType, types.StringType)},
+				types.NewMapType(types.StringType, types.AnyType),
+				cel.FunctionBinding(impl.list_resources_string_string_string_map),
+			),
+			cel.MemberOverload(
 				"list_resources_gvr_string",
 				[]*cel.Type{ContextType, GVRType, types.StringType},
 				types.NewMapType(types.StringType, types.AnyType),
 				cel.FunctionBinding(impl.list_resources_gvr_string),
+			),
+			cel.MemberOverload(
+				"list_resources_gvr_string_map",
+				[]*cel.Type{ContextType, GVRType, types.StringType, types.NewMapType(types.StringType, types.StringType)},
+				types.NewMapType(types.StringType, types.AnyType),
+				cel.FunctionBinding(impl.list_resources_gvr_string_map),
 			),
 		},
 		"Get": {

--- a/pkg/cel/libs/resource/mock.go
+++ b/pkg/cel/libs/resource/mock.go
@@ -6,14 +6,14 @@ import (
 )
 
 type ContextMock struct {
-	ListResourcesFunc func(string, string, string) (*unstructured.UnstructuredList, error)
+	ListResourcesFunc func(string, string, string, map[string]string) (*unstructured.UnstructuredList, error)
 	GetResourceFunc   func(string, string, string, string) (*unstructured.Unstructured, error)
 	PostResourceFunc  func(string, string, string, map[string]any) (*unstructured.Unstructured, error)
 	ToGVRFunc         func(string, string) (*schema.GroupVersionResource, error)
 }
 
-func (mock *ContextMock) ListResources(apiVersion, resource, namespace string) (*unstructured.UnstructuredList, error) {
-	return mock.ListResourcesFunc(apiVersion, resource, namespace)
+func (mock *ContextMock) ListResources(apiVersion, resource, namespace string, labels map[string]string) (*unstructured.UnstructuredList, error) {
+	return mock.ListResourcesFunc(apiVersion, resource, namespace, labels)
 }
 
 func (mock *ContextMock) GetResource(apiVersion, resource, namespace, name string) (*unstructured.Unstructured, error) {

--- a/pkg/cel/libs/resource/types.go
+++ b/pkg/cel/libs/resource/types.go
@@ -11,7 +11,7 @@ var ContextType = types.NewOpaqueType("resource.Context")
 var GVRType = types.NewOpaqueType("schema.GroupVersionResource")
 
 type ContextInterface interface {
-	ListResources(apiVersion, resource, namespace string) (*unstructured.UnstructuredList, error)
+	ListResources(apiVersion, resource, namespace string, labels map[string]string) (*unstructured.UnstructuredList, error)
 	GetResource(apiVersion, resource, namespace, name string) (*unstructured.Unstructured, error)
 	PostResource(apiVersion, resource, namespace string, data map[string]any) (*unstructured.Unstructured, error)
 	ToGVR(apiVersion, kind string) (*schema.GroupVersionResource, error)


### PR DESCRIPTION
Optional argument to filter resources via label selector map

## Example

```yaml
apiVersion: policies.kyverno.io/v1alpha1
kind: GeneratingPolicy
metadata:
  name: generate-secrets
spec:
  matchConstraints:
    resourceRules:
    - apiGroups:   [""]
      apiVersions: ["v1"]
      operations:  ["CREATE", "UPDATE"]
      resources:   ["namespaces"]
  variables:
    - name: nsName
      expression: "object.metadata.name"
    - name: sources
      expression: resource.List("v1", "secrets", "default", { "copy": "true" })
  generate:
    - expression: generator.Apply(variables.nsName, [variables.sources])
```
