### PR TITLE
fix: set UseSignedTimestamps when TSACertChain is provided in IVPOL cosign verifier

### DIFF
--- a/pkg/imageverification/imageverifiers/cosign/opts.go
+++ b/pkg/imageverification/imageverifiers/cosign/opts.go
@@ -88,6 +88,7 @@ func checkOptions(ctx context.Context, att *v1beta1.Cosign, baseROpts []remote.O
 			}
 			opts.TSAIntermediateCertificates = intermediates
 			opts.TSARootCertificates = roots
+			opts.UseSignedTimestamps = true
 		}
 	}
 

--- a/pkg/imageverification/imageverifiers/cosign/opts_test.go
+++ b/pkg/imageverification/imageverifiers/cosign/opts_test.go
@@ -20,6 +20,55 @@ rFxZI4BL3S6ZGyJFockpfppxOycEkUaGVTUvL0Tp7Yi0eYRJ4TtKxs1lXQ==
 
 	testIssuer  = "https://token.actions.githubusercontent.com"
 	testSubject = "https://github.com/test/repo/.github/workflows/test.yml@refs/heads/main"
+
+	// FreeTSA root CA certificate, same as used in pkg/cosign/cosign_test.go.
+	testTSACertChain = `
+-----BEGIN CERTIFICATE-----
+MIIH/zCCBeegAwIBAgIJAMHphhYNqOmAMA0GCSqGSIb3DQEBDQUAMIGVMREwDwYD
+VQQKEwhGcmVlIFRTQTEQMA4GA1UECxMHUm9vdCBDQTEYMBYGA1UEAxMPd3d3LmZy
+ZWV0c2Eub3JnMSIwIAYJKoZIhvcNAQkBFhNidXNpbGV6YXNAZ21haWwuY29tMRIw
+EAYDVQQHEwlXdWVyemJ1cmcxDzANBgNVBAgTBkJheWVybjELMAkGA1UEBhMCREUw
+HhcNMTYwMzEzMDE1MjEzWhcNNDEwMzA3MDE1MjEzWjCBlTERMA8GA1UEChMIRnJl
+ZSBUU0ExEDAOBgNVBAsTB1Jvb3QgQ0ExGDAWBgNVBAMTD3d3dy5mcmVldHNhLm9y
+ZzEiMCAGCSqGSIb3DQEJARYTYnVzaWxlemFzQGdtYWlsLmNvbTESMBAGA1UEBxMJ
+V3VlcnpidXJnMQ8wDQYDVQQIEwZCYXllcm4xCzAJBgNVBAYTAkRFMIICIjANBgkq
+hkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAtgKODjAy8REQ2WTNqUudAnjhlCrpE6ql
+mQfNppeTmVvZrH4zutn+NwTaHAGpjSGv4/WRpZ1wZ3BRZ5mPUBZyLgq0YrIfQ5Fx
+0s/MRZPzc1r3lKWrMR9sAQx4mN4z11xFEO529L0dFJjPF9MD8Gpd2feWzGyptlel
+b+PqT+++fOa2oY0+NaMM7l/xcNHPOaMz0/2olk0i22hbKeVhvokPCqhFhzsuhKsm
+q4Of/o+t6dI7sx5h0nPMm4gGSRhfq+z6BTRgCrqQG2FOLoVFgt6iIm/BnNffUr7V
+DYd3zZmIwFOj/H3DKHoGik/xK3E82YA2ZulVOFRW/zj4ApjPa5OFbpIkd0pmzxzd
+EcL479hSA9dFiyVmSxPtY5ze1P+BE9bMU1PScpRzw8MHFXxyKqW13Qv7LWw4sbk3
+SciB7GACbQiVGzgkvXG6y85HOuvWNvC5GLSiyP9GlPB0V68tbxz4JVTRdw/Xn/XT
+FNzRBM3cq8lBOAVt/PAX5+uFcv1S9wFE8YjaBfWCP1jdBil+c4e+0tdywT2oJmYB
+BF/kEt1wmGwMmHunNEuQNzh1FtJY54hbUfiWi38mASE7xMtMhfj/C4SvapiDN837
+gYaPfs8x3KZxbX7C3YAsFnJinlwAUss1fdKar8Q/YVs7H/nU4c4Ixxxz4f67fcVq
+M2ITKentbCMCAwEAAaOCAk4wggJKMAwGA1UdEwQFMAMBAf8wDgYDVR0PAQH/BAQD
+AgHGMB0GA1UdDgQWBBT6VQ2MNGZRQ0z357OnbJWveuaklzCBygYDVR0jBIHCMIG/
+gBT6VQ2MNGZRQ0z357OnbJWveuakl6GBm6SBmDCBlTERMA8GA1UEChMIRnJlZSBU
+U0ExEDAOBgNVBAsTB1Jvb3QgQ0ExGDAWBgNVBAMTD3d3dy5mcmVldHNhLm9yZzEi
+MCAGCSqGSIb3DQEJARYTYnVzaWxlemFzQGdtYWlsLmNvbTESMBAGA1UEBxMJV3Vl
+cnpidXJnMQ8wDQYDVQQIEwZCYXllcm4xCzAJBgNVBAYTAkRFggkAwemGFg2o6YAw
+MwYDVR0fBCwwKjAooCagJIYiaHR0cDovL3d3dy5mcmVldHNhLm9yZy9yb290X2Nh
+LmNybDCBzwYDVR0gBIHHMIHEMIHBBgorBgEEAYHyJAEBMIGyMDMGCCsGAQUFBwIB
+FidodHRwOi8vd3d3LmZyZWV0c2Eub3JnL2ZyZWV0c2FfY3BzLmh0bWwwMgYIKwYB
+BQUHAgEWJmh0dHA6Ly93d3cuZnJlZXRzYS5vcmcvZnJlZXRzYV9jcHMucGRmMEcG
+CCsGAQUFBwICMDsaOUZyZWVUU0EgdHJ1c3RlZCB0aW1lc3RhbXBpbmcgU29mdHdh
+cmUgYXMgYSBTZXJ2aWNlIChTYWFTKTA3BggrBgEFBQcBAQQrMCkwJwYIKwYBBQUH
+MAGGG2h0dHA6Ly93d3cuZnJlZXRzYS5vcmc6MjU2MDANBgkqhkiG9w0BAQ0FAAOC
+AgEAaK9+v5OFYu9M6ztYC+L69sw1omdyli89lZAfpWMMh9CRmJhM6KBqM/ipwoLt
+nxyxGsbCPhcQjuTvzm+ylN6VwTMmIlVyVSLKYZcdSjt/eCUN+41K7sD7GVmxZBAF
+ILnBDmTGJmLkrU0KuuIpj8lI/E6Z6NnmuP2+RAQSHsfBQi6sssnXMo4HOW5gtPO7
+gDrUpVXID++1P4XndkoKn7Svw5n0zS9fv1hxBcYIHPPQUze2u30bAQt0n0iIyRLz
+aWuhtpAtd7ffwEbASgzB7E+NGF4tpV37e8KiA2xiGSRqT5ndu28fgpOY87gD3ArZ
+DctZvvTCfHdAS5kEO3gnGGeZEVLDmfEsv8TGJa3AljVa5E40IQDsUXpQLi8G+UC4
+1DWZu8EVT4rnYaCw1VX7ShOR1PNCCvjb8S8tfdudd9zhU3gEB0rxdeTy1tVbNLXW
+99y90xcwr1ZIDUwM/xQ/noO8FRhm0LoPC73Ef+J4ZBdrvWwauF3zJe33d4ibxEcb
+8/pz5WzFkeixYM2nsHhqHsBKw7JPouKNXRnl5IAE1eFmqDyC7G/VT7OF669xM6hb
+Ut5G21JE4cNK6NNucS+fzg1JPX0+3VhsYZjj7D5uljRvQXrJ8iHgr/M6j2oLHvTA
+I2MLdq2qjZFDOCXsxBxJpbmLGBx9ow6ZerlUxzws2AWv2pk=
+-----END CERTIFICATE-----
+`
 )
 
 func baseOpts() ([]remote.Option, []name.Option) {
@@ -440,6 +489,56 @@ func TestCheckOptions_VerifierTypes(t *testing.T) {
 				if tt.checkFn != nil {
 					tt.checkFn(t, opts)
 				}
+			}
+		})
+	}
+}
+
+func TestCheckOptions_TSACertChain_UseSignedTimestamps(t *testing.T) {
+	tests := []struct {
+		name             string
+		tsaCertChain     string
+		wantUseSignedTS  bool
+		wantTSARootCerts bool
+	}{
+		{
+			name:             "TSACertChain provided enables UseSignedTimestamps",
+			tsaCertChain:     testTSACertChain,
+			wantUseSignedTS:  true,
+			wantTSARootCerts: true,
+		},
+		{
+			name:             "empty TSACertChain does not enable UseSignedTimestamps",
+			tsaCertChain:     "",
+			wantUseSignedTS:  false,
+			wantTSARootCerts: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			baseROpts, baseNOpts := baseOpts()
+
+			cosignCfg := &v1beta1.Cosign{
+				Key: &v1beta1.Key{
+					Data: testPublicKey,
+				},
+				CTLog: &v1beta1.CTLog{
+					URL:                "https://rekor.sigstore.dev",
+					InsecureIgnoreTlog: true,
+					InsecureIgnoreSCT:  true,
+					TSACertChain:       tt.tsaCertChain,
+				},
+			}
+
+			opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantUseSignedTS, opts.UseSignedTimestamps)
+			if tt.wantTSARootCerts {
+				assert.NotNil(t, opts.TSARootCertificates)
+			} else {
+				assert.Nil(t, opts.TSARootCertificates)
 			}
 		})
 	}


### PR DESCRIPTION
## Explanation

The IVPOL (ImageValidatingPolicy) cosign verifier's `checkOptions()` in `pkg/imageverification/imageverifiers/cosign/opts.go` parses the `TSACertChain` and correctly populates `TSACertificate`, `TSAIntermediateCertificates`, and `TSARootCertificates` on `cosign.CheckOpts`, but never sets `UseSignedTimestamps = true`. This causes cosign to silently ignore RFC 3161 timestamps during verification via ImageValidatingPolicy, which fails for short-lived signing certificates (e.g., SPIRE SVIDs) once they expire.

This is the IVPOL counterpart of the ClusterPolicy fix in #15192. The same bug existed in both code paths because the CPOL path (`pkg/cosign/cosign.go`) and the IVPOL path (`pkg/imageverification/imageverifiers/cosign/opts.go`) build `cosign.CheckOpts` independently.

## Related issue

Closes #15304

## Milestone of this PR

/milestone 1.17.1

## What type of PR is this

/kind bug

## Proposed Changes

Single-line fix: set `opts.UseSignedTimestamps = true` after populating the TSA certificate fields in `checkOptions()`, mirroring the fix from #15192 for the ClusterPolicy path.

Added a table-driven test `TestCheckOptions_TSACertChain_UseSignedTimestamps` covering both the positive case (TSACertChain provided → UseSignedTimestamps enabled) and the negative case (empty TSACertChain → UseSignedTimestamps not enabled).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

Discovered during E2E testing of container image signing with SPIRE SVIDs and RFC 3161 timestamps. The CPOL path was fixed in #15192 (shipped in v1.17.1-rc.1), but the parallel IVPOL path was missed. The fix is identical in intent — one line to enable signed timestamp verification when a TSA certificate chain is configured.