### PR TITLE
chore: add option to disable kubectl-evict install in chainsaw tests

### DIFF
--- a/.github/actions/run-tests/action.yaml
+++ b/.github/actions/run-tests/action.yaml
@@ -31,6 +31,9 @@ inputs:
   install-cert-manager:
     description: Install cert-manager before running tests
     default: 'false'
+  install-kubectl-evict:
+    description: Install kubectl-evict before running tests
+    default: 'false'
   explicit-install-settings:
     description: Additional helm install settings for Kyverno (e.g., --set admissionController.tlsKeyAlgorithm=Ed25519)
     default: ''
@@ -84,8 +87,8 @@ runs:
         export EXPLICIT_INSTALL_SETTINGS="${{ inputs.explicit-install-settings }}"
         echo "Installing Kyverno from main"
         make kind-install-kyverno
-    # install kubectl-evict plugin needed for testing eviction subresource trigger
     - name: Install kubectl-evict
+      if: inputs.install-kubectl-evict == 'true'
       shell: bash
       run: |
         set -e

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -247,6 +247,7 @@ jobs:
           tests-path: generate
           shard-index: ${{ matrix.shard-index }}
           shard-count: 8
+          install-kubectl-evict: true
 
   generate-validating-admission-policy:
     runs-on: ubuntu-latest
@@ -641,6 +642,7 @@ jobs:
           tests-path: generating-policies
           shard-index: ${{ matrix.shard-index }}
           shard-count: 3
+          install-kubectl-evict: true
 
   namespaced-validating-policies:
     runs-on: ubuntu-latest

--- a/test/conformance/chainsaw/assert/allow-existing-violations/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/assert/allow-existing-violations/chainsaw-test.yaml
@@ -1,8 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
   name: check-old-object
 spec:
+  concurrent: false
   steps:
   - name: step-01
     try:

--- a/test/conformance/chainsaw/assert/old-object-exists/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/assert/old-object-exists/chainsaw-test.yaml
@@ -1,8 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
   name: check-old-object
 spec:
+  concurrent: false
   steps:
   - name: create policy
     use:


### PR DESCRIPTION
## Explanation

Add option to disable kubectl-evict install in chainsaw tests.
