### PR TITLE
fix(cli): handle multiple foreach loops and element indexing in mocked variables

### DIFF
--- a/cmd/cli/kubectl-kyverno/apis/v1alpha1/rule.go
+++ b/cmd/cli/kubectl-kyverno/apis/v1alpha1/rule.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 // Rule declares values for a given policy rule
 type Rule struct {
-	// Name is the name of the ppolicy rule
+	// Name is the name of the policy rule
 	Name string `json:"name"`
 
 	// Values are the values for the given policy rule
@@ -11,9 +11,9 @@ type Rule struct {
 	// +kubebuilder:validation:Schemaless
 	Values map[string]interface{} `json:"values,omitempty"`
 
-	// ForeachValues are the foreach values for the given policy rule
-	// +kubebuilder:validation:Type=object
+	// ForeachValues are the foreach values for the given policy rule, indexed per foreach block
+	// +kubebuilder:validation:Type=array
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Schemaless
-	ForeachValues map[string][]interface{} `json:"foreachValues,omitempty"`
+	ForeachValues []map[string][]interface{} `json:"foreachValues,omitempty"`
 }

--- a/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
@@ -489,11 +489,13 @@ spec:
                         properties:
                           foreachValues:
                             description: ForeachValues are the foreach values for
-                              the given policy rule
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
+                              the given policy rule, indexed per foreach block
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
                           name:
-                            description: Name is the name of the ppolicy rule
+                            description: Name is the name of the policy rule
                             type: string
                           values:
                             description: Values are the values for the given policy

--- a/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_values.yaml
+++ b/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_values.yaml
@@ -180,11 +180,13 @@ spec:
                     properties:
                       foreachValues:
                         description: ForeachValues are the foreach values for the
-                          given policy rule
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
+                          given policy rule, indexed per foreach block
+                        items:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        type: array
                       name:
-                        description: Name is the name of the ppolicy rule
+                        description: Name is the name of the policy rule
                         type: string
                       values:
                         description: Values are the values for the given policy rule

--- a/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
@@ -489,11 +489,13 @@ spec:
                         properties:
                           foreachValues:
                             description: ForeachValues are the foreach values for
-                              the given policy rule
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
+                              the given policy rule, indexed per foreach block
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
                           name:
-                            description: Name is the name of the ppolicy rule
+                            description: Name is the name of the policy rule
                             type: string
                           values:
                             description: Values are the values for the given policy

--- a/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_values.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_values.yaml
@@ -180,11 +180,13 @@ spec:
                     properties:
                       foreachValues:
                         description: ForeachValues are the foreach values for the
-                          given policy rule
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
+                          given policy rule, indexed per foreach block
+                        items:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        type: array
                       name:
-                        description: Name is the name of the ppolicy rule
+                        description: Name is the name of the policy rule
                         type: string
                       values:
                         description: Values are the values for the given policy rule

--- a/cmd/cli/kubectl-kyverno/store/contextloader.go
+++ b/cmd/cli/kubectl-kyverno/store/contextloader.go
@@ -26,18 +26,47 @@ func ContextLoaderFactory(s *Store, cmResolver engineapi.ConfigmapResolver) engi
 	}
 	return func(policy kyvernov1.PolicyInterface, rule kyvernov1.Rule) engineapi.ContextLoader {
 		init := func(jsonContext enginecontext.Interface) error {
-			rule := s.GetPolicyRule(policy.GetName(), rule.Name)
-			if rule != nil && len(rule.Values) > 0 {
-				variables := rule.Values
-				for key, value := range variables {
+			storeRule := s.GetPolicyRule(policy.GetName(), rule.Name)
+			if storeRule == nil {
+				return nil
+			}
+			if len(storeRule.Values) > 0 {
+				for key, value := range storeRule.Values {
 					if err := jsonContext.AddVariable(key, value); err != nil {
 						return err
 					}
 				}
 			}
-			if rule != nil && len(rule.ForEachValues) > 0 {
-				for key, value := range rule.ForEachValues {
-					if err := jsonContext.AddVariable(key, value[s.GetForeachElement()]); err != nil {
+			if len(storeRule.ForEachValues) == 0 {
+				return nil
+			}
+			// Only inject foreachValues when inside a foreach element; elementIndex
+			// is set by the engine only during foreach iteration, so its absence
+			// means we're at rule-level context load and should skip mock injection.
+			rawElem, err := jsonContext.Query("elementIndex")
+			if err != nil {
+				return nil
+			}
+			elemIdx := 0
+			if v, ok := rawElem.(int64); ok {
+				elemIdx = int(v)
+			}
+			blockIdx := 0
+			if raw, err := jsonContext.Query("foreachBlockIndex"); err == nil {
+				if v, ok := raw.(int64); ok {
+					blockIdx = int(v)
+				}
+			}
+			if blockIdx >= len(storeRule.ForEachValues) {
+				return nil
+			}
+			blockValues := storeRule.ForEachValues[blockIdx]
+			if len(blockValues) == 0 {
+				return nil
+			}
+			for key, values := range blockValues {
+				if elemIdx < len(values) {
+					if err := jsonContext.AddVariable(key, values[elemIdx]); err != nil {
 						return err
 					}
 				}

--- a/cmd/cli/kubectl-kyverno/store/store.go
+++ b/cmd/cli/kubectl-kyverno/store/store.go
@@ -16,9 +16,9 @@ type Policy struct {
 }
 
 type Rule struct {
-	Name          string                   `json:"name"`
-	Values        map[string]interface{}   `json:"values"`
-	ForEachValues map[string][]interface{} `json:"foreachValues"`
+	Name          string                     `json:"name"`
+	Values        map[string]interface{}     `json:"values"`
+	ForEachValues []map[string][]interface{} `json:"foreachValues"`
 }
 
 type Store struct {
@@ -26,7 +26,6 @@ type Store struct {
 	registryClient       registryclient.Client
 	allowApiCalls        bool
 	policies             []Policy
-	foreachElement       int
 	gctxStore            loaders.Store
 	apiCallResponses     []v1alpha1.APICallResponseEntry
 	globalContextEntries []v1alpha1.GlobalContextEntryValue
@@ -41,14 +40,6 @@ func (s *Store) SetLocal(m bool) {
 // IsLocal returns 'true' if the CLI is in local (clusterless) execution
 func (s *Store) IsLocal() bool {
 	return s.local
-}
-
-func (s *Store) SetForEachElement(element int) {
-	s.foreachElement = element
-}
-
-func (s *Store) GetForeachElement() int {
-	return s.foreachElement
 }
 
 func (s *Store) SetRegistryAccess(access bool) {

--- a/cmd/cli/kubectl-kyverno/variables/variables_test.go
+++ b/cmd/cli/kubectl-kyverno/variables/variables_test.go
@@ -108,8 +108,8 @@ func TestVariables_SetInStore(t *testing.T) {
 			Values: map[string]interface{}{
 				"foo": "bar",
 			},
-			ForeachValues: map[string][]interface{}{
-				"baz": nil,
+			ForeachValues: []map[string][]interface{}{
+				{"baz": nil},
 			},
 		}},
 	})

--- a/docs/user/cli/crd/index.html
+++ b/docs/user/cli/crd/index.html
@@ -1288,7 +1288,7 @@ string
 </em>
 </td>
 <td>
-<p>Name is the name of the ppolicy rule</p>
+<p>Name is the name of the policy rule</p>
 </td>
 </tr>
 <tr>
@@ -1306,11 +1306,11 @@ map[string]interface{}
 <td>
 <code>foreachValues</code><br/>
 <em>
-map[string][]interface{}
+[]map[string][]interface{}
 </em>
 </td>
 <td>
-<p>ForeachValues are the foreach values for the given policy rule</p>
+<p>ForeachValues are the foreach values for the given policy rule, indexed per foreach block</p>
 </td>
 </tr>
 </tbody>

--- a/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
+++ b/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
@@ -2814,7 +2814,7 @@ If empty, the entry matches any method via plain URL lookup.</p>
         <td>
           
 
-          <p>Name is the name of the ppolicy rule</p>
+          <p>Name is the name of the policy rule</p>
 
 
           
@@ -2865,14 +2865,14 @@ If empty, the entry matches any method via plain URL lookup.</p>
           
           
             
-              <span style="font-family: monospace">map[string][]interface{}</span>
+              <span style="font-family: monospace">[]map[string][]interface{}</span>
             
           
         </td>
         <td>
           
 
-          <p>ForeachValues are the foreach values for the given policy rule</p>
+          <p>ForeachValues are the foreach values for the given policy rule, indexed per foreach block</p>
 
 
           

--- a/pkg/engine/context/context.go
+++ b/pkg/engine/context/context.go
@@ -24,7 +24,7 @@ import (
 var (
 	logger       = logging.WithName("context")
 	json         = jsoniter.ConfigCompatibleWithStandardLibrary
-	ReservedKeys = regexp.MustCompile(`request|serviceAccountName|serviceAccountNamespace|element|elementIndex|@|images|image|([a-z_0-9]+\()[^{}]`)
+	ReservedKeys = regexp.MustCompile(`request|serviceAccountName|serviceAccountNamespace|element|elementIndex|foreachBlockIndex|@|images|image|([a-z_0-9]+\()[^{}]`)
 )
 
 // EvalInterface is used to query and inspect context data

--- a/pkg/engine/handlers/mutation/common.go
+++ b/pkg/engine/handlers/mutation/common.go
@@ -28,11 +28,15 @@ type forEachMutator struct {
 func (f *forEachMutator) mutateForEach(ctx context.Context) *mutate.Response {
 	var applyCount int
 
-	for _, foreach := range f.foreach {
+	for i, foreach := range f.foreach {
 		elements, err := engineutils.EvaluateList(foreach.List, f.policyContext.JSONContext())
 		if err != nil {
 			msg := fmt.Sprintf("failed to evaluate list %s: %v", foreach.List, err)
 			return mutate.NewErrorResponse(msg, err)
+		}
+
+		if err := f.policyContext.JSONContext().AddVariable("foreachBlockIndex", int64(i)); err != nil {
+			f.logger.Error(err, "failed to set foreachBlockIndex")
 		}
 
 		mutateResp := f.mutateElements(ctx, foreach, elements)

--- a/pkg/engine/handlers/validation/validate_resource.go
+++ b/pkg/engine/handlers/validation/validate_resource.go
@@ -223,7 +223,7 @@ func (v *validator) validateOldObject(ctx context.Context) (resp *engineapi.Rule
 func (v *validator) validateForEach(ctx context.Context) *engineapi.RuleResponse {
 	applyCount := 0
 	var listEvalError error
-	for _, foreach := range v.forEach {
+	for i, foreach := range v.forEach {
 		elements, err := engineutils.EvaluateList(foreach.List, v.policyContext.JSONContext())
 		if err != nil {
 			if strings.Contains(err.Error(), "Unknown key") {
@@ -233,6 +233,9 @@ func (v *validator) validateForEach(ctx context.Context) *engineapi.RuleResponse
 			v.log.V(2).Info("failed to evaluate list", "list", foreach.List, "error", err.Error())
 			listEvalError = err
 			continue
+		}
+		if err := v.policyContext.JSONContext().AddVariable("foreachBlockIndex", int64(i)); err != nil {
+			v.log.Error(err, "failed to set foreachBlockIndex")
 		}
 		resp, count := v.validateElements(ctx, foreach, elements, foreach.ElementScope)
 		if resp.Status() != engineapi.RuleStatusPass {

--- a/test/cli/test/context-foreach-multi/kyverno-test.yaml
+++ b/test/cli/test/context-foreach-multi/kyverno-test.yaml
@@ -1,0 +1,28 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: test-context-foreach-multi
+policies:
+- policy.yaml
+resources:
+- resources.yaml
+variables: values.yaml
+results:
+- kind: Pod
+  policy: check-images
+  rule: check-images
+  resources:
+  - good-pod
+  result: pass
+- kind: Pod
+  policy: check-images
+  rule: check-images
+  resources:
+  - bad-container-pod
+  result: pass
+- kind: Pod
+  policy: check-images
+  rule: check-images
+  resources:
+  - bad-initcontainer-pod
+  result: pass

--- a/test/cli/test/context-foreach-multi/kyverno-test.yaml
+++ b/test/cli/test/context-foreach-multi/kyverno-test.yaml
@@ -6,23 +6,13 @@ policies:
 - policy.yaml
 resources:
 - resources.yaml
-variables: values.yaml
 results:
 - kind: Pod
   policy: check-images
-  rule: check-images
   resources:
   - good-pod
-  result: pass
-- kind: Pod
-  policy: check-images
-  rule: check-images
-  resources:
   - bad-container-pod
-  result: pass
-- kind: Pod
-  policy: check-images
-  rule: check-images
-  resources:
   - bad-initcontainer-pod
   result: pass
+  rule: check-images
+variables: values.yaml

--- a/test/cli/test/context-foreach-multi/policy.yaml
+++ b/test/cli/test/context-foreach-multi/policy.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: check-images
+spec:
+  rules:
+  - name: check-images
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      failureAction: Enforce
+      foreach:
+      - list: request.object.spec.containers
+        context:
+        - name: registryData
+          imageRegistry:
+            reference: "{{ element.image }}"
+        deny:
+          conditions:
+            any:
+            - key: "{{ registryData }}"
+              operator: Equals
+              value: "blocked"
+      - list: request.object.spec.initContainers
+        context:
+        - name: initRegistryData
+          imageRegistry:
+            reference: "{{ element.image }}"
+        deny:
+          conditions:
+            any:
+            - key: "{{ initRegistryData }}"
+              operator: Equals
+              value: "blocked"
+      message: "Image is blocked by policy."

--- a/test/cli/test/context-foreach-multi/resources.yaml
+++ b/test/cli/test/context-foreach-multi/resources.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+spec:
+  initContainers:
+  - name: init-setup
+    image: busybox:1.28
+  containers:
+  - name: app
+    image: nginx:latest
+  - name: sidecar
+    image: busybox:1.28
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-container-pod
+spec:
+  initContainers:
+  - name: init-setup
+    image: busybox:1.28
+  containers:
+  - name: app
+    image: nginx:latest
+  - name: bad
+    image: blocked:latest
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-initcontainer-pod
+spec:
+  initContainers:
+  - name: init-blocked
+    image: evil:latest
+  containers:
+  - name: app
+    image: nginx:latest

--- a/test/cli/test/context-foreach-multi/values.yaml
+++ b/test/cli/test/context-foreach-multi/values.yaml
@@ -1,0 +1,12 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Values
+policies:
+- name: check-images
+  rules:
+  - name: check-images
+    foreachValues:
+    - registryData:
+        - ok
+        - ok
+    - initRegistryData:
+        - ok

--- a/test/cli/test/context-foreach-multi/values.yaml
+++ b/test/cli/test/context-foreach-multi/values.yaml
@@ -3,10 +3,10 @@ kind: Values
 policies:
 - name: check-images
   rules:
-  - name: check-images
-    foreachValues:
+  - foreachValues:
     - registryData:
-        - ok
-        - ok
+      - ok
+      - ok
     - initRegistryData:
-        - ok
+      - ok
+    name: check-images

--- a/test/cli/test/context-foreach/values.yaml
+++ b/test/cli/test/context-foreach/values.yaml
@@ -3,8 +3,8 @@ kind: Values
 policies:
 - name: block-images
   rules:
-  - foreachValues:
-      imageData:
-      - foo
-      - foo1
-    name: block-images
+  - name: block-images
+    foreachValues:
+    - imageData:
+        - foo
+        - foo1

--- a/test/cli/test/context-foreach/values.yaml
+++ b/test/cli/test/context-foreach/values.yaml
@@ -3,8 +3,8 @@ kind: Values
 policies:
 - name: block-images
   rules:
-  - name: block-images
-    foreachValues:
+  - foreachValues:
     - imageData:
-        - foo
-        - foo1
+      - foo
+      - foo1
+    name: block-images


### PR DESCRIPTION
## Explanation

This PR fixes a bug in the Kyverno CLI where mocked variables for foreach loops were not correctly applied when a rule contained multiple foreach blocks or when iterating beyond the first element. The CLI previously lacked a mechanism to differentiate between separate foreach blocks and was stuck using index 0 for all elements.

The fix introduces proper block and element indexing by leveraging the engine's JSON context, ensuring that the CLI context loader can accurately retrieve the corresponding mocked values for each iteration.

## Related issue

Closes #4095

## Milestone of this PR

/milestone 1.13.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [x] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

- API Schema Change: Updated ForeachValues from map[string][]interface{} to []map[string][]interface{}. This allows providing distinct value sets for multiple sequential foreach blocks.
- Engine Context Tracking: Both validation and mutation handlers now write the current foreach block index (foreachBlockIndex) into the JSON context.
- CLI Context Loader Refactoring: Modified the context loader to read both foreachBlockIndex and elementIndex directly from the JSON context. This removes the reliance on internal store state which was not being correctly updated by the engine.
- CRD Update: Synchronized cli.kyverno.io_values.yaml to match the updated API.
- Cleanup: Removed unused foreachElement and foreachIndex fields and methods from the CLI store.

### Proof Manifests

# Kyverno Policy

```apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: check-images
spec:
  rules:
  - name: check-images
    match:
      any:
      - resources:
          kinds:
          - Pod
    validate:
      foreach:
      - list: request.object.spec.containers
        context:
        - name: registryData
          imageRegistry:
            reference: "{{ element.image }}"
        deny:
          conditions:
            any:
            - key: "{{ registryData }}"
              operator: Equals
              value: "blocked"
      - list: request.object.spec.initContainers
        context:
        - name: initRegistryData
          imageRegistry:
            reference: "{{ element.image }}"
        deny:
          conditions:
            any:
            - key: "{{ initRegistryData }}"
              operator: Equals
              value: "blocked"
```

# Kyverno CLI Values

```apiVersion: cli.kyverno.io/v1alpha1
kind: Values
policies:
- name: check-images
  rules:
  - name: check-images
    foreachValues:
    # First entry for containers block
    - registryData:
      - ok
      - ok
    # Second entry for initContainers block
    - initRegistryData:
      - ok
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The solution follows the existing pattern used by the engine for elementIndex. By writing the block index to the JSON context, we maintain a clean separation between the engine logic and the CLI's mocked value injection, avoiding further complexity in the Store interface.
