### PR TITLE
fix: suppress skip policy reports for non-matching VPOL matchConditions

### DIFF
--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -218,7 +218,12 @@ func (s *scanner) ScanResource(
 			engineResponse, err := engine.Handle(ctx, request, nil)
 			rules := make([]engineapi.RuleResponse, 0)
 			for _, policy := range engineResponse.Policies {
-				rules = append(rules, policy.Rules...)
+				for _, rule := range policy.Rules {
+					if rule.Status() == engineapi.RuleStatusSkip && rule.Name() == "" && rule.Message() == "skip" {
+						continue
+					}
+					rules = append(rules, rule)
+				}
 			}
 
 			response := engineapi.EngineResponse{


### PR DESCRIPTION
## Fix: Stop ValidatingPolicies from spamming "Skip" reports
I noticed that ValidatingPolicy (VPOL) creates a lot of unnecessary noise when using matchConditions.

The Problem Right now, if you set a condition (like "only apply to namespaces with label=foo"), Kyverno generates a Skip report for every single resource that doesn't match. In a busy cluster, this creates a flood of "Skip" reports for things that are simply out of scope.

The Fix I added a simple filter in the background scanner. Now, if the engine returns a generic "skip" because a resource is 
out of scope, we just ignore it. This aligns VPOL with how ClusterPolicy works: if it doesn't apply, it stays quiet.

Fixes #14702 
Checklist
- [x] I have signed the DCO.
- [x] My changes generate no new warnings.
- [x] I verified the fix locally.