### PR TITLE
fix nil namespace initialization for cluster wide param resources

### DIFF
--- a/pkg/admissionpolicy/validate.go
+++ b/pkg/admissionpolicy/validate.go
@@ -143,7 +143,7 @@ func Validate(
 		resPath       = fmt.Sprintf("%s/%s/%s", resource.GetNamespace(), resource.GetKind(), resource.GetName())
 		policy        = policyData.GetDefinition()
 		bindings      = policyData.GetBindings()
-		namespace     *corev1.Namespace
+		namespace     = &corev1.Namespace{}
 		namespaceName = resource.GetNamespace()
 	)
 
@@ -159,7 +159,6 @@ func Validate(
 			},
 		}
 	}
-
 	var user UserInfo
 	if userInfo != nil {
 		user = NewUser(*userInfo)


### PR DESCRIPTION
## Explanation

If the paramKind for a VAP is a cluster scoped resource, the namespace pointer that gets passed to processVAPWithClient never becomes non nil. this initializes the pointer as an empty pointer instead of nil


## Milestone of this PR


## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind bug


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

