### PR TITLE
Update Go version to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyverno/kyverno
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6


### PR DESCRIPTION
This pull request updates the Go version used in the project from 1.25.7 to 1.26.0 in the `go.mod` file. This ensures the project uses the latest language features, performance improvements, and security patches.