### PR TITLE
change indentation of validationActions fields 

### DIFF
--- a/charts/kyverno-policies/templates/_helpers.tpl
+++ b/charts/kyverno-policies/templates/_helpers.tpl
@@ -112,9 +112,9 @@ helm.sh/chart: {{ template "kyverno-policies.chart" . }}
 {{/* Maps: Audit -> Audit, Enforce -> Deny */}}
 {{- define "kyverno-policies.validationActions" -}}
 {{- if eq . "Enforce" -}}
-{{- list "Deny" -}}
+{{- list "Deny" | toYaml -}}
 {{- else -}}
-{{- list "Audit" -}}
+{{- list "Audit" | toYaml -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/kyverno-policies/templates/baseline/disallow-capabilities.cel.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-capabilities.cel.yaml
@@ -48,6 +48,5 @@ spec:
         FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT)
         are disallowed.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
-

--- a/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.cel.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-namespaces.cel.yaml
@@ -37,6 +37,6 @@ spec:
         Sharing the host namespaces is disallowed. The fields spec.hostNetwork,
         spec.hostIPC, and spec.hostPID must be unset or set to `false`.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/baseline/disallow-host-path.cel.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-path.cel.yaml
@@ -33,6 +33,6 @@ spec:
       message: >-
         HostPath volumes are forbidden. The field spec.volumes[*].hostPath must be unset.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/baseline/disallow-host-ports.cel.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-ports.cel.yaml
@@ -40,6 +40,6 @@ spec:
         , spec.initContainers[*].ports[*].hostPort, and spec.ephemeralContainers[*].ports[*].hostPort
         must either be unset or set to `0`.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/baseline/disallow-host-process.cel.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-host-process.cel.yaml
@@ -53,6 +53,6 @@ spec:
         spec.initContainers[*].securityContext.windowsOptions.hostProcess, and
         spec.ephemeralContainers[*].securityContext.windowsOptions.hostProcess must be unset or set to `false`.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.cel.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-privileged-containers.cel.yaml
@@ -35,6 +35,6 @@ spec:
         Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged
         and spec.initContainers[*].securityContext.privileged must be unset or set to `false`.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/baseline/disallow-proc-mount.cel.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-proc-mount.cel.yaml
@@ -46,6 +46,6 @@ spec:
         spec.initContainers[*].securityContext.procMount, and
         spec.ephemeralContainers[*].securityContext.procMount must be unset or set to `Default`.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/baseline/disallow-selinux.cel.yaml
+++ b/charts/kyverno-policies/templates/baseline/disallow-selinux.cel.yaml
@@ -57,6 +57,6 @@ spec:
         spec.initContainers[*].securityContext.seLinuxOptions, and
         spec.ephemeralContainers[*].securityContext.seLinuxOptions must be unset or restricted.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.cel.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-apparmor-profiles.cel.yaml
@@ -59,6 +59,6 @@ spec:
         spec.initContainers[*].securityContext.appArmorProfile.type, and
         spec.ephemeralContainers[*].securityContext.appArmorProfile.type must be unset or set to allowed values.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/baseline/restrict-seccomp.cel.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-seccomp.cel.yaml
@@ -56,6 +56,6 @@ spec:
         spec.ephemeralContainers[*].securityContext.seccompProfile.type
         must be unset or set to `RuntimeDefault` or `Localhost`.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/baseline/restrict-sysctls.cel.yaml
+++ b/charts/kyverno-policies/templates/baseline/restrict-sysctls.cel.yaml
@@ -35,6 +35,5 @@ spec:
         Sysctls must be restricted to safe values. The field spec.securityContext.sysctls[*].name
         must be one of the allowed safe sysctls.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
-

--- a/charts/kyverno-policies/templates/other/require-non-root-groups.cel.yaml
+++ b/charts/kyverno-policies/templates/other/require-non-root-groups.cel.yaml
@@ -50,6 +50,6 @@ spec:
         spec.initContainers[*].securityContext.runAsGroup, and
         spec.ephemeralContainers[*].securityContext.runAsGroup must not be set to `0`.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.cel.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-capabilities-strict.cel.yaml
@@ -47,6 +47,6 @@ spec:
       message: >-
         Containers must drop `ALL` capabilities and may only add `NET_BIND_SERVICE`.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.cel.yaml
+++ b/charts/kyverno-policies/templates/restricted/disallow-privilege-escalation.cel.yaml
@@ -47,6 +47,6 @@ spec:
         and spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation
         must be set to `false`.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.cel.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.cel.yaml
@@ -50,6 +50,6 @@ spec:
         spec.initContainers[*].securityContext.runAsUser, and
         spec.ephemeralContainers[*].securityContext.runAsUser must not be set to `0`.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.cel.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.cel.yaml
@@ -51,6 +51,6 @@ spec:
         spec.initContainers[*].securityContext.runAsNonRoot, and spec.ephemeralContainers[*].securityContext.runAsNonRoot
         must be set to `true`.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.cel.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.cel.yaml
@@ -56,6 +56,6 @@ spec:
         spec.ephemeralContainers[*].securityContext.seccompProfile.type
         must be set to `RuntimeDefault` or `Localhost`.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/templates/restricted/restrict-volume-types.cel.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-volume-types.cel.yaml
@@ -43,6 +43,6 @@ spec:
         Only the following types of volumes may be used: configMap, csi, downwardAPI,
         emptyDir, ephemeral, persistentVolumeClaim, projected, and secret.
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
-  validationActions: {{ $actions | toYaml | nindent 4 }}
+  validationActions: {{ $actions | nindent 4 }}
 {{- end }}
 

--- a/charts/kyverno-policies/values.yaml
+++ b/charts/kyverno-policies/values.yaml
@@ -44,20 +44,20 @@ validationFailureAction: Audit
 # -- Define validationFailureActionByPolicy for specific policies.
 # Override the defined `validationFailureAction` with a individual validationFailureAction for individual Policies.
 validationFailureActionByPolicy: {}
-#  disallow-capabilities-strict: enforce
-#  disallow-host-path: enforce
-#  disallow-host-ports: enforce
+#  disallow-capabilities-strict: Enforce
+#  disallow-host-path: Enforce
+#  disallow-host-ports: Enforce
 
 # -- Define validationFailureActionOverrides for specific policies.
 # The overrides for `all` will apply to all policies.
 validationFailureActionOverrides:
   all: []
   # all:
-  #   - action: audit
+  #   - action: Audit
   #     namespaces:
   #       - ingress-nginx
   # disallow-host-path:
-  #   - action: audit
+  #   - action: Audit
   #     namespaces:
   #       - fluent
 
@@ -84,6 +84,7 @@ policyExclude: {}
   #       - Pod
   #       namespaces:
   #       - kube-system
+
 # -- Add preconditions to individual policies.
 # Policies with multiple rules can have individual rules excluded by using the name of the rule as the key in the `policyPreconditions` map.
 policyPreconditions: {}


### PR DESCRIPTION
## Explanation

This PR fixes `validationActions` fields indentation 

## Related issue

closes https://github.com/kyverno/kyverno/issues/15199





## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

