### PR TITLE
fix(cli): prevent setting default namespace on cluster-scoped resources

### DIFF
--- a/cmd/cli/kubectl-kyverno/resource/resource.go
+++ b/cmd/cli/kubectl-kyverno/resource/resource.go
@@ -53,10 +53,49 @@ func YamlToUnstructured(resourceYaml []byte) (*unstructured.Unstructured, error)
 	if decodeErr == nil {
 		resource.SetGroupVersionKind(*metaData)
 	}
-	if resource.GetNamespace() == "" {
+	if resource.GetNamespace() == "" && !isClusterScopedResource(resource.GetKind()) {
 		resource.SetNamespace("default")
 	}
 	return resource, nil
+}
+
+// isClusterScopedResource checks if a resource kind is cluster-scoped
+func isClusterScopedResource(kind string) bool {
+	clusterScopedKinds := []string{
+		"Namespace",
+		"Node",
+		"PersistentVolume",
+		"ClusterRole",
+		"ClusterRoleBinding",
+		"ClusterPolicy",
+		"ClusterPolicyReport",
+		"StorageClass",
+		"CustomResourceDefinition",
+		"MutatingWebhookConfiguration",
+		"ValidatingWebhookConfiguration",
+		"APIService",
+		"TokenReview",
+		"SubjectAccessReview",
+		"SelfSubjectAccessReview",
+		"SelfSubjectRulesReview",
+		"CertificateSigningRequest",
+		"ValidatingAdmissionPolicy",
+		"ValidatingAdmissionPolicyBinding",
+		"MutatingAdmissionPolicy",
+		"MutatingAdmissionPolicyBinding",
+		"PriorityClass",
+		"RuntimeClass",
+		"CSIDriver",
+		"CSINode",
+		"VolumeAttachment",
+		"IngressClass",
+	}
+	for _, clusterKind := range clusterScopedKinds {
+		if kind == clusterKind {
+			return true
+		}
+	}
+	return false
 }
 
 // should be able to specify a single resource in a multi yaml file, dont error out when there are multiple resource

--- a/cmd/cli/kubectl-kyverno/resource/resource_test.go
+++ b/cmd/cli/kubectl-kyverno/resource/resource_test.go
@@ -1,0 +1,100 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestYamlToUnstructured_ClusterScopedResources(t *testing.T) {
+	tests := []struct {
+		name              string
+		yaml              string
+		expectedNamespace string
+	}{
+		{
+			name: "Namespace should not get default namespace",
+			yaml: `apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-namespace`,
+			expectedNamespace: "",
+		},
+		{
+			name: "Pod should get default namespace",
+			yaml: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod`,
+			expectedNamespace: "default",
+		},
+		{
+			name: "Node should not get default namespace",
+			yaml: `apiVersion: v1
+kind: Node
+metadata:
+  name: test-node`,
+			expectedNamespace: "",
+		},
+		{
+			name: "ClusterRole should not get default namespace",
+			yaml: `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-cluster-role`,
+			expectedNamespace: "",
+		},
+		{
+			name: "Deployment should get default namespace",
+			yaml: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment`,
+			expectedNamespace: "default",
+		},
+		{
+			name: "PersistentVolume should not get default namespace",
+			yaml: `apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: test-pv`,
+			expectedNamespace: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, err := YamlToUnstructured([]byte(tt.yaml))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedNamespace, resource.GetNamespace(),
+				"Resource %s should have namespace %q but got %q",
+				resource.GetKind(), tt.expectedNamespace, resource.GetNamespace())
+		})
+	}
+}
+
+func TestIsClusterScopedResource(t *testing.T) {
+	tests := []struct {
+		kind     string
+		expected bool
+	}{
+		{"Namespace", true},
+		{"Node", true},
+		{"PersistentVolume", true},
+		{"ClusterRole", true},
+		{"ClusterRoleBinding", true},
+		{"StorageClass", true},
+		{"Pod", false},
+		{"Deployment", false},
+		{"Service", false},
+		{"ConfigMap", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			result := isClusterScopedResource(tt.kind)
+			assert.Equal(t, tt.expected, result,
+				"Kind %s: expected %v, got %v", tt.kind, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Description

**Fixes #14207**

### Problem
The Kyverno CLI was incorrectly setting `namespace='default'` on all resources that didn't have a namespace specified, including cluster-scoped resources like Namespaces, Nodes, ClusterRoles, etc.

This caused `kyverno test` command to fail when testing mutation policies on Namespace resources because:
1. Namespace resources were being loaded with `namespace='default'` 
2. The resource key used for matching became incorrect: `v1,Namespace,default,name` instead of `v1,Namespace,,name`
3. Target resources in `mutate-existing` tests failed to match, resulting in "Not found" errors

### Solution
Added logic to detect cluster-scoped resources before setting the default namespace:

- **New function**: `isClusterScopedResource()` - checks if a resource kind is cluster-scoped
- **Modified**: `YamlToUnstructured()` - only sets default namespace for namespaced resources
- **Added tests**: Comprehensive test coverage for both cluster-scoped and namespaced resources

The function includes detection for common cluster-scoped resources:
- Core resources: Namespace, Node, PersistentVolume
- RBAC: ClusterRole, ClusterRoleBinding
- Policy resources: ClusterPolicy, ValidatingAdmissionPolicy, etc.
- Storage: StorageClass, CSIDriver, CSINode, VolumeAttachment
- And more...

### Testing
1. Added unit tests with 100% coverage on new code
2. Tested with the reproduction case from issue #14207
3. All existing tests continue to pass

#### Test Case Example:
```yaml
# Policy with mutateExistingOnPolicyUpdate targeting Namespaces
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: add-label-to-namespace
spec:
  rules:
    - name: add-label
      match:
        all:
          - resources:
              kinds:
                - Namespace
      mutate:
        patchStrategicMerge:
          metadata:
            labels:
              managed: "true"
        mutateExistingOnPolicyUpdate: true
        targets:
          - apiVersion: v1
            kind: Namespace
```

**Before**: Test fails with "Not found" error  
**After**: Test passes correctly ✅

### Checklist
- [x] Issue reference included (Fixes #14207)
- [x] Unit tests added with 100% coverage on new code
- [x] All tests passing (`make test-unit`)
- [x] Code formatted (`make fmt-check`)
- [x] Imports checked (`make imports-check`)
- [x] Go vet clean (`make vet`)
- [x] Build successful (`go build ./...`)
- [x] Unused packages checked

### Related Issues
Closes #14207