### PR TITLE
feat: restrict global context access and add cache bounds

### DIFF
--- a/cmd/background-controller/main.go
+++ b/cmd/background-controller/main.go
@@ -133,6 +133,7 @@ func main() {
 		apiCallTimeout                  time.Duration
 		maxBackgroundReports            int
 		controllerRuntimeMetricsAddress string
+		maxGlobalContextEntries         int
 	)
 	flagset := flag.NewFlagSet("updaterequest-controller", flag.ExitOnError)
 	flagset.IntVar(&genWorkers, "genWorkers", 10, "Workers for the background controller.")
@@ -145,6 +146,7 @@ func main() {
 	flagset.Func(toggle.AllowHTTPInNamespacedPoliciesFlagName, toggle.AllowHTTPInNamespacedPoliciesDescription, toggle.AllowHTTPInNamespacedPolicies.Parse)
 	flagset.Func(toggle.HTTPBlocklistFlagName, toggle.HTTPBlocklistDescription, toggle.HTTPBlocklist.Parse)
 	flagset.Func(toggle.HTTPAllowlistFlagName, toggle.HTTPAllowlistDescription, toggle.HTTPAllowlist.Parse)
+	flagset.IntVar(&maxGlobalContextEntries, "maxGlobalContextEntries", 1000, "Maximum number of global context entries allowed.")
 
 	// config
 	appConfig := internal.NewConfiguration(
@@ -213,7 +215,7 @@ func main() {
 			event.Workers,
 		)
 		urGenerator := generator.NewUpdateRequestGenerator(setup.Configuration, setup.MetadataClient)
-		gcstore := store.New()
+		gcstore := store.New(maxGlobalContextEntries)
 		gceController := internal.NewController(
 			globalcontextcontroller.ControllerName,
 			globalcontextcontroller.NewController(

--- a/cmd/cleanup-controller/main.go
+++ b/cmd/cleanup-controller/main.go
@@ -91,6 +91,7 @@ func main() {
 		apiCallTimeout           time.Duration
 		autoDeleteWebhooks       bool
 		tlsKeyAlgorithm          string
+		maxGlobalContextEntries  int
 	)
 	flagset := flag.NewFlagSet("cleanup-controller", flag.ExitOnError)
 	flagset.BoolVar(&dumpPayload, "dumpPayload", false, "Set this flag to activate/deactivate debug mode.")
@@ -111,6 +112,7 @@ func main() {
 	flagset.DurationVar(&apiCallTimeout, "apiCallTimeout", 30*time.Second, "Timeout for HTTP API calls made by policies. A value of 0 means no timeout.")
 	flagset.BoolVar(&autoDeleteWebhooks, "autoDeleteWebhooks", false, "Set this flag to 'true' to enable autodeletion of webhook configurations using finalizers (requires extra permissions).")
 	flagset.StringVar(&tlsKeyAlgorithm, "tlsKeyAlgorithm", "RSA", "Key algorithm for self-signed TLS certificates (RSA, ECDSA, Ed25519)")
+	flagset.IntVar(&maxGlobalContextEntries, "maxGlobalContextEntries", 1000, "Maximum number of global context entries allowed.")
 	// config
 	appConfig := internal.NewConfiguration(
 		internal.WithProfiling(),
@@ -200,7 +202,7 @@ func main() {
 			eventGenerator,
 			event.Workers,
 		)
-		gcstore := store.New()
+		gcstore := store.New(maxGlobalContextEntries)
 		gceController := internal.NewController(
 			globalcontextcontroller.ControllerName,
 			globalcontextcontroller.NewController(

--- a/cmd/cli/kubectl-kyverno/processor/utils.go
+++ b/cmd/cli/kubectl-kyverno/processor/utils.go
@@ -28,7 +28,7 @@ func NewContextProvider(dclient dclient.Interface, restMapper meta.RESTMapper, f
 		return libs.NewContextProvider(
 			dclient,
 			[]imagedataloader.Option{imagedataloader.WithLocalCredentials(registryAccess)},
-			gctxstore.New(),
+			gctxstore.New(0),
 			restMapper,
 			true,
 		)

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -372,6 +372,7 @@ func main() {
 		maxAdmissionReports             int
 		controllerRuntimeMetricsAddress string
 		tlsKeyAlgorithm                 string
+		maxGlobalContextEntries         int
 	)
 	flagset := flag.NewFlagSet("kyverno", flag.ExitOnError)
 	flagset.BoolVar(&dumpPayload, "dumpPayload", false, "Set this flag to activate/deactivate debug mode.")
@@ -405,6 +406,7 @@ func main() {
 	flagset.IntVar(&maxAdmissionReports, "maxAdmissionReports", 10000, "Maximum number of admission reports before we stop creating new ones")
 	flagset.StringVar(&controllerRuntimeMetricsAddress, "controllerRuntimeMetricsAddress", "", `Bind address for controller-runtime metrics server. It will be defaulted to ":8080" if unspecified. Set this to "0" to disable the metrics server.`)
 	flagset.StringVar(&tlsKeyAlgorithm, "tlsKeyAlgorithm", "RSA", "Key algorithm for self-signed TLS certificates (RSA, ECDSA, Ed25519)")
+	flagset.IntVar(&maxGlobalContextEntries, "maxGlobalContextEntries", 1000, "Maximum number of global context entries allowed.")
 	// config
 	appConfig := internal.NewConfiguration(
 		internal.WithProfiling(),
@@ -509,7 +511,7 @@ func main() {
 			setup.Configuration,
 			strings.Split(omitEvents, ",")...,
 		)
-		gcstore := store.New()
+		gcstore := store.New(maxGlobalContextEntries)
 		restMapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(setup.KubeClient.Discovery()))
 
 		gceController := internal.NewController(

--- a/cmd/reports-controller/main.go
+++ b/cmd/reports-controller/main.go
@@ -293,6 +293,7 @@ func main() {
 		maxAPICallResponseLength         int64
 		apiCallTimeout                   time.Duration
 		maxBackgroundReports             int
+		maxGlobalContextEntries          int
 	)
 	flagset := flag.NewFlagSet("reports-controller", flag.ExitOnError)
 	flagset.BoolVar(&backgroundScan, "backgroundScan", true, "Enable or disable background scan.")
@@ -309,6 +310,7 @@ func main() {
 	flagset.BoolVar(&skipResourceFilters, "skipResourceFilters", true, "If true, resource filters wont be considered.")
 	flagset.Int64Var(&maxAPICallResponseLength, "maxAPICallResponseLength", 2*1000*1000, "Maximum allowed response size from API Calls. A value of 0 bypasses checks (not recommended).")
 	flagset.DurationVar(&apiCallTimeout, "apiCallTimeout", 30*time.Second, "Timeout for HTTP API calls made by policies. A value of 0 means no timeout.")
+	flagset.IntVar(&maxGlobalContextEntries, "maxGlobalContextEntries", 1000, "Maximum number of global context entries allowed.")
 	flagset.IntVar(&maxBackgroundReports, "maxBackgroundReports", 10000, "Maximum number of ephemeralreports created for the background policies before we stop creating new ones")
 	flagset.BoolVar(&reportsCRDsSanityChecks, "reportsCRDsSanityChecks", true, "Enable or disable sanity checks for policy reports and ephemeral reports CRDs.")
 	flagset.Func(toggle.AllowHTTPInNamespacedPoliciesFlagName, toggle.AllowHTTPInNamespacedPoliciesDescription, toggle.AllowHTTPInNamespacedPolicies.Parse)
@@ -374,7 +376,7 @@ func main() {
 		setup.Logger.V(2).Info("background scan interval", "duration", backgroundScanInterval.String())
 
 		// call NewContextProvider to initialize the libraries context globally, needed during background scan
-		gcstore := store.New()
+		gcstore := store.New(maxGlobalContextEntries)
 		restMapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(setup.KubeClient.Discovery()))
 		_, err := libs.NewContextProvider(
 			setup.KyvernoDynamicClient,

--- a/pkg/engine/context/loaders/globalcontext.go
+++ b/pkg/engine/context/loaders/globalcontext.go
@@ -19,13 +19,14 @@ type Store interface {
 }
 
 type gctxLoader struct {
-	ctx       context.Context //nolint:containedctx
-	logger    logr.Logger
-	entry     kyvernov1.ContextEntry
-	enginectx enginecontext.Interface
-	jp        jmespath.Interface
-	gctxStore Store
-	data      []byte
+	ctx             context.Context //nolint:containedctx
+	logger          logr.Logger
+	entry           kyvernov1.ContextEntry
+	enginectx       enginecontext.Interface
+	jp              jmespath.Interface
+	gctxStore       Store
+	data            []byte
+	policyNamespace string
 }
 
 func NewGCTXLoader(
@@ -35,14 +36,16 @@ func NewGCTXLoader(
 	enginectx enginecontext.Interface,
 	jp jmespath.Interface,
 	gctxStore Store,
+	policyNamespace string,
 ) enginecontext.Loader {
 	return &gctxLoader{
-		ctx:       ctx,
-		logger:    logger,
-		entry:     entry,
-		enginectx: enginectx,
-		jp:        jp,
-		gctxStore: gctxStore,
+		ctx:             ctx,
+		logger:          logger,
+		entry:           entry,
+		enginectx:       enginectx,
+		jp:              jp,
+		gctxStore:       gctxStore,
+		policyNamespace: policyNamespace,
 	}
 }
 
@@ -97,6 +100,11 @@ func (g *gctxLoader) loadGctxData() ([]byte, error) {
 	storeEntry, ok := g.gctxStore.Get(gctxName)
 	if !ok {
 		err := fmt.Errorf("failed to fetch entry key=%s", gctxName)
+		g.logger.Error(err, "")
+		return nil, err
+	}
+	if !storeEntry.IsAllowed(g.policyNamespace) {
+		err := fmt.Errorf("global context entry %s is not allowed for namespace %s", gctxName, g.policyNamespace)
 		g.logger.Error(err, "")
 		return nil, err
 	}

--- a/pkg/engine/factories/contextloaderfactory.go
+++ b/pkg/engine/factories/contextloaderfactory.go
@@ -122,7 +122,7 @@ func (l *contextLoader) newLoader(
 		}
 	} else if entry.GlobalReference != nil {
 		if gctx != nil {
-			ldr := loaders.NewGCTXLoader(ctx, l.logger, entry, jsonContext, jp, gctx)
+			ldr := loaders.NewGCTXLoader(ctx, l.logger, entry, jsonContext, jp, gctx, l.policyNamespace)
 			return enginecontext.NewDeferredLoader(entry.Name, ldr, l.logger)
 		} else {
 			l.logger.V(3).Info("disabled loading of GlobalContext context entry", "name", entry.Name)

--- a/pkg/globalcontext/externalapi/entry.go
+++ b/pkg/globalcontext/externalapi/entry.go
@@ -124,6 +124,10 @@ func (e *entry) Get(projection string) (any, error) {
 	return data, nil
 }
 
+func (e *entry) IsAllowed(_ string) bool {
+	return true
+}
+
 func (e *entry) Stop() {
 	e.Lock()
 	defer e.Unlock()

--- a/pkg/globalcontext/invalid/entry.go
+++ b/pkg/globalcontext/invalid/entry.go
@@ -8,8 +8,12 @@ type entry struct {
 	err error
 }
 
-func (i *entry) Get() (any, error) {
+func (i *entry) Get(_ string) (any, error) {
 	return nil, errors.Wrapf(i.err, "failed to create cached context entry")
+}
+
+func (i *entry) IsAllowed(_ string) bool {
+	return true
 }
 
 func (i *entry) Stop() {}

--- a/pkg/globalcontext/invalid/entry_test.go
+++ b/pkg/globalcontext/invalid/entry_test.go
@@ -27,7 +27,7 @@ func TestEntry_Get_ReturnsWrappedError(t *testing.T) {
 	testErr := errors.New("original error")
 	e := New(testErr)
 
-	result, err := e.Get()
+	result, err := e.Get("")
 
 	assert.Nil(t, result)
 	assert.Error(t, err)
@@ -38,7 +38,7 @@ func TestEntry_Get_ReturnsWrappedError(t *testing.T) {
 func TestEntry_Get_WithNilError(t *testing.T) {
 	e := New(nil)
 
-	result, err := e.Get()
+	result, err := e.Get("")
 
 	assert.Nil(t, result)
 	// When the stored error is nil, errors.Wrapf returns nil
@@ -72,7 +72,7 @@ func TestEntry_Get_MultipleScenarios(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := New(tt.inputErr)
 
-			result, err := e.Get()
+			result, err := e.Get("")
 
 			assert.Nil(t, result)
 			assert.Error(t, err)
@@ -123,7 +123,7 @@ func TestEntry_Get_AlwaysReturnsNilResult(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := New(tt.inputErr)
 
-			result, _ := e.Get()
+			result, _ := e.Get("")
 
 			assert.Nil(t, result, "Get should always return nil result")
 		})
@@ -143,7 +143,7 @@ func TestEntry_Get_AlwaysReturnsError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := New(tt.inputErr)
 
-			_, err := e.Get()
+			_, err := e.Get("")
 
 			assert.Error(t, err, "Get should return an error when underlying error is non-nil")
 		})

--- a/pkg/globalcontext/k8sresource/entry.go
+++ b/pkg/globalcontext/k8sresource/entry.go
@@ -209,6 +209,16 @@ func (e *entry) Get(projection string) (any, error) {
 	return nil, fmt.Errorf("projection %q not found", projection)
 }
 
+func (e *entry) IsAllowed(namespace string) bool {
+	if namespace == "" {
+		return true
+	}
+	if e.gce.Spec.KubernetesResource != nil && e.gce.Spec.KubernetesResource.Namespace == namespace {
+		return true
+	}
+	return false
+}
+
 func (e *entry) Stop() {
 	e.stop()
 }

--- a/pkg/globalcontext/store/entry.go
+++ b/pkg/globalcontext/store/entry.go
@@ -10,4 +10,5 @@ type Projection struct {
 type Entry interface {
 	Get(projection string) (any, error)
 	Stop()
+	IsAllowed(namespace string) bool
 }

--- a/pkg/globalcontext/store/store.go
+++ b/pkg/globalcontext/store/store.go
@@ -12,12 +12,14 @@ type Store interface {
 
 type store struct {
 	sync.RWMutex
-	store map[string]Entry
+	store      map[string]Entry
+	maxEntries int
 }
 
-func New() Store {
+func New(maxEntries int) Store {
 	return &store{
-		store: make(map[string]Entry),
+		store:      make(map[string]Entry),
+		maxEntries: maxEntries,
 	}
 }
 
@@ -25,9 +27,13 @@ func (l *store) Set(key string, val Entry) {
 	l.Lock()
 	defer l.Unlock()
 	old := l.store[key]
-	// If the key already exists, stop it before replacing it
 	if old != nil {
 		old.Stop()
+	} else if l.maxEntries > 0 && len(l.store) >= l.maxEntries {
+		if val != nil {
+			val.Stop()
+		}
+		return
 	}
 	l.store[key] = val
 }

--- a/pkg/globalcontext/store/store_test.go
+++ b/pkg/globalcontext/store/store_test.go
@@ -24,6 +24,10 @@ func (m *mockEntry) Get(projection string) (any, error) {
 	return m.data[projection], nil
 }
 
+func (m *mockEntry) IsAllowed(namespace string) bool {
+	return true
+}
+
 func (m *mockEntry) Stop() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -37,8 +41,8 @@ func (m *mockEntry) isStopped() bool {
 }
 
 func TestNew_CreatesEmptyStore(t *testing.T) {
-	s := New()
-	assert.NotNil(t, s, "New() should return a non-nil store")
+	s := New(0)
+	assert.NotNil(t, s, "New(0) should return a non-nil store")
 
 	// Verify store is empty by checking a random key
 	entry, exists := s.Get("nonexistent")
@@ -47,7 +51,7 @@ func TestNew_CreatesEmptyStore(t *testing.T) {
 }
 
 func TestStore_SetAndGet_BasicOperations(t *testing.T) {
-	s := New()
+	s := New(0)
 	entry := newMockEntry(map[string]any{"foo": "bar"})
 
 	// Set an entry
@@ -65,7 +69,7 @@ func TestStore_SetAndGet_BasicOperations(t *testing.T) {
 }
 
 func TestStore_SetOverwrite_StopsOldEntry(t *testing.T) {
-	s := New()
+	s := New(0)
 	oldEntry := newMockEntry(map[string]any{"version": "old"})
 	newEntry := newMockEntry(map[string]any{"version": "new"})
 
@@ -86,7 +90,7 @@ func TestStore_SetOverwrite_StopsOldEntry(t *testing.T) {
 }
 
 func TestStore_Get_ReturnsNilForMissingKey(t *testing.T) {
-	s := New()
+	s := New(0)
 
 	entry, exists := s.Get("missing-key")
 	assert.False(t, exists, "exists should be false for missing key")
@@ -94,7 +98,7 @@ func TestStore_Get_ReturnsNilForMissingKey(t *testing.T) {
 }
 
 func TestStore_Delete_RemovesEntryAndStopsIt(t *testing.T) {
-	s := New()
+	s := New(0)
 	entry := newMockEntry(map[string]any{"data": "value"})
 
 	s.Set("to-delete", entry)
@@ -115,7 +119,7 @@ func TestStore_Delete_RemovesEntryAndStopsIt(t *testing.T) {
 }
 
 func TestStore_Delete_HandlesNonexistentKey(t *testing.T) {
-	s := New()
+	s := New(0)
 
 	// Should not panic when deleting nonexistent key
 	assert.NotPanics(t, func() {
@@ -124,7 +128,7 @@ func TestStore_Delete_HandlesNonexistentKey(t *testing.T) {
 }
 
 func TestStore_Delete_HandlesNilEntry(t *testing.T) {
-	s := New().(*store)
+	s := New(0).(*store)
 
 	// Manually set nil to simulate edge case
 	s.Lock()
@@ -138,7 +142,7 @@ func TestStore_Delete_HandlesNilEntry(t *testing.T) {
 }
 
 func TestStore_ConcurrentAccess(t *testing.T) {
-	s := New()
+	s := New(0)
 	var wg sync.WaitGroup
 	numGoroutines := 100
 
@@ -180,7 +184,7 @@ func TestStore_ConcurrentAccess(t *testing.T) {
 }
 
 func TestStore_MultipleKeys(t *testing.T) {
-	s := New()
+	s := New(0)
 
 	entries := make(map[string]*mockEntry)
 	keys := []string{"alpha", "beta", "gamma", "delta"}
@@ -215,7 +219,7 @@ func TestStore_MultipleKeys(t *testing.T) {
 }
 
 func TestStore_SetNilEntry(t *testing.T) {
-	s := New()
+	s := New(0)
 
 	// Setting nil should work without panic
 	assert.NotPanics(t, func() {
@@ -228,7 +232,7 @@ func TestStore_SetNilEntry(t *testing.T) {
 }
 
 func TestStore_OverwriteNilWithValue(t *testing.T) {
-	s := New()
+	s := New(0)
 
 	// Set nil first
 	s.Set("key", nil)
@@ -242,4 +246,38 @@ func TestStore_OverwriteNilWithValue(t *testing.T) {
 	retrieved, exists := s.Get("key")
 	assert.True(t, exists)
 	assert.Same(t, entry, retrieved)
+}
+
+func TestStore_MaxEntries(t *testing.T) {
+	s := New(2)
+
+	e1 := newMockEntry(map[string]any{"id": 1})
+	e2 := newMockEntry(map[string]any{"id": 2})
+	e3 := newMockEntry(map[string]any{"id": 3})
+
+	// Filling to limit
+	s.Set("key1", e1)
+	s.Set("key2", e2)
+
+	// Verify both exist
+	_, ok1 := s.Get("key1")
+	_, ok2 := s.Get("key2")
+	assert.True(t, ok1)
+	assert.True(t, ok2)
+
+	// Try adding a third
+	s.Set("key3", e3)
+
+	// Verify key3 does not exist and e3 was stopped
+	_, ok3 := s.Get("key3")
+	assert.False(t, ok3, "key3 should not be added because limit reached")
+	assert.True(t, e3.isStopped(), "entry should be stopped if not added")
+
+	// Verify existing keys can still be overwritten
+	e1new := newMockEntry(map[string]any{"id": "1-new"})
+	s.Set("key1", e1new)
+	retrieved, ok1 := s.Get("key1")
+	assert.True(t, ok1)
+	assert.Same(t, e1new, retrieved)
+	assert.True(t, e1.isStopped(), "old e1 should be stopped")
 }


### PR DESCRIPTION
Restricts namespaced policies from accessing global context entries and introduces a configurable cache limit to prevent memory exhaustion. Addresses security findings in #15335.

## Explanation

This PR hardens the security of the Global Context Store by ensuring namespaced policies cannot access unauthorized global data, mitigating potential data leakage across namespaces. It also introduces a configurable limit on the number of entries stored in the global context cache to protect the system against resource exhaustion (DoS) attacks. This change adds two security-focused features to existing behavior.

## Related issue

Partially addresses #15335
Closes #15359

## Milestone of this PR

/milestone 1.14.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind feature

## Proposed Changes

- Access Control: Implemented an authorization check in the GlobalContextEntry interface. The engine now verifies if a policy's namespace is allowed to access a specific global entry before loading it. Specifically, namespaced policies are restricted from accessing external API entries or Kubernetes resources from different namespaces.

- Resource Limiting: Added a bounding mechanism to the global context store. New entries are rejected once the cache reaches a maximum size, preventing potential Denial of Service via memory overconsumption.

- Configuration: Exposed a new CLI flag --maxGlobalContextEntries (defaulting to 1000) across all Kyverno controllers to allow administrators to tune cache limits.

### Proof Manifests

# Kubernetes resource

```apiVersion: kyverno.io/v2beta1
kind: GlobalContextEntry
metadata:
  name: restricted-gctx
spec:
  kubernetesResource:
    group: ""
    version: v1
    resource: configmaps
    namespace: secure-namespace
```

# Namespaced Policy Attempting Access

```apiVersion: kyverno.io/v1
kind: Policy
metadata:
  name: test-access
  namespace: other-namespace
spec:
  rules:
  - name: check-gctx
    context:
    - name: data
      globalReference:
        name: restricted-gctx
    match:
      any:
      - resources:
          kinds:
          - Pod
    validate:
      message: "Accessing global context"
      deny:
        conditions:
          all:
          - key: "{{ data }}"
            operator: AnyIn
            value: []
```
In this scenario, the engine will now correctly block the namespaced policy from loading the global context entry because it belongs to a different namespace.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [x] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The solution uses the existing GCTXLoader as the enforcement point. By performing the check before any JMESPath projection, we ensure that no sensitive data enters the policy context if the policy is unauthorized. The cache bounding logic was added directly to the Store's Set method to provide immediate protection against overflow during background refreshes.
