### PR TITLE
fix: use consistent rule_execution_cause label across all policy metrics

### DIFF
--- a/pkg/metrics/ivpol.go
+++ b/pkg/metrics/ivpol.go
@@ -55,7 +55,7 @@ func (m *imageValidatingMetrics) RecordDuration(ctx context.Context, seconds flo
 		attribute.String("resource_kind", resource.GetKind()),
 		attribute.String("resource_namespace", resource.GetNamespace()),
 		attribute.String("resource_request_operation", strings.ToLower(operation)),
-		attribute.String("execution_cause", ruleExecutionCause),
+		attribute.String("rule_execution_cause", ruleExecutionCause),
 		attribute.String("result", status),
 	))
 }

--- a/pkg/metrics/mpol.go
+++ b/pkg/metrics/mpol.go
@@ -54,7 +54,7 @@ func (m *mutatingMetrics) RecordDuration(ctx context.Context, seconds float64, s
 		attribute.String("resource_kind", resource.GetKind()),
 		attribute.String("resource_namespace", resource.GetNamespace()),
 		attribute.String("resource_request_operation", strings.ToLower(operation)),
-		attribute.String("execution_cause", ruleExecutionCause),
+		attribute.String("rule_execution_cause", ruleExecutionCause),
 		attribute.String("result", status),
 	))
 }

--- a/pkg/metrics/vpol.go
+++ b/pkg/metrics/vpol.go
@@ -58,7 +58,7 @@ func (m *validatingMetrics) RecordDuration(ctx context.Context, seconds float64,
 		attribute.String("resource_kind", resource.GetKind()),
 		attribute.String("resource_namespace", resource.GetNamespace()),
 		attribute.String("resource_request_operation", strings.ToLower(operation)),
-		attribute.String("execution_cause", ruleExecutionCause),
+		attribute.String("rule_execution_cause", ruleExecutionCause),
 		attribute.String("result", status),
 	))
 }


### PR DESCRIPTION
## Summary

This PR standardizes the metric label name to `rule_execution_cause` across all policy execution duration metrics (validating, mutating, and image validating policies).

## Background

Previously, commit f9aa7776e (#14001) changed all metrics to use `execution_cause`, but commit ffd1051cb (#14471) reverted only the `policy_engine.go` file back to `rule_execution_cause` to avoid a breaking change for the `kyverno_policy_results` metric. 

This left an inconsistency where:
- `policy_engine.go` used `rule_execution_cause` 
- `vpol.go`, `mpol.go`, and `ivpol.go` used `execution_cause`

## Changes

This PR aligns all files to use `rule_execution_cause` for consistency by updating:
- `pkg/metrics/vpol.go` - changed `execution_cause` to `rule_execution_cause`
- `pkg/metrics/mpol.go` - changed `execution_cause` to `rule_execution_cause`  
- `pkg/metrics/ivpol.go` - changed `execution_cause` to `rule_execution_cause`

## Related Issues

Fixes the inconsistency introduced in #14001 and partially reverted in #14471.