### PR TITLE
ci(conformance): conditionally run conformance tests based on relevant path

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -18,10 +18,25 @@ concurrency:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    outputs:
+     run_conformance: ${{ steps.changes.outputs.run_conformance }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Detect relevant changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            run_conformance:
+              - 'pkg/**'
+              - 'api/**'
+              - 'cmd/**'
+              - 'charts/**'
+              - 'ext/**'
+              - '.github/workflows/conformance.yaml'
       - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        if: steps.changes.outputs.run_conformance == 'true'
         with:
           android: true
           docker-images: false
@@ -33,6 +48,7 @@ jobs:
       - name: Setup Go
         id: setup-go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        if: steps.changes.outputs.run_conformance == 'true'
         with:
           go-version-file: go.mod
           cache: false
@@ -47,6 +63,7 @@ jobs:
           echo "CACHE_OS_SUFFIX=$ImageOS-" >> $GITHUB_ENV
       - name: Restore gomod cache
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        if: steps.changes.outputs.run_conformance == 'true'
         with:
           path: ${{ env.GO_MOD_CACHE }}
           key: gomod-${{ runner.os }}-${{ env.ARCH }}-${{ env.CACHE_OS_SUFFIX }}go-${{ steps.setup-go.outputs.go-version }}-${{ env.GO_CACHE_DATE }}-${{ hashFiles('**/go.sum') }}
@@ -54,7 +71,7 @@ jobs:
             gomod-${{ runner.os }}-${{ env.ARCH }}-${{ env.CACHE_OS_SUFFIX }}go-${{ steps.setup-go.outputs.go-version }}-${{ env.GO_CACHE_DATE }}-
             gomod-${{ runner.os }}-${{ env.ARCH }}-${{ env.CACHE_OS_SUFFIX }}go-${{ steps.setup-go.outputs.go-version }}-
       - name: Restore gobuild cache
-        if: github.ref != 'refs/heads/main'
+        if: steps.changes.outputs.run_conformance == 'true' && github.ref != 'refs/heads/main'
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ env.GO_BUILD_CACHE }}
@@ -64,6 +81,7 @@ jobs:
             gobuild-${{ runner.os }}-${{ env.ARCH }}-${{ env.CACHE_OS_SUFFIX }}go-${{ steps.setup-go.outputs.go-version }}-
       - name: Install Ko
         uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+        if: steps.changes.outputs.run_conformance == 'true'
       - name: Ko build
         shell: bash
         run: |
@@ -71,6 +89,7 @@ jobs:
           KO=/usr/local/bin/ko VERSION=${{ github.ref_name }} make docker-save-image-all
       - name: Upload images archive
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: steps.changes.outputs.run_conformance == 'true'
         with:
           name: kyverno.tar
           path: kyverno.tar
@@ -83,6 +102,8 @@ jobs:
           VERSION=${{ github.ref_name }} make build-cli
       - name: Upload binary
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: steps.changes.outputs.run_conformance == 'true'
+
         with:
           name: kubectl-kyverno
           path: cmd/cli/kubectl-kyverno/kubectl-kyverno
@@ -99,6 +120,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -118,6 +140,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -137,6 +160,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -156,6 +180,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -177,6 +202,7 @@ jobs:
           - v1.33.x
           - v1.34.x
     needs: prepare
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -258,6 +284,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -278,6 +305,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2, 3, 4, 5]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -299,6 +327,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -319,6 +348,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -340,6 +370,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -359,6 +390,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -379,6 +411,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -401,6 +434,7 @@ jobs:
       matrix:
         k8s-version: [v1.32.8, v1.33.4, v1.34.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -422,6 +456,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -442,6 +477,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2, 3, 4, 5]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -465,6 +501,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -485,6 +522,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -506,6 +544,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -526,6 +565,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -547,6 +587,7 @@ jobs:
       matrix:
         k8s-version: [v1.32.8, v1.33.4, v1.34.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -567,6 +608,7 @@ jobs:
       matrix:
         k8s-version: [v1.34.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -587,6 +629,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -608,6 +651,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -628,6 +672,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -650,6 +695,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -669,6 +715,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -689,6 +736,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -710,6 +758,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -730,6 +779,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -749,6 +799,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -768,6 +819,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -788,6 +840,7 @@ jobs:
         kyverno-configs: [standard, default, force-failure-policy-ignore]
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -808,6 +861,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -829,6 +883,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -849,6 +904,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -869,6 +925,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2, 3, 4, 5, 6, 7]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -890,6 +947,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -910,6 +968,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1, 2, 3, 4]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -932,6 +991,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         shard-index: [0, 1]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -953,6 +1013,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -972,6 +1033,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -991,6 +1053,7 @@ jobs:
       matrix:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-tests
@@ -1010,6 +1073,7 @@ jobs:
       matrix:
         k8s-version: [v1.35.0]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1060,6 +1124,7 @@ jobs:
       packages: read
     needs:
       - prepare
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1108,6 +1173,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs:
       - prepare
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1161,6 +1227,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
     needs:
       - prepare
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - name: Checkout kyverno/kyverno
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1211,6 +1278,7 @@ jobs:
         k8s-version: [v1.33.7, v1.34.2, v1.35.0]
         kyverno-version: ["3.6"]
     needs: [prepare]
+    if: needs.prepare.outputs.run_conformance == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install helm
@@ -1275,6 +1343,7 @@ jobs:
             helm-settings: --set admissionController.certManager.enabled=true --set admissionController.certManager.algorithm=ECDSA --set admissionController.certManager.size=256 --set cleanupController.certManager.enabled=true --set cleanupController.certManager.algorithm=ECDSA --set cleanupController.certManager.size=256
     needs:
       - prepare
+    if: needs.prepare.outputs.run_conformance == 'true'
     name: ${{ matrix.k8s-version.name }} - cert-manager ${{ matrix.key-algorithm.name }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1307,6 +1376,7 @@ jobs:
             helm-settings: --set admissionController.tlsKeyAlgorithm=Ed25519 --set cleanupController.tlsKeyAlgorithm=Ed25519
     needs:
       - prepare
+    if: needs.prepare.outputs.run_conformance == 'true'
     name: ${{ matrix.k8s-version.name }} - self-signed ${{ matrix.key-algorithm.name }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1371,7 +1441,7 @@ jobs:
       - cert-manager-certificates
       - self-signed-certificates
     runs-on: ubuntu-latest
-    if: ${{ success() }}
+    if: ${{ always() && (needs.prepare.outputs.run_conformance == 'false' || success()) }}
     steps:
       - run: ${{ true }}
 
@@ -1428,6 +1498,6 @@ jobs:
       - cert-manager-certificates
       - self-signed-certificates
     runs-on: ubuntu-latest
-    if: ${{ failure() || cancelled() }}
+    if: ${{ always() && needs.prepare.outputs.run_conformance == 'true' && (failure() || cancelled()) }}
     steps:
       - run: ${{ false }}


### PR DESCRIPTION
## Summary

This PR implements conditional execution of conformance tests based on relevant code path changes, as requested in #14334.

Previously, conformance tests were triggered for all pull requests, including documentation-only or unrelated changes. This resulted in unnecessary CI workload and increased execution time.

This update introduces a `paths-filter` check in the `prepare` job to detect whether changes affect relevant source directories. Conformance jobs are now executed only when modifications occur in the following paths:

- pkg/**
- api/**
- cmd/**
- charts/**
- ext/**
- .github/workflows/conformance.yaml

---

## Changes Made

- Added `dorny/paths-filter` in the `prepare` job to detect relevant changes
- Exposed `run_conformance` output from `prepare` job
- Added conditional execution (`if: needs.prepare.outputs.run_conformance == 'true'`) to all conformance test jobs
- Updated `conformance-required-success` and `conformance-required-failure` jobs to ensure required status checks resolve correctly even when tests are skipped
- Ensured GitHub required check (`conformance-required`) always completes successfully when conformance tests are not applicable

---

## Result

This improves CI efficiency by:

- Skipping conformance tests for non-code changes
- Reducing unnecessary CI runtime and resource consumption
- Preserving required status check integrity for branch protection

---

## Validation

- Workflow executes normally when relevant source paths are modified
- Workflow skips conformance jobs when unrelated files change
- Required status check (`conformance-required`) correctly reports success or failure

---

Fixes #14334
