### PR TITLE
fix: panic in CLI when verifying images with registry credentials (#14944)

### DIFF
--- a/pkg/registryclient/utils.go
+++ b/pkg/registryclient/utils.go
@@ -12,6 +12,9 @@ import (
 
 // generateKeychainForPullSecrets generates keychain by fetching secrets data from imagePullSecrets.
 func generateKeychainForPullSecrets(lister corev1listers.SecretNamespaceLister, imagePullSecrets ...string) (authn.Keychain, error) {
+	if lister == nil {
+		return authn.DefaultKeychain, nil
+	}
 	var secrets []corev1.Secret
 	for _, imagePullSecret := range imagePullSecrets {
 		secret, err := lister.Get(imagePullSecret)


### PR DESCRIPTION
## Explanation

This PR fixes a critical bug where the Kyverno CLI (`kyverno apply`) would panic if `imageRegistryCredentials` were defined in a `verifyImages` rule. The crash occurred because the code attempted to access a Kubernetes SecretLister which is not initialized in the CLI environment (dry-run). This fix ensures the CLI safely falls back to the default keychain (local credentials) instead of crashing with a nil pointer dereference.

## Related issue

Closes #14944

## Milestone of this PR

## Documentation (required for features)

## What type of PR is this

/kind bug

## Proposed Changes

* Added a guard clause in `pkg/registryclient/utils.go` inside the `generateKeychainForPullSecrets` function.
* If the `lister` is `nil` (which occurs during CLI execution), the function now returns `authn.DefaultKeychain` immediately.
* This prevents the nil pointer dereference that was causing the panic.

### Proof Manifests

**Policy (`test-policy.yaml`):**

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: verify-image
spec:
  background: false
  rules:
    - name: verify-image
      match:
        any:
        - resources:
            kinds:
              - Pod
      verifyImages:
      - imageReferences:
        - "*"
        imageRegistryCredentials:
          secrets:
            - test123
        failureAction: Enforce
        attestors:
        - entries:
          - keys:
              publicKeys: |-
                -----BEGIN PUBLIC KEY-----
                MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjdVLLvypcaLM9aexBcPwjC0CZRp3
                U0wpDBPRw+ueoIKvOxMTA7I0TJgeG5dQ4f0DJpQX8TOD5OOopTwgmY9MwA==
                -----END PUBLIC KEY-----

```

**Resource (`test-deployment.yaml`):**

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: image-test
spec:
  replicas: 1
  template:
    spec:
      containers:
      - image: nginx:latest
        name: image-test

```

**Reproduction Command:**

```bash
kyverno apply --resource test-deployment.yaml test-policy.yaml

```

**Result:**

* **Before:** Panic `runtime error: invalid memory address or nil pointer dereference`
* **After:** CLI executes successfully (reports signature verification failure as expected, but does not crash).

## Checklist

* [x] I have read the [[contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md)](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
* [x] I have read the [[PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md)](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.