### PR TITLE
test: add envtest integration test framework PoC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -854,6 +854,17 @@ test-unit:
 	@echo Running unit tests... >&2
 	@go test -race -covermode atomic -coverprofile $(CODE_COVERAGE_FILE_OUT) ./...
 
+#####################
+# INTEGRATION TESTS #
+#####################
+
+.PHONY: test-integration
+test-integration: ## Run integration tests (envtest, no cluster required)
+test-integration:
+	@echo Running integration tests... >&2
+	@KUBEBUILDER_ASSETS=$$($(shell go env GOPATH)/bin/setup-envtest use 1.30 -p path) \
+	go test -race -v -count=1 ./test/integration/...
+
 #############
 # CLI TESTS #
 #############

--- a/test/integration/framework/clients.go
+++ b/test/integration/framework/clients.go
@@ -1,0 +1,24 @@
+package framework
+
+import (
+	"testing"
+
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// NewClients creates real Kubernetes and Kyverno clientsets backed by the
+// envtest API server — replacing the fake.NewSimpleClientset() pattern.
+func NewClients(t *testing.T, cfg *rest.Config) (kubernetes.Interface, versioned.Interface) {
+	t.Helper()
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("failed to create kubernetes client: %v", err)
+	}
+	kyvernoClient, err := versioned.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("failed to create kyverno client: %v", err)
+	}
+	return kubeClient, kyvernoClient
+}

--- a/test/integration/framework/helpers.go
+++ b/test/integration/framework/helpers.go
@@ -1,0 +1,47 @@
+package framework
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CreateClusterPolicy creates a ClusterPolicy in the envtest API server
+// and registers a cleanup function to delete it when the test finishes.
+func CreateClusterPolicy(t *testing.T, client versioned.Interface, policy *kyvernov1.ClusterPolicy) *kyvernov1.ClusterPolicy {
+	t.Helper()
+	created, err := client.KyvernoV1().ClusterPolicies().Create(
+		context.Background(), policy, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = client.KyvernoV1().ClusterPolicies().Delete(
+			context.Background(), created.Name, metav1.DeleteOptions{})
+	})
+	return created
+}
+
+// UniqueNamespace creates a per-test namespace for isolation and registers
+// cleanup to delete it when the test finishes.
+func UniqueNamespace(t *testing.T, kubeClient kubernetes.Interface) *corev1.Namespace {
+	t.Helper()
+	name := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "-"))
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	ns, err := kubeClient.CoreV1().Namespaces().Create(context.Background(),
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}},
+		metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = kubeClient.CoreV1().Namespaces().Delete(
+			context.Background(), name, metav1.DeleteOptions{})
+	})
+	return ns
+}

--- a/test/integration/framework/setup.go
+++ b/test/integration/framework/setup.go
@@ -1,0 +1,42 @@
+package framework
+
+import (
+	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// SetupEnvTest boots a lightweight local API server + etcd via envtest,
+// installs all Kyverno CRDs, and returns the rest.Config for client creation.
+func SetupEnvTest(t *testing.T) (*rest.Config, *runtime.Scheme) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = kyvernov1.Install(scheme)
+	_ = apiextensions.AddToScheme(scheme)
+	_ = apiextensionsv1.AddToScheme(scheme)
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			"../../../config/crds/kyverno",
+		},
+		Scheme: scheme,
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("failed to start envtest: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := testEnv.Stop(); err != nil {
+			t.Errorf("failed to stop envtest: %v", err)
+		}
+	})
+	return cfg, scheme
+}

--- a/test/integration/framework/smoke_test.go
+++ b/test/integration/framework/smoke_test.go
@@ -1,0 +1,107 @@
+package framework_test
+
+import (
+	"context"
+	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/test/integration/framework"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newRequireLabelsPolicy(name string) *kyvernov1.ClusterPolicy {
+	return &kyvernov1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: kyvernov1.Spec{
+			Rules: []kyvernov1.Rule{{
+				Name: "check-labels",
+				MatchResources: kyvernov1.MatchResources{
+					ResourceDescription: kyvernov1.ResourceDescription{
+						Kinds: []string{"Pod"},
+					},
+				},
+				Validation: &kyvernov1.Validation{
+					Message: "label 'app' is required",
+					RawPattern: &apiextv1.JSON{
+						Raw: []byte(`{"metadata":{"labels":{"app":"?*"}}}`),
+					},
+				},
+			}},
+		},
+	}
+}
+
+func TestEnvTestBootstrap(t *testing.T) {
+	cfg, _ := framework.SetupEnvTest(t)
+	assert.NotNil(t, cfg, "envtest config should not be nil")
+	assert.NotEmpty(t, cfg.Host, "API server host should be set")
+}
+
+func TestClusterPolicy_CRUD(t *testing.T) {
+	cfg, _ := framework.SetupEnvTest(t)
+	_, kyvernoClient := framework.NewClients(t, cfg)
+
+	policy := newRequireLabelsPolicy("test-require-labels")
+
+	// Create
+	created, err := kyvernoClient.KyvernoV1().ClusterPolicies().Create(
+		context.Background(), policy, metav1.CreateOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "test-require-labels", created.Name)
+	assert.Len(t, created.Spec.Rules, 1)
+
+	// Read
+	fetched, err := kyvernoClient.KyvernoV1().ClusterPolicies().Get(
+		context.Background(), created.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "check-labels", fetched.Spec.Rules[0].Name)
+
+	// Update
+	fetched.Spec.Rules[0].Validation.Message = "updated message"
+	updated, err := kyvernoClient.KyvernoV1().ClusterPolicies().Update(
+		context.Background(), fetched, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "updated message", updated.Spec.Rules[0].Validation.Message)
+
+	// Delete
+	err = kyvernoClient.KyvernoV1().ClusterPolicies().Delete(
+		context.Background(), created.Name, metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	// Verify deletion
+	_, err = kyvernoClient.KyvernoV1().ClusterPolicies().Get(
+		context.Background(), created.Name, metav1.GetOptions{})
+	assert.Error(t, err, "policy should not exist after deletion")
+}
+
+func TestNamespaceIsolation(t *testing.T) {
+	cfg, _ := framework.SetupEnvTest(t)
+	kubeClient, _ := framework.NewClients(t, cfg)
+
+	ns := framework.UniqueNamespace(t, kubeClient)
+	assert.NotEmpty(t, ns.Name)
+
+	// Verify namespace exists in the API server
+	fetched, err := kubeClient.CoreV1().Namespaces().Get(
+		context.Background(), ns.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, ns.Name, fetched.Name)
+}
+
+func TestClusterPolicy_List(t *testing.T) {
+	cfg, _ := framework.SetupEnvTest(t)
+	_, kyvernoClient := framework.NewClients(t, cfg)
+
+	// Create two policies
+	framework.CreateClusterPolicy(t, kyvernoClient, newRequireLabelsPolicy("policy-a"))
+	framework.CreateClusterPolicy(t, kyvernoClient, newRequireLabelsPolicy("policy-b"))
+
+	// List should return both
+	list, err := kyvernoClient.KyvernoV1().ClusterPolicies().List(
+		context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Len(t, list.Items, 2)
+}


### PR DESCRIPTION
 ## Explanation      
  I've been hitting 30+ minute Chainsaw E2E feedback loops while debugging policy
   bugs, so I put together a small envtest-based integration test setup to see if
   we can get real API server behavior without spinning up a Kind cluster. This  
  PR is just the foundation — boots envtest, installs Kyverno CRDs, and runs a   
  few smoke tests to prove it works.

  ## Related issue

  Ref #14725

  ## Milestone of this PR

  N/A

  ## Documentation (required for features)

  My PR contains new or altered behavior to Kyverno.
  - [ ] I have sent the draft PR to add or update [the
  documentation](https://github.com/kyverno/website) and the link is:

  ## What type of PR is this

  /kind feature

  ## Proposed Changes

  Set up `test/integration/framework/` with:

  - `setup.go` — boots envtest with Kyverno CRDs from `config/crds/kyverno/`     
  - `clients.go` — creates real clientsets backed by the envtest API server      
  instead of `fake.NewSimpleClientset()`
  - `helpers.go` — `CreateClusterPolicy()` and `UniqueNamespace()` with
  `t.Cleanup()`
  - `smoke_test.go` — 4 tests: envtest bootstrap, ClusterPolicy CRUD, namespace  
  isolation, policy list

  Also added a `make test-integration` target. All tests pass locally in ~30s.   

  This is just the starting point — policy cache, engine, and controller tests   
  would build on top of this.

  ### Proof Manifests

  Not applicable — this PR only adds Go test files. Tests can be run with:       

  **bash**  make test-integration

  ##  Checklist

  - I have read the https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md.
  - I have read the
  https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md and   
  followed the process including adding proof manifests to this PR.
  - This is a bug fix and I have added unit tests that prove my fix is effective.
  - This is a feature and I have added CLI tests that are applicable.
  - My PR needs to be cherry picked to a specific release branch which is .      
  - My PR contains new or altered behavior to Kyverno and
    - CLI support should be added and my PR doesn't contain that functionality.  

  Further Comments

  Opening as a draft — this is a proof-of-concept for the envtest approach in    
  #14725, not a complete framework yet.
