### PR TITLE
Added unit tests for webhook/utils and fixed a linter suggestion

### DIFF
--- a/pkg/engine/api/policyresponse.go
+++ b/pkg/engine/api/policyresponse.go
@@ -14,9 +14,10 @@ func (pr *PolicyResponse) Add(stats ExecutionStats, responses ...RuleResponse) {
 	for _, response := range responses {
 		pr.Rules = append(pr.Rules, response.WithStats(stats))
 		status := response.Status()
-		if status == RuleStatusPass || status == RuleStatusFail {
+		switch status {
+		case RuleStatusPass, RuleStatusFail:
 			pr.stats.rulesAppliedCount++
-		} else if status == RuleStatusError {
+		case RuleStatusError:
 			pr.stats.rulesErrorCount++
 		}
 	}

--- a/pkg/webhooks/utils/error_test.go
+++ b/pkg/webhooks/utils/error_test.go
@@ -1,0 +1,100 @@
+package utils
+
+import (
+	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGetErrorMsg(t *testing.T) {
+	policy := engineapi.NewKyvernoPolicy(&kyvernov1.ClusterPolicy{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "restrict-privileged",
+		},
+	})
+
+	resource := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "Pod",
+			"metadata": map[string]interface{}{
+				"namespace": "default",
+				"name":      "mypod",
+			},
+		},
+	}
+
+	type args struct {
+		engineResponses []engineapi.EngineResponse
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "single failed rule",
+			args: args{
+				engineResponses: []engineapi.EngineResponse{
+					engineapi.NewEngineResponse(resource, policy, nil).
+						WithPolicyResponse(engineapi.PolicyResponse{
+							Rules: []engineapi.RuleResponse{
+								*engineapi.RuleFail(
+									"deny-privileged",
+									engineapi.Validation,
+									"privileged containers are not allowed",
+									nil,
+								),
+							},
+						}),
+				},
+			},
+			want: "Resource Pod/default/mypod failed policy restrict-privileged:;rule deny-privileged (Validation): privileged containers are not allowed",
+		},
+		{
+			name: "only pass rule",
+			args: args{
+				engineResponses: []engineapi.EngineResponse{
+					engineapi.NewEngineResponse(resource, policy, nil).
+						WithPolicyResponse(engineapi.PolicyResponse{
+							Rules: []engineapi.RuleResponse{
+								*engineapi.RulePass(
+									"allow",
+									engineapi.Validation,
+									"allowed",
+									nil,
+								),
+							},
+						}),
+				},
+			},
+			want: "Resource  ",
+		},
+		{
+			name: "multiple failed rules",
+			args: args{
+				engineResponses: []engineapi.EngineResponse{
+					engineapi.NewEngineResponse(resource, policy, nil).
+						WithPolicyResponse(engineapi.PolicyResponse{
+							Rules: []engineapi.RuleResponse{
+								*engineapi.RuleFail("rule-fail", engineapi.Validation, "failure", nil),
+								*engineapi.RuleError("rule-error", engineapi.Validation, "error", nil, nil),
+							},
+						}),
+				},
+			},
+			want: "Resource Pod/default/mypod failed policy restrict-privileged:;rule rule-fail (Validation): failure;rule rule-error (Validation): error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetErrorMsg(tt.args.engineResponses)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/webhooks/utils/event_test.go
+++ b/pkg/webhooks/utils/event_test.go
@@ -1,0 +1,247 @@
+package utils
+
+import (
+	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/kyverno/kyverno/pkg/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGenerateEvents(t *testing.T) {
+	policy := engineapi.NewKyvernoPolicy(&kyvernov1.ClusterPolicy{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-policy",
+		},
+		Spec: kyvernov1.Spec{
+			Rules: []kyvernov1.Rule{
+				{
+					Name: "validate-rule",
+					Validation: &kyvernov1.Validation{
+						Message: "ok",
+					},
+				},
+			},
+		},
+	})
+
+	resource := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"namespace": "default",
+				"name":      "mypod",
+			},
+		},
+	}
+
+	type args struct {
+		engineResponses []engineapi.EngineResponse
+		blocked         bool
+	}
+
+	tests := []struct {
+		name      string
+		args      args
+		wantCount int
+		wantCheck func(t *testing.T, events []event.Info)
+	}{
+		{
+			name: "failed rule generates policy and resource violation events",
+			args: args{
+				engineResponses: []engineapi.EngineResponse{
+					engineapi.NewEngineResponse(resource, policy, nil).
+						WithPolicyResponse(engineapi.PolicyResponse{
+							Rules: []engineapi.RuleResponse{
+								*engineapi.RuleFail(
+									"deny-privileged",
+									engineapi.Validation,
+									"privileged containers are not allowed",
+									nil,
+								),
+							},
+						}),
+				},
+				blocked: false,
+			},
+			wantCount: 2,
+			wantCheck: func(t *testing.T, events []event.Info) {
+				assert.Equal(t, event.PolicyViolation, events[0].Reason)
+				assert.Equal(t, event.ResourcePassed, events[0].Action)
+				assert.Contains(t, events[0].Message, "privileged containers are not allowed")
+
+				assert.Equal(t, event.PolicyViolation, events[1].Reason)
+				assert.Equal(t, event.ResourcePassed, events[1].Action)
+			},
+		},
+		{
+			name: "blocked failure marks policy event as blocked",
+			args: args{
+				engineResponses: []engineapi.EngineResponse{
+					engineapi.NewEngineResponse(resource, policy, nil).
+						WithPolicyResponse(engineapi.PolicyResponse{
+							Rules: []engineapi.RuleResponse{
+								*engineapi.RuleFail(
+									"deny-privileged",
+									engineapi.Validation,
+									"privileged containers are not allowed",
+									nil,
+								),
+							},
+						}),
+				},
+				blocked: true,
+			},
+			wantCount: 1,
+			wantCheck: func(t *testing.T, events []event.Info) {
+				assert.Equal(t, event.ResourceBlocked, events[0].Action)
+				assert.Contains(t, events[0].Message, "(blocked)")
+			},
+		},
+		{
+			name: "successful policy generates policy applied event",
+			args: args{
+				engineResponses: []engineapi.EngineResponse{
+					engineapi.NewEngineResponse(resource, policy, nil).
+						WithPolicyResponse(engineapi.PolicyResponse{
+							Rules: []engineapi.RuleResponse{
+								*engineapi.RulePass(
+									"allow",
+									engineapi.Validation,
+									"allowed",
+									nil,
+								),
+							},
+						}),
+				},
+				blocked: false,
+			},
+			wantCount: 1,
+			wantCheck: func(t *testing.T, events []event.Info) {
+				assert.Equal(t, event.PolicyApplied, events[0].Reason)
+				assert.Equal(t, event.ResourcePassed, events[0].Action)
+				assert.Contains(t, events[0].Message, "pass")
+			},
+		},
+		{
+			name: "error rule generates violation events",
+			args: args{
+				engineResponses: []engineapi.EngineResponse{
+					engineapi.NewEngineResponse(resource, policy, nil).
+						WithPolicyResponse(engineapi.PolicyResponse{
+							Rules: []engineapi.RuleResponse{
+								*engineapi.RuleError(
+									"rule-error",
+									engineapi.Validation,
+									"something went wrong",
+									nil,
+									nil,
+								),
+							},
+						}),
+				},
+				blocked: false,
+			},
+			wantCount: 2,
+			wantCheck: func(t *testing.T, events []event.Info) {
+				assert.Equal(t, event.PolicyViolation, events[0].Reason)
+				assert.Contains(t, events[0].Message, "error")
+			},
+		},
+		{
+			name: "skipped rule with exception generates policy exception events",
+			args: args{
+				engineResponses: []engineapi.EngineResponse{
+					engineapi.NewEngineResponse(resource, policy, nil).
+						WithPolicyResponse(engineapi.PolicyResponse{
+							Rules: []engineapi.RuleResponse{
+								*engineapi.RuleSkip(
+									"skip-rule",
+									engineapi.Validation,
+									"skipped",
+									nil,
+								).WithExceptions([]engineapi.GenericException{
+									engineapi.NewPolicyException(
+										&kyvernov2.PolicyException{
+											ObjectMeta: metav1.ObjectMeta{
+												Name:      "my-exception",
+												Namespace: "default",
+											},
+										},
+									),
+								}),
+							},
+						}),
+				},
+				blocked: false,
+			},
+			wantCount: 2,
+			wantCheck: func(t *testing.T, events []event.Info) {
+				var exceptionEvent, policyEvent *event.Info
+
+				for i := range events {
+					if events[i].Regarding.Kind == "PolicyException" {
+						exceptionEvent = &events[i]
+					} else {
+						policyEvent = &events[i]
+					}
+				}
+
+				require.NotNil(t, exceptionEvent)
+				require.NotNil(t, policyEvent)
+
+				assert.Equal(t, event.PolicySkipped, exceptionEvent.Reason)
+				assert.Equal(t, event.ResourcePassed, exceptionEvent.Action)
+				assert.Contains(t, exceptionEvent.Message, "was skipped")
+
+				assert.Equal(t, event.PolicySkipped, policyEvent.Reason)
+				assert.Contains(t, policyEvent.Message, "policy exceptions")
+			},
+		},
+		{
+			name: "empty engine response produces no events",
+			args: args{
+				engineResponses: []engineapi.EngineResponse{
+					engineapi.NewEngineResponse(resource, policy, nil),
+				},
+				blocked: false,
+			},
+			wantCount: 0,
+			wantCheck: func(t *testing.T, events []event.Info) {},
+		},
+		{
+			name: "resource without name is ignored",
+			args: args{
+				engineResponses: []engineapi.EngineResponse{
+					engineapi.NewEngineResponse(
+						unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"kind": "Pod",
+							},
+						},
+						policy,
+						nil,
+					),
+				},
+				blocked: false,
+			},
+			wantCount: 0,
+			wantCheck: func(t *testing.T, events []event.Info) {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := GenerateEvents(tt.args.engineResponses, tt.args.blocked)
+			assert.Len(t, events, tt.wantCount)
+			tt.wantCheck(t, events)
+		})
+	}
+}

--- a/pkg/webhooks/utils/match_test.go
+++ b/pkg/webhooks/utils/match_test.go
@@ -1,0 +1,90 @@
+package utils
+
+import (
+	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+)
+
+func TestMatchDeleteOperation(t *testing.T) {
+	tests := []struct {
+		name string
+		rule kyvernov1.Rule
+		want bool
+	}{
+		{
+			name: "delete operation in top-level match",
+			rule: kyvernov1.Rule{
+				MatchResources: kyvernov1.MatchResources{
+					ResourceDescription: kyvernov1.ResourceDescription{
+						Operations: []kyvernov1.AdmissionOperation{
+							kyvernov1.Delete,
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "delete operation in match.any",
+			rule: kyvernov1.Rule{
+				MatchResources: kyvernov1.MatchResources{
+					Any: []kyvernov1.ResourceFilter{
+						{
+							ResourceDescription: kyvernov1.ResourceDescription{
+								Operations: []kyvernov1.AdmissionOperation{
+									kyvernov1.Delete,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "delete operation in match.all",
+			rule: kyvernov1.Rule{
+				MatchResources: kyvernov1.MatchResources{
+					All: []kyvernov1.ResourceFilter{
+						{
+							ResourceDescription: kyvernov1.ResourceDescription{
+								Operations: []kyvernov1.AdmissionOperation{
+									kyvernov1.Delete,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "non-delete operation",
+			rule: kyvernov1.Rule{
+				MatchResources: kyvernov1.MatchResources{
+					ResourceDescription: kyvernov1.ResourceDescription{
+						Operations: []kyvernov1.AdmissionOperation{
+							kyvernov1.Create,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "no operations defined",
+			rule: kyvernov1.Rule{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MatchDeleteOperation(tt.rule)
+			if got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Explanation

This PR improves code quality and test coverage in the webhook utils package. It adds unit tests to validate existing behavior and refactors a conditional `if-else` block into a `switch` statement as suggested by the linter, improving readability without changing functionality.

## Related issue

N/A

## Milestone of this PR

/milestone 

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind cleanup

## Proposed Changes

- Added unit tests for webhook utils to improve coverage and guard existing behavior.
- Refactored an `if-else` statement into a `switch` statement as recommended by the linter.
- No functional or user-facing behavior changes.

### Proof Manifests

N/A (unit-test-only change)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md).
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This PR is focused on internal quality improvements only and keeps behavior unchanged.
