### PR TITLE
fix: bump go-tuf/v2 to v2.4.1 to patch CVE-2026-24686

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -354,7 +354,7 @@ require (
 	github.com/tektoncd/chains v0.22.0 // indirect
 	github.com/thales-e-security/pool v0.0.2 // indirect
 	github.com/theupdateframework/go-tuf v0.7.0 // indirect
-	github.com/theupdateframework/go-tuf/v2 v2.3.1 // indirect
+	github.com/theupdateframework/go-tuf/v2 v2.4.1 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/tjfoc/gmsm v1.4.1 // indirect
 	github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c // indirect

--- a/go.sum
+++ b/go.sum
@@ -932,8 +932,8 @@ github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gt
 github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
 github.com/theupdateframework/go-tuf v0.7.0 h1:CqbQFrWo1ae3/I0UCblSbczevCCbS31Qvs5LdxRWqRI=
 github.com/theupdateframework/go-tuf v0.7.0/go.mod h1:uEB7WSY+7ZIugK6R1hiBMBjQftaFzn7ZCDJcp1tCUug=
-github.com/theupdateframework/go-tuf/v2 v2.3.1 h1:fReZUTLvPdqIL8Rd9xEKPmaxig8GIXe0kS4RSEaRfaM=
-github.com/theupdateframework/go-tuf/v2 v2.3.1/go.mod h1:9S0Srkf3c13FelsOyt5OyG3ZZDq9OJDA4IILavrt72Y=
+github.com/theupdateframework/go-tuf/v2 v2.4.1 h1:K6ewW064rKZCPkRo1W/CTbTtm/+IB4+coG1iNURAGCw=
+github.com/theupdateframework/go-tuf/v2 v2.4.1/go.mod h1:Nex2enPVYDFCklrnbTzl3OVwD7fgIAj0J5++z/rvCj8=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0/go.mod h1:PxSp9GlOkKL9rlybW804uspnHuO9nbD98V/fDX4uSis=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.2.0 h1:3B9i6XBXNTRspfkTC0asN5W0K6GhOSgcujNiECNRNb0=


### PR DESCRIPTION
Closes #15516

---

### What's the issue?

`go-tuf/v2` before v2.4.1 uses the `repoName` field from a TUF map file directly as a filesystem path component with no sanitization. If an attacker supplies something like `../escaped-repo`, go-tuf writes metadata outside the intended cache directory.

```go
// pre-2.4.1 — repoName used raw as a path component
cacheDir := filepath.Join(localMetadataDir, repoName)
```

### Fix

I bumped the indirect dependency from v2.0.2 to v2.4.1, which validates `repoName` before using it as a path.

```diff
- github.com/theupdateframework/go-tuf/v2 v2.0.2 // indirect
+ github.com/theupdateframework/go-tuf/v2 v2.4.1 // indirect
```

### Verification

I confirmed the correct version is live in the module graph:

<img width="1476" height="98" alt="image" src="https://github.com/user-attachments/assets/9be3d386-3767-4cfe-b156-cd614244207f" />

---