### PR TITLE
fix: expose original request object/oldObject via params in MutatingPolicy for mutate existing resources

### DIFF
--- a/pkg/cel/compiler/keys.go
+++ b/pkg/cel/compiler/keys.go
@@ -16,4 +16,6 @@ const (
 	GeneratorKey       = "generator"
 	VariablesKey       = "variables"
 	ExceptionsKey      = "exceptions"
+	OriginalRequestKey = "originalRequest"
+	ParamsKey          = "params"
 )

--- a/pkg/cel/policies/mpol/compiler/compiler.go
+++ b/pkg/cel/policies/mpol/compiler/compiler.go
@@ -62,6 +62,7 @@ func (c *compilerImpl) Compile(policy policiesv1beta1.MutatingPolicyLike, except
 				cel.Variable(compiler.OldObjectKey, cel.DynType),
 				cel.Variable(compiler.RequestKey, compiler.RequestType.CelType()),
 				cel.Variable(compiler.ImagesKey, image.ImageType),
+				cel.Variable(compiler.ParamsKey, cel.DynType),
 				cel.Types(compiler.NamespaceType.CelType()),
 				cel.Types(compiler.RequestType.CelType()),
 				globalcontext.Lib(globalcontext.Context{ContextInterface: libCtx}, globalcontext.Latest()),

--- a/pkg/cel/policies/mpol/compiler/policy.go
+++ b/pkg/cel/policies/mpol/compiler/policy.go
@@ -11,7 +11,9 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/cel/compiler"
+	"github.com/kyverno/kyverno/pkg/cel/engine"
 	"github.com/kyverno/kyverno/pkg/cel/libs"
+	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	"github.com/kyverno/sdk/cel/utils"
 	"go.uber.org/multierr"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -49,7 +51,7 @@ func (c *compositionContext) Variables(activation any) ref.Val {
 	lazyMap := lazy.NewMapValue(c.evaluator.CompositionEnv.MapType)
 
 	// Extract object and oldObject from the activation context
-	var objectVal, oldObjectVal interface{}
+	var objectVal, oldObjectVal, paramsVal interface{}
 	if evalActivation, ok := activation.(interface {
 		ResolveName(string) (interface{}, bool)
 	}); ok {
@@ -59,6 +61,9 @@ func (c *compositionContext) Variables(activation any) ref.Val {
 		if oldObj, found := evalActivation.ResolveName("oldObject"); found {
 			oldObjectVal = oldObj
 		}
+		if paramsObj, found := evalActivation.ResolveName("params"); found {
+			paramsVal = paramsObj
+		}
 	}
 
 	// Set up context data for variable evaluation
@@ -66,6 +71,7 @@ func (c *compositionContext) Variables(activation any) ref.Val {
 		compiler.VariablesKey: lazyMap,
 		compiler.ObjectKey:    objectVal,
 		compiler.OldObjectKey: oldObjectVal,
+		compiler.ParamsKey:    paramsVal,
 	}
 
 	for name, result := range c.evaluator.CompositionEnv.CompiledVariables {
@@ -106,14 +112,18 @@ func (c *compositionContext) Value(key interface{}) interface{} {
 	return c.ctx.Value(key)
 }
 
-func (p *Policy) MatchesConditions(ctx context.Context, attr admission.Attributes, namespace *corev1.Namespace) bool {
+func (p *Policy) MatchesConditions(ctx context.Context, attr admission.Attributes, namespace *corev1.Namespace, request engine.EngineRequest) bool {
 	if p.evaluator.Matcher != nil {
 		versionedAttributes := &admission.VersionedAttributes{
 			Attributes:      attr,
 			VersionedObject: attr.GetObject(),
 			VersionedKind:   attr.GetKind(),
 		}
-		matchResult := p.evaluator.Matcher.Match(ctx, versionedAttributes, namespace, nil)
+		params, err := p.getParams(request.Request)
+		if err != nil {
+			return false
+		}
+		matchResult := p.evaluator.Matcher.Match(ctx, versionedAttributes, params, nil)
 		if matchResult.Error != nil || !matchResult.Matches {
 			return false
 		}
@@ -137,8 +147,13 @@ func (p *Policy) Evaluate(
 		VersionedKind:   attr.GetKind(),
 	}
 
+	params, err := p.getParams(request)
+	if err != nil {
+		return &EvaluationResult{Error: err}
+	}
+
 	if len(p.exceptions) > 0 {
-		matchedExceptions, err := p.matchExceptions(ctx, attr, request, namespace)
+		matchedExceptions, err := p.matchExceptions(ctx, attr, params, request, namespace)
 		if err != nil {
 			return &EvaluationResult{Error: err}
 		}
@@ -154,7 +169,7 @@ func (p *Policy) Evaluate(
 	}
 
 	if p.evaluator.Matcher != nil {
-		matchResult := p.evaluator.Matcher.Match(compositionCtx, versionedAttributes, namespace, nil)
+		matchResult := p.evaluator.Matcher.Match(compositionCtx, versionedAttributes, params, nil)
 		if matchResult.Error != nil {
 			return &EvaluationResult{Error: matchResult.Error}
 		}
@@ -169,7 +184,7 @@ func (p *Policy) Evaluate(
 			MatchedResource:     attr.GetResource(),
 			VersionedAttributes: versionedAttributes,
 			ObjectInterfaces:    o,
-			OptionalVariables:   plugincel.OptionalVariableBindings{VersionedParams: nil, Authorizer: nil},
+			OptionalVariables:   plugincel.OptionalVariableBindings{VersionedParams: params, Authorizer: nil},
 			Namespace:           namespace,
 			TypeConverter:       tcm.GetTypeConverter(versionedAttributes.VersionedKind),
 		}
@@ -186,7 +201,31 @@ func (p *Policy) Evaluate(
 	return &EvaluationResult{PatchedResource: versionedAttributes.VersionedObject.(*unstructured.Unstructured)}
 }
 
-func (p *Policy) matchExceptions(ctx context.Context, attr admission.Attributes, request admissionv1.AdmissionRequest, namespace *corev1.Namespace) ([]*policiesv1beta1.PolicyException, error) {
+func (p *Policy) getParams(request admissionv1.AdmissionRequest) (*unstructured.Unstructured, error) {
+	originalRequestObject, originalRequestOldObject, err := admissionutils.ExtractResources(nil, request)
+	if err != nil {
+		return nil, err
+	}
+	originalRequestObjectVal, err := utils.ObjectToResolveVal(&originalRequestObject)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare object variable for evaluation: %w", err)
+	}
+	originalRequestOldObjectVal, err := utils.ObjectToResolveVal(&originalRequestOldObject)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare object variable for evaluation: %w", err)
+	}
+
+	originalRequestData := map[string]any{
+		compiler.ObjectKey:    originalRequestObjectVal,
+		compiler.OldObjectKey: originalRequestOldObjectVal,
+	}
+	paramsData := map[string]any{
+		compiler.OriginalRequestKey: originalRequestData,
+	}
+	return &unstructured.Unstructured{Object: paramsData}, nil
+}
+
+func (p *Policy) matchExceptions(ctx context.Context, attr admission.Attributes, params *unstructured.Unstructured, request admissionv1.AdmissionRequest, namespace *corev1.Namespace) ([]*policiesv1beta1.PolicyException, error) {
 	var errs []error
 	matchedExceptions := make([]*policiesv1beta1.PolicyException, 0)
 	objectVal, err := utils.ObjectToResolveVal(attr.GetObject())
@@ -201,6 +240,7 @@ func (p *Policy) matchExceptions(ctx context.Context, attr admission.Attributes,
 	data := map[string]any{
 		compiler.NamespaceObjectKey: namespaceVal,
 		compiler.ObjectKey:          objectVal,
+		compiler.ParamsKey:          params,
 	}
 
 	if attr.GetOldObject() != nil {

--- a/pkg/cel/policies/mpol/compiler/policy_test.go
+++ b/pkg/cel/policies/mpol/compiler/policy_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/cel-go/common/types"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/cel/compiler"
+	"github.com/kyverno/kyverno/pkg/cel/engine"
 	"github.com/kyverno/kyverno/pkg/cel/libs"
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -404,7 +405,7 @@ func TestMatchesConditions(t *testing.T) {
 	ctx := context.TODO()
 	t.Run("no matcher", func(t *testing.T) {
 		p := Policy{}
-		res := p.MatchesConditions(ctx, &mockAttributes{}, &corev1.Namespace{})
+		res := p.MatchesConditions(ctx, &mockAttributes{}, &corev1.Namespace{}, engine.EngineRequest{})
 		assert.False(t, res)
 	})
 
@@ -417,7 +418,7 @@ func TestMatchesConditions(t *testing.T) {
 			},
 		}
 
-		res := p.MatchesConditions(ctx, &mockAttributes{}, &corev1.Namespace{})
+		res := p.MatchesConditions(ctx, &mockAttributes{}, &corev1.Namespace{}, engine.EngineRequest{})
 		assert.False(t, res)
 	})
 
@@ -427,7 +428,7 @@ func TestMatchesConditions(t *testing.T) {
 				Matcher: &fakeMatcher{matches: false},
 			},
 		}
-		res := p.MatchesConditions(ctx, &mockAttributes{}, &corev1.Namespace{})
+		res := p.MatchesConditions(ctx, &mockAttributes{}, &corev1.Namespace{}, engine.EngineRequest{})
 		assert.False(t, res)
 	})
 
@@ -437,7 +438,7 @@ func TestMatchesConditions(t *testing.T) {
 				Matcher: &fakeMatcher{matches: true},
 			},
 		}
-		res := p.MatchesConditions(ctx, &mockAttributes{}, &corev1.Namespace{})
+		res := p.MatchesConditions(ctx, &mockAttributes{}, &corev1.Namespace{}, engine.EngineRequest{})
 		assert.True(t, res)
 	})
 }
@@ -481,7 +482,7 @@ func TestMatchExceptions_FullCoverage(t *testing.T) {
 				},
 			},
 		}
-		res, err := p.matchExceptions(ctx, attr, req, validNS)
+		res, err := p.matchExceptions(ctx, attr, nil, req, validNS)
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 	})
@@ -508,7 +509,7 @@ func TestMatchExceptions_FullCoverage(t *testing.T) {
 				},
 			},
 		}
-		res, err := p.matchExceptions(ctx, attr, req, validNS)
+		res, err := p.matchExceptions(ctx, attr, nil, req, validNS)
 		assert.Error(t, err)
 		assert.NotNil(t, res)
 	})
@@ -534,7 +535,7 @@ func TestMatchExceptions_FullCoverage(t *testing.T) {
 				},
 			},
 		}
-		res, err := p.matchExceptions(ctx, attr, req, validNS)
+		res, err := p.matchExceptions(ctx, attr, nil, req, validNS)
 		assert.Error(t, err)
 		assert.NotNil(t, res)
 	})
@@ -552,7 +553,7 @@ func TestMatchExceptions_FullCoverage(t *testing.T) {
 				},
 			},
 		}
-		res, err := p.matchExceptions(ctx, attr, req, validNS)
+		res, err := p.matchExceptions(ctx, attr, nil, req, validNS)
 		assert.NoError(t, err)
 		assert.Empty(t, res)
 	})

--- a/pkg/cel/policies/mpol/engine/engine.go
+++ b/pkg/cel/policies/mpol/engine/engine.go
@@ -301,5 +301,5 @@ func (e *engineImpl) MatchedMutateExistingPolicies(ctx context.Context, request 
 		namespace = e.nsResolver(ns)
 	}
 
-	return e.provider.MatchesMutateExisting(ctx, attr, namespace)
+	return e.provider.MatchesMutateExisting(ctx, attr, namespace, request)
 }

--- a/pkg/cel/policies/mpol/engine/engine_test.go
+++ b/pkg/cel/policies/mpol/engine/engine_test.go
@@ -198,7 +198,7 @@ type mockFailingProvider struct{}
 func (m *mockFailingProvider) Fetch(ctx context.Context, mutate bool) []Policy {
 	return nil
 }
-func (m *mockFailingProvider) MatchesMutateExisting(context.Context, admission.Attributes, *corev1.Namespace) []string {
+func (m *mockFailingProvider) MatchesMutateExisting(context.Context, admission.Attributes, *corev1.Namespace, engine.EngineRequest) []string {
 	return nil
 }
 

--- a/pkg/cel/policies/mpol/engine/provider.go
+++ b/pkg/cel/policies/mpol/engine/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/kyverno/kyverno/pkg/cel/engine"
 	"github.com/kyverno/kyverno/pkg/cel/matching"
 	"github.com/kyverno/kyverno/pkg/cel/policies/mpol/autogen"
 	"github.com/kyverno/kyverno/pkg/cel/policies/mpol/compiler"
@@ -23,7 +24,7 @@ import (
 
 type Provider interface {
 	Fetch(context.Context, bool) []Policy
-	MatchesMutateExisting(context.Context, admission.Attributes, *corev1.Namespace) []string
+	MatchesMutateExisting(context.Context, admission.Attributes, *corev1.Namespace, engine.EngineRequest) []string
 }
 
 func NewKubeProvider(
@@ -113,7 +114,7 @@ func (p *staticProvider) Fetch(ctx context.Context, mutateExisting bool) []Polic
 	return filtered
 }
 
-func (r *staticProvider) MatchesMutateExisting(ctx context.Context, attr admission.Attributes, namespace *corev1.Namespace) []string {
+func (r *staticProvider) MatchesMutateExisting(ctx context.Context, attr admission.Attributes, namespace *corev1.Namespace, request engine.EngineRequest) []string {
 	policies := r.Fetch(ctx, true)
 	matchedPolicies := []string{}
 	for _, mpol := range policies {
@@ -124,7 +125,7 @@ func (r *staticProvider) MatchesMutateExisting(ctx context.Context, attr admissi
 		}
 
 		if mpol.Policy.GetSpec().MatchConditions != nil {
-			if !mpol.CompiledPolicy.MatchesConditions(ctx, attr, namespace) {
+			if !mpol.CompiledPolicy.MatchesConditions(ctx, attr, namespace, request) {
 				continue
 			}
 		}

--- a/pkg/cel/policies/mpol/engine/provider_test.go
+++ b/pkg/cel/policies/mpol/engine/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/kyverno/kyverno/pkg/cel/engine"
 	corev1 "k8s.io/api/core/v1"
 	admissionv1 "k8s.io/apiserver/pkg/admission"
 
@@ -149,7 +150,7 @@ func TestStaticProviderMatchesMutateExisting(t *testing.T) {
 	}
 
 	t.Run("match all", func(t *testing.T) {
-		names := provider.MatchesMutateExisting(context.Background(), &mockAttributes{}, &corev1.Namespace{})
+		names := provider.MatchesMutateExisting(context.Background(), &mockAttributes{}, &corev1.Namespace{}, engine.EngineRequest{})
 		assert.Equal(t, []string{"match"}, names)
 	})
 }

--- a/pkg/cel/policies/mpol/engine/reconciler.go
+++ b/pkg/cel/policies/mpol/engine/reconciler.go
@@ -135,7 +135,7 @@ func (r *reconciler) Fetch(ctx context.Context, mutateExisting bool) []Policy {
 	return policies
 }
 
-func (r *reconciler) MatchesMutateExisting(ctx context.Context, attr admission.Attributes, namespace *corev1.Namespace) []string {
+func (r *reconciler) MatchesMutateExisting(ctx context.Context, attr admission.Attributes, namespace *corev1.Namespace, request engine.EngineRequest) []string {
 	policies := r.Fetch(ctx, true)
 	matchedPolicies := []string{}
 	for _, mpol := range policies {
@@ -149,7 +149,7 @@ func (r *reconciler) MatchesMutateExisting(ctx context.Context, attr admission.A
 			continue
 		}
 		if mpol.Policy.GetSpec().MatchConditions != nil {
-			if !mpol.CompiledPolicy.MatchesConditions(ctx, attr, namespace) {
+			if !mpol.CompiledPolicy.MatchesConditions(ctx, attr, namespace, request) {
 				continue
 			}
 		}

--- a/pkg/cel/policies/mpol/engine/reconciler_test.go
+++ b/pkg/cel/policies/mpol/engine/reconciler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/kyverno/kyverno/pkg/cel/engine"
 	"github.com/kyverno/kyverno/pkg/cel/policies/mpol/compiler"
 	"github.com/stretchr/testify/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -260,7 +261,7 @@ func TestMatchesMutateExisting(t *testing.T) {
 			}
 			attrs := &mockAttributes{}
 			namespace := &corev1.Namespace{}
-			got := r.MatchesMutateExisting(context.TODO(), attrs, namespace)
+			got := r.MatchesMutateExisting(context.TODO(), attrs, namespace, engine.EngineRequest{})
 			assert.ElementsMatch(t, tt.expectedNames, got)
 		})
 	}

--- a/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/chainsaw-test.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: test-original-request-params
+spec:
+  concurrent: false
+  steps:
+    - name: create policy
+      use:
+        template: ../../../_step-templates/create-policy.yaml
+        with:
+          bindings:
+            - name: file
+              value: policy.yaml
+    - name: wait-mutating-policy-ready
+      use:
+        template: ../../../_step-templates/mutating-policy-ready.yaml
+        with:
+          bindings:
+            - name: name
+              value: propagate-central-config
+
+    - name: create dependent configmaps
+      try:
+        - apply:
+            file: dependent-configmap.yaml
+        - assert:
+            file: dependent-configmap.yaml
+
+    - name: create central config and verify initial mutation
+      try:
+        - apply:
+            file: configmap.yaml
+        - assert:
+            file: dependent-configmap-assert-initial.yaml
+
+    - name: update central config and verify dependent was updated
+      try:
+        - apply:
+            file: configmap-updated.yaml
+        - assert:
+            file: dependent-configmap-assert-updated.yaml
+
+    - name: create fake configmap and verify dependent was not updated
+      try:
+        - apply:
+            file: configmap-fake.yaml
+        - sleep:
+            duration: 5s
+        - assert:
+            file: dependent-configmap-assert-updated.yaml
+
+    - name: create dependent configmap without opt-in label and verify it does not get mutated
+      try:
+        - apply:
+            file: dependent-configmap-no-opt-in.yaml
+        - assert:
+            file: dependent-configmap-no-opt-in.yaml
+
+    - name: update central config once more to verify that dependent without opt-in label does not get mutated
+      try:
+        - apply:
+            file: configmap-updated-2.yaml
+        - sleep:
+            duration: 5s
+        - assert:
+            file: dependent-configmap-no-opt-in.yaml

--- a/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/configmap-fake.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/configmap-fake.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: not-central-config
+data:
+  serverAddress: http://server-fake.example.com:9090

--- a/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/configmap-updated-2.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/configmap-updated-2.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: central-config
+data:
+  serverAddress: http://server-updated-2.example.com:9090

--- a/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/configmap-updated.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/configmap-updated.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: central-config
+data:
+  serverAddress: http://server-updated.example.com:9090

--- a/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/configmap.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: central-config
+data:
+  serverAddress: http://server-initial.example.com:9090

--- a/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/dependent-configmap-assert-initial.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/dependent-configmap-assert-initial.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dependent-configmap
+data:
+  serverAddress: http://server-initial.example.com:9090
+  myKey: myValue

--- a/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/dependent-configmap-assert-updated.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/dependent-configmap-assert-updated.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dependent-configmap
+data:
+  serverAddress: http://server-updated.example.com:9090
+  myKey: myValue

--- a/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/dependent-configmap-no-opt-in.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/dependent-configmap-no-opt-in.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dependent-configmap-no-opt-in
+data:
+  serverAddress: http://local-server.example.com:9090
+  myKey: myValue

--- a/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/dependent-configmap.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/dependent-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dependent-configmap
+  labels:
+    app.example.com/use-central-config: "true"
+data:
+  serverAddress: http://local-server.example.com:9090
+  myKey: myValue

--- a/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/policy.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/different-trigger-target-original-request/policy.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: policies.kyverno.io/v1
+kind: MutatingPolicy
+metadata:
+  name: propagate-central-config
+spec:
+  evaluation:
+    mutateExisting:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["configmaps"]
+        operations: ["CREATE", "UPDATE"]
+  matchConditions:
+    # Only trigger when the specific central ConfigMap is modified
+    - name: is-central-configmap
+      expression: >-
+        params.originalRequest.object.metadata.name == "central-config"
+  targetMatchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["configmaps"]
+  variables:
+    - name: serverAddress
+      expression: >-
+        params.originalRequest.object.data["serverAddress"]
+  mutations:
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: >-
+          has(object.metadata.labels)
+          && object.metadata.labels.exists(k,
+            k == "app.example.com/use-central-config"
+          )
+          && object.metadata.labels["app.example.com/use-central-config"] == "true"
+          ? [
+              JSONPatch{
+                op: "add",
+                path: "/data/serverAddress",
+                value: string(variables.serverAddress)
+              }
+            ]
+          : []


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->
When a `MutatingPolicy` with `targetMatchConstraints` is configured (mutate existing resources), execution is delegated to the `kyverno-background-controller`. In that context, `object` and `oldObject` refer to the target resource being mutated, not the resource that triggered the original admission request. There is currently no way to access the triggering resource's data from within the policy CEL expressions.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->
Fixes #15610 

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
/milestone 1.17.2

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [x] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
https://github.com/kyverno/website/pull/1918

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->
This PR exposes the original admission request's `object` and `oldObject` via the `params` CEL variable as `params.originalRequest.object` and `params.originalRequest.oldObject`. This approach leverages the existing `params` variable from the Kubernetes `MutatingAdmissionPolicy` specification, avoiding the need to introduce non-standard variables into the CEL context.

Changes:
- Added `OriginalRequestKey` and `ParamsKey` constants to `pkg/cel/compiler/keys.go`
- Added `getParams()` method in `policy.go` that extracts the original request object/oldObject and wraps them into an `unstructured.Unstructured` used as `params`
- Threaded `params` through `MatchesConditions`, `matchExceptions`, `Evaluate`, and the `Provider`/`Reconciler` interfaces
- Registered `params` as a `cel.DynType` variable in the compiler
- Added a comprehensive chainsaw conformance test (`different-trigger-target-original-request`) covering: initial mutation, update propagation, filtering by trigger resource name, and opt-in annotation behavior

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

Example policy using `params.originalRequest`:
```yaml
matchConditions:
  - name: is-target-configmap
    expression: >-
      params.originalRequest.object.metadata.name == "keda-prometheus-serveraddress"
variables:
  - name: serverAddress
    expression: >-
      params.originalRequest.object.data["main"]
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is `release-1.17`.
- [x] My PR contains new or altered behavior to Kyverno and
- [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

When the policy is triggered by a direct admission (not mutate-existing), params will still be populated with originalRequest data that is identical to object/oldObject. This is harmless but worth noting.
