### PR TITLE
fix(cli/apply): use namespace from flag for manifests without namespace

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -204,7 +204,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVarP(&applyCommandConfig.ContextPath, "context-file", "", "", "File containing context data for CEL policies")
 	cmd.Flags().BoolVarP(&applyCommandConfig.PolicyReport, "policy-report", "p", false, "Generates policy report when passed (default policyviolation)")
 	cmd.Flags().StringVarP(&applyCommandConfig.OutputFormat, "output-format", "", "yaml", "Specifies the policy report format (json or yaml). Default: yaml.")
-	cmd.Flags().StringVarP(&applyCommandConfig.Namespace, "namespace", "n", "", "Optional Policy parameter passed with cluster flag")
+	cmd.Flags().StringVarP(&applyCommandConfig.Namespace, "namespace", "n", "", "Optional Policy parameter")
 	cmd.Flags().BoolVarP(&applyCommandConfig.Stdin, "stdin", "i", false, "Optional mutate policy parameter to pipe directly through to kubectl")
 	cmd.Flags().BoolVar(&applyCommandConfig.RegistryAccess, "registry", false, "If set to true, access the image registry using local docker credentials to populate external data")
 	cmd.Flags().StringVar(&applyCommandConfig.KubeConfig, "kubeconfig", "", "path to kubeconfig file with authorization and master location information")

--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -896,7 +896,14 @@ func (c *ApplyCommandConfig) loadPolicies() (
 		}
 		for _, policy := range policies {
 			if policy.GetNamespace() == "" && policy.GetKind() == "Policy" {
-				log.Log.V(3).Info(fmt.Sprintf("Namespace is empty for a namespaced Policy %s. This might cause incorrect report generation.", policy.GetName()))
+				var namespace string
+				if c.Namespace != "" {
+					namespace = c.Namespace
+				} else {
+					namespace = "default"
+				}
+				log.Log.V(3).Info(fmt.Sprintf("Namespace is empty for a namespaced Policy %s, setting it to \"%s\"", policy.GetName(), namespace))
+				policy.SetNamespace(namespace)
 			}
 		}
 	}

--- a/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/report"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
 	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -71,9 +72,9 @@ func TestMain(m *testing.M) {
 
 func Test_Apply(t *testing.T) {
 	type TestCase struct {
-		expectedReports []openreportsv1alpha1.Report
-		config          ApplyCommandConfig
-		stdinFile       string
+		expectedReportSummary []openreportsv1alpha1.ReportSummary
+		config                ApplyCommandConfig
+		stdinFile             string
 	}
 	// copy disallow_latest_tag.yaml to local path
 	localFileName, err := copyFileToThisDir("../../../../../test/best_practices/disallow_latest_tag.yaml")
@@ -88,14 +89,12 @@ func Test_Apply(t *testing.T) {
 				exceptionsWithinPolicies: true,
 				PolicyReport:             true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  2,
-					Fail:  0,
-					Skip:  1,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  2,
+				Fail:  0,
+				Skip:  1,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -105,14 +104,12 @@ func Test_Apply(t *testing.T) {
 				exceptionsWithinResources: true,
 				PolicyReport:              true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  2,
-					Fail:  0,
-					Skip:  1,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  2,
+				Fail:  0,
+				Skip:  1,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -123,14 +120,12 @@ func Test_Apply(t *testing.T) {
 				exceptionsWithinPolicies:  true,
 				PolicyReport:              true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  1,
-					Fail:  0,
-					Skip:  2,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  1,
+				Fail:  0,
+				Skip:  2,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -139,14 +134,12 @@ func Test_Apply(t *testing.T) {
 				ResourcePaths: []string{"../../../../../test/resources/pod_with_version_tag.yaml"},
 				PolicyReport:  true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  2,
-					Fail:  0,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  2,
+				Fail:  0,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -155,14 +148,12 @@ func Test_Apply(t *testing.T) {
 				ResourcePaths: []string{"../../../../../test/resources/pod_with_version_tag.yaml"},
 				PolicyReport:  true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  2,
-					Fail:  0,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  2,
+				Fail:  0,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -171,14 +162,12 @@ func Test_Apply(t *testing.T) {
 				ResourcePaths: []string{"../../../../../test/resources/pod_with_latest_tag.yaml"},
 				PolicyReport:  true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  1,
-					Fail:  1,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  1,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -187,14 +176,12 @@ func Test_Apply(t *testing.T) {
 				ResourcePaths: []string{"../../../../../test/cli/apply/resource"},
 				PolicyReport:  true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  1,
-					Fail:  1,
-					Skip:  0,
-					Error: 0,
-					Warn:  2,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  1,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  2,
 			}},
 		},
 		{
@@ -204,14 +191,12 @@ func Test_Apply(t *testing.T) {
 				PolicyReport:  true,
 				AuditWarn:     true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  1,
-					Fail:  0,
-					Skip:  0,
-					Error: 0,
-					Warn:  1,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  1,
+				Fail:  0,
+				Skip:  0,
+				Error: 0,
+				Warn:  1,
 			}},
 		},
 		{
@@ -223,14 +208,12 @@ func Test_Apply(t *testing.T) {
 				warnExitCode:  3,
 			},
 			stdinFile: "../../../../../test/best_practices/disallow_latest_tag.yaml",
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  1,
-					Fail:  0,
-					Skip:  0,
-					Error: 0,
-					Warn:  1,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  1,
+				Fail:  0,
+				Skip:  0,
+				Error: 0,
+				Warn:  1,
 			}},
 		},
 		{
@@ -241,14 +224,12 @@ func Test_Apply(t *testing.T) {
 				AuditWarn:     true,
 			},
 			stdinFile: "../../../../../test/resources/pod_with_latest_tag.yaml",
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  1,
-					Fail:  0,
-					Skip:  0,
-					Error: 0,
-					Warn:  1,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  1,
+				Fail:  0,
+				Skip:  0,
+				Error: 0,
+				Warn:  1,
 			}},
 		},
 		{
@@ -258,14 +239,12 @@ func Test_Apply(t *testing.T) {
 				Variables:     []string{"request.operation=UPDATE"},
 				PolicyReport:  true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  2,
-					Fail:  0,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  2,
+				Fail:  0,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -274,14 +253,12 @@ func Test_Apply(t *testing.T) {
 				ResourcePaths: []string{"../../../../../test/cli/test-validating-admission-policy/check-deployments-replica/deployment1.yaml"},
 				PolicyReport:  true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  1,
-					Fail:  0,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  1,
+				Fail:  0,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -290,14 +267,12 @@ func Test_Apply(t *testing.T) {
 				ResourcePaths: []string{"../../../../../test/cli/test-validating-admission-policy/check-deployments-replica/deployment2.yaml"},
 				PolicyReport:  true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  0,
-					Fail:  1,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  0,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -306,14 +281,12 @@ func Test_Apply(t *testing.T) {
 				ResourcePaths: []string{"../../../../../test/cli/test-validating-admission-policy/disallow-host-path/pod1.yaml"},
 				PolicyReport:  true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  1,
-					Fail:  0,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  1,
+				Fail:  0,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -322,14 +295,12 @@ func Test_Apply(t *testing.T) {
 				ResourcePaths: []string{"../../../../../test/cli/test-validating-admission-policy/disallow-host-path/pod2.yaml"},
 				PolicyReport:  true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  0,
-					Fail:  1,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  0,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -338,14 +309,12 @@ func Test_Apply(t *testing.T) {
 				ResourcePaths: []string{"../../../../../test/cli/test-validating-admission-policy/check-deployment-labels/deployment1.yaml"},
 				PolicyReport:  true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  1,
-					Fail:  0,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  1,
+				Fail:  0,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -354,14 +323,12 @@ func Test_Apply(t *testing.T) {
 				ResourcePaths: []string{"../../../../../test/cli/test-validating-admission-policy/check-deployment-labels/deployment2.yaml"},
 				PolicyReport:  true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  0,
-					Fail:  1,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  0,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -373,14 +340,12 @@ func Test_Apply(t *testing.T) {
 				},
 				PolicyReport: true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  0,
-					Fail:  1,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  0,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -392,14 +357,12 @@ func Test_Apply(t *testing.T) {
 				},
 				PolicyReport: true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  0,
-					Fail:  1,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  0,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -413,14 +376,12 @@ func Test_Apply(t *testing.T) {
 				ValuesFile:   "../../../../../test/cli/test-validating-admission-policy/with-bindings-3/values.yaml",
 				PolicyReport: true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  2,
-					Fail:  2,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  2,
+				Fail:  2,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -432,14 +393,12 @@ func Test_Apply(t *testing.T) {
 				},
 				PolicyReport: true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  1,
-					Fail:  1,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  1,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -451,14 +410,12 @@ func Test_Apply(t *testing.T) {
 				UserInfoPath: "../../../../../test/cli/test-validating-admission-policy/check-user-info/userinfo.yaml",
 				PolicyReport: true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  1,
-					Fail:  0,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  1,
+				Fail:  0,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -469,14 +426,12 @@ func Test_Apply(t *testing.T) {
 				PolicyReport:  true,
 				Cloner:        fakeCloner(t, "../../../../../test/cli/apply/git-test-fixtures"),
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  2,
-					Fail:  1,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  2,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -488,14 +443,12 @@ func Test_Apply(t *testing.T) {
 				PolicyReport:  true,
 				Cloner:        fakeCloner(t, "../../../../../test/cli/apply/git-test-fixtures"),
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  2,
-					Fail:  1,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  2,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -509,14 +462,12 @@ func Test_Apply(t *testing.T) {
 				GitBranch:     "main",
 				PolicyReport:  true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  3,
-					Fail:  0,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  3,
+				Fail:  0,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -525,14 +476,12 @@ func Test_Apply(t *testing.T) {
 				ResourcePaths: []string{"../../../../../test/resources/pod_without_namespace.yaml"},
 				PolicyReport:  true,
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  0,
-					Fail:  1,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  0,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
 		},
 		{
@@ -543,15 +492,78 @@ func Test_Apply(t *testing.T) {
 				PolicyReport:  true,
 				Namespace:     "myapp-namespace",
 			},
-			expectedReports: []openreportsv1alpha1.Report{{
-				Summary: openreportsv1alpha1.ReportSummary{
-					Pass:  1,
-					Fail:  0,
-					Skip:  0,
-					Error: 0,
-					Warn:  0,
-				},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  1,
+				Fail:  0,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
 			}},
+		},
+		{
+			// Policy and resource using implicit namespace ("default" because CLI flag isn't set)
+			config: ApplyCommandConfig{
+				PolicyPaths:   []string{"../../../../../test/best_practices/disallow_latest_tag_namespaced_implicit.yaml"},
+				ResourcePaths: []string{"../../../../../test/resources/pod_with_latest_tag.yaml"},
+				PolicyReport:  true,
+			},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  0,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
+			}},
+		},
+		{
+			// Policy and resource using implicit namespace ("mynamespace" set via CLI flag")
+			config: ApplyCommandConfig{
+				PolicyPaths:   []string{"../../../../../test/best_practices/disallow_latest_tag_namespaced_implicit.yaml"},
+				ResourcePaths: []string{"../../../../../test/resources/pod_with_latest_tag.yaml"},
+				PolicyReport:  true,
+				Namespace:     "mynamespace",
+			},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  0,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
+			}},
+		},
+		{
+			// Policy and resource using same explicit namespace different from implicit namespace set as CLI flag
+			config: ApplyCommandConfig{
+				PolicyPaths:   []string{"../../../../../test/best_practices/disallow_latest_tag_namespaced_explicit.yaml"},
+				ResourcePaths: []string{"../../../../../test/resources/pod_with_latest_tag_custom_namespace.yaml"},
+				PolicyReport:  true,
+				Namespace:     "mynamespace",
+			},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{{
+				Pass:  0,
+				Fail:  1,
+				Skip:  0,
+				Error: 0,
+				Warn:  0,
+			}},
+		},
+		{
+			// Policy using implicit namespace, resource using different explicit namespace (no results)
+			config: ApplyCommandConfig{
+				PolicyPaths:   []string{"../../../../../test/best_practices/disallow_latest_tag_namespaced_implicit.yaml"},
+				ResourcePaths: []string{"../../../../../test/resources/pod_with_latest_tag_custom_namespace.yaml"},
+				PolicyReport:  true,
+			},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{},
+		},
+		{
+			// Policy using explicit namespace, resource using implicit namespace (no results)
+			config: ApplyCommandConfig{
+				PolicyPaths:   []string{"../../../../../test/best_practices/disallow_latest_tag_namespaced_explicit.yaml"},
+				ResourcePaths: []string{"../../../../../test/resources/pod_with_latest_tag.yaml"},
+				PolicyReport:  true,
+			},
+			expectedReportSummary: []openreportsv1alpha1.ReportSummary{},
 		},
 	}
 
@@ -582,15 +594,33 @@ func Test_Apply(t *testing.T) {
 		_, _, _, responses, err := tc.config.applyCommandHelper(os.Stdout)
 		assert.NoError(t, err, desc)
 
-		clustered, _ := report.ComputePolicyReports(tc.config.AuditWarn, responses...)
-		assert.Greater(t, len(clustered), 0, "policy reports should not be empty: %s", desc)
-		combined := []openreportsv1alpha1.ClusterReport{
-			report.MergeClusterReports(clustered),
+		clustered, namespaced := report.ComputePolicyReports(tc.config.AuditWarn, responses...)
+
+		if len(tc.expectedReportSummary) == 0 {
+			assert.Equal(t, 0, len(clustered), "test case expects no results, got %s cluster reports")
+			assert.Equal(t, 0, len(namespaced), "test case expects no results, got %s namespace reports")
+			return
 		}
-		assert.Equal(t, len(combined), len(tc.expectedReports))
-		for i, resp := range combined {
-			compareSummary(tc.expectedReports[i].Summary, resp.Summary, desc)
+
+		hasClustered := len(clustered) > 0
+		hasNamespaced := len(namespaced) > 0
+
+		assert.Condition(t, func() (sucess bool) { return hasClustered || hasNamespaced && !(hasClustered && hasNamespaced) }, "test must return either a cluster policy reports or namespace policy reports")
+
+		var summary openreportsv1alpha1.ReportSummary
+		if hasClustered {
+			combined := report.MergeClusterReports(clustered)
+			summary = combined.Summary
+		} else if hasNamespaced {
+			results := []openreportsv1alpha1.ReportResult{}
+			for _, resp := range namespaced {
+				results = append(results, resp.Results...)
+			}
+			summary = reportutils.CalculateSummary(results)
 		}
+
+		assert.Equal(t, 1, len(tc.expectedReportSummary), "test must specify either no or exactly one expected report summary, got %s")
+		compareSummary(tc.expectedReportSummary[0], summary, desc)
 	}
 
 	for _, tc := range testcases {

--- a/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
@@ -519,6 +519,40 @@ func Test_Apply(t *testing.T) {
 				},
 			}},
 		},
+		{
+			config: ApplyCommandConfig{
+				PolicyPaths:   []string{"../../../../../test/best_practices/disallow_default_namespace.yaml"},
+				ResourcePaths: []string{"../../../../../test/resources/pod_without_namespace.yaml"},
+				PolicyReport:  true,
+			},
+			expectedReports: []openreportsv1alpha1.Report{{
+				Summary: openreportsv1alpha1.ReportSummary{
+					Pass:  0,
+					Fail:  1,
+					Skip:  0,
+					Error: 0,
+					Warn:  0,
+				},
+			}},
+		},
+		{
+			// Same as the above, but sets (fallback) namespace, making the policy pass
+			config: ApplyCommandConfig{
+				PolicyPaths:   []string{"../../../../../test/best_practices/disallow_default_namespace.yaml"},
+				ResourcePaths: []string{"../../../../../test/resources/pod_without_namespace.yaml"},
+				PolicyReport:  true,
+				Namespace:     "myapp-namespace",
+			},
+			expectedReports: []openreportsv1alpha1.Report{{
+				Summary: openreportsv1alpha1.ReportSummary{
+					Pass:  1,
+					Fail:  0,
+					Skip:  0,
+					Error: 0,
+					Warn:  0,
+				},
+			}},
+		},
 	}
 
 	compareSummary := func(expected openreportsv1alpha1.ReportSummary, actual openreportsv1alpha1.ReportSummary, desc string) {

--- a/cmd/cli/kubectl-kyverno/processor/generate.go
+++ b/cmd/cli/kubectl-kyverno/processor/generate.go
@@ -33,7 +33,7 @@ func handleGeneratePolicy(out io.Writer, store *store.Store, generateResponse *e
 			if err != nil {
 				fmt.Fprintf(out, "failed to get resource bytes\n")
 			} else {
-				r, err := resource.GetUnstructuredResources(resourceBytes)
+				r, err := resource.GetUnstructuredResources(resourceBytes, "")
 				if err != nil {
 					fmt.Fprintf(out, "failed to convert resource bytes to unstructured format\n")
 				}

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor_test.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor_test.go
@@ -99,7 +99,7 @@ func Test_NamespaceSelector(t *testing.T) {
 	rc := &ResultCounts{}
 	for _, tc := range testcases {
 		policyArray, _, _, _, _, _, _, _ := yamlutils.GetPolicy(tc.policy)
-		resourceArray, _ := resource.GetUnstructuredResources(tc.resource)
+		resourceArray, _ := resource.GetUnstructuredResources(tc.resource, "")
 		processor := PolicyProcessor{
 			Store:                &store.Store{},
 			Policies:             policyArray,

--- a/cmd/cli/kubectl-kyverno/resource/duplicate_test.go
+++ b/cmd/cli/kubectl-kyverno/resource/duplicate_test.go
@@ -31,7 +31,7 @@ func TestRemoveDuplicates(t *testing.T) {
 		t.Run(tt.testFile, func(t *testing.T) {
 			fileBytes, err := GetFileBytes(filepath.Join(baseTestDir, tt.testFile))
 			assert.NilError(t, err)
-			resources, err := GetUnstructuredResources(fileBytes)
+			resources, err := GetUnstructuredResources(fileBytes, "")
 			assert.NilError(t, err)
 
 			uniques, duplicates := RemoveDuplicates(resources)

--- a/cmd/cli/kubectl-kyverno/resource/resource.go
+++ b/cmd/cli/kubectl-kyverno/resource/resource.go
@@ -18,14 +18,14 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func GetUnstructuredResources(resourceBytes []byte) ([]*unstructured.Unstructured, error) {
+func GetUnstructuredResources(resourceBytes []byte, fallbackNamespace string) ([]*unstructured.Unstructured, error) {
 	documents, err := yamlutils.SplitDocuments(resourceBytes)
 	if err != nil {
 		return nil, err
 	}
 	resources := make([]*unstructured.Unstructured, 0, len(documents))
 	for _, document := range documents {
-		resource, err := YamlToUnstructured(document)
+		resource, err := YamlToUnstructured(document, fallbackNamespace)
 		if err != nil {
 			return nil, err
 		}
@@ -34,7 +34,11 @@ func GetUnstructuredResources(resourceBytes []byte) ([]*unstructured.Unstructure
 	return resources, nil
 }
 
-func YamlToUnstructured(resourceYaml []byte) (*unstructured.Unstructured, error) {
+func YamlToUnstructured(resourceYaml []byte, fallbackNamespace string) (*unstructured.Unstructured, error) {
+	if fallbackNamespace == "" {
+		fallbackNamespace = "default"
+	}
+
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	_, metaData, decodeErr := decode(resourceYaml, nil, nil)
 	if decodeErr != nil {
@@ -54,7 +58,7 @@ func YamlToUnstructured(resourceYaml []byte) (*unstructured.Unstructured, error)
 		resource.SetGroupVersionKind(*metaData)
 	}
 	if resource.GetNamespace() == "" {
-		resource.SetNamespace("default")
+		resource.SetNamespace(fallbackNamespace)
 	}
 	// Normalize nil map fields to empty maps
 	// This handles cases where YAML has keys without values (e.g., "annotations:")
@@ -84,7 +88,7 @@ func GetResourceFromPath(fs billy.Filesystem, path string, apiVersion, kind, res
 		}
 		resourceBytes = data
 	}
-	resources, err := GetUnstructuredResources(resourceBytes)
+	resources, err := GetUnstructuredResources(resourceBytes, resourceNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cli/kubectl-kyverno/resource/resource_test.go
+++ b/cmd/cli/kubectl-kyverno/resource/resource_test.go
@@ -158,7 +158,7 @@ data:`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resource, err := YamlToUnstructured([]byte(tt.yaml))
+			resource, err := YamlToUnstructured([]byte(tt.yaml), "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("YamlToUnstructured() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/cli/kubectl-kyverno/utils/common/common.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common.go
@@ -55,7 +55,7 @@ func GetResourceAccordingToResourcePath(
 				}
 
 				yamlBytes := []byte(resourceStr)
-				resources, err = resource.GetUnstructuredResources(yamlBytes)
+				resources, err = resource.GetUnstructuredResources(yamlBytes, namespace)
 				if err != nil {
 					return nil, fmt.Errorf("failed to extract the resources (%w)", err)
 				}

--- a/cmd/cli/kubectl-kyverno/utils/common/fetch.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/fetch.go
@@ -81,7 +81,7 @@ func (rf *ResourceFetcher) getFromLocalFiles() ([]*unstructured.Unstructured, er
 			continue
 		}
 
-		getResources, err := resource.GetUnstructuredResources(resourceBytes)
+		getResources, err := resource.GetUnstructuredResources(resourceBytes, rf.Namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -367,7 +367,7 @@ func GetResourcesWithTest(out io.Writer, fs billy.Filesystem, resourcePaths []st
 				continue
 			}
 
-			getResources, err := resource.GetUnstructuredResources(resourceBytes)
+			getResources, err := resource.GetUnstructuredResources(resourceBytes, "")
 			if err != nil {
 				return nil, err
 			}

--- a/docs/user/cli/commands/kyverno_apply.md
+++ b/docs/user/cli/commands/kyverno_apply.md
@@ -58,7 +58,7 @@ kyverno apply [flags]
   -h, --help                               help for apply
       --json strings                       Path to JSON payload files
       --kubeconfig string                  path to kubeconfig file with authorization and master location information
-  -n, --namespace string                   Optional Policy parameter passed with cluster flag
+  -n, --namespace string                   Optional Policy parameter
   -o, --output string                      Prints the mutated/generated resources in provided file/directory
       --output-format string               Specifies the policy report format (json or yaml). Default: yaml. (default "yaml")
       --parameter-resource strings         Path to resource files that act as ValidatingAdmissionPolicy/MutatingAdmissionPolicy parameters

--- a/test/best_practices/disallow_default_namespace.yaml
+++ b/test/best_practices/disallow_default_namespace.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-default-namespace
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+    policies.kyverno.io/title: Disallow Default Namespace
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: Kubernetes Namespaces are an optional feature that provide a way to segment and isolate cluster resources across multiple applications and users. As a best practice, workloads should be isolated with Namespaces. Namespaces should be required and the default (empty) Namespace should not be used. This policy validates that Pods specify a Namespace name other than `default`. Rule auto-generation is disabled here due to Pod controllers need to specify the `namespace` field under the top-level `metadata` object and not at the Pod template level.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: validate-namespace
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: Using 'default' namespace is not allowed.
+        pattern:
+          metadata:
+            namespace: "!default"
+    - name: validate-podcontroller-namespace
+      match:
+        any:
+          - resources:
+              kinds:
+                - DaemonSet
+                - Deployment
+                - Job
+                - StatefulSet
+      validate:
+        message: Using 'default' namespace is not allowed for pod controllers.
+        pattern:
+          metadata:
+            namespace: "!default"

--- a/test/best_practices/disallow_latest_tag_namespaced_explicit.yaml
+++ b/test/best_practices/disallow_latest_tag_namespaced_explicit.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+    policies.kyverno.io/category: Workload Isolation
+    policies.kyverno.io/description: The ':latest' tag is mutable and can lead to
+      unexpected errors if the image changes. A best practice is to use an immutable
+      tag that maps to a specific version of an application pod.
+  name: disallow-latest-tag
+  namespace: custom
+spec:
+  admission: true
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: validate-image-tag
+    validate:
+      message: Using a mutable image tag e.g. 'latest' is not allowed
+      pattern:
+        spec:
+          containers:
+          - image: '!*:latest'
+  validationFailureAction: Audit

--- a/test/best_practices/disallow_latest_tag_namespaced_implicit.yaml
+++ b/test/best_practices/disallow_latest_tag_namespaced_implicit.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+    policies.kyverno.io/category: Workload Isolation
+    policies.kyverno.io/description: The ':latest' tag is mutable and can lead to
+      unexpected errors if the image changes. A best practice is to use an immutable
+      tag that maps to a specific version of an application pod.
+  name: disallow-latest-tag
+  # NOTE: namespace is intentionally not set to test the correct is one injected
+spec:
+  admission: true
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: validate-image-tag
+    validate:
+      message: Using a mutable image tag e.g. 'latest' is not allowed
+      pattern:
+        spec:
+          containers:
+          - image: '!*:latest'
+  validationFailureAction: Audit

--- a/test/resources/pod_with_latest_tag_custom_namespace.yaml
+++ b/test/resources/pod_with_latest_tag_custom_namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  namespace: custom
+  labels:
+    app: myapp
+spec: 
+  containers:
+  - name: nginx
+    image: nginx:latest

--- a/test/resources/pod_without_namespace.yaml
+++ b/test/resources/pod_without_namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec: 
+  containers:
+  - name: nginx
+    image: nginx:1.12


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

While it is considered best practice to always explicitly include .metadata.namespace in the manifests for namespaced resources - for example, by using "{{ .Release.Namespace }}" in Helm charts - it isn't always done, because it isn't strictly necessary to deploy to the correct namespace.

When a manifest for a namespaced resource doesn't include the namespace, kubectl (and other tools using it, like Helm and ArgoCD) first tries the namespace passed to the CLI (-n/--namespace), then the namespace configured on the context, and only then falls back to "default".

Therefore, kyverno apply should follow the same behavior, and use the -n/--namespace flag to inject the namespace into manifests that don't set one (until this commit, the flag was only used when applying kyverno policies against live resources on a cluster).

To keep the impact minimal, the fallback namespace parameter falls back to "default" when set to an empty string, and only the ResourceFetcher used by the apply and test CLI commands sets it to a non-empty string - if a namespace was passed as a command line flag.

The test verifies exactly this behavior: for a Pod manifest that doesn't specify a namespace, and a ClusterPolicy that disallows the usage of the "default" namespace (at least for some resources including Pods), the policy will pass when running kyverno apply with the namespace flag set, and fail if running it without it (because the "default" namespace is used in that case).

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

I've tried finding one, but any search query with "namespace" in it wil return  many unrelated PRs with example manifests in it....

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

TODO: I don't know whether updating the CLI flag help text is enough. I guess it would be automatically updated on the website's documentation?

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

1. Prior to this PR, when running `kyverno apply` against a (or multiple) manifest for a namespaced resource that doesn't include `.metadata.namespace`, kyverno would **always** inject `default` as the namespace

For example, this Pod manifest:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: myapp-pod
  labels:
    app: myapp
spec: 
  containers:
  - name: nginx
    image: nginx:1.12
```

Would be patched to look like this before the policies are applied:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: myapp-pod
  namespace: default
  labels:
    app: myapp
spec: 
  containers:
  - name: nginx
    image: nginx:1.12
```

2. This PR changes the behavior to use the namespace from the `-n`/`--namespace` CLI flag instead of `default` if the CLI flag is set. When running `kyverno apply -n myapp-namespace <path to policies> <path to pod manifest>`, the resulting manifest would be this one:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: myapp-pod
  namespace: myapp-namespace
  labels:
    app: myapp
spec: 
  containers:
  - name: nginx
    image: nginx:1.12
```

This helps in scenarios where the manifests don't (always) include a namespace, but are applied (via kubectl or tools based on it) against a specific namespace (other than default) - by aligning the behavior of `kyverno apply -n <namespace>` with `kubectl apply -n <namespace>`.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

This isn't about the policy engine or the operation of Kyverno in a cluster, just the behavior of the offline apply command.
However, a test validating the behavior is added.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] ((I'm not sure whether to categorize this as bug fix or feature, but I've added tests)
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
