### PR TITLE
added a global node selector for linux only node scheduling

### DIFF
--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -44,7 +44,8 @@ global:
   #   value: 'https://proxy.example.com:3128'
 
   # -- Global node labels for pod assignment. Non-global values will override the global value.
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/os: linux
 
   # -- Global List of node taints to tolerate. Non-global values will override the global value.
   tolerations: []


### PR DESCRIPTION
## Explanation

This PR contains the fix for the issue #14360 , added a global nodeSelector with default linux host label 
 nodeSelector:
   kubernetes.io/os: linux
 

## Related issue
https://github.com/kyverno/kyverno/issues/14360
