### PR TITLE
fix: inject namespaceObject into MutatingPolicy CEL context

### DIFF
--- a/pkg/cel/policies/mpol/compiler/policy.go
+++ b/pkg/cel/policies/mpol/compiler/policy.go
@@ -41,6 +41,7 @@ type compositionContext struct {
 	ctx             context.Context //nolint:containedctx
 	evaluator       *mutating.PolicyEvaluator
 	contextProvider libs.Context
+	namespace       *corev1.Namespace
 	accumulatedCost int64
 }
 
@@ -61,11 +62,19 @@ func (c *compositionContext) Variables(activation any) ref.Val {
 		}
 	}
 
+	var namespaceVal any
+	if c.namespace != nil {
+		if namespace, err := utils.ObjectToResolveVal(c.namespace); err == nil {
+			namespaceVal = namespace
+		}
+	}
+
 	// Set up context data for variable evaluation
 	ctxData := map[string]any{
-		compiler.VariablesKey: lazyMap,
-		compiler.ObjectKey:    objectVal,
-		compiler.OldObjectKey: oldObjectVal,
+		compiler.VariablesKey:       lazyMap,
+		compiler.ObjectKey:          objectVal,
+		compiler.OldObjectKey:       oldObjectVal,
+		compiler.NamespaceObjectKey: namespaceVal,
 	}
 
 	for name, result := range c.evaluator.CompositionEnv.CompiledVariables {
@@ -151,6 +160,7 @@ func (p *Policy) Evaluate(
 		ctx:             ctx,
 		evaluator:       &p.evaluator,
 		contextProvider: contextProvider,
+		namespace:       namespace,
 	}
 
 	if p.evaluator.Matcher != nil {

--- a/test/conformance/chainsaw/mutating-policies/admission/namespaceobject/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/mutating-policies/admission/namespaceobject/chainsaw-test.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: namespaceobject
+spec:
+  concurrent: false
+  steps:
+  - name: create policy
+    use:
+      template: ..//../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait-mutating-policy-ready
+    use:
+      template: ..//../../_step-templates/mutating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: test-mpol-namespaceobject
+  - name: sleep
+    try:
+    - sleep:
+        duration: 3s
+  - name: create deployments
+    try:
+    - create:
+        file: deployments.yaml
+    - assert:
+        file: deployments.yaml
+  - name: check patches
+    try:
+    - assert:
+        file: patched-deployments.yaml

--- a/test/conformance/chainsaw/mutating-policies/admission/namespaceobject/deployments.yaml
+++ b/test/conformance/chainsaw/mutating-policies/admission/namespaceobject/deployments.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deploy
+  namespace: namespaceobject
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: nginx
+        image: public.ecr.aws/docker/library/nginx

--- a/test/conformance/chainsaw/mutating-policies/admission/namespaceobject/patched-deployments.yaml
+++ b/test/conformance/chainsaw/mutating-policies/admission/namespaceobject/patched-deployments.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deploy
+  namespace: namespaceobject
+  labels:
+    env_from_namespace: production

--- a/test/conformance/chainsaw/mutating-policies/admission/namespaceobject/policy.yaml
+++ b/test/conformance/chainsaw/mutating-policies/admission/namespaceobject/policy.yaml
@@ -1,0 +1,35 @@
+apiVersion: policies.kyverno.io/v1
+kind: MutatingPolicy
+metadata:
+  name: test-mpol-namespaceobject
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [ "apps" ]
+      apiVersions: [ "v1" ]
+      operations: [ "CREATE" ]
+      resources: [ "deployments" ]
+  matchConditions:
+  - name: is-namespaceobject-namespace
+    expression: object.metadata.namespace == 'namespaceobject'
+  variables:
+  - name: nsLabel
+    expression: 'string(namespaceObject.metadata.labels["env"])'
+  mutations:
+  - patchType: ApplyConfiguration
+    applyConfiguration:
+      expression: >
+        Object{
+          metadata: Object.metadata{
+            labels: Object.metadata.labels{
+              env_from_namespace: variables.nsLabel
+            }
+          }
+        }
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: namespaceobject
+  labels:
+    env: production


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

MutatingPolicy CEL expressions cannot access `namespaceObject`, which is a standard Kubernetes admission variable that provides the namespace object for namespaced resources.
This is because the `compositionContext.Variables()` method only injects `object` and `oldObject` into the CEL evaluation data, but not `namespaceObject`.
This fix adds `namespaceObject` to the CEL context, consistent with how it's already wired for ValidatingPolicy, DeletingPolicy, and GeneratingPolicy.
K8S Reference https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/#patch-type-apply-configuration

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

No existing issue. This was discovered while writing a MutatingPolicy that reads namespace labels:
```
expression: 'namespaceObject.metadata.labels["my-label"]'
```

Error:
```
fails at runtime with: `no such attribute(s): namespaceObject`
```

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

- Add `namespace` field to `compositionContext` struct
- Inject `namespaceObject` into `ctxData` in `Variables()`, nil for cluster-scoped resources per K8s spec
- Pass namespace when creating `compositionContext` in `Evaluate()`
- Add chainsaw conformance test verifying `namespaceObject` works in MutatingPolicy

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->
```
apiVersion: policies.kyverno.io/v1
kind: MutatingPolicy
metadata:
  name: test-mpol-namespaceobject
spec:
  matchConstraints:
    resourceRules:
    - apiGroups: [ "apps" ]
      apiVersions: [ "v1" ]
      operations: [ "CREATE" ]
      resources: [ "deployments" ]
  variables:
  - name: nsLabel
    expression: 'string(namespaceObject.metadata.labels["env"])'
  mutations:
  - patchType: ApplyConfiguration
    applyConfiguration:
      expression: >
        Object{
          metadata: Object.metadata{
            labels: Object.metadata.labels{
              env_from_namespace: variables.nsLabel
            }
          }
        }
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
