### PR TITLE
test: added unit tests for pkg/webhooks/resource/validation/utils.go

### DIFF
--- a/pkg/webhooks/resource/validation/utils_test.go
+++ b/pkg/webhooks/resource/validation/utils_test.go
@@ -1,0 +1,191 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/kyverno/kyverno/pkg/utils/report"
+	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestNeedsReports(t *testing.T) {
+	dryRunTrue := true
+	dryRunFalse := false
+
+	resourceWithUID := unstructured.Unstructured{}
+	resourceWithUID.SetUID(types.UID("12345-abcde"))
+
+	resourceWithoutUID := unstructured.Unstructured{}
+
+	tests := []struct {
+		name            string
+		request         handlers.AdmissionRequest
+		resource        unstructured.Unstructured
+		admissionReport bool
+		setup           func()
+		want            bool
+	}{
+		{
+			name: "Happy Path - Reports Needed",
+			request: handlers.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					DryRun:    &dryRunFalse,
+					Kind: metav1.GroupVersionKind{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+					},
+				},
+			},
+			resource:        resourceWithUID,
+			admissionReport: true,
+			setup: func() {
+				// Reset and initialize the global config to enable validation reports
+				report.ReportingCfg = nil
+				report.NewReportingConfig(nil, "validate")
+			},
+			want: true,
+		},
+		{
+			name: "Admission Report explicitly false",
+			request: handlers.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					DryRun:    &dryRunFalse,
+					Kind: metav1.GroupVersionKind{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+					},
+				},
+			},
+			resource:        resourceWithUID,
+			admissionReport: false,
+			setup: func() {
+				report.ReportingCfg = nil
+				report.NewReportingConfig(nil, "validate")
+			},
+			want: false,
+		},
+		{
+			name: "Is Dry Run",
+			request: handlers.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					DryRun:    &dryRunTrue,
+					Kind: metav1.GroupVersionKind{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+					},
+				},
+			},
+			resource:        resourceWithUID,
+			admissionReport: true,
+			setup: func() {
+				report.ReportingCfg = nil
+				report.NewReportingConfig(nil, "validate")
+			},
+			want: false,
+		},
+		{
+			name: "Validate Reports Disabled in Global Config",
+			request: handlers.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					DryRun:    &dryRunFalse,
+					Kind: metav1.GroupVersionKind{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+					},
+				},
+			},
+			resource:        resourceWithUID,
+			admissionReport: true,
+			setup: func() {
+				report.ReportingCfg = nil
+				report.NewReportingConfig(nil)
+			},
+			want: false,
+		},
+		{
+			name: "Operation is Delete",
+			request: handlers.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+					DryRun:    &dryRunFalse,
+					Kind: metav1.GroupVersionKind{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+					},
+				},
+			},
+			resource:        resourceWithUID,
+			admissionReport: true,
+			setup: func() {
+				report.ReportingCfg = nil
+				report.NewReportingConfig(nil, "validate")
+			},
+			want: false,
+		},
+		{
+			name: "Unsupported GVK - Banned Owner (Event)",
+			request: handlers.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					DryRun:    &dryRunFalse,
+					Kind: metav1.GroupVersionKind{
+						Group:   "", // corev1
+						Version: "v1",
+						Kind:    "Event", // Matches the bannedOwners map
+					},
+				},
+			},
+			resource:        resourceWithUID,
+			admissionReport: true,
+			setup: func() {
+				report.ReportingCfg = nil
+				report.NewReportingConfig(nil, "validate")
+			},
+			want: false,
+		},
+		{
+			name: "Resource has no UID",
+			request: handlers.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					DryRun:    &dryRunFalse,
+					Kind: metav1.GroupVersionKind{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+					},
+				},
+			},
+			resource:        resourceWithoutUID,
+			admissionReport: true,
+			setup: func() {
+				report.ReportingCfg = nil
+				report.NewReportingConfig(nil, "validate")
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup()
+			}
+			got := NeedsReports(tt.request, tt.resource, tt.admissionReport)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/webhooks/resource/validation/utils_test.go
+++ b/pkg/webhooks/resource/validation/utils_test.go
@@ -3,9 +3,9 @@ package validation
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/kyverno/kyverno/pkg/utils/report"
 	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
+	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"


### PR DESCRIPTION
## Explanation
This PR introduces a comprehensive table-driven test suite for the `NeedsReports` utility function located in `pkg/webhooks/resources/validation/utils.go`. Previously lacking test coverage, this function evaluates multiple critical early-exit conditions before generating admission reports.

The tests now guarantee 100% line coverage for this function. Additionally, the test suite safely mocks and initializes Kyverno's global `report.ReportingCfg` for each test case, preventing `nil pointer dereference` panics during test execution and ensuring test isolation.

## Related issue
Improves unit test coverage for `pkg/webhooks/resource/validation`.

## What type of PR is this
/kind test

## Proposed Changes
1. Created `pkg/webhooks/resources/validation/utils_test.go`.
2. Added `setup` functions to cleanly initialize `report.ReportingCfg` via `report.NewReportingConfig()` for each test scenario, avoiding nil pointer panics.

## Test Results
```
=== RUN   TestNeedsReports
=== RUN   TestNeedsReports/Happy_Path_-_Reports_Needed
=== RUN   TestNeedsReports/Admission_Report_explicitly_false
=== RUN   TestNeedsReports/Is_Dry_Run
=== RUN   TestNeedsReports/Validate_Reports_Disabled_in_Global_Config
=== RUN   TestNeedsReports/Operation_is_Delete
=== RUN   TestNeedsReports/Unsupported_GVK_-_Banned_Owner_(Event)
=== RUN   TestNeedsReports/Resource_has_no_UID
--- PASS: TestNeedsReports (0.00s)
    --- PASS: TestNeedsReports/Happy_Path_-_Reports_Needed (0.00s)
    --- PASS: TestNeedsReports/Admission_Report_explicitly_false (0.00s)
    --- PASS: TestNeedsReports/Is_Dry_Run (0.00s)
    --- PASS: TestNeedsReports/Validate_Reports_Disabled_in_Global_Config (0.00s)
    --- PASS: TestNeedsReports/Operation_is_Delete (0.00s)
    --- PASS: TestNeedsReports/Unsupported_GVK_-_Banned_Owner_(Event) (0.00s)
    --- PASS: TestNeedsReports/Resource_has_no_UID (0.00s)
=== RUN   TestHandleValidationEnforce_EmptyPolicies
--- PASS: TestHandleValidationEnforce_EmptyPolicies (0.00s)
=== RUN   TestHandleValidationEnforce_EmptyPoliciesSlice
--- PASS: TestHandleValidationEnforce_EmptyPoliciesSlice (0.00s)
=== RUN   TestHasReportablePolicy_NilPolicies
--- PASS: TestHasReportablePolicy_NilPolicies (0.00s)
=== RUN   TestHasReportablePolicy_EmptyPolicies
--- PASS: TestHasReportablePolicy_EmptyPolicies (0.00s)
=== RUN   TestHasReportablePolicy_WithBackgroundTrue
--- PASS: TestHasReportablePolicy_WithBackgroundTrue (0.00s)
=== RUN   TestHasReportablePolicy_MixedPolicies
--- PASS: TestHasReportablePolicy_MixedPolicies (0.00s)
PASS
ok      github.com/kyverno/kyverno/pkg/webhooks/resource/validation     0.019s
```

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] I have added unit tests that prove my fix is effective.