### PR TITLE
fix: eliminate memcache error spam from fake client discovery polling

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -365,6 +365,7 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 				testCase.Fs,
 				contextPath,
 				false,
+				true,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to apply policies on resource %v (%w)", resource.GetName(), err)
@@ -383,6 +384,7 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 				true,
 				testCase.Fs,
 				contextPath,
+				true,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to apply policies on resource %v (%w)", resource.GetName(), err)
@@ -442,6 +444,7 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 				testCase.Fs,
 				contextPath,
 				false,
+				true,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to apply validating policies on JSON payload %s (%w)", testCase.Test.JSONPayload, err)
@@ -460,6 +463,7 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 				true,
 				testCase.Fs,
 				contextPath,
+				true,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to apply policies on JSON payload %v (%w)", testCase.Test.JSONPayload, err)
@@ -495,6 +499,7 @@ func applyImageValidatingPolicies(
 	f billy.Filesystem,
 	contextPath string,
 	continueOnFail bool,
+	isFake bool,
 ) ([]engineapi.EngineResponse, error) {
 	provider, err := ivpolengine.NewProvider(ivps, celExceptions)
 	if err != nil {
@@ -515,7 +520,7 @@ func applyImageValidatingPolicies(
 	if err != nil {
 		return nil, err
 	}
-	contextProvider, err := processor.NewContextProvider(dclient, restMapper, f, contextPath, registryAccess, true)
+	contextProvider, err := processor.NewContextProvider(dclient, restMapper, f, contextPath, registryAccess, isFake)
 	if err != nil {
 		return nil, err
 	}
@@ -622,6 +627,7 @@ func applyDeletingPolicies(
 	registryAccess bool,
 	f billy.Filesystem,
 	contextPath string,
+	isFake bool,
 ) ([]engineapi.EngineResponse, error) {
 	provider, err := dpolengine.NewProvider(dpolcompiler.NewCompiler(), dps, celExceptions)
 	if err != nil {
@@ -633,7 +639,7 @@ func applyDeletingPolicies(
 		return nil, err
 	}
 
-	contextProvider, err := processor.NewContextProvider(dclient, restMapper, f, contextPath, registryAccess, true)
+	contextProvider, err := processor.NewContextProvider(dclient, restMapper, f, contextPath, registryAccess, isFake)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cli/kubectl-kyverno/utils/common/fetch.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/fetch.go
@@ -229,7 +229,7 @@ func (rf *ResourceFetcher) getKindsFromPolicy(
 	matchResources *admissionregistrationv1.MatchResources,
 	info *resourceTypeInfo,
 ) {
-	restMapper, err := utils.GetRESTMapper(rf.Client, false)
+	restMapper, err := utils.GetRESTMapper(rf.Client, !rf.Cluster)
 	if err != nil {
 		log.Log.V(3).Info("failed to get rest mapper", "error", err)
 		return

--- a/ext/cluster/fake.go
+++ b/ext/cluster/fake.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"context"
 	"errors"
-	"time"
 
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
 	kdata "github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/data"
@@ -126,12 +125,11 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 	}
 	kclient := kubefake.NewSimpleClientset(resource.ConvertResources(kubeObjects)...)
 
-	dClient, _ := dclient.NewClient(context.Background(), dyn, kclient, time.Hour, false, nil)
 	discoClient := dclient.NewFakeDiscoveryClient(list)
 	for gvr, gvk := range gvrToGVK {
 		discoClient.AddGVRToGVKMapping(gvr, gvk)
 	}
-	dClient.SetDiscovery(discoClient)
+	dClient := dclient.NewFakeClientWithDisco(dyn, kclient, discoClient)
 
 	return dClient, nil
 }

--- a/pkg/clients/dclient/fake.go
+++ b/pkg/clients/dclient/fake.go
@@ -12,7 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -50,6 +52,16 @@ func NewFakeClient(scheme *runtime.Scheme, gvrToListKind map[schema.GroupVersion
 		dyn:  c,
 		kube: kclient,
 	}, nil
+}
+
+// NewFakeClientWithDisco creates a fake client with the given dynamic, kube, and discovery clients.
+// Unlike NewClient, this does not start a background discovery cache polling goroutine.
+func NewFakeClientWithDisco(dyn dynamic.Interface, kube kubernetes.Interface, disco IDiscovery) Interface {
+	return &client{
+		dyn:   dyn,
+		disco: disco,
+		kube:  kube,
+	}
 }
 
 func NewEmptyFakeClient() Interface {


### PR DESCRIPTION
## Summary

- Adds `NewFakeClientWithDisco()` to `dclient/fake.go` — creates a fake client without starting a background discovery `Poll` goroutine (unlike `NewClient()` which spawns a goroutine that repeatedly fails against a fake kube client)
- Updates `ext/cluster/fake.go` to use `NewFakeClientWithDisco` instead of `dclient.NewClient()`, eliminating repeated `"couldn't get current server API group list"` errors during `kyverno test`
- Adds `isFake` parameter to `applyImageValidatingPolicies` and `applyDeletingPolicies` helper functions instead of hardcoding `true` for `NewContextProvider`
- Fixes `ResourceFetcher.getKindsFromPolicy` which was hardcoding `isFake=false` for `GetRESTMapper` regardless of whether a real cluster is connected

Complements #15177 — this PR handles the memcache error spam and helper function fixes while #15177 handles the cmResolver timing, Cluster flag, NamespaceCache init, and RESTMapper auto-detect.

## Test plan
- [x] `go build ./cmd/cli/kubectl-kyverno/...` passes
- [x] `go test ./cmd/cli/kubectl-kyverno/commands/test/` passes
- [x] `go test ./cmd/cli/kubectl-kyverno/processor/` passes
- [x] Verified memcache errors no longer appear when running benchmarks with vpol tests