### PR TITLE
Fix Duplicate dependency

### DIFF
--- a/pkg/cosign/mock.go
+++ b/pkg/cosign/mock.go
@@ -65,7 +65,7 @@ func (m *mock) getSignatures(signedImgRef name.Reference) ([]oci.Signature, bool
 }
 
 func getSignature(sp cosign.SignedPayload) (oci.Signature, error) {
-	chain := make([]byte, 0)
+	var chain []byte //nolint:prealloc
 	for _, cert := range sp.Chain {
 		chain = append(chain, cert.Raw...)
 	}

--- a/pkg/cosign/sigstore.go
+++ b/pkg/cosign/sigstore.go
@@ -17,8 +17,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/root"
+	"github.com/sigstore/sigstore-go/pkg/tuf"
 	"github.com/sigstore/sigstore-go/pkg/verify"
-	"github.com/sigstore/sigstore/pkg/tuf"
 )
 
 var (
@@ -209,17 +209,14 @@ func buildVerifyOptions(opts images.Options) []verify.VerifierOption {
 }
 
 func getTrustedRoot(ctx context.Context) (*root.TrustedRoot, error) {
-	tufClient, err := tuf.NewFromEnv(ctx)
+	opts := tuf.DefaultOptions()
+	client, err := tuf.New(opts)
 	if err != nil {
 		return nil, fmt.Errorf("initializing tuf: %w", err)
 	}
-	targetBytes, err := tufClient.GetTarget("trusted_root.json")
+	trustedRoot, err := root.GetTrustedRoot(client)
 	if err != nil {
-		return nil, fmt.Errorf("error getting targets: %w", err)
-	}
-	trustedRoot, err := root.NewTrustedRootFromJSON(targetBytes)
-	if err != nil {
-		return nil, fmt.Errorf("error creating trusted root: %w", err)
+		return nil, fmt.Errorf("error getting trusted root: %w", err)
 	}
 
 	return trustedRoot, nil

--- a/pkg/cosign/sigstore.go
+++ b/pkg/cosign/sigstore.go
@@ -17,8 +17,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/root"
-	"github.com/sigstore/sigstore-go/pkg/tuf"
 	"github.com/sigstore/sigstore-go/pkg/verify"
+	"github.com/sigstore/sigstore-go/pkg/tuf"
 )
 
 var (


### PR DESCRIPTION
## Explanation
 
As in #15125, go-tuf v0 and v2 both were present in go.mod

## Related issue
#15125 


## What type of PR is this
/kind bug

## Proposed Changes

`pkg/cosign/sigstore.go` was explicitly importing the old library, migrated to new one

## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

