### PR TITLE
test: add unit tests for background common constants

### DIFF
--- a/pkg/background/common/constants_test.go
+++ b/pkg/background/common/constants_test.go
@@ -1,0 +1,71 @@
+package common
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateLabelConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		label    string
+		contains string
+	}{
+		{"GeneratePolicyLabel", GeneratePolicyLabel, "policy-name"},
+		{"GeneratePolicyNamespaceLabel", GeneratePolicyNamespaceLabel, "policy-namespace"},
+		{"GenerateRuleLabel", GenerateRuleLabel, "rule-name"},
+		{"GenerateTriggerNameLabel", GenerateTriggerNameLabel, "trigger-name"},
+		{"GenerateTriggerUIDLabel", GenerateTriggerUIDLabel, "trigger-uid"},
+		{"GenerateTriggerNSLabel", GenerateTriggerNSLabel, "trigger-namespace"},
+		{"GenerateTriggerKindLabel", GenerateTriggerKindLabel, "trigger-kind"},
+		{"GenerateTriggerVersionLabel", GenerateTriggerVersionLabel, "trigger-version"},
+		{"GenerateTriggerGroupLabel", GenerateTriggerGroupLabel, "trigger-group"},
+		{"GenerateSourceNameLabel", GenerateSourceNameLabel, "source-name"},
+		{"GenerateSourceUIDLabel", GenerateSourceUIDLabel, "source-uid"},
+		{"GenerateSourceNSLabel", GenerateSourceNSLabel, "source-namespace"},
+		{"GenerateSourceKindLabel", GenerateSourceKindLabel, "source-kind"},
+		{"GenerateSourceVersionLabel", GenerateSourceVersionLabel, "source-version"},
+		{"GenerateSourceGroupLabel", GenerateSourceGroupLabel, "source-group"},
+		{"GenerateTypeCloneSourceLabel", GenerateTypeCloneSourceLabel, "clone-source"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !strings.HasPrefix(tt.label, "generate.kyverno.io/") {
+				t.Errorf("%s = %v, should start with generate.kyverno.io/", tt.name, tt.label)
+			}
+			if !strings.Contains(tt.label, tt.contains) {
+				t.Errorf("%s = %v, should contain %v", tt.name, tt.label, tt.contains)
+			}
+		})
+	}
+}
+
+func TestLabelUniqueness(t *testing.T) {
+	labels := []string{
+		GeneratePolicyLabel,
+		GeneratePolicyNamespaceLabel,
+		GenerateRuleLabel,
+		GenerateTriggerNameLabel,
+		GenerateTriggerUIDLabel,
+		GenerateTriggerNSLabel,
+		GenerateTriggerKindLabel,
+		GenerateTriggerVersionLabel,
+		GenerateTriggerGroupLabel,
+		GenerateSourceNameLabel,
+		GenerateSourceUIDLabel,
+		GenerateSourceNSLabel,
+		GenerateSourceKindLabel,
+		GenerateSourceVersionLabel,
+		GenerateSourceGroupLabel,
+		GenerateTypeCloneSourceLabel,
+	}
+
+	seen := make(map[string]bool)
+	for _, label := range labels {
+		if seen[label] {
+			t.Errorf("duplicate label found: %v", label)
+		}
+		seen[label] = true
+	}
+}


### PR DESCRIPTION
## Explanation

Adds comprehensive unit tests for `pkg/background/common/constants.go` to improve test coverage for all generate label constants used in background processing.

## Related issue

This PR addresses test coverage for the background/common package.

## Milestone of this PR

/milestone 1.18.0

## What type of PR is this

/kind test

## Proposed Changes

- Add `TestGenerateLabelConstants` with table-driven tests verifying:
  - All 16 label constants have proper `generate.kyverno.io/` prefix
  - Each label contains expected suffix (policy-name, trigger-uid, etc.)
- Add `TestLabelUniqueness` to ensure no duplicate label values exist

## Test Results

All 18 tests pass:

```
=== RUN   TestGenerateLabelConstants
=== RUN   TestGenerateLabelConstants/GeneratePolicyLabel
=== RUN   TestGenerateLabelConstants/GeneratePolicyNamespaceLabel
... (16 subtests)
--- PASS: TestGenerateLabelConstants (0.00s)
=== RUN   TestLabelUniqueness
--- PASS: TestLabelUniqueness (0.00s)
```

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the PR documentation guide and followed the process including adding the labels for the PR.
- [x] I have added tests that prove my fix is effective or that my feature works.