### PR TITLE
fix: Update Go version to fix stdlib CVEs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,9 +7,9 @@ RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
 
 # Install Golang
 RUN ARCH="$(dpkg --print-architecture)"; \
-    curl -LO https://dl.google.com/go/go1.24.6.linux-$ARCH.tar.gz \
-    && tar -C /usr/local -xzf go1.24.6.linux-$ARCH.tar.gz \
-    && rm go1.24.6.linux-$ARCH.tar.gz \
+    curl -LO https://dl.google.com/go/go1.25.3.linux-$ARCH.tar.gz \
+    && tar -C /usr/local -xzf go1.25.3.linux-$ARCH.tar.gz \
+    && rm go1.25.3.linux-$ARCH.tar.gz \
     && echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile
 
 # Install Docker

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyverno/kyverno
 
-go 1.25.0
+go 1.25.3
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6

--- a/hack/api-group-resources/go.mod
+++ b/hack/api-group-resources/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyverno/kyverno/hack/api-group-resources
 
-go 1.24.6
+go 1.25.3
 
 require k8s.io/client-go v0.34.1
 

--- a/hack/controller-gen/go.mod
+++ b/hack/controller-gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyverno/kyverno/hack/controller-gen
 
-go 1.24.6
+go 1.25.3
 
 require (
 	github.com/spf13/cobra v1.10.1


### PR DESCRIPTION
## Description

Fix go stdlib CVES related in `1.25.0` by updating to `1.25.3`

## Related issue

- https://github.com/kyverno/kyverno/issues/14273
- 

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

/milestone 1.16.0-rc.2



## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind bug

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
