### PR TITLE
fix: out of bounds panic in deferred loaders matching

### DIFF
--- a/pkg/engine/context/deferred.go
+++ b/pkg/engine/context/deferred.go
@@ -168,6 +168,9 @@ func (d *deferredLoaders) setLevelAndIndex(level, index int) {
 }
 
 func (d *deferredLoaders) match(query string, level, index int) (*leveledLoader, int) {
+	if index > len(d.loaders) {
+		index = len(d.loaders)
+	}
 	for i := 0; i < index; i++ {
 		dl := d.loaders[i]
 		if dl.matched || dl.loader.HasLoaded() {


### PR DESCRIPTION
## Explanation

This PR fixes a runtime panic (`index out of range`) in the admission controller. While debugging **#10962**, I found that if a deferred loader calls [Reset()](cci:1://file:///e:/opensource/kyverno/pkg/engine/context/context.go:468:0-471:1) or [Restore()](cci:1://file:///e:/opensource/kyverno/pkg/engine/context/context.go:106:1-107:10) during its [LoadData()](cci:1://file:///e:/opensource/kyverno/pkg/engine/context/context.go:388:0-395:1) execution, it shrinks the `d.loaders` slice. Since [LoadMatching](cci:1://file:///e:/opensource/kyverno/pkg/engine/context/deferred.go:135:0-152:1) is still iterating using an index captured at the start of the call, it eventually tries to access a now-missing element in the slice, causing a panic. 

## Related issue

Closes #10962

## Milestone of this PR

<!--
Add the milestone label by commenting /milestone 1.x.x
-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

- Added a check in [match()](cci:1://file:///e:/opensource/kyverno/pkg/engine/context/deferred.go:169:0-187:1) to ensure the `index` never exceeds the current length of `d.loaders`.
- This ensures that if the slice is modified (shrunked) during iteration, the engine won't try to access out-of-bounds indices.

### Proof Manifests

Verified with a new unit test in [pkg/engine/context/deferred_test.go](cci:7://file:///e:/opensource/kyverno/pkg/engine/context/deferred_test.go:0:0-0:0). The test ([TestDeferredResetDuringLoad](cci:1://file:///e:/opensource/kyverno/pkg/engine/context/deferred_test.go:426:0-436:1)) sets up a loader that triggers a [Reset()](cci:1://file:///e:/opensource/kyverno/pkg/engine/context/context.go:468:0-471:1) while other results are still pending, which reliably reproduces the crash without the fix.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The fix is minimal and just caps the index to the current slice length. This is safer than the current behavior where we trust the initial index even after the slice might have changed.