### PR TITLE
Add link to AI Usage Policy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ We’re here to help:
 Thank you for your interest in contributing to Kyverno!
 
 - ✅ Read the [Contribution Guidelines](/CONTRIBUTING.md)
+- 🤖 Read The [AI_Usage_Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md)
 - 🧵 Join [GitHub Discussions](https://github.com/kyverno/kyverno/discussions)
 - 📖 Read the [Development Guide](/DEVELOPMENT.md)
 - 🏁 Check [Good First Issues](https://github.com/kyverno/kyverno/labels/good%20first%20issue) and request with `/assign`


### PR DESCRIPTION
This pull request adds a reference to the project's AI Usage Policy in the `README.md` to help contributors understand guidelines around AI usage.

Closes: #15313 

* Documentation update:
  * Added a link to the AI Usage Policy (`AI_USAGE_POLICY.md`) in the contributor help section of `README.md`.