### PR TITLE
fix(cel): replace context.TODO() with real context in CEL image verification functions.

### DIFF
--- a/pkg/cel/libs/imageverify/impl.go
+++ b/pkg/cel/libs/imageverify/impl.go
@@ -21,6 +21,7 @@ import (
 type ivfuncs struct {
 	types.Adapter
 
+	ctx             context.Context
 	logger          logr.Logger
 	imgCtx          imagedataloader.ImageContext
 	creds           *v1beta1.Credentials
@@ -31,6 +32,7 @@ type ivfuncs struct {
 }
 
 func ImageVerifyCELFuncs(
+	ctx context.Context,
 	logger logr.Logger,
 	imgCtx imagedataloader.ImageContext,
 	ivpol v1beta1.ImageValidatingPolicyLike,
@@ -51,6 +53,7 @@ func ImageVerifyCELFuncs(
 	}
 	return &ivfuncs{
 		Adapter:         adapter,
+		ctx:             ctx,
 		imgCtx:          imgCtx,
 		creds:           spec.Credentials,
 		imgRules:        imgRules,
@@ -61,7 +64,7 @@ func ImageVerifyCELFuncs(
 }
 
 func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attestors ref.Val) ref.Val {
-	ctx := context.TODO()
+	ctx := f.ctx
 	if image, err := utils.ConvertToNative[string](image); err != nil {
 		return types.WrapErr(err)
 	} else if attestors, err := utils.ConvertToNative[[]v1beta1.Attestor](attestors); err != nil {
@@ -106,7 +109,7 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 }
 
 func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...ref.Val) ref.Val {
-	ctx := context.TODO()
+	ctx := f.ctx
 	if len(args) != 3 {
 		return types.NewErr("function usage: <image> <attestation> <attestor list>")
 	}
@@ -162,7 +165,7 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 }
 
 func (f *ivfuncs) payload_string_string(image ref.Val, attestation ref.Val) ref.Val {
-	ctx := context.TODO()
+	ctx := f.ctx
 	if image, err := utils.ConvertToNative[string](image); err != nil {
 		return types.WrapErr(err)
 	} else if attestation, err := utils.ConvertToNative[string](attestation); err != nil {
@@ -186,7 +189,7 @@ func (f *ivfuncs) payload_string_string(image ref.Val, attestation ref.Val) ref.
 }
 
 func (f *ivfuncs) get_image_data_string(image ref.Val) ref.Val {
-	ctx := context.TODO()
+	ctx := f.ctx
 	if image, err := utils.ConvertToNative[string](image); err != nil {
 		return types.WrapErr(err)
 	} else {

--- a/pkg/cel/libs/imageverify/impl_test.go
+++ b/pkg/cel/libs/imageverify/impl_test.go
@@ -1,6 +1,7 @@
 package imageverify
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/cel-go/cel"
@@ -61,7 +62,7 @@ func Test_impl_verify_image_signature_string_stringarray(t *testing.T) {
 
 	options := []cel.EnvOption{
 		cel.Variable("attestors", cel.MapType(cel.StringType, cel.DynType)),
-		Lib(nil, imgCtx, ivpol, nil),
+		Lib(context.Background(), nil, imgCtx, ivpol, nil),
 	}
 	env, err := cel.NewEnv(options...)
 	assert.NoError(t, err)
@@ -99,7 +100,7 @@ func Test_impl_verify_image_attestations_string_string_stringarray(t *testing.T)
 
 	options := []cel.EnvOption{
 		cel.Variable("attestors", cel.MapType(cel.StringType, cel.DynType)),
-		Lib(nil, imgCtx, ivpol, nil),
+		Lib(context.Background(), nil, imgCtx, ivpol, nil),
 	}
 	env, err := cel.NewEnv(options...)
 	assert.NoError(t, err)

--- a/pkg/cel/libs/imageverify/lib.go
+++ b/pkg/cel/libs/imageverify/lib.go
@@ -1,6 +1,8 @@
 package imageverify
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
@@ -15,6 +17,7 @@ import (
 const libraryName = "kyverno.imageverify"
 
 type lib struct {
+	ctx     context.Context
 	logger  logr.Logger
 	version *version.Version
 	imgCtx  imagedataloader.ImageContext
@@ -26,9 +29,10 @@ func Latest() *version.Version {
 	return versions.KyvernoLatest
 }
 
-func Lib(v *version.Version, imgCtx imagedataloader.ImageContext, ivpol policiesv1beta1.ImageValidatingPolicyLike, lister k8scorev1.SecretInterface) cel.EnvOption {
+func Lib(ctx context.Context, v *version.Version, imgCtx imagedataloader.ImageContext, ivpol policiesv1beta1.ImageValidatingPolicyLike, lister k8scorev1.SecretInterface) cel.EnvOption {
 	// create the cel lib env option
 	return cel.Lib(&lib{
+		ctx:     ctx,
 		version: v,
 		imgCtx:  imgCtx,
 		ivpol:   ivpol,
@@ -55,7 +59,7 @@ func (*lib) ProgramOptions() []cel.ProgramOption {
 }
 
 func (c *lib) extendEnv(env *cel.Env) (*cel.Env, error) {
-	impl, err := ImageVerifyCELFuncs(c.logger, c.imgCtx, c.ivpol, c.lister, env.CELTypeAdapter())
+	impl, err := ImageVerifyCELFuncs(c.ctx, c.logger, c.imgCtx, c.ivpol, c.lister, env.CELTypeAdapter())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cel/policies/ivpol/engine/engine.go
+++ b/pkg/cel/policies/ivpol/engine/engine.go
@@ -249,7 +249,7 @@ func (e *engineImpl) handleMutation(
 			Exceptions: ivpol.Exceptions,
 		}
 		startTime := time.Now()
-		if p, errList := c.Compile(ivpol.Policy, ivpol.Exceptions); errList != nil {
+		if p, errList := c.Compile(ctx, ivpol.Policy, ivpol.Exceptions); errList != nil {
 			response.Result = *engineapi.RuleError("evaluation", engineapi.ImageVerify, "failed to compile policy", errList.ToAggregate(), nil)
 		} else {
 			result, err := p.Evaluate(ctx, ictx, attr, request, namespace, true, context)

--- a/pkg/image/verification/evaluator/compiler.go
+++ b/pkg/image/verification/evaluator/compiler.go
@@ -38,7 +38,7 @@ import (
 var ivpolCompilerVersion = version.MajorMinor(1, 0)
 
 type Compiler interface {
-	Compile(policiesv1beta1.ImageValidatingPolicyLike, []*policiesv1beta1.PolicyException) (CompiledPolicy, field.ErrorList)
+	Compile(context.Context, policiesv1beta1.ImageValidatingPolicyLike, []*policiesv1beta1.PolicyException) (CompiledPolicy, field.ErrorList)
 }
 
 func NewCompiler(ictx imagedataloader.ImageContext, lister k8scorev1.SecretInterface, reqGVR *metav1.GroupVersionResource) Compiler {
@@ -55,9 +55,11 @@ type compilerImpl struct {
 	reqGVR *metav1.GroupVersionResource
 }
 
-func (c *compilerImpl) Compile(ivpolicy policiesv1beta1.ImageValidatingPolicyLike, exceptions []*policiesv1beta1.PolicyException) (CompiledPolicy, field.ErrorList) {
+func (c *compilerImpl) Compile(ctx context.Context, ivpolicy policiesv1beta1.ImageValidatingPolicyLike, exceptions []*policiesv1beta1.PolicyException) (CompiledPolicy, field.ErrorList) {
 	var allErrs field.ErrorList
-	ivpolEnvSet, variablesProvider, err := c.createBaseIvpolEnv(libs.GetLibsCtx(), ivpolicy)
+
+	libsCtx := libs.GetLibsCtx()
+	ivpolEnvSet, variablesProvider, err := c.createBaseIvpolEnv(ctx, libsCtx, ivpolicy)
 	if err != nil {
 		return nil, append(allErrs, field.InternalError(nil, err))
 	}
@@ -149,7 +151,7 @@ func (c *compilerImpl) Compile(ivpolicy policiesv1beta1.ImageValidatingPolicyLik
 	}
 
 	return &compiledPolicy{
-		failurePolicy:        ivpolicy.GetFailurePolicy(toggle.FromContext(context.TODO()).ForceFailurePolicyIgnore()),
+		failurePolicy:        ivpolicy.GetFailurePolicy(toggle.FromContext(ctx).ForceFailurePolicyIgnore()),
 		matchConditions:      matchConditions,
 		matchImageReferences: matchImageReferences,
 		validations:          validations,
@@ -163,7 +165,7 @@ func (c *compilerImpl) Compile(ivpolicy policiesv1beta1.ImageValidatingPolicyLik
 	}, nil
 }
 
-func (c *compilerImpl) createBaseIvpolEnv(libsctx libs.Context, ivpol policiesv1beta1.ImageValidatingPolicyLike) (*environment.EnvSet, *engine.VariablesProvider, error) {
+func (c *compilerImpl) createBaseIvpolEnv(ctx context.Context, libsctx libs.Context, ivpol policiesv1beta1.ImageValidatingPolicyLike) (*environment.EnvSet, *engine.VariablesProvider, error) {
 	baseOpts := engine.DefaultEnvOptions()
 	baseOpts = append(baseOpts,
 		cel.Variable(engine.ResourceKey, resource.ContextType),
@@ -211,7 +213,7 @@ func (c *compilerImpl) createBaseIvpolEnv(libsctx libs.Context, ivpol policiesv1
 			imagedata.Latest(),
 		),
 		imageverify.Lib(
-			imageverify.Latest(), c.ictx, ivpol, c.lister,
+			ctx, imageverify.Latest(), c.ictx, ivpol, c.lister,
 		),
 		resource.Lib(
 			resource.Context{ContextInterface: libsctx},

--- a/pkg/image/verification/evaluator/eval.go
+++ b/pkg/image/verification/evaluator/eval.go
@@ -40,7 +40,7 @@ func Evaluate(ctx context.Context, ivpols []*CompiledImageValidatingPolicy, requ
 	c := NewCompiler(ictx, lister, gvr)
 	results := make(map[string]*EvaluationResult, len(policies))
 	for _, ivpol := range policies {
-		p, errList := c.Compile(ivpol.Policy, ivpol.Exceptions)
+		p, errList := c.Compile(ctx, ivpol.Policy, ivpol.Exceptions)
 		if errList != nil {
 			return nil, fmt.Errorf("failed to compile policy %v", errList)
 		}

--- a/pkg/image/verification/evaluator/validate.go
+++ b/pkg/image/verification/evaluator/validate.go
@@ -1,6 +1,7 @@
 package evaluator
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 
@@ -97,7 +98,7 @@ func Validate(ivpol policiesv1beta1.ImageValidatingPolicyLike, lister k8scorev1.
 	}
 
 	compiler := NewCompiler(ictx, lister, nil)
-	_, errList := compiler.Compile(ivpol, nil)
+	_, errList := compiler.Compile(context.Background(), ivpol, nil)
 
 	errs := make(field.ErrorList, 0, len(errList))
 	if len(errList) > 0 {


### PR DESCRIPTION
## Description

Fixes #15468

All four CEL image verification functions in [pkg/cel/libs/imageverify/impl.go](cci:7://file:///Users/satyam/Desktop/open%20source%20lfx/Kyverno/kyverno/pkg/cel/libs/imageverify/impl.go:0:0-0:0)
used `context.TODO()` — a non-cancellable placeholder. If the admission webhook
request is cancelled or times out, image fetching and cryptographic verification
continue running indefinitely, wasting resources.

### Changes
- Added `ctx context.Context` field to [ivfuncs](cci:2://file:///Users/satyam/Desktop/open%20source%20lfx/Kyverno/kyverno/pkg/cel/libs/imageverify/impl.go:20:0-31:1) struct
- Threaded the real request-scoped context from [Evaluate(ctx)](cci:1://file:///Users/satyam/Desktop/open%20source%20lfx/Kyverno/kyverno/pkg/imageverification/evaluator/eval.go:24:0-54:1) all the way down:
  [Compile(ctx)](cci:1://file:///Users/satyam/Desktop/open%20source%20lfx/Kyverno/kyverno/pkg/imageverification/evaluator/compiler.go:57:0-165:1) → [createBaseIvpolEnv(ctx, ...)](cci:1://file:///Users/satyam/Desktop/open%20source%20lfx/Kyverno/kyverno/pkg/imageverification/evaluator/compiler.go:167:0-266:1) → `imageverify.Lib(ctx, ...)` → [ImageVerifyCELFuncs(ctx)](cci:1://file:///Users/satyam/Desktop/open%20source%20lfx/Kyverno/kyverno/pkg/cel/libs/imageverify/impl.go:33:0-63:1) → `f.ctx`
- Replaced all 4 `context.TODO()` locals with `f.ctx`
- Updated [Compiler](cci:2://file:///Users/satyam/Desktop/open%20source%20lfx/Kyverno/kyverno/pkg/imageverification/evaluator/compiler.go:39:0-41:1) interface to accept `context.Context`
- Updated tests accordingly

### Files Changed
- [pkg/cel/libs/imageverify/impl.go](cci:7://file:///Users/satyam/Desktop/open%20source%20lfx/Kyverno/kyverno/pkg/cel/libs/imageverify/impl.go:0:0-0:0)
- [pkg/cel/libs/imageverify/lib.go](cci:7://file:///Users/satyam/Desktop/open%20source%20lfx/Kyverno/kyverno/pkg/cel/libs/imageverify/lib.go:0:0-0:0)
- [pkg/cel/libs/imageverify/impl_test.go](cci:7://file:///Users/satyam/Desktop/open%20source%20lfx/Kyverno/kyverno/pkg/cel/libs/imageverify/impl_test.go:0:0-0:0)
- [pkg/imageverification/evaluator/compiler.go](cci:7://file:///Users/satyam/Desktop/open%20source%20lfx/Kyverno/kyverno/pkg/imageverification/evaluator/compiler.go:0:0-0:0)
- [pkg/imageverification/evaluator/eval.go](cci:7://file:///Users/satyam/Desktop/open%20source%20lfx/Kyverno/kyverno/pkg/imageverification/evaluator/eval.go:0:0-0:0)
- `pkg/imageverification/evaluator/validate.go`
