### PR TITLE
Add paths filter for conformance tests

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -15,8 +15,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-changes:
+    # This job determines if the conformance tests are necessary to run.
+    # The tests should run if any files in the "should-run" filter below has been changed.
+    # Otherwise they can be skipped.
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.filter.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            should-run:
+              - 'pkg/**'
+              - 'api/**'
+              - 'cmd/**'
+              - 'charts/**'
+              - 'ext/**'
+              - 'test/**'
+              - 'scripts/**'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - '.github/workflows/conformance.yaml'
+
   prepare-images:
     runs-on: ubuntu-latest
+    needs: check-changes
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -40,6 +68,8 @@ jobs:
 
   prepare-cli:
     runs-on: ubuntu-latest
+    needs: check-changes
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -69,7 +99,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -87,7 +118,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -106,7 +138,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -124,7 +157,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -142,7 +176,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -160,7 +195,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -177,9 +213,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -199,7 +236,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -217,7 +255,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -234,7 +273,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2, 3, 4, 5, 6, 7]
     needs: [prepare-images]
     steps:
@@ -256,7 +295,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -274,7 +314,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.32.8, v1.33.4, v1.34.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -293,7 +334,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -311,7 +353,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -328,9 +371,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -350,7 +394,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -368,7 +413,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -388,7 +434,8 @@ jobs:
         kyverno-configs:
           [standard, default, standard, force-failure-policy-ignore]
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -405,9 +452,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -427,7 +475,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -444,7 +493,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2, 3, 4, 5]
     needs: [prepare-images]
     steps:
@@ -466,7 +515,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -484,7 +534,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.32.8, v1.33.4, v1.34.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -502,9 +553,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -523,9 +575,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -544,9 +597,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -565,9 +619,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -586,9 +641,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -607,9 +663,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -628,9 +685,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -649,9 +707,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -670,7 +729,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
     needs: [prepare-images]
     steps:
@@ -691,7 +750,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
     needs: [prepare-images]
     steps:
@@ -713,7 +772,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -731,7 +791,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -748,9 +809,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -770,7 +832,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -788,7 +851,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -806,7 +870,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/run-tests
@@ -829,7 +894,8 @@ jobs:
           - v1.34.x
         tests:
           - custom-sigstore
-    needs: prepare-images
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -905,11 +971,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
     needs:
+      - check-changes
       - prepare-images
       - prepare-cli
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - name: Checkout kyverno/kyverno
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -1042,7 +1110,9 @@ jobs:
         tests:
           - ^cli$
     needs:
+      - check-changes
       - prepare-cli
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -1087,9 +1157,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.33.7, v1.34.2, v1.35.0]        
+        k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         kyverno-version: ["3.2"]
-    needs: [prepare-images]
+    needs: [check-changes, prepare-images]
+    if: needs.check-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install helm
@@ -1150,7 +1221,9 @@ jobs:
             values:
               - kyverno-cleanup
     needs:
+      - check-changes
       - prepare-images
+    if: needs.check-changes.outputs.should-run == 'true'
     name: ${{ matrix.k8s-version.name }} - kyverno uninstall
     steps:
       - name: Checkout kyverno/kyverno
@@ -1325,7 +1398,7 @@ jobs:
       - helm-uninstall
       - cert-manager-certificates
     runs-on: ubuntu-latest
-    if: ${{ success() }}
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') }}
     steps:
       - run: ${{ true }}
 
@@ -1375,6 +1448,6 @@ jobs:
       - helm-uninstall
       - cert-manager-certificates
     runs-on: ubuntu-latest
-    if: ${{ failure() || cancelled() }}
+    if: ${{ always() && (cancelled() || contains(needs.*.result, 'failure')) }}
     steps:
       - run: ${{ false }}


### PR DESCRIPTION

## Explanation

This avoids running the tests for irrelevant changes, saving time and resources.
The dorny/paths-filer action is used to detect if the relevant files are touched.
Jobs then include this as a needed dependency and run based on the output of it.

The tricky part is the "aggregate" jobs (conformance-required-success
and conformance-required-failure). They need to now succeed/fail even if some
dependencies were skipped because no relevant files were touched.
We cannot use success() because that would fail if a job was skipped.
Instead we check if any of them failed explicitly (skipped is then allowed).

## Related issue

Closes https://github.com/kyverno/kyverno/issues/14334

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind cleanup

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
