### PR TITLE
fix(ivpol): Add retry on status update conflict

### DIFF
--- a/pkg/controllers/policystatus/ivpol.go
+++ b/pkg/controllers/policystatus/ivpol.go
@@ -9,7 +9,9 @@ import (
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
 	datautils "github.com/kyverno/kyverno/pkg/utils/data"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 func (c controller) updateIvpolStatus(ctx context.Context, ivpol *policiesv1beta1.ImageValidatingPolicy) error {
@@ -50,5 +52,26 @@ func (c controller) updateIvpolStatus(ctx context.Context, ivpol *policiesv1beta
 			return datautils.DeepEqual(current.Status, expect.Status)
 		},
 	)
+	if err != nil && apierrors.IsConflict(err) {
+		// Retry on conflict by getting the latest version and trying again
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			objNew, getErr := c.client.PoliciesV1beta1().ImageValidatingPolicies().Get(ctx, ivpol.GetName(), metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
+			return controllerutils.UpdateStatus(ctx,
+				objNew,
+				c.client.PoliciesV1beta1().ImageValidatingPolicies(),
+				updateFunc,
+				func(current, expect *policiesv1beta1.ImageValidatingPolicy) bool {
+					return datautils.DeepEqual(current.Status, expect.Status)
+				},
+			)
+		})
+		if retryErr != nil {
+			return retryErr
+		}
+		return nil
+	}
 	return err
 }

--- a/pkg/controllers/policystatus/nivpol.go
+++ b/pkg/controllers/policystatus/nivpol.go
@@ -9,7 +9,9 @@ import (
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
 	datautils "github.com/kyverno/kyverno/pkg/utils/data"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 func (c controller) updateNivpolStatus(ctx context.Context, nivpol *policiesv1beta1.NamespacedImageValidatingPolicy) error {
@@ -50,5 +52,26 @@ func (c controller) updateNivpolStatus(ctx context.Context, nivpol *policiesv1be
 			return datautils.DeepEqual(current.Status, expect.Status)
 		},
 	)
+	if err != nil && apierrors.IsConflict(err) {
+		// Retry on conflict by getting the latest version and trying again
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			objNew, getErr := c.client.PoliciesV1beta1().NamespacedImageValidatingPolicies(nivpol.GetNamespace()).Get(ctx, nivpol.GetName(), metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
+			return controllerutils.UpdateStatus(ctx,
+				objNew,
+				c.client.PoliciesV1beta1().NamespacedImageValidatingPolicies(nivpol.GetNamespace()),
+				updateFunc,
+				func(current, expect *policiesv1beta1.NamespacedImageValidatingPolicy) bool {
+					return datautils.DeepEqual(current.Status, expect.Status)
+				},
+			)
+		})
+		if retryErr != nil {
+			return retryErr
+		}
+		return nil
+	}
 	return err
 }


### PR DESCRIPTION
## Explanation

When I'm adding a new IVPOL / NIVPOL, I sometimes have the following error logs:

```sh
2026-01-15T18:46:18Z ERR github.com/kyverno/kyverno/pkg/utils/controller/run.go:84 > Failed to process request error="Operation cannot be fulfilled on imagevalidatingpolicies.policies.kyverno.io \"verify-kyverno-cosign-testbed-keyless\": the object has been modified; please apply your changes to the latest version and try again" id=0 logger=status-controller/worker obj=ImageValidatingPolicy/verify-kyverno-cosign-testbed-keyless
2026-01-15T18:46:39Z ERR github.com/kyverno/kyverno/pkg/utils/controller/run.go:84 > Failed to process request error="Operation cannot be fulfilled on imagevalidatingpolicies.policies.kyverno.io \"verify-kyverno-cosign-testbed-keyless\": the object has been modified; please apply your changes to the latest version and try again" id=0 logger=status-controller/worker obj=ImageValidatingPolicy/verify-kyverno-cosign-testbed-keyless
2026-01-15T18:46:39Z ERR github.com/kyverno/kyverno/pkg/utils/controller/run.go:84 > Failed to process request error="Operation cannot be fulfilled on imagevalidatingpolicies.policies.kyverno.io \"verify-kyverno-cosign-testbed-keyless\": the object has been modified; please apply your changes to the latest version and try again" id=2 logger=status-controller/worker obj=ImageValidatingPolicy/verify-kyverno-cosign-testbed-keyless
```

Looks like kyverno isn't able to reconcile the policy's status because of a conflict on the object.


## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

/milestone 1.17

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind bug

## Proposed Changes

1. Checks if the controller.Update fails with a conflict error
2. Retry by getting the current policy and update again

### Proof Manifests

Policy: 
```yaml
apiVersion: policies.kyverno.io/v1
kind: ImageValidatingPolicy
metadata:
  name: verify-kyverno-cosign-testbed-keyless
spec:
  validationActions: [Deny]
  webhookConfiguration:
    timeoutSeconds: 15
  failurePolicy: Fail
  matchConstraints:
    resourceRules:
      - apiGroups: [""]
        apiVersions: ["v1"]
        resources: ["pods"]
        operations: ["CREATE", "UPDATE"]
  matchImageReferences:
    - glob: "ghcr.io/lucchmielowski/kyverno-cosign-testbed:*"
  attestors:
    - name: cosign
      cosign:
        keyless:
          identities:
            - subject: "https://github.com/lucchmielowski/kyverno-cosign-testbed/.github/workflows/ci.yml@refs/heads/main"
              issuer: "https://token.actions.githubusercontent.com"
        ctlog:
          url: "https://rekor.sigstore.dev"
  validations:
    - expression: >-
        images.containers.map(image, verifyImageSignatures(image, [attestors.cosign])).all(e, e > 0)
      message: "Failed to verify keyless signature for kyverno-cosign-testbed image"
```

(may not fail the first time depending on whether we have a status conflict at some point)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
