### PR TITLE
fix: update admissionregistration to v1beta1 for mutations

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -69,7 +69,7 @@ import (
 	"k8s.io/client-go/discovery/cached/memory"
 	kubeinformers "k8s.io/client-go/informers"
 	admissionregistrationv1informers "k8s.io/client-go/informers/admissionregistration/v1"
-	admissionregistrationv1alpha1informers "k8s.io/client-go/informers/admissionregistration/v1alpha1"
+	admissionregsitrationv1beta1informers "k8s.io/client-go/informers/admissionregistration/v1beta1"
 	appsv1informers "k8s.io/client-go/informers/apps/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -297,11 +297,12 @@ func createrLeaderControllers(
 			vapBindingInformer = kubeInformer.Admissionregistration().V1().ValidatingAdmissionPolicyBindings()
 		}
 
-		var mapInformer admissionregistrationv1alpha1informers.MutatingAdmissionPolicyInformer
-		var mapBindingInformer admissionregistrationv1alpha1informers.MutatingAdmissionPolicyBindingInformer
+		// TODO: move mutating admission to v1 for kyverno 1.18+ (where k8s >= 1.33+)
+		var mapInformer admissionregsitrationv1beta1informers.MutatingAdmissionPolicyInformer
+		var mapBindingInformer admissionregsitrationv1beta1informers.MutatingAdmissionPolicyBindingInformer
 		if mapsRegistered {
-			mapInformer = kubeInformer.Admissionregistration().V1alpha1().MutatingAdmissionPolicies()
-			mapBindingInformer = kubeInformer.Admissionregistration().V1alpha1().MutatingAdmissionPolicyBindings()
+			mapInformer = kubeInformer.Admissionregistration().V1beta1().MutatingAdmissionPolicies()
+			mapBindingInformer = kubeInformer.Admissionregistration().V1beta1().MutatingAdmissionPolicyBindings()
 		}
 
 		admissionpolicyController := admissionpolicygenerator.NewController(

--- a/pkg/admissionpolicy/builder.go
+++ b/pkg/admissionpolicy/builder.go
@@ -14,7 +14,7 @@ import (
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	slicesutils "github.com/kyverno/kyverno/pkg/utils/slices"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -240,24 +240,24 @@ func BuildValidatingAdmissionPolicyBinding(
 
 // BuildMutatingAdmissionPolicy is used to build a Kubernetes MutatingAdmissionPolicy from a MutatingPolicy
 func BuildMutatingAdmissionPolicy(
-	mapol *admissionregistrationv1alpha1.MutatingAdmissionPolicy,
+	mapol *admissionregistrationv1beta1.MutatingAdmissionPolicy,
 	mp *policiesv1beta1.MutatingPolicy,
 	exceptions []policiesv1beta1.PolicyException,
 ) {
-	matchConditions := make([]admissionregistrationv1alpha1.MatchCondition, 0)
+	matchConditions := make([]admissionregistrationv1beta1.MatchCondition, 0)
 	// convert celexceptions if exist
 	for _, exception := range exceptions {
 		for _, matchCondition := range exception.Spec.MatchConditions {
 			// negate the match condition
 			expression := "!(" + matchCondition.Expression + ")"
-			matchConditions = append(matchConditions, admissionregistrationv1alpha1.MatchCondition{
+			matchConditions = append(matchConditions, admissionregistrationv1beta1.MatchCondition{
 				Name:       matchCondition.Name,
 				Expression: expression,
 			})
 		}
 	}
 	for _, mc := range mp.Spec.MatchConditions {
-		matchConditions = append(matchConditions, admissionregistrationv1alpha1.MatchCondition(mc))
+		matchConditions = append(matchConditions, admissionregistrationv1beta1.MatchCondition(mc))
 	}
 	// set owner reference
 	mapol.OwnerReferences = []metav1.OwnerReference{
@@ -269,17 +269,17 @@ func BuildMutatingAdmissionPolicy(
 		},
 	}
 
-	var fpt *admissionregistrationv1alpha1.FailurePolicyType
+	var fpt *admissionregistrationv1beta1.FailurePolicyType
 	if mp.Spec.FailurePolicy != nil {
-		conv := admissionregistrationv1alpha1.FailurePolicyType(*mp.Spec.FailurePolicy)
+		conv := admissionregistrationv1beta1.FailurePolicyType(*mp.Spec.FailurePolicy)
 		fpt = &conv
 	}
 
 	// set policy spec
-	mapol.Spec = admissionregistrationv1alpha1.MutatingAdmissionPolicySpec{
-		MatchConstraints: &admissionregistrationv1alpha1.MatchResources{
-			ResourceRules: slicesutils.Map(mp.Spec.MatchConstraints.ResourceRules, func(rule admissionregistrationv1.NamedRuleWithOperations) admissionregistrationv1alpha1.NamedRuleWithOperations {
-				return admissionregistrationv1alpha1.NamedRuleWithOperations{
+	mapol.Spec = admissionregistrationv1beta1.MutatingAdmissionPolicySpec{
+		MatchConstraints: &admissionregistrationv1beta1.MatchResources{
+			ResourceRules: slicesutils.Map(mp.Spec.MatchConstraints.ResourceRules, func(rule admissionregistrationv1.NamedRuleWithOperations) admissionregistrationv1beta1.NamedRuleWithOperations {
+				return admissionregistrationv1beta1.NamedRuleWithOperations{
 					ResourceNames:      rule.ResourceNames,
 					RuleWithOperations: rule.RuleWithOperations,
 				}
@@ -287,8 +287,8 @@ func BuildMutatingAdmissionPolicy(
 		},
 		MatchConditions: matchConditions,
 		Mutations:       mp.Spec.Mutations,
-		Variables: slicesutils.Map(mp.Spec.Variables, func(v admissionregistrationv1.Variable) admissionregistrationv1alpha1.Variable {
-			return admissionregistrationv1alpha1.Variable(v)
+		Variables: slicesutils.Map(mp.Spec.Variables, func(v admissionregistrationv1.Variable) admissionregistrationv1beta1.Variable {
+			return admissionregistrationv1beta1.Variable(v)
 		}),
 		FailurePolicy:      fpt,
 		ReinvocationPolicy: mp.Spec.GetReinvocationPolicy(),
@@ -303,7 +303,7 @@ func BuildMutatingAdmissionPolicy(
 
 // BuildMutatingAdmissionPolicyBinding is used to build a Kubernetes MutatingAdmissionPolicyBinding from a MutatingPolicy
 func BuildMutatingAdmissionPolicyBinding(
-	mapbinding *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding,
+	mapbinding *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding,
 	mp *policiesv1beta1.MutatingPolicy,
 ) {
 	// set owner reference
@@ -316,7 +316,7 @@ func BuildMutatingAdmissionPolicyBinding(
 		},
 	}
 	// set binding spec
-	mapbinding.Spec = admissionregistrationv1alpha1.MutatingAdmissionPolicyBindingSpec{
+	mapbinding.Spec = admissionregistrationv1beta1.MutatingAdmissionPolicyBindingSpec{
 		PolicyName: "mpol-" + mp.GetName(),
 	}
 	// set labels

--- a/pkg/admissionpolicy/utils.go
+++ b/pkg/admissionpolicy/utils.go
@@ -61,15 +61,15 @@ func HasMutatingAdmissionPolicyBindingPermission(s checker.AuthChecker) bool {
 // IsMutatingAdmissionPolicyRegistered checks if MutatingAdmissionPolicies are registered in the API Server.
 // It checks for v1beta1 first, then falls back to v1alpha1.
 func IsMutatingAdmissionPolicyRegistered(kubeClient kubernetes.Interface) (bool, error) {
-	groupVersion := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1beta1"}
+	groupVersion := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1alpha1"}
 	if _, err := kubeClient.Discovery().ServerResourcesForGroupVersion(groupVersion.String()); err == nil {
 		return true, nil
 	}
-	groupVersion = schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1alpha1"}
+	groupVersion = schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1beta1"}
 	if _, err := kubeClient.Discovery().ServerResourcesForGroupVersion(groupVersion.String()); err != nil {
-		return false, err
+		return true, err
 	}
-	return true, nil
+	return false, nil
 }
 
 // IsValidatingAdmissionPolicyRegistered checks if ValidatingAdmissionPolicies are registered in the API Server.

--- a/pkg/controllers/admissionpolicygenerator/controller.go
+++ b/pkg/controllers/admissionpolicygenerator/controller.go
@@ -25,10 +25,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	admissionregistrationv1informers "k8s.io/client-go/informers/admissionregistration/v1"
-	admissionregistrationv1alpha1informers "k8s.io/client-go/informers/admissionregistration/v1alpha1"
+	admissionregistrationv1beta1informers "k8s.io/client-go/informers/admissionregistration/v1beta1"
 	"k8s.io/client-go/kubernetes"
 	admissionregistrationv1listers "k8s.io/client-go/listers/admissionregistration/v1"
-	admissionregistrationv1alpha1listers "k8s.io/client-go/listers/admissionregistration/v1alpha1"
+	admissionregistrationv1beta1listers "k8s.io/client-go/listers/admissionregistration/v1beta1"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -59,8 +59,8 @@ type controller struct {
 	celpolexLister   policiesv1beta1listers.PolicyExceptionLister
 	vapLister        admissionregistrationv1listers.ValidatingAdmissionPolicyLister
 	vapbindingLister admissionregistrationv1listers.ValidatingAdmissionPolicyBindingLister
-	mapLister        admissionregistrationv1alpha1listers.MutatingAdmissionPolicyLister
-	mapbindingLister admissionregistrationv1alpha1listers.MutatingAdmissionPolicyBindingLister
+	mapLister        admissionregistrationv1beta1listers.MutatingAdmissionPolicyLister
+	mapbindingLister admissionregistrationv1beta1listers.MutatingAdmissionPolicyBindingLister
 
 	// queue
 	queue workqueue.TypedRateLimitingInterface[any]
@@ -82,8 +82,8 @@ func NewController(
 	celpolexInformer policiesv1beta1informers.PolicyExceptionInformer,
 	vapInformer admissionregistrationv1informers.ValidatingAdmissionPolicyInformer,
 	vapbindingInformer admissionregistrationv1informers.ValidatingAdmissionPolicyBindingInformer,
-	mapInformer admissionregistrationv1alpha1informers.MutatingAdmissionPolicyInformer,
-	mapbindingInformer admissionregistrationv1alpha1informers.MutatingAdmissionPolicyBindingInformer,
+	mapInformer admissionregistrationv1beta1informers.MutatingAdmissionPolicyInformer,
+	mapbindingInformer admissionregistrationv1beta1informers.MutatingAdmissionPolicyBindingInformer,
 	eventGen event.Interface,
 	checker checker.AuthChecker,
 ) controllers.Controller {

--- a/pkg/controllers/admissionpolicygenerator/generate-map.go
+++ b/pkg/controllers/admissionpolicygenerator/generate-map.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/admissionpolicy"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
-	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -50,13 +50,13 @@ func (c *controller) handleMAPGeneration(ctx context.Context, mpol *policiesv1be
 	if shouldDelete {
 		// delete the MutatingAdmissionPolicy if exist
 		if mapErr == nil {
-			if err := c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies().Delete(ctx, mapName, metav1.DeleteOptions{}); err != nil {
+			if err := c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicies().Delete(ctx, mapName, metav1.DeleteOptions{}); err != nil {
 				return err
 			}
 		}
 		// delete the MutatingAdmissionPolicyBinding if exist
 		if mapBindingErr == nil {
-			if err := c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings().Delete(ctx, mapBindingName, metav1.DeleteOptions{}); err != nil {
+			if err := c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicyBindings().Delete(ctx, mapBindingName, metav1.DeleteOptions{}); err != nil {
 				return err
 			}
 		}
@@ -72,7 +72,7 @@ func (c *controller) handleMAPGeneration(ctx context.Context, mpol *policiesv1be
 		if !apierrors.IsNotFound(mapErr) {
 			return fmt.Errorf("failed to get mutatingadmissionpolicy %s: %v", mapName, mapErr)
 		}
-		observedMAP = &admissionregistrationv1alpha1.MutatingAdmissionPolicy{
+		observedMAP = &admissionregistrationv1beta1.MutatingAdmissionPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: mapName,
 			},
@@ -82,7 +82,7 @@ func (c *controller) handleMAPGeneration(ctx context.Context, mpol *policiesv1be
 		if !apierrors.IsNotFound(mapBindingErr) {
 			return fmt.Errorf("failed to get mutatingadmissionpolicybinding %s: %v", mapBindingName, mapBindingErr)
 		}
-		observedMAPbinding = &admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{
+		observedMAPbinding = &admissionregistrationv1beta1.MutatingAdmissionPolicyBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: mapBindingName,
 			},
@@ -91,7 +91,7 @@ func (c *controller) handleMAPGeneration(ctx context.Context, mpol *policiesv1be
 
 	if observedMAP.ResourceVersion == "" {
 		admissionpolicy.BuildMutatingAdmissionPolicy(observedMAP, mpol, celexceptions)
-		_, err := c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies().Create(ctx, observedMAP, metav1.CreateOptions{})
+		_, err := c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicies().Create(ctx, observedMAP, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to create mutatingadmissionpolicy %s: %v", observedMAP.GetName(), err)
 		}
@@ -99,8 +99,8 @@ func (c *controller) handleMAPGeneration(ctx context.Context, mpol *policiesv1be
 		_, err := controllerutils.Update(
 			ctx,
 			observedMAP,
-			c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies(),
-			func(observed *admissionregistrationv1alpha1.MutatingAdmissionPolicy) error {
+			c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicies(),
+			func(observed *admissionregistrationv1beta1.MutatingAdmissionPolicy) error {
 				admissionpolicy.BuildMutatingAdmissionPolicy(observed, mpol, celexceptions)
 				return nil
 			})
@@ -111,7 +111,7 @@ func (c *controller) handleMAPGeneration(ctx context.Context, mpol *policiesv1be
 
 	if observedMAPbinding.ResourceVersion == "" {
 		admissionpolicy.BuildMutatingAdmissionPolicyBinding(observedMAPbinding, mpol)
-		_, err := c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings().Create(ctx, observedMAPbinding, metav1.CreateOptions{})
+		_, err := c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicyBindings().Create(ctx, observedMAPbinding, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to create mutatingadmissionpolicybinding %s: %v", observedMAPbinding.GetName(), err)
 		}
@@ -119,8 +119,8 @@ func (c *controller) handleMAPGeneration(ctx context.Context, mpol *policiesv1be
 		_, err := controllerutils.Update(
 			ctx,
 			observedMAPbinding,
-			c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings(),
-			func(observed *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding) error {
+			c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicyBindings(),
+			func(observed *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding) error {
 				admissionpolicy.BuildMutatingAdmissionPolicyBinding(observed, mpol)
 				return nil
 			})

--- a/pkg/controllers/admissionpolicygenerator/map.go
+++ b/pkg/controllers/admissionpolicygenerator/map.go
@@ -2,26 +2,26 @@ package admissionpolicygenerator
 
 import (
 	datautils "github.com/kyverno/kyverno/pkg/utils/data"
-	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 )
 
 // this file contains the handler functions for MAP and bindings resources.
-func (c *controller) addMAP(obj *admissionregistrationv1alpha1.MutatingAdmissionPolicy) {
+func (c *controller) addMAP(obj *admissionregistrationv1beta1.MutatingAdmissionPolicy) {
 	c.enqueueMAP(obj)
 }
 
-func (c *controller) updateMAP(old, obj *admissionregistrationv1alpha1.MutatingAdmissionPolicy) {
+func (c *controller) updateMAP(old, obj *admissionregistrationv1beta1.MutatingAdmissionPolicy) {
 	if datautils.DeepEqual(old.Spec, obj.Spec) {
 		return
 	}
 	c.enqueueMAP(obj)
 }
 
-func (c *controller) deleteMAP(obj *admissionregistrationv1alpha1.MutatingAdmissionPolicy) {
+func (c *controller) deleteMAP(obj *admissionregistrationv1beta1.MutatingAdmissionPolicy) {
 	c.enqueueMAP(obj)
 }
 
-func (c *controller) enqueueMAP(m *admissionregistrationv1alpha1.MutatingAdmissionPolicy) {
+func (c *controller) enqueueMAP(m *admissionregistrationv1beta1.MutatingAdmissionPolicy) {
 	if len(m.OwnerReferences) == 1 {
 		if m.OwnerReferences[0].Kind == "MutatingPolicy" {
 			mpol, err := c.mpolLister.Get(m.OwnerReferences[0].Name)
@@ -33,22 +33,22 @@ func (c *controller) enqueueMAP(m *admissionregistrationv1alpha1.MutatingAdmissi
 	}
 }
 
-func (c *controller) addMAPbinding(obj *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding) {
+func (c *controller) addMAPbinding(obj *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding) {
 	c.enqueueMAPbinding(obj)
 }
 
-func (c *controller) updateMAPbinding(old, obj *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding) {
+func (c *controller) updateMAPbinding(old, obj *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding) {
 	if datautils.DeepEqual(old.Spec, obj.Spec) {
 		return
 	}
 	c.enqueueMAPbinding(obj)
 }
 
-func (c *controller) deleteMAPbinding(obj *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding) {
+func (c *controller) deleteMAPbinding(obj *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding) {
 	c.enqueueMAPbinding(obj)
 }
 
-func (c *controller) enqueueMAPbinding(mb *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding) {
+func (c *controller) enqueueMAPbinding(mb *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding) {
 	if len(mb.OwnerReferences) == 1 {
 		if mb.OwnerReferences[0].Kind == "MutatingPolicy" {
 			mpol, err := c.mpolLister.Get(mb.OwnerReferences[0].Name)

--- a/pkg/controllers/admissionpolicygenerator/utils.go
+++ b/pkg/controllers/admissionpolicygenerator/utils.go
@@ -7,7 +7,7 @@ import (
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -63,7 +63,7 @@ func (c *controller) getValidatingAdmissionPolicyBinding(name string) (*admissio
 }
 
 // getMutatingAdmissionPolicy gets the Kubernetes MutatingAdmissionPolicy
-func (c *controller) getMutatingAdmissionPolicy(name string) (*admissionregistrationv1alpha1.MutatingAdmissionPolicy, error) {
+func (c *controller) getMutatingAdmissionPolicy(name string) (*admissionregistrationv1beta1.MutatingAdmissionPolicy, error) {
 	if c.mapLister == nil {
 		return nil, fmt.Errorf("MutatingAdmissionPolicy lister is nil")
 	}
@@ -75,7 +75,7 @@ func (c *controller) getMutatingAdmissionPolicy(name string) (*admissionregistra
 }
 
 // getMutatingAdmissionPolicyBinding gets the Kubernetes MutatingAdmissionPolicyBinding
-func (c *controller) getMutatingAdmissionPolicyBinding(name string) (*admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding, error) {
+func (c *controller) getMutatingAdmissionPolicyBinding(name string) (*admissionregistrationv1beta1.MutatingAdmissionPolicyBinding, error) {
 	if c.mapbindingLister == nil {
 		return nil, fmt.Errorf("MutatingAdmissionPolicyBinding lister is nil")
 	}


### PR DESCRIPTION
⚠️ Note: This PR is currently a draft because it needs an update in the `kyverno/api` repository as well.

# Explanation

This PR fixes a startup failure of the Kyverno admission controller on Kubernetes 1.35 when the `MutatingAdmissionPolicy` v1alpha1 API is no longer served.  
Kyverno now detects support for `MutatingAdmissionPolicy` using the v1beta1 API (and the actual MAP resources) and the admissionpolicy generator consistently uses the v1beta1 client/informers instead of relying on the deprecated v1alpha1 API.

## Related issue

Fixes #15364

## Milestone of this PR

/milestone 1.17.2

## What type of PR is this

/kind bug

## Proposed Changes

- Ensure the new behaviour works across Kubernetes 1.32–1.35 (see compatibility matrix) without requiring `admissionregistration.k8s.io/v1` for MAP, and avoid creating informers for APIs not supported by the apiserver. 
- Update the registration check to look for `mutatingadmissionpolicies` / `mutatingadmissionpolicybindings` on the `admissionregistration.k8s.io` v1beta1 API
- Wire the admissionpolicy generator to use v1beta1 `MutatingAdmissionPolicy` / `MutatingAdmissionPolicyBinding` informers and clients instead of v1alpha1.

### Proof Manifests

<!--
Add or reference:
- A Kyverno MutatingPolicy which generates a MutatingAdmissionPolicy.
- A Kubernetes 1.35 (or equivalent) environment where admissionregistration.k8s.io/v1alpha1 is absent and the admission controller starts successfully.
- Optional: Kyverno CLI tests exercising MutatingAdmissionPolicy generation and reporting.
-->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is `release-1.17`.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This is aimed at being backported to 1.17. For kubernetes 1.18, we could probably to migrate to `v1` since we'll most-likely support k8s >= `1.33` where v1 is available