### PR TITLE
fix: use %w to wrap errors in registry client

### DIFF
--- a/pkg/registryclient/client.go
+++ b/pkg/registryclient/client.go
@@ -180,15 +180,15 @@ func (c *client) FetchImageDescriptor(ctx context.Context, imageRef string) (*gc
 	nameOpts := c.NameOptions()
 	parsedRef, err := name.ParseReference(imageRef, nameOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse image reference: %s, error: %v", imageRef, err)
+		return nil, fmt.Errorf("failed to parse image reference: %s, error: %w", imageRef, err)
 	}
 	remoteOpts, err := c.Options(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get gcr remote opts: %s, error: %v", imageRef, err)
+		return nil, fmt.Errorf("failed to get gcr remote opts: %s, error: %w", imageRef, err)
 	}
 	desc, err := gcrremote.Get(parsedRef, remoteOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch image reference: %s, error: %v", imageRef, err)
+		return nil, fmt.Errorf("failed to fetch image reference: %s, error: %w", imageRef, err)
 	}
 	if _, ok := parsedRef.(name.Digest); ok && parsedRef.Identifier() != desc.Digest.String() {
 		return nil, fmt.Errorf("digest mismatch, expected: %s, received: %s", parsedRef.Identifier(), desc.Digest.String())


### PR DESCRIPTION
## Description

Update `pkg/registryclient` to use `%w` instead of `%v` for error wrapping.

### Why
Using `%v` hides the original error type, preventing callers from using `errors.Is()` or `errors.As()` to check the root cause. Using `%w` correctly wraps the error, maintaining the error chain as per Go best practices.

### Checklist
- [x] Signed-off-by (DCO)
- [x] No new lint errors
- [x] Single commit