### PR TITLE
fix: use local helm-docs binary instead of Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ $(HELM):
 
 $(HELM_DOCS):
 	@echo Install helm-docs... >&2
-	@GOBIN=$(TOOLS_DIR) go install github.com/norwoodj/helm-docs/cmd/helm-docs@$(HELM_DOCS_VERSION)
+	@GOBIN=$(TOOLS_DIR) go install -ldflags "-X main.version=$(HELM_DOCS_VERSION:v%=%)" github.com/norwoodj/helm-docs/cmd/helm-docs@$(HELM_DOCS_VERSION)
 
 $(KO):
 	@echo Install ko... >&2
@@ -682,7 +682,7 @@ helm-setup-dependency-charts: $(HELM) ## Add dependency helm repos and build dep
 	@$(HELM) dependency build ./charts/kyverno
 
 # Legacy alias for backward compatibility
-.PHONY: helm-setup-openreports  
+.PHONY: helm-setup-openreports
 helm-setup-openreports: helm-setup-dependency-charts ## (Deprecated) Use helm-setup-dependency-charts instead
 
 .PHONY: codegen-helm-crds
@@ -724,9 +724,9 @@ codegen-helm-crds: codegen-crds-all
 	@rm -rf ./charts/crds/templates/wgpolicyk8s.io
 
 .PHONY: codegen-helm-docs
-codegen-helm-docs: ## Generate helm docs
+codegen-helm-docs: $(HELM_DOCS) ## Generate helm docs
 	@echo Generate helm docs... >&2
-	@docker run -v ${PWD}/charts:/work -w /work jnorwood/helm-docs:$(HELM_DOCS_VERSION) -s file
+	@cd ./charts && $(HELM_DOCS) -s file
 
 .PHONY: codegen-helm-all
 codegen-helm-all: ## Generate helm docs and CRDs


### PR DESCRIPTION

## Explanation

Install helm-docs (used for codegen-helm-docs make target) using `go install` to avoid issues with different paths inside and outside of the devcontainer and to keep consistency with other tools.

## Related issue

Closes https://github.com/kyverno/kyverno/issues/14617

## Milestone of this PR

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

Should it be cleanup or bug?
/kind cleanup

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

The codegen-helm-docs Makefile target uses Docker to run helm-docs, which doesn't work in devcontainer environments that use docker-outside-of-docker. The Docker daemon runs on the host and cannot access paths inside the devcontainer.

Additionally, the docker command lacked the --rm flag, causing containers to accumulate over time.

This change uses the locally installed helm-docs binary instead, which:
- Fixes compatibility with devcontainer environments
- Eliminates container cleanup issues
- Uses the existing tool installation mechanism
- Works consistently in CI, local, and devcontainer environments

Also adds ldflags to the helm-docs installation to set the version variable, which is required for generating the version footer in the documentation (the template uses helm-docs.versionFooter which checks if HelmDocsVersion is set). See https://github.com/norwoodj/helm-docs/issues/306.

### Proof Manifests

There are no changes to the generated docs.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
