### PR TITLE
Added unit tests for CheckSubjects function

### DIFF
--- a/pkg/utils/match/subjects_test.go
+++ b/pkg/utils/match/subjects_test.go
@@ -1,0 +1,359 @@
+package match
+
+import (
+	"testing"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestCheckSubjects(t *testing.T) {
+	tests := []struct {
+		name         string
+		ruleSubjects []rbacv1.Subject
+		userInfo     authenticationv1.UserInfo
+		want         bool
+	}{
+		//For null cases
+		{
+			name:         "empty subjects returns false",
+			ruleSubjects: []rbacv1.Subject{},
+			userInfo: authenticationv1.UserInfo{
+				Username: "admin",
+			},
+			want: false,
+		},
+		{
+			name:         "nil subjects returns false",
+			ruleSubjects: nil,
+			userInfo: authenticationv1.UserInfo{
+				Username: "admin",
+			},
+			want: false,
+		},
+
+		// For service account matching
+		{
+			name: "ServiceAccount exact match",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "default",
+				Namespace: "kube-system",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "system:serviceaccount:kube-system:default",
+			},
+			want: true,
+		},
+		{
+			name: "ServiceAccount no match - different namespace",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "default",
+				Namespace: "kube-system",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "system:serviceaccount:default:default",
+			},
+			want: false,
+		},
+		{
+			name: "ServiceAccount no match - different name",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "admin",
+				Namespace: "kube-system",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "system:serviceaccount:kube-system:default",
+			},
+			want: false,
+		},
+		{
+			name: "ServiceAccount wildcard name match",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "*",
+				Namespace: "kube-system",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "system:serviceaccount:kube-system:any-sa",
+			},
+			want: true,
+		},
+		{
+			name: "ServiceAccount wildcard namespace via pattern",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "kyverno",
+				Namespace: "kyverno*",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "system:serviceaccount:kyverno-system:kyverno",
+			},
+			want: true,
+		},
+
+		// User matching
+		{
+			name: "User exact match",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind: rbacv1.UserKind,
+				Name: "alice",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "alice",
+			},
+			want: true,
+		},
+		{
+			name: "User no match",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind: rbacv1.UserKind,
+				Name: "alice",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "bob",
+			},
+			want: false,
+		},
+		{
+			name: "User wildcard match",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind: rbacv1.UserKind,
+				Name: "admin-*",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "admin-alice",
+			},
+			want: true,
+		},
+		{
+			name: "User wildcard no match",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind: rbacv1.UserKind,
+				Name: "admin-*",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "user-alice",
+			},
+			want: false,
+		},
+
+		// To match grps
+		{
+			name: "Group exact match",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind: rbacv1.GroupKind,
+				Name: "system:masters",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "admin",
+				Groups:   []string{"system:authenticated", "system:masters"},
+			},
+			want: true,
+		},
+		{
+			name: "Group no match",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind: rbacv1.GroupKind,
+				Name: "system:masters",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "user",
+				Groups:   []string{"system:authenticated"},
+			},
+			want: false,
+		},
+		{
+			name: "Group wildcard match",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind: rbacv1.GroupKind,
+				Name: "system:*",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "user",
+				Groups:   []string{"developers", "system:authenticated"},
+			},
+			want: true,
+		},
+		{
+			name: "Group empty groups in userInfo",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind: rbacv1.GroupKind,
+				Name: "admin",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "user",
+				Groups:   []string{},
+			},
+			want: false,
+		},
+		{
+			name: "Group nil groups in userInfo",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind: rbacv1.GroupKind,
+				Name: "admin",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "user",
+				Groups:   nil,
+			},
+			want: false,
+		},
+
+		// For multiple subjects
+		{
+			name: "Multiple subjects - first matches",
+			ruleSubjects: []rbacv1.Subject{
+				{
+					Kind: rbacv1.UserKind,
+					Name: "alice",
+				},
+				{
+					Kind: rbacv1.UserKind,
+					Name: "bob",
+				},
+			},
+			userInfo: authenticationv1.UserInfo{
+				Username: "alice",
+			},
+			want: true,
+		},
+		{
+			name: "Multiple subjects - second matches",
+			ruleSubjects: []rbacv1.Subject{
+				{
+					Kind: rbacv1.UserKind,
+					Name: "alice",
+				},
+				{
+					Kind: rbacv1.UserKind,
+					Name: "bob",
+				},
+			},
+			userInfo: authenticationv1.UserInfo{
+				Username: "bob",
+			},
+			want: true,
+		},
+		{
+			name: "Multiple subjects - none match",
+			ruleSubjects: []rbacv1.Subject{
+				{
+					Kind: rbacv1.UserKind,
+					Name: "alice",
+				},
+				{
+					Kind: rbacv1.UserKind,
+					Name: "bob",
+				},
+			},
+			userInfo: authenticationv1.UserInfo{
+				Username: "charlie",
+			},
+			want: false,
+		},
+
+		// Mixed subject types
+		{
+			name: "Mixed types - User matches",
+			ruleSubjects: []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      "default",
+					Namespace: "kube-system",
+				},
+				{
+					Kind: rbacv1.UserKind,
+					Name: "alice",
+				},
+				{
+					Kind: rbacv1.GroupKind,
+					Name: "admins",
+				},
+			},
+			userInfo: authenticationv1.UserInfo{
+				Username: "alice",
+				Groups:   []string{"developers"},
+			},
+			want: true,
+		},
+		{
+			name: "Mixed types - Group matches",
+			ruleSubjects: []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      "default",
+					Namespace: "kube-system",
+				},
+				{
+					Kind: rbacv1.UserKind,
+					Name: "alice",
+				},
+				{
+					Kind: rbacv1.GroupKind,
+					Name: "admins",
+				},
+			},
+			userInfo: authenticationv1.UserInfo{
+				Username: "bob",
+				Groups:   []string{"admins", "developers"},
+			},
+			want: true,
+		},
+		{
+			name: "Mixed types - ServiceAccount matches",
+			ruleSubjects: []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      "kyverno",
+					Namespace: "kyverno",
+				},
+				{
+					Kind: rbacv1.UserKind,
+					Name: "alice",
+				},
+			},
+			userInfo: authenticationv1.UserInfo{
+				Username: "system:serviceaccount:kyverno:kyverno",
+				Groups:   []string{"system:serviceaccounts"},
+			},
+			want: true,
+		},
+
+		// Edge cases
+		{
+			name: "Unknown subject kind is ignored",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind: "UnknownKind",
+				Name: "test",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "test",
+			},
+			want: false,
+		},
+		{
+			name: "ServiceAccount with empty namespace",
+			ruleSubjects: []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "default",
+				Namespace: "",
+			}},
+			userInfo: authenticationv1.UserInfo{
+				Username: "system:serviceaccount::default",
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CheckSubjects(tt.ruleSubjects, tt.userInfo)
+			if got != tt.want {
+				t.Errorf("CheckSubjects() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Explanation

This PR adds comprehensive unit tests for the `CheckSubjects` function in `pkg/utils/match/subjects.go`. This function is security-critical as it's used in policy matching and policy exception evaluation to verify if RBAC subjects (ServiceAccounts, Users, Groups) match the admission request's user info. Previously, this function had no test coverage despite other match functions in the same package (`CheckName`, `CheckLabels`, `CheckAnnotations`) having tests. This PR adds 24 test cases achieving 100% code coverage for the function.

## Related issue

This PR addresses a test coverage gap identified in the `pkg/utils/match` package. The `CheckSubjects` function is used in critical paths:
- `pkg/utils/match/match.go` - Policy matching
- `pkg/engine/utils/exceptions.go` - Policy exception evaluation

## Milestone of this PR

/milestone 1.14.0

## What type of PR is this

/kind cleanup

## Proposed Changes

Added table-driven unit tests for `CheckSubjects` function covering:

- **Empty/nil inputs**: Verifies function handles empty or nil subject slices correctly
- **ServiceAccount matching**: Tests exact match, namespace/name variations, and wildcard patterns
- **User matching**: Tests exact and wildcard pattern matching
- **Group matching**: Tests exact match, wildcards, and edge cases with empty/nil groups
- **Multiple subjects**: Verifies OR logic when multiple subjects are specified
- **Mixed subject types**: Real-world scenarios with combinations of ServiceAccount, User, and Group
- **Edge cases**: Unknown subject kinds, empty namespace handling

### Test Results
<img width="1278" height="768" alt="image" src="https://github.com/user-attachments/assets/5afcd035-63ca-4480-999d-d103b86ea723" />


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This test file follows the existing patterns used in the `pkg/utils/match` package (see `name_test.go`, `labels_test.go`, etc.) and uses table-driven tests for maintainability. The tests cover all three RBAC subject types and verify the wildcard matching behavior that the function relies on.
