### PR TITLE
feat: add PoC integration test framework via envtest (Issue #14725)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ cmd/reports-controller/reports-controller
 cmd/background-controller/background-controller
 coverage.out
 kyverno.tar
+bin/

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1,0 +1,88 @@
+package integration
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func TestIntegration(t *testing.T) {
+	// 1. Setup a Local Scheme (Best Practice)
+	// This ensures we don't rely on global state that might be empty
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(kyvernov1.AddToScheme(scheme))
+
+	// 2. Setup the Environment
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crds")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	defer testEnv.Stop()
+
+	// 3. Create Client using the Local Scheme
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	require.NoError(t, err)
+	require.NotNil(t, k8sClient)
+
+	t.Run("Create and Verify ClusterPolicy", func(t *testing.T) {
+		policyName := "test-policy"
+		policy := &kyvernov1.ClusterPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: policyName,
+			},
+			Spec: kyvernov1.Spec{
+				Rules: []kyvernov1.Rule{
+					{
+						Name: "match-pods",
+						MatchResources: kyvernov1.MatchResources{
+							Any: []kyvernov1.ResourceFilter{
+								{
+									ResourceDescription: kyvernov1.ResourceDescription{
+										Kinds: []string{"Pod"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// Create
+		err := k8sClient.Create(context.Background(), policy)
+		assert.NoError(t, err)
+
+		// Verify with Debug Logging
+		fetchedPolicy := &kyvernov1.ClusterPolicy{}
+		assert.Eventually(t, func() bool {
+			err := k8sClient.Get(context.Background(), client.ObjectKey{Name: policyName}, fetchedPolicy)
+			if err != nil {
+				t.Logf("Get failed: %v", err)
+				return false
+			}
+			if fetchedPolicy.Name == "" {
+				t.Logf("Get succeeded but Name is empty (decoding issue). Object: %+v", fetchedPolicy)
+				return false
+			}
+			return true
+		}, 10*time.Second, 250*time.Millisecond, "Policy should be created and readable")
+		
+		assert.Equal(t, policyName, fetchedPolicy.Name)
+	})
+}


### PR DESCRIPTION
## Explanation

This PR introduces a **Proof-of-Concept (PoC) integration testing framework** using `controller-runtime/envtest` to address the need for faster, code-level integration tests (Issue #14725). Currently, Kyverno relies heavily on Chainsaw for end-to-end testing, which can be slow and resource-intensive for verifying simple logic. This addition allows developers to spin up a local control plane (API server + Etcd) in seconds and run integration tests without needing a full Docker or Kind environment.

## Proposed Changes

I have established the initial scaffolding for a "white-box" integration test suite. This PR includes:

1. **Framework Setup:** Configured `envtest` to manage a local Kubernetes control plane (API Server and Etcd).
2. **CRD Management:** Automated the registration of Kyverno CRDs (specifically `ClusterPolicy`) into the test environment using the stable v1 schema.
3. **Scheme Registration:** Solved the Go client scheme registration to ensure the test client properly recognizes Kyverno types.
4. **PoC Test:** Added a working test case (`TestIntegration/Create_and_Verify_ClusterPolicy`) that:
* Starts the environment.
* Creates a `ClusterPolicy`.
* Verifies its existence via the client.
* Runs in **~2 seconds** (significantly faster than equivalent Chainsaw tests).



### Proof Manifests

This PR does not change user-facing behavior or require YAML manifests. It adds a Go test file. The proof of functionality is the successful execution of the new test suite.

**To verify locally:**

```bash
# 1. Install dependencies (if not already present)
go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest

# 2. Setup environment variables (pointing to K8s 1.29)
export KUBEBUILDER_ASSETS=$(setup-envtest use 1.29 --bin-dir ./bin -p path)

# 3. Run the integration test
go test -v ./test/integration/...

```

**Expected Output:**

```text
=== RUN   TestIntegration
=== RUN   TestIntegration/Create_and_Verify_ClusterPolicy
--- PASS: TestIntegration (2.06s)
    --- PASS: TestIntegration/Create_and_Verify_ClusterPolicy (0.25s)
PASS
ok      github.com/kyverno/kyverno/test/integration     2.564s

```

## Checklist

* [x] I have read the [[contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md)](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
* [x] I have read the [[PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md)](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
* [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
* [ ] This is a feature and I have added CLI tests that are applicable.
* [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
* [ ] My PR contains new or altered behavior to Kyverno and
* [ ] CLI support should be added and my PR doesn't contain that functionality.



## Further Comments

**Why Envtest?**
I chose `envtest` because it offers the best balance between speed and fidelity for integration testing. Unlike unit tests, it uses a real API server, ensuring our interaction with Kubernetes is valid. Unlike Chainsaw/Kind, it skips the node/pod scheduling layer, making it orders of magnitude faster for controller logic verification.

**Note on `.gitignore`:**
I updated `.gitignore` to exclude the `bin/` directory. This is necessary because `setup-envtest` downloads the K8s binaries (apiserver/etcd) to this local folder, and we must ensure these large binary artifacts are not accidentally committed to the repository.