### PR TITLE
fix(chart): global image registry bug for webhooks cleanup pre-delete hook

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -41,6 +41,8 @@ annotations:
       description: Enable the flag `--generateValidatingAdmissionPolicy` by default in the admission controller.
     - kind: changed
       description: Enable the flag `--validatingAdmissionPolicyReports` by default in the reports controller.
+    - kind: fixed
+      description: Fix webhook cleanup hook image registry defaults so global image registry is respected.
 dependencies:
   - name: grafana
     version: v0.0.0

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -789,7 +789,8 @@ The chart values are organised per component.
 |-----|------|---------|-------------|
 | webhooksCleanup.enabled | bool | `true` | Create a helm pre-delete hook to cleanup webhooks. |
 | webhooksCleanup.autoDeleteWebhooks.enabled | bool | `false` | Allow webhooks controller to delete webhooks using finalizers |
-| webhooksCleanup.image.registry | string | `"registry.k8s.io"` | Image registry |
+| webhooksCleanup.image.registry | string | `nil` | Image registry |
+| webhooksCleanup.image.defaultRegistry | string | `"registry.k8s.io"` |  |
 | webhooksCleanup.image.repository | string | `"kubectl"` | Image repository |
 | webhooksCleanup.image.tag | string | `"v1.32.7"` | Image tag Defaults to `latest` if omitted |
 | webhooksCleanup.image.pullPolicy | string | `nil` | Image pull policy Defaults to image.pullPolicy if omitted |

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -590,7 +590,8 @@ webhooksCleanup:
 
   image:
     # -- (string) Image registry
-    registry: registry.k8s.io
+    registry: ~
+    defaultRegistry: registry.k8s.io
     # -- Image repository
     repository: kubectl
     # -- Image tag


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

This fixes webhook cleanup pre-delete hook image registry defaults so that `global.image.registry` gets to be used as default when `global.image.registry` is set and webhook cleanup pre-delete hook image registry explicit override is not set.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

Fix for Kyverno Deployments was introduced via https://github.com/kyverno/kyverno/pull/11604 which fixed https://github.com/kyverno/kyverno/issues/11579 for Deployments but not for pre-delete hooks.

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

/milestone 1.16.3

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

PR fixes the bug by introducing `webhooksCleanup.image.defaultRegistry` and setting `webhooksCleanup.image.registry` to nil, as expected by `kyverno.image` helper [used](https://github.com/kyverno/kyverno/blob/main/charts/kyverno/templates/hooks/pre-delete-scale-to-zero.yaml#L44) for webhooks cleanup pre-delete hook image.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

Defaults remain as before
```bash
$ helm template ./charts/kyverno | grep image:
                          image:
                              image:
                              image:
                          image:
                              image:
                              image:
          image: "reg.kyverno.io/kyverno/kyvernopre:latest"
          image: "reg.kyverno.io/kyverno/kyverno:latest"
          image: "reg.kyverno.io/kyverno/background-controller:latest"
          image: "reg.kyverno.io/kyverno/cleanup-controller:latest"
          image: "reg.kyverno.io/kyverno/reports-controller:latest"
      image: curlimages/curl:8.10.1
      image: curlimages/curl:8.10.1
      image: curlimages/curl:8.10.1
      image: curlimages/curl:8.10.1
      image: curlimages/curl:8.10.1
          image: "reg.kyverno.io/kyverno/kyverno-cli:latest"
          image: "registry.k8s.io/kubectl:v1.32.7"
          image: "registry.k8s.io/kubectl:v1.32.7"
          image: "registry.k8s.io/kubectl:v1.32.7"
```

When `global.image.registry` is set, it gets respected as webhooks cleanup pre-delete hook image registry.
```bash
$ helm template ./charts/kyverno --set global.image.registry=myregistry | grep image:
                          image:
                              image:
                              image:
                          image:
                              image:
                              image:
          image: "myregistry/kyverno/kyvernopre:latest"
          image: "myregistry/kyverno/kyverno:latest"
          image: "myregistry/kyverno/background-controller:latest"
          image: "myregistry/kyverno/cleanup-controller:latest"
          image: "myregistry/kyverno/reports-controller:latest"
      image: curlimages/curl:8.10.1
      image: curlimages/curl:8.10.1
      image: curlimages/curl:8.10.1
      image: curlimages/curl:8.10.1
      image: curlimages/curl:8.10.1
          image: "myregistry/kyverno/kyverno-cli:latest"
          image: "myregistry/kubectl:v1.32.7"
          image: "myregistry/kubectl:v1.32.7"
          image: "myregistry/kubectl:v1.32.7"
```

Even when `global.image.registry` is set, `webhooksCleanup.image.registry` has precedence as webhooks cleanup pre-delete hook image registry explicit override.
```bash
$ helm template ./charts/kyverno --set global.image.registry=myregistry --set webhooksCleanup.image.registry=myotherregistry | grep image:
                          image:
                              image:
                              image:
                          image:
                              image:
                              image:
          image: "myregistry/kyverno/kyvernopre:latest"
          image: "myregistry/kyverno/kyverno:latest"
          image: "myregistry/kyverno/background-controller:latest"
          image: "myregistry/kyverno/cleanup-controller:latest"
          image: "myregistry/kyverno/reports-controller:latest"
      image: curlimages/curl:8.10.1
      image: curlimages/curl:8.10.1
      image: curlimages/curl:8.10.1
      image: curlimages/curl:8.10.1
      image: curlimages/curl:8.10.1
          image: "myregistry/kyverno/kyverno-cli:latest"
          image: "myotherregistry/kubectl:v1.32.7"
          image: "myotherregistry/kubectl:v1.32.7"
          image: "myotherregistry/kubectl:v1.32.7"
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
