### PR TITLE
fix(helm): allow global.image.registry to override cleanup and test images 

### DIFF
--- a/charts/kyverno/templates/tests/_helpers.tpl
+++ b/charts/kyverno/templates/tests/_helpers.tpl
@@ -23,7 +23,7 @@
 {{- end -}}
 
 {{- define "kyverno.test.image" -}}
-{{- template "kyverno.image" (dict "image" .Values.test.image "defaultTag" "latest") -}}
+{{- template "kyverno.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.test.image "defaultTag" "latest") -}}
 {{- end -}}
 
 {{- define "kyverno.test.imagePullPolicy" -}}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -9,7 +9,7 @@ global:
 
   image:
     # -- (string) Global value that allows to set a single image registry across all deployments.
-    # When set, it will override any values set under `.image.registry` across the chart.
+    # When set, it will override any values set under `.image.registry` across the chart.   
     registry: ~
   # -- (list) Global list of Image pull secrets
   # When set, it will override any values set under `imagePullSecrets` under different components across the chart.
@@ -518,7 +518,7 @@ test:
 
   image:
     # -- (string) Image registry
-    registry: bitnami
+    defaultRegistry: bitnami
     # -- Image repository
     repository: kubectl
     # -- Image tag
@@ -582,7 +582,7 @@ webhooksCleanup:
 
   image:
     # -- (string) Image registry
-    registry: registry.k8s.io
+    defaultRegistry: registry.k8s.io
     # -- Image repository
     repository: kubectl
     # -- Image tag


### PR DESCRIPTION
## Explanation

This PR fixes the Helm chart so that `global.image.registry` correctly overrides the image registry for **test** and **webhooksCleanup** components, while preserving valid default images when no global override is provided.

Previously, the override logic was not applied consistently because the test image helper was not forwarding the global registry information to the shared `kyverno.image` helper. As a result, users deploying Kyverno with a private registry could not rely on a single global registry setting for all chart components.

This change ensures that:
- Default images remain valid and pullable out of the box
- `global.image.registry` cleanly overrides registries when set
- Existing Helm helper abstractions are preserved and reused

---

## Related issue

Closes #14488

---

## Milestone of this PR

/milestone 

---

## What type of PR is this

/kind bug

---

## Proposed Changes

### Problem

When users set `global.image.registry` to deploy Kyverno in private or air-gapped environments, some components (notably **test pods** and **webhooksCleanup**) did not consistently honor the global registry override.

### Root Cause

- The shared `kyverno.image` helper already supports global registry overrides via `defaultRegistry`
- The `kyverno.test.image` helper was not passing `globalRegistry` / `defaultRegistry` information through
- As a result, global overrides were silently ignored for test images

### Solution

- Updated the `kyverno.test.image` helper to forward `globalRegistry` to the base `kyverno.image` helper
- Preserved valid default registries (`bitnami` for test images, `registry.k8s.io` for cleanup hooks)
- Avoided duplicating image logic across templates by keeping helpers as the single source of truth

### Resulting Behavior

| Scenario | Rendered Image |
|--------|----------------|
| No global override | `bitnami/kubectl:latest` |
| `--set global.image.registry=mike` | `mike/kubectl:latest` |
| `-f test-global.yaml` | `override-registry.io/kubectl:latest` |

This ensures predictable, consistent behavior without breaking existing defaults.

---

## Proof Manifests

### Test values file

```yaml
global:
  image:
    registry: override-registry.io

admissionController:
  enabled: true

test:
  enabled: true

openreports:
  enabled: false
  installCrds: false

reportsServer:
  enabled: false
```

**Terminal output**
```zsh

lokeshmacbook@Lokeshs-MacBook-Air kyverno % helm template . --set admissionController.enabled=true --set global.image.registry=mike --show-only=templates/tests/admission-controller-liveness.yaml | grep image:
      image: mike/kubectl:latest
lokeshmacbook@Lokeshs-MacBook-Air kyverno % helm template kyverno . \
  -f test-global.yaml \
  --show-only templates/tests/admission-controller-liveness.yaml \
  | grep image:
      image: override-registry.io/kubectl:latest
lokeshmacbook@Lokeshs-MacBook-Air kyverno % helm template kyverno . \
  --set admissionController.enabled=true \
  --show-only templates/tests/admission-controller-liveness.yaml \
  | grep image:
      image: bitnami/kubectl:latest
```
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [x] My PR contains user-facing behavior change limited to Helm chart configuration and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
 
## Further Comments

This fix improves consistency and usability for users deploying Kyverno in restricted or private registry environments by ensuring a single global registry configuration behaves as expected across all chart components.