### PR TITLE
test: add unit tests for background generate response

### DIFF
--- a/pkg/background/generate/response_test.go
+++ b/pkg/background/generate/response_test.go
@@ -1,0 +1,72 @@
+package generate
+
+import (
+	"errors"
+	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+)
+
+func TestNewGenerateResponse(t *testing.T) {
+	data := map[string]interface{}{"key": "value"}
+	target := kyvernov1.ResourceSpec{Kind: "ConfigMap", Name: "test"}
+	testErr := errors.New("test error")
+
+	resp := newGenerateResponse(data, Create, target, testErr)
+
+	if resp.GetAction() != Create {
+		t.Errorf("GetAction() = %v, want %v", resp.GetAction(), Create)
+	}
+	if resp.GetTarget().Kind != "ConfigMap" {
+		t.Errorf("GetTarget().Kind = %v, want ConfigMap", resp.GetTarget().Kind)
+	}
+	if resp.GetError() != testErr {
+		t.Errorf("GetError() = %v, want %v", resp.GetError(), testErr)
+	}
+	if resp.GetData()["key"] != "value" {
+		t.Errorf("GetData()[key] = %v, want value", resp.GetData()["key"])
+	}
+}
+
+func TestNewSkipGenerateResponse(t *testing.T) {
+	target := kyvernov1.ResourceSpec{Kind: "Secret", Name: "skip-test"}
+	resp := newSkipGenerateResponse(nil, target, nil)
+
+	if resp.GetAction() != Skip {
+		t.Errorf("GetAction() = %v, want %v", resp.GetAction(), Skip)
+	}
+}
+
+func TestNewUpdateGenerateResponse(t *testing.T) {
+	target := kyvernov1.ResourceSpec{Kind: "ConfigMap", Name: "update-test"}
+	resp := newUpdateGenerateResponse(nil, target, nil)
+
+	if resp.GetAction() != Update {
+		t.Errorf("GetAction() = %v, want %v", resp.GetAction(), Update)
+	}
+}
+
+func TestNewCreateGenerateResponse(t *testing.T) {
+	target := kyvernov1.ResourceSpec{Kind: "ConfigMap", Name: "create-test"}
+	resp := newCreateGenerateResponse(nil, target, nil)
+
+	if resp.GetAction() != Create {
+		t.Errorf("GetAction() = %v, want %v", resp.GetAction(), Create)
+	}
+}
+
+func TestResourceModeConstants(t *testing.T) {
+	tests := []struct {
+		mode resourceMode
+		want string
+	}{
+		{Skip, "SKIP"},
+		{Create, "CREATE"},
+		{Update, "UPDATE"},
+	}
+	for _, tt := range tests {
+		if string(tt.mode) != tt.want {
+			t.Errorf("resourceMode = %v, want %v", tt.mode, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Explanation

Adds comprehensive unit tests for `pkg/background/generate/response.go` to improve test coverage for generate response handling and resource mode constants.

## Related issue

This PR addresses test coverage for the background/generate package.

## Milestone of this PR

/milestone 1.18.0

## What type of PR is this

/kind test

## Proposed Changes

- Add `TestNewGenerateResponse` to verify response construction and getter methods
- Add `TestNewSkipGenerateResponse` to verify Skip action
- Add `TestNewUpdateGenerateResponse` to verify Update action
- Add `TestNewCreateGenerateResponse` to verify Create action
- Add `TestResourceModeConstants` to verify Skip/Create/Update string values

## Test Results

All 5 tests pass:

```
=== RUN   TestNewGenerateResponse
--- PASS: TestNewGenerateResponse (0.00s)
=== RUN   TestNewSkipGenerateResponse
--- PASS: TestNewSkipGenerateResponse (0.00s)
=== RUN   TestNewUpdateGenerateResponse
--- PASS: TestNewUpdateGenerateResponse (0.00s)
=== RUN   TestNewCreateGenerateResponse
--- PASS: TestNewCreateGenerateResponse (0.00s)
=== RUN   TestResourceModeConstants
--- PASS: TestResourceModeConstants (0.00s)
```

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the PR documentation guide and followed the process including adding the labels for the PR.
- [x] I have added tests that prove my fix is effective or that my feature works.