### PR TITLE
fix: propagate non-NotFound errors in manageClone

### DIFF
--- a/pkg/background/generate/clone.go
+++ b/pkg/background/generate/clone.go
@@ -60,6 +60,8 @@ func manageClone(log logr.Logger, target, sourceSpec kyvernov1.ResourceSpec, sev
 	if err != nil && apierrors.IsNotFound(err) {
 		// the target resource should always exist regardless of synchronize settings
 		return newCreateGenerateResponse(sourceObjCopy.UnstructuredContent(), target, nil)
+	} else if err != nil {
+		return newSkipGenerateResponse(nil, target, err)
 	}
 
 	if targetObj != nil {


### PR DESCRIPTION
## Summary

While testing generate rules with `clone` + `synchronize: true`, I noticed that `manageClone()` seems to ignore non-`NotFound` errors returned by `GetResource()`.

Right now it only handles the 404 case:

```go
targetObj, err := client.GetResource(...)

if err != nil && apierrors.IsNotFound(err) {
    return newCreateGenerateResponse(sourceObjCopy.UnstructuredContent(), target, nil)
}
```

If `err` is something else (e.g. 503, timeout, throttling), it isn’t propagated. Execution falls through to a `Create` response. If the resource already exists, `AlreadyExists` gets swallowed and the `UpdateRequest` can end up marked `Completed`.

From what I can tell, this means a transient API error could cause the UR to finish without actually syncing the target.

---

## Why this matters

Transient API failures are fairly common in real clusters (API restarts, etcd elections, throttling, etc.).

In that window, a clone sync might fail once and never retry, leaving the target resource out of sync until the source changes again.

---

## Proposed fix

Add an explicit branch to propagate non-404 errors:

```go
if err != nil && apierrors.IsNotFound(err) {
    return newCreateGenerateResponse(sourceObjCopy.UnstructuredContent(), target, nil)
} else if err != nil {
    return newSkipGenerateResponse(nil, target, err)
}
```

This way non-404 errors bubble up, the `UpdateRequest` retries, and we avoid prematurely marking it `Completed`.

As far as I can see, this doesn’t change the happy path, it just restores the expected retry behavior and makes `manageClone()` consistent with `manageData()`.

Happy to adjust if I’m misunderstanding the intended flow here.
