### PR TITLE
feat: add multi-cluster support for policy matching

### DIFF
--- a/api/kyverno/v1/resource_description_types.go
+++ b/api/kyverno/v1/resource_description_types.go
@@ -32,6 +32,13 @@ type ResourceDescription struct {
 	// +optional
 	Namespaces []string `json:"namespaces,omitempty"`
 
+	// Clusters is a list of cluster names. Each name supports wildcard characters
+	// "*" (matches zero or many characters) and "?" (at least one character).
+	// This field is used for multi-cluster policy support to match resources
+	// from specific clusters when Kyverno is deployed with KYVERNO_CLUSTER_NAME.
+	// +optional
+	Clusters []string `json:"clusters,omitempty"`
+
 	// Annotations is a  map of annotations (key-value pairs of type string). Annotation keys
 	// and values support the wildcard characters "*" (matches zero or many characters) and
 	// "?" (matches at least one character).
@@ -63,6 +70,7 @@ func (r ResourceDescription) IsEmpty() bool {
 		r.Name == "" &&
 		len(r.Names) == 0 &&
 		len(r.Namespaces) == 0 &&
+		len(r.Clusters) == 0 &&
 		len(r.Annotations) == 0 &&
 		r.Selector == nil &&
 		r.NamespaceSelector == nil

--- a/api/kyverno/v1/zz_generated.deepcopy.go
+++ b/api/kyverno/v1/zz_generated.deepcopy.go
@@ -1291,6 +1291,11 @@ func (in *ResourceDescription) DeepCopyInto(out *ResourceDescription) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Clusters != nil {
+		in, out := &in.Clusters, &out.Clusters
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
 		*out = make(map[string]string, len(*in))

--- a/pkg/background/common/context.go
+++ b/pkg/background/common/context.go
@@ -67,6 +67,14 @@ func NewBackgroundContext(
 	if err != nil {
 		return nil, err
 	}
+	// Add cluster name for multi-cluster support
+	clusterName := config.KyvernoClusterName()
+	if clusterName != "" {
+		policyContext = policyContext.WithClusterName(clusterName)
+		if err := policyContext.JSONContext().AddClusterInfo(clusterName); err != nil {
+			return nil, fmt.Errorf("failed to add cluster info in context: %w", err)
+		}
+	}
 	policyContext = policyContext.
 		WithPolicy(policy).
 		WithNewResource(*trigger).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -141,6 +141,9 @@ var (
 	kyvernoMetricsConfigMapName = osutils.GetEnvWithFallback("METRICS_CONFIG", "kyverno-metrics")
 	// kyvernoDryRunNamespace is the namespace for DryRun option of YAML verification
 	kyvernoDryrunNamespace = osutils.GetEnvWithFallback("KYVERNO_DRYRUN_NAMESPACE", "kyverno-dryrun")
+	// kyvernoClusterName is the name of the cluster where Kyverno is deployed
+	// This is used for multi-cluster policy support to identify which cluster the request comes from
+	kyvernoClusterName = osutils.GetEnvWithFallback("KYVERNO_CLUSTER_NAME", "")
 )
 
 func KyvernoNamespace() string {
@@ -181,6 +184,11 @@ func KyvernoMetricsConfigMapName() string {
 
 func KyvernoUserName(serviceaccount string) string {
 	return fmt.Sprintf("system:serviceaccount:%s:%s", kyvernoNamespace, serviceaccount)
+}
+
+// KyvernoClusterName returns the configured cluster name for multi-cluster support
+func KyvernoClusterName() string {
+	return kyvernoClusterName
 }
 
 // Configuration to be used by consumer to check filters

--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -380,6 +380,14 @@ func (s *scanner) validateResource(ctx context.Context, resource unstructured.Un
 	if err != nil {
 		return nil, err
 	}
+	// Add cluster name for multi-cluster support
+	clusterName := config.KyvernoClusterName()
+	if clusterName != "" {
+		policyCtx = policyCtx.WithClusterName(clusterName)
+		if err := policyCtx.JSONContext().AddClusterInfo(clusterName); err != nil {
+			return nil, err
+		}
+	}
 	policyCtx = policyCtx.
 		WithNewResource(resource).
 		WithPolicy(policy).
@@ -401,6 +409,14 @@ func (s *scanner) validateImages(ctx context.Context, resource unstructured.Unst
 	policyCtx, err := engine.NewPolicyContext(s.jp, resource, kyvernov1.Create, nil, s.config)
 	if err != nil {
 		return nil, err
+	}
+	// Add cluster name for multi-cluster support
+	clusterName := config.KyvernoClusterName()
+	if clusterName != "" {
+		policyCtx = policyCtx.WithClusterName(clusterName)
+		if err := policyCtx.JSONContext().AddClusterInfo(clusterName); err != nil {
+			return nil, err
+		}
 	}
 	policyCtx = policyCtx.
 		WithNewResource(resource).

--- a/pkg/engine/api/policycontext.go
+++ b/pkg/engine/api/policycontext.go
@@ -26,6 +26,8 @@ type PolicyContext interface {
 	AdmissionOperation() bool
 	Element() unstructured.Unstructured
 	SetElement(element unstructured.Unstructured)
+	// ClusterName returns the cluster name for multi-cluster policy support
+	ClusterName() string
 
 	JSONContext() enginecontext.Interface
 	Copy() PolicyContext

--- a/pkg/engine/background.go
+++ b/pkg/engine/background.go
@@ -91,11 +91,11 @@ func (e *engine) filterRule(
 	policy := policyContext.Policy()
 	gvk, subresource := policyContext.ResourceKind()
 
-	if err := engineutils.MatchesResourceDescription(newResource, rule, admissionInfo, namespaceLabels, policy.GetNamespace(), gvk, subresource, policyContext.Operation()); err != nil {
+	if err := engineutils.MatchesResourceDescription(newResource, rule, admissionInfo, namespaceLabels, policy.GetNamespace(), gvk, subresource, policyContext.Operation(), policyContext.ClusterName()); err != nil {
 		logger.V(4).Info("new resource does not match...", "reason", err.Error())
 		if ruleType == engineapi.Generation {
 			// if the oldResource matched, return "false" to delete GR for it
-			if err = engineutils.MatchesResourceDescription(oldResource, rule, admissionInfo, namespaceLabels, policy.GetNamespace(), gvk, subresource, policyContext.Operation()); err == nil {
+			if err = engineutils.MatchesResourceDescription(oldResource, rule, admissionInfo, namespaceLabels, policy.GetNamespace(), gvk, subresource, policyContext.Operation(), policyContext.ClusterName()); err == nil {
 				return engineapi.RuleFail(rule.Name, ruleType, "", rule.ReportProperties)
 			}
 		}

--- a/pkg/engine/context/context.go
+++ b/pkg/engine/context/context.go
@@ -81,6 +81,10 @@ type Interface interface {
 	// AddNamespace merges resource json under request.namespace
 	AddNamespace(namespace string) error
 
+	// AddClusterInfo adds cluster information to the context under request.cluster
+	// This is used for multi-cluster policy support
+	AddClusterInfo(clusterName string) error
+
 	// AddElement adds element info to the context
 	AddElement(data interface{}, index, nesting int) error
 
@@ -313,6 +317,19 @@ func (ctx *context) AddServiceAccount(userName string) error {
 // AddNamespace merges resource json under request.namespace
 func (ctx *context) AddNamespace(namespace string) error {
 	return addToContext(ctx, namespace, false, "request", "namespace")
+}
+
+// AddClusterInfo adds cluster information to the context under request.cluster
+// This is used for multi-cluster policy support to enable policies to match
+// resources based on the cluster they originate from
+func (ctx *context) AddClusterInfo(clusterName string) error {
+	if clusterName == "" {
+		return nil
+	}
+	data := map[string]interface{}{
+		"name": clusterName,
+	}
+	return addToContext(ctx, data, false, "request", "cluster")
 }
 
 func (ctx *context) AddElement(data interface{}, index, nesting int) error {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -200,6 +200,7 @@ func (e *engine) matches(
 		gvk,
 		subresource,
 		policyContext.Operation(),
+		policyContext.ClusterName(),
 	)
 	if err == nil {
 		return nil
@@ -215,6 +216,7 @@ func (e *engine) matches(
 			gvk,
 			subresource,
 			policyContext.Operation(),
+			policyContext.ClusterName(),
 		)
 		if err == nil {
 			return nil

--- a/pkg/engine/handlers/validation/utils.go
+++ b/pkg/engine/handlers/validation/utils.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func matchResource(logger logr.Logger, resource unstructured.Unstructured, rule kyvernov1.Rule, namespaceLabels map[string]string, policyNamespace string, operation kyvernov1.AdmissionOperation, jsonContext enginecontext.Interface) bool {
+func matchResource(logger logr.Logger, resource unstructured.Unstructured, rule kyvernov1.Rule, namespaceLabels map[string]string, policyNamespace string, operation kyvernov1.AdmissionOperation, jsonContext enginecontext.Interface, clusterName string) bool {
 	if rule.RawAnyAllConditions != nil {
 		preconditionsPassed, _, err := internal.CheckPreconditions(logger, jsonContext, rule.RawAnyAllConditions)
 		if !preconditionsPassed || err != nil {
@@ -39,6 +39,7 @@ func matchResource(logger logr.Logger, resource unstructured.Unstructured, rule 
 		resource.GroupVersionKind(),
 		"",
 		operation,
+		clusterName,
 	)
 	return err == nil
 }

--- a/pkg/engine/handlers/validation/validate_assert.go
+++ b/pkg/engine/handlers/validation/validate_assert.go
@@ -183,7 +183,7 @@ func validateOldObject(ctx context.Context, logger logr.Logger, policyContext en
 		payload["operation"] = kyvernov1.Update
 	}()
 
-	if ok := matchResource(logger, oldResource, rule, policyContext.NamespaceLabels(), policyContext.Policy().GetNamespace(), kyvernov1.Create, policyContext.JSONContext()); !ok {
+	if ok := matchResource(logger, oldResource, rule, policyContext.NamespaceLabels(), policyContext.Policy().GetNamespace(), kyvernov1.Create, policyContext.JSONContext(), policyContext.ClusterName()); !ok {
 		return
 	}
 

--- a/pkg/engine/handlers/validation/validate_pss.go
+++ b/pkg/engine/handlers/validation/validate_pss.go
@@ -207,7 +207,7 @@ func (h validatePssHandler) validateOldObject(
 		}
 	}()
 
-	if ok := matchResource(logger, oldResource, rule, policyContext.NamespaceLabels(), policyContext.Policy().GetNamespace(), kyvernov1.Create, policyContext.JSONContext()); !ok {
+	if ok := matchResource(logger, oldResource, rule, policyContext.NamespaceLabels(), policyContext.Policy().GetNamespace(), kyvernov1.Create, policyContext.JSONContext(), policyContext.ClusterName()); !ok {
 		return
 	}
 

--- a/pkg/engine/handlers/validation/validate_resource.go
+++ b/pkg/engine/handlers/validation/validate_resource.go
@@ -210,7 +210,7 @@ func (v *validator) validateOldObject(ctx context.Context) (resp *engineapi.Rule
 		}
 	}()
 
-	if ok := matchResource(v.log, oldResource, v.rule, v.policyContext.NamespaceLabels(), v.policyContext.Policy().GetNamespace(), kyvernov1.Create, v.policyContext.JSONContext()); !ok {
+	if ok := matchResource(v.log, oldResource, v.rule, v.policyContext.NamespaceLabels(), v.policyContext.Policy().GetNamespace(), kyvernov1.Create, v.policyContext.JSONContext(), v.policyContext.ClusterName()); !ok {
 		resp = engineapi.RuleSkip(v.rule.Name, engineapi.Validation, "resource not matched", nil)
 		return
 	}

--- a/pkg/engine/policycontext/policy_context.go
+++ b/pkg/engine/policycontext/policy_context.go
@@ -54,6 +54,9 @@ type PolicyContext struct {
 
 	// admissionOperation represents if the caller is from the webhook server
 	admissionOperation bool
+
+	// clusterName is the name of the cluster for multi-cluster policy support
+	clusterName string
 }
 
 // engineapi.PolicyContext interface
@@ -122,6 +125,10 @@ func (c *PolicyContext) AdmissionOperation() bool {
 	return c.admissionOperation
 }
 
+func (c *PolicyContext) ClusterName() string {
+	return c.clusterName
+}
+
 func (c *PolicyContext) Element() unstructured.Unstructured {
 	return c.element
 }
@@ -182,6 +189,11 @@ func (c *PolicyContext) WithResources(newResource unstructured.Unstructured, old
 
 func (c PolicyContext) WithAdmissionOperation(admissionOperation bool) *PolicyContext {
 	c.admissionOperation = admissionOperation
+	return &c
+}
+
+func (c PolicyContext) WithClusterName(clusterName string) *PolicyContext {
+	c.clusterName = clusterName
 	return &c
 }
 

--- a/pkg/engine/utils/utils_test.go
+++ b/pkg/engine/utils/utils_test.go
@@ -905,7 +905,7 @@ func TestMatchesResourceDescription(t *testing.T) {
 		resource, _ := kubeutils.BytesToUnstructured(tc.Resource)
 
 		for _, rule := range autogen.Default.ComputeRules(&policy, "") {
-			err := MatchesResourceDescription(*resource, rule, tc.AdmissionInfo, nil, "", resource.GroupVersionKind(), "", "CREATE")
+			err := MatchesResourceDescription(*resource, rule, tc.AdmissionInfo, nil, "", resource.GroupVersionKind(), "", "CREATE", "")
 			if err != nil {
 				if !tc.areErrorsExpected {
 					t.Errorf("Testcase %d Unexpected error: %v\nmsg: %s", i+1, err, tc.Description)
@@ -1810,7 +1810,7 @@ func TestMatchesResourceDescription_GenerateName(t *testing.T) {
 		resource, _ := kubeutils.BytesToUnstructured(tc.Resource)
 
 		for _, rule := range autogen.Default.ComputeRules(&policy, "") {
-			err := MatchesResourceDescription(*resource, rule, tc.AdmissionInfo, nil, "", resource.GroupVersionKind(), "", "CREATE")
+			err := MatchesResourceDescription(*resource, rule, tc.AdmissionInfo, nil, "", resource.GroupVersionKind(), "", "CREATE", "")
 			if err != nil {
 				if !tc.areErrorsExpected {
 					t.Errorf("Testcase %d Unexpected error: %v\nmsg: %s", i+1, err, tc.Description)
@@ -1877,7 +1877,7 @@ func TestResourceDescriptionMatch_MultipleKind(t *testing.T) {
 	}
 	rule := v1.Rule{MatchResources: v1.MatchResources{ResourceDescription: resourceDescription}}
 
-	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE"); err != nil {
+	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE", ""); err != nil {
 		t.Errorf("Testcase has failed due to the following:%v", err)
 	}
 }
@@ -1980,7 +1980,7 @@ func TestResourceDescriptionMatch_ExcludeDefaultGroups(t *testing.T) {
 	}
 
 	// First test: confirm that this above rule produces errors (and raise an error if err == nil)
-	if err := MatchesResourceDescription(*resource, rule, requestInfo, nil, "", resource.GroupVersionKind(), "", "CREATE"); err == nil {
+	if err := MatchesResourceDescription(*resource, rule, requestInfo, nil, "", resource.GroupVersionKind(), "", "CREATE", ""); err == nil {
 		t.Error("Testcase was expected to fail, but err was nil")
 	}
 
@@ -2000,7 +2000,7 @@ func TestResourceDescriptionMatch_ExcludeDefaultGroups(t *testing.T) {
 	}
 
 	// Second test: confirm that matching this rule does not create any errors (and raise if err != nil)
-	if err := MatchesResourceDescription(*resource, rule2, requestInfo, nil, "", resource.GroupVersionKind(), "", "CREATE"); err != nil {
+	if err := MatchesResourceDescription(*resource, rule2, requestInfo, nil, "", resource.GroupVersionKind(), "", "CREATE", ""); err != nil {
 		t.Errorf("Testcase was expected to not fail, but err was %s", err)
 	}
 
@@ -2014,7 +2014,7 @@ func TestResourceDescriptionMatch_ExcludeDefaultGroups(t *testing.T) {
 	}}
 
 	// Third test: confirm that now the custom exclude-snippet should run in CheckSubjects() and that should result in this rule failing (raise if err == nil for that reason)
-	if err := MatchesResourceDescription(*resource, rule2, requestInfo, nil, "", resource.GroupVersionKind(), "", "CREATE"); err == nil {
+	if err := MatchesResourceDescription(*resource, rule2, requestInfo, nil, "", resource.GroupVersionKind(), "", "CREATE", ""); err == nil {
 		t.Error("Testcase was expected to fail, but err was nil #1!")
 	}
 }
@@ -2073,7 +2073,7 @@ func TestResourceDescriptionMatch_Name(t *testing.T) {
 	}
 	rule := v1.Rule{MatchResources: v1.MatchResources{ResourceDescription: resourceDescription}}
 
-	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE"); err != nil {
+	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE", ""); err != nil {
 		t.Errorf("Testcase has failed due to the following:%v", err)
 	}
 }
@@ -2131,7 +2131,7 @@ func TestResourceDescriptionMatch_GenerateName(t *testing.T) {
 	}
 	rule := v1.Rule{MatchResources: v1.MatchResources{ResourceDescription: resourceDescription}}
 
-	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE"); err != nil {
+	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE", ""); err != nil {
 		t.Errorf("Testcase has failed due to the following:%v", err)
 	}
 }
@@ -2190,7 +2190,7 @@ func TestResourceDescriptionMatch_Name_Regex(t *testing.T) {
 	}
 	rule := v1.Rule{MatchResources: v1.MatchResources{ResourceDescription: resourceDescription}}
 
-	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE"); err != nil {
+	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE", ""); err != nil {
 		t.Errorf("Testcase has failed due to the following:%v", err)
 	}
 }
@@ -2248,7 +2248,7 @@ func TestResourceDescriptionMatch_GenerateName_Regex(t *testing.T) {
 	}
 	rule := v1.Rule{MatchResources: v1.MatchResources{ResourceDescription: resourceDescription}}
 
-	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE"); err != nil {
+	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE", ""); err != nil {
 		t.Errorf("Testcase has failed due to the following:%v", err)
 	}
 }
@@ -2315,7 +2315,7 @@ func TestResourceDescriptionMatch_Label_Expression_NotMatch(t *testing.T) {
 	}
 	rule := v1.Rule{MatchResources: v1.MatchResources{ResourceDescription: resourceDescription}}
 
-	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE"); err != nil {
+	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE", ""); err != nil {
 		t.Errorf("Testcase has failed due to the following:%v", err)
 	}
 }
@@ -2383,7 +2383,7 @@ func TestResourceDescriptionMatch_Label_Expression_Match(t *testing.T) {
 	}
 	rule := v1.Rule{MatchResources: v1.MatchResources{ResourceDescription: resourceDescription}}
 
-	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE"); err != nil {
+	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE", ""); err != nil {
 		t.Errorf("Testcase has failed due to the following:%v", err)
 	}
 }
@@ -2464,7 +2464,182 @@ func TestResourceDescriptionExclude_Label_Expression_Match(t *testing.T) {
 		ExcludeResources: &v1.MatchResources{ResourceDescription: resourceDescriptionExclude},
 	}
 
-	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE"); err == nil {
+	if err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE", ""); err == nil {
 		t.Errorf("Testcase has failed due to the following:\n Function has returned no error, even though it was supposed to fail")
+	}
+}
+
+// Test cluster matching for multi-cluster support
+func TestCheckCluster(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusters    []string
+		clusterName string
+		expected    bool
+	}{
+		{
+			name:        "exact match",
+			clusters:    []string{"cluster-a", "cluster-b"},
+			clusterName: "cluster-a",
+			expected:    true,
+		},
+		{
+			name:        "no match",
+			clusters:    []string{"cluster-a", "cluster-b"},
+			clusterName: "cluster-c",
+			expected:    false,
+		},
+		{
+			name:        "wildcard match with *",
+			clusters:    []string{"prod-*"},
+			clusterName: "prod-us-east",
+			expected:    true,
+		},
+		{
+			name:        "wildcard match with ?",
+			clusters:    []string{"cluster-?"},
+			clusterName: "cluster-a",
+			expected:    true,
+		},
+		{
+			name:        "wildcard match all",
+			clusters:    []string{"*"},
+			clusterName: "any-cluster",
+			expected:    true,
+		},
+		{
+			name:        "empty clusters list",
+			clusters:    []string{},
+			clusterName: "cluster-a",
+			expected:    false,
+		},
+		{
+			name:        "empty cluster name",
+			clusters:    []string{"cluster-a"},
+			clusterName: "",
+			expected:    false,
+		},
+		{
+			name:        "complex wildcard pattern",
+			clusters:    []string{"prod-*-us-*"},
+			clusterName: "prod-app-us-east",
+			expected:    true,
+		},
+		{
+			name:        "complex wildcard pattern no match",
+			clusters:    []string{"prod-*-us-*"},
+			clusterName: "prod-app-eu-west",
+			expected:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := checkCluster(tc.clusters, tc.clusterName)
+			if result != tc.expected {
+				t.Errorf("checkCluster(%v, %s) = %v, expected %v", tc.clusters, tc.clusterName, result, tc.expected)
+			}
+		})
+	}
+}
+
+// Test cluster matching in MatchesResourceDescription
+func TestMatchesResourceDescription_ClusterMatching(t *testing.T) {
+	rawResource := []byte(`{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "test-pod",
+			"namespace": "default"
+		}
+	}`)
+	resource, _ := kubeutils.BytesToUnstructured(rawResource)
+
+	tests := []struct {
+		name              string
+		clusterName       string
+		matchClusters     []string
+		excludeClusters   []string
+		areErrorsExpected bool
+	}{
+		{
+			name:              "match cluster exact",
+			clusterName:       "cluster-a",
+			matchClusters:     []string{"cluster-a", "cluster-b"},
+			areErrorsExpected: false,
+		},
+		{
+			name:              "no match cluster",
+			clusterName:       "cluster-c",
+			matchClusters:     []string{"cluster-a", "cluster-b"},
+			areErrorsExpected: true,
+		},
+		{
+			name:              "match cluster wildcard",
+			clusterName:       "prod-us-east",
+			matchClusters:     []string{"prod-*"},
+			areErrorsExpected: false,
+		},
+		{
+			name:              "empty cluster list matches all",
+			clusterName:       "any-cluster",
+			matchClusters:     []string{},
+			areErrorsExpected: false,
+		},
+		{
+			name:              "empty cluster name with cluster filter",
+			clusterName:       "",
+			matchClusters:     []string{"cluster-a"},
+			areErrorsExpected: true,
+		},
+		{
+			name:              "exclude cluster",
+			clusterName:       "cluster-a",
+			matchClusters:     []string{"cluster-*"},
+			excludeClusters:   []string{"cluster-a"},
+			areErrorsExpected: true,
+		},
+		{
+			name:              "exclude cluster wildcard",
+			clusterName:       "dev-cluster",
+			matchClusters:     []string{"*"},
+			excludeClusters:   []string{"dev-*"},
+			areErrorsExpected: true,
+		},
+		{
+			name:              "exclude cluster no match",
+			clusterName:       "prod-cluster",
+			matchClusters:     []string{"*"},
+			excludeClusters:   []string{"dev-*"},
+			areErrorsExpected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resourceDescription := v1.ResourceDescription{
+				Kinds:    []string{"Pod"},
+				Clusters: tc.matchClusters,
+			}
+			rule := v1.Rule{
+				MatchResources: v1.MatchResources{ResourceDescription: resourceDescription},
+			}
+
+			if len(tc.excludeClusters) > 0 {
+				rule.ExcludeResources = &v1.MatchResources{
+					ResourceDescription: v1.ResourceDescription{
+						Clusters: tc.excludeClusters,
+					},
+				}
+			}
+
+			err := MatchesResourceDescription(*resource, rule, v2.RequestInfo{}, nil, "", resource.GroupVersionKind(), "", "CREATE", tc.clusterName)
+			if tc.areErrorsExpected && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !tc.areErrorsExpected && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
 	}
 }

--- a/pkg/webhooks/handlers/admission.go
+++ b/pkg/webhooks/handlers/admission.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/julienschmidt/httprouter"
+	"github.com/kyverno/kyverno/pkg/config"
 	admissionv1 "k8s.io/api/admission/v1"
 )
 
@@ -53,6 +54,7 @@ func (inner AdmissionHandler) withAdmission(logger logr.Logger) HttpHandler {
 		admissionRequest := AdmissionRequest{
 			AdmissionRequest: *admissionReview.Request,
 			URLParams:        params.ByName("policy"),
+			ClusterName:      config.KyvernoClusterName(),
 		}
 		admissionResponse := inner(request.Context(), logger, admissionRequest, startTime)
 		admissionReview.Response = &admissionResponse

--- a/pkg/webhooks/handlers/types.go
+++ b/pkg/webhooks/handlers/types.go
@@ -25,6 +25,10 @@ type AdmissionRequest struct {
 	GroupVersionKind schema.GroupVersionKind
 
 	URLParams string
+
+	// ClusterName is the name of the cluster where the request originated.
+	// This is used for multi-cluster policy support.
+	ClusterName string
 }
 
 type AdmissionResponse = admissionv1.AdmissionResponse

--- a/pkg/webhooks/resource/generation/handler.go
+++ b/pkg/webhooks/resource/generation/handler.go
@@ -334,6 +334,7 @@ func (h *generationHandler) processRequest(ctx context.Context, policyContext *e
 					gvk,
 					subresource,
 					policyContext.Operation(),
+					policyContext.ClusterName(),
 				); err == nil {
 					h.log.V(4).Info("skip creating UR as the admission resource is both the source and the trigger")
 					continue

--- a/pkg/webhooks/resource/handlers.go
+++ b/pkg/webhooks/resource/handlers.go
@@ -191,7 +191,7 @@ func (h *resourceHandlers) Mutate(ctx context.Context, logger logr.Logger, reque
 		return admissionutils.ResponseSuccess(request.UID)
 	}
 	logger.V(4).Info("processing policies for mutate admission request", "mutatePolicies", len(mutatePolicies), "verifyImagesPolicies", len(verifyImagesPolicies))
-	policyContext, err := h.pcBuilder.Build(request.AdmissionRequest, request.Roles, request.ClusterRoles, request.GroupVersionKind)
+	policyContext, err := h.pcBuilder.Build(request.AdmissionRequest, request.Roles, request.ClusterRoles, request.GroupVersionKind, request.ClusterName)
 	if err != nil {
 		logger.Error(err, "failed to build policy context")
 		return admissionutils.Response(request.UID, err)
@@ -205,7 +205,7 @@ func (h *resourceHandlers) Mutate(ctx context.Context, logger logr.Logger, reque
 	if len(verifyImagesPolicies) != 0 {
 		newRequest := patchRequest(patches, request.AdmissionRequest, logger)
 		// rebuild context to process images updated via mutate policies
-		policyContext, err = h.pcBuilder.Build(newRequest, request.Roles, request.ClusterRoles, request.GroupVersionKind)
+		policyContext, err = h.pcBuilder.Build(newRequest, request.Roles, request.ClusterRoles, request.GroupVersionKind, request.ClusterName)
 		if err != nil {
 			logger.Error(err, "failed to build policy context")
 			return admissionutils.Response(request.UID, err)
@@ -306,7 +306,7 @@ func (h *resourceHandlers) retrieveAndCategorizePolicies(
 }
 
 func (h *resourceHandlers) buildPolicyContextFromAdmissionRequest(logger logr.Logger, request handlers.AdmissionRequest, policies []kyvernov1.PolicyInterface) (*policycontext.PolicyContext, error) {
-	policyContext, err := h.pcBuilder.Build(request.AdmissionRequest, request.Roles, request.ClusterRoles, request.GroupVersionKind)
+	policyContext, err := h.pcBuilder.Build(request.AdmissionRequest, request.Roles, request.ClusterRoles, request.GroupVersionKind, request.ClusterName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/webhooks/resource/handlers_test.go
+++ b/pkg/webhooks/resource/handlers_test.go
@@ -835,7 +835,7 @@ func newMockPolicyContextBuilder(
 	}
 }
 
-func (b *mockPolicyContextBuilder) Build(request admissionv1.AdmissionRequest, roles, clusterRoles []string, gvk schema.GroupVersionKind) (*engine.PolicyContext, error) {
+func (b *mockPolicyContextBuilder) Build(request admissionv1.AdmissionRequest, roles, clusterRoles []string, gvk schema.GroupVersionKind, clusterName string) (*engine.PolicyContext, error) {
 	b.Lock()
 	defer b.Unlock()
 
@@ -847,6 +847,10 @@ func (b *mockPolicyContextBuilder) Build(request admissionv1.AdmissionRequest, r
 	pc, err := engine.NewPolicyContextFromAdmissionRequest(b.jp, request, userRequestInfo, gvk, b.configuration)
 	if err != nil {
 		return nil, err
+	}
+	// Add cluster name for multi-cluster support
+	if clusterName != "" {
+		pc = pc.WithClusterName(clusterName)
 	}
 	b.contexts = append(b.contexts, pc)
 	return pc, err

--- a/pkg/webhooks/resource/validation/validation.go
+++ b/pkg/webhooks/resource/validation/validation.go
@@ -249,7 +249,7 @@ func (v *validationHandler) buildAuditResponses(
 }
 
 func (v *validationHandler) buildPolicyContextFromAdmissionRequest(logger logr.Logger, request handlers.AdmissionRequest, policies []kyvernov1.PolicyInterface) (*policycontext.PolicyContext, error) {
-	policyContext, err := v.pcBuilder.Build(request.AdmissionRequest, request.Roles, request.ClusterRoles, request.GroupVersionKind)
+	policyContext, err := v.pcBuilder.Build(request.AdmissionRequest, request.Roles, request.ClusterRoles, request.GroupVersionKind, request.ClusterName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Related issue

Closes #11989

## Proposed Changes

### Implementation Details

1. **New `clusters` field in ResourceDescription**: Added a `clusters` field to `ResourceDescription` that accepts a list of cluster name patterns with wildcard support (`*` and `?`).

2. **Environment variable `KYVERNO_CLUSTER_NAME`**: Added configuration to identify which cluster Kyverno is deployed in. This is set via the `KYVERNO_CLUSTER_NAME` environment variable.

3. **Policy Context Enhancement**: Added cluster name to the policy context, making it available throughout the engine for policy evaluation.

4. **JSON Context Enhancement**: Added cluster information to the JSON context under `request.cluster.name`, enabling access in policy expressions.

5. **Match/Exclude Support**: Updated `MatchesResourceDescription` to filter resources based on cluster name patterns.

### Example Usage

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: restrict-pods-on-prod-clusters
spec:
  validationFailureAction: Enforce
  rules:
  - name: require-labels
    match:
      resources:
        kinds:
        - Pod
        clusters:
        - "prod-*"    # Matches prod-east, prod-west, etc.
    validate:
      message: "Pods in production clusters must have required labels"
      pattern:
        metadata:
          labels:
            app: "?*"
```

### Proof Manifests

```yaml
# Policy matching specific clusters
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: cluster-specific-policy
spec:
  validationFailureAction: Enforce
  rules:
  - name: prod-cluster-rule
    match:
      resources:
        kinds:
        - Pod
        clusters:
        - "prod-*"
        - "staging"
    validate:
      message: "This rule only applies to prod and staging clusters"
      pattern:
        metadata:
          labels:
            environment: "?*"
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a feature and I have added CLI tests that are applicable.
- [x] My PR contains new or altered behavior to Kyverno and
