### PR TITLE
chore: fix flake in ivpol chainsaw tests

### DIFF
--- a/test/conformance/chainsaw/image-validating-policies/.chainsaw.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/.chainsaw.yaml
@@ -4,10 +4,13 @@ kind: Configuration
 metadata:
   name: configuration
 spec:
+  cleanup:
+    delayBeforeCleanup: 1s
   discovery:
     fullName: true
   execution:
     failFast: true
+    forceTerminationGracePeriod: 1s
   namespace:
     fastDelete: true
   timeouts:


### PR DESCRIPTION
## Explanation

Fix flake in ivpol chainsaw tests.
