### PR TITLE
fix(event): warn on omitEvents/successEvents clash

### DIFF
--- a/pkg/event/controller.go
+++ b/pkg/event/controller.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -54,6 +55,7 @@ type controller struct {
 	metrics         metrics.EventMetrics
 	maxQueuedEvents int
 	cfg             config.Configuration
+	warnOnce        sync.Once
 }
 
 // NewEventGenerator to generate a new event controller
@@ -92,6 +94,11 @@ func (gen *controller) Add(infos ...Info) {
 			continue
 		}
 		if gen.omitEvents.Has(string(info.Reason)) {
+			if info.Reason == PolicyApplied && gen.cfg.GetGenerateSuccessEvents() {
+				gen.warnOnce.Do(func() {
+					logger.Error(nil, "generateSuccessEvents is enabled but PolicyApplied is in omitEvents -- no success events will be generated, remove PolicyApplied from --omitEvents to fix this")
+				})
+			}
 			logger.V(6).Info("omitting event", "kind", info.Regarding.Kind, "name", info.Regarding.Name, "namespace", info.Regarding.Namespace, "reason", info.Reason, "action", info.Action, "note", info.Message)
 			continue
 		}


### PR DESCRIPTION


## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

When `generateSuccessEvents` is set to true in the Kyverno ConfigMap but `PolicyApplied` is included in `--omitEvents` (the Helm chart default), success events are silently dropped. This fix adds an error log to alert operators about the misconfiguration so they can remove PolicyApplied from `--omitEvents`.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

https://github.com/kyverno/kyverno/pull/15466#issuecomment-4019831343

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change -->
/kind bug
<!--
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

An error log is emitted once when `info.Reason == PolicyApplied` and `generateSuccessEvents` is enabled. This makes the conflict between the two settings visible in controller logs rather than silently dropping events.

### Proof Manifests

Deploy Kyverno with omitEvents including PolicyApplied:

```bash
helm upgrade kyverno charts/kyverno -n kyverno --set 'features.omitEvents.eventTypes={PolicyApplied,PolicySkipped}'
kubectl patch cm kyverno -n kyverno --type merge -p '{"data":{"generateSuccessEvents":"true"}}'
```

Policy:

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: Audit
  rules:
  - name: check-team-label
    match:
      any:
      - resources:
          kinds:
          - Pod
    validate:
      message: "label 'team' is required"
      pattern:
        metadata:
          labels:
            team: "?*"
```

Create a pod:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
  namespace: default
  labels:
    team: backend
spec:
  containers:
  - name: nginx
    image: nginx
```

Check logs:

```bash
kubectl logs -n kyverno -l app.kubernetes.io/component=admission-controller | grep "generateSuccessEvents"
```

Output:

```
ERR > generateSuccessEvents is enabled but PolicyApplied is in omitEvents -- no success events will be generated, remove PolicyApplied from --omitEvents to fix this
```


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

`sync.Once` guards the error log because even a single pod creation can trigger 12+ PolicyApplied events through the admission controller.