### PR TITLE
fix: Remove -o pipefail option from containers that are using sh shell

### DIFF
--- a/charts/kyverno/templates/hooks/post-delete-configmap.yaml
+++ b/charts/kyverno/templates/hooks/post-delete-configmap.yaml
@@ -97,7 +97,7 @@ spec:
             - /bin/sh
             - -c
             - |-
-              set -euo pipefail
+              set -eu
               kubectl delete cm --ignore-not-found -n {{ template "kyverno.namespace" . }} {{ template "kyverno.config.configMapName" . }}
           {{- with .Values.webhooksCleanup.securityContext }}
           securityContext:

--- a/charts/kyverno/templates/hooks/post-upgrade-clean-reports.yaml
+++ b/charts/kyverno/templates/hooks/post-upgrade-clean-reports.yaml
@@ -39,7 +39,7 @@ spec:
             - /bin/sh
             - -c
             - |-
-              set -euo pipefail
+              set -eu
               NAMESPACES=$(kubectl get namespaces --no-headers=true | awk '{print $1}')
 
               for ns in $NAMESPACES

--- a/charts/kyverno/templates/hooks/pre-delete-scale-to-zero.yaml
+++ b/charts/kyverno/templates/hooks/pre-delete-scale-to-zero.yaml
@@ -44,7 +44,7 @@ spec:
             - /bin/sh
             - -c
             - |-
-              set -euo pipefail
+              set -eu
               kubectl scale -n {{ template "kyverno.namespace" . }} deployment -l app.kubernetes.io/part-of={{ template "kyverno.fullname" . }} --replicas=0
               sleep 30
               kubectl delete validatingwebhookconfiguration -l webhook.kyverno.io/managed-by=kyverno


### PR DESCRIPTION
## Explanation

After the merge of https://github.com/kyverno/kyverno/pull/14268, the clean-reports job is failing with:

```
kubectl logs -n kyverno kyverno-clean-reports-wx2wr
/bin/sh: 1: set: Illegal option -o pipefail
```

This PR simply aims on removing the -o pipefail options from the containers that are using the sh shell.

## Related issue

Closes https://github.com/kyverno/kyverno/issues/14303

## Milestone of this PR
 
 /milestone 1.14.6
 
## What type of PR is this

/kind bug

## Proposed Changes

This PR simply aims on removing the -o pipefail options from the containers that are using the sh shell.


### Proof Manifests


## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
