### PR TITLE
refactor: make everything in cpol image verifiers private

### DIFF
--- a/pkg/image/verifiers/cpol/cosign/client.go
+++ b/pkg/image/verifiers/cpol/cosign/client.go
@@ -8,9 +8,9 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/oci"
 )
 
-var client Cosign = &driver{}
+var client cosignDriver = &driver{}
 
-type Cosign interface {
+type cosignDriver interface {
 	VerifyImageSignatures(ctx context.Context, signedImgRef name.Reference, co *cosign.CheckOpts) ([]oci.Signature, bool, error)
 	VerifyImageAttestations(ctx context.Context, signedImgRef name.Reference, co *cosign.CheckOpts) (checkedAttestations []oci.Signature, bundleVerified bool, err error)
 }

--- a/pkg/image/verifiers/cpol/cosign/cosign.go
+++ b/pkg/image/verifiers/cpol/cosign/cosign.go
@@ -40,11 +40,11 @@ var signatureAlgorithmMap = map[string]crypto.Hash{
 	"sha512": crypto.SHA512,
 }
 
+type cosignVerifier struct{}
+
 func NewVerifier() verifiers.ImageVerifier {
 	return &cosignVerifier{}
 }
-
-type cosignVerifier struct{}
 
 func (v *cosignVerifier) VerifySignature(ctx context.Context, opts verifiers.Options) (*verifiers.Response, error) {
 	if opts.SigstoreBundle {
@@ -109,6 +109,86 @@ func (v *cosignVerifier) VerifySignature(ctx context.Context, opts verifiers.Opt
 	return &verifiers.Response{Digest: digest}, nil
 }
 
+func (v *cosignVerifier) FetchAttestations(ctx context.Context, opts verifiers.Options) (*verifiers.Response, error) {
+	if opts.SigstoreBundle {
+		results, err := verifyBundleAndFetchAttestations(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(results) == 0 {
+			return nil, fmt.Errorf("sigstore bundle verification failed: no matching signatures found")
+		}
+
+		statements, err := decodeStatementsFromBundles(results)
+		if err != nil {
+			return nil, err
+		}
+		return &verifiers.Response{Digest: results[0].Desc.Digest.String(), Statements: statements}, nil
+	}
+	cosignOpts, err := buildCosignOptions(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	nameOpts := opts.Client.NameOptions()
+	signatures, bundleVerified, err := tracing.ChildSpan3(
+		ctx,
+		"",
+		"VERIFY IMG ATTESTATIONS",
+		func(ctx context.Context, span trace.Span) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
+			ref, err := name.ParseReference(opts.ImageRef, nameOpts...)
+			if err != nil {
+				return nil, false, fmt.Errorf("failed to parse image: %w", err)
+			}
+			return client.VerifyImageAttestations(ctx, ref, cosignOpts)
+		},
+	)
+	if err != nil {
+		msg := err.Error()
+		logger.Info("failed to fetch attestations", "error", msg)
+		if strings.Contains(msg, "MANIFEST_UNKNOWN: manifest unknown") {
+			return nil, fmt.Errorf("not found")
+		}
+
+		return nil, err
+	}
+
+	payload, err := extractPayload(signatures)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, signature := range signatures {
+		match, predicateType, err := matchType(signature, opts.Type)
+		if err != nil {
+			return nil, err
+		}
+
+		if !match {
+			logger.V(4).Info("type doesn't match, continue", "expected", opts.Type, "received", predicateType)
+			continue
+		}
+
+		if err := matchSignatures([]oci.Signature{signature}, opts.Subject, opts.SubjectRegExp, opts.Issuer, opts.IssuerRegExp, opts.AdditionalExtensions); err != nil {
+			return nil, err
+		}
+	}
+
+	err = checkAnnotations(payload, opts.Annotations)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.V(3).Info("verified images", "signatures", len(signatures), "bundleVerified", bundleVerified)
+	inTotoStatements, digest, err := decodeStatements(signatures)
+	if err != nil {
+		return nil, err
+	}
+
+	return &verifiers.Response{Digest: digest, Statements: inTotoStatements}, nil
+}
+
 func buildCosignOptions(ctx context.Context, opts verifiers.Options) (*cosign.CheckOpts, error) {
 	var err error
 
@@ -118,7 +198,7 @@ func buildCosignOptions(ctx context.Context, opts verifiers.Options) (*cosign.Ch
 	}
 
 	cosignOpts := &cosign.CheckOpts{
-		Annotations:        map[string]interface{}{},
+		Annotations:        map[string]any{},
 		RegistryClientOpts: []remote.Option{remote.WithRemoteOptions(options...)},
 	}
 
@@ -281,86 +361,6 @@ func loadCertChain(pem []byte) ([]*x509.Certificate, error) {
 	return cryptoutils.LoadCertificatesFromPEM(bytes.NewReader(pem))
 }
 
-func (v *cosignVerifier) FetchAttestations(ctx context.Context, opts verifiers.Options) (*verifiers.Response, error) {
-	if opts.SigstoreBundle {
-		results, err := verifyBundleAndFetchAttestations(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(results) == 0 {
-			return nil, fmt.Errorf("sigstore bundle verification failed: no matching signatures found")
-		}
-
-		statements, err := decodeStatementsFromBundles(results)
-		if err != nil {
-			return nil, err
-		}
-		return &verifiers.Response{Digest: results[0].Desc.Digest.String(), Statements: statements}, nil
-	}
-	cosignOpts, err := buildCosignOptions(ctx, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	nameOpts := opts.Client.NameOptions()
-	signatures, bundleVerified, err := tracing.ChildSpan3(
-		ctx,
-		"",
-		"VERIFY IMG ATTESTATIONS",
-		func(ctx context.Context, span trace.Span) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
-			ref, err := name.ParseReference(opts.ImageRef, nameOpts...)
-			if err != nil {
-				return nil, false, fmt.Errorf("failed to parse image: %w", err)
-			}
-			return client.VerifyImageAttestations(ctx, ref, cosignOpts)
-		},
-	)
-	if err != nil {
-		msg := err.Error()
-		logger.Info("failed to fetch attestations", "error", msg)
-		if strings.Contains(msg, "MANIFEST_UNKNOWN: manifest unknown") {
-			return nil, fmt.Errorf("not found")
-		}
-
-		return nil, err
-	}
-
-	payload, err := extractPayload(signatures)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, signature := range signatures {
-		match, predicateType, err := matchType(signature, opts.Type)
-		if err != nil {
-			return nil, err
-		}
-
-		if !match {
-			logger.V(4).Info("type doesn't match, continue", "expected", opts.Type, "received", predicateType)
-			continue
-		}
-
-		if err := matchSignatures([]oci.Signature{signature}, opts.Subject, opts.SubjectRegExp, opts.Issuer, opts.IssuerRegExp, opts.AdditionalExtensions); err != nil {
-			return nil, err
-		}
-	}
-
-	err = checkAnnotations(payload, opts.Annotations)
-	if err != nil {
-		return nil, err
-	}
-
-	logger.V(3).Info("verified images", "signatures", len(signatures), "bundleVerified", bundleVerified)
-	inTotoStatements, digest, err := decodeStatements(signatures)
-	if err != nil {
-		return nil, err
-	}
-
-	return &verifiers.Response{Digest: digest, Statements: inTotoStatements}, nil
-}
-
 func matchType(sig oci.Signature, expectedType string) (bool, string, error) {
 	if expectedType != "" {
 		statement, _, err := decodeStatement(sig)
@@ -377,14 +377,14 @@ func matchType(sig oci.Signature, expectedType string) (bool, string, error) {
 	return false, "", nil
 }
 
-func decodeStatements(sigs []oci.Signature) ([]map[string]interface{}, string, error) {
+func decodeStatements(sigs []oci.Signature) ([]map[string]any, string, error) {
 	if len(sigs) == 0 {
-		return []map[string]interface{}{}, "", nil
+		return []map[string]any{}, "", nil
 	}
 
 	var digest string
-	var statement map[string]interface{}
-	decodedStatements := make([]map[string]interface{}, len(sigs))
+	var statement map[string]any
+	decodedStatements := make([]map[string]any, len(sigs))
 	for i, sig := range sigs {
 		var err error
 		statement, digest, err = decodeStatement(sig)
@@ -398,7 +398,7 @@ func decodeStatements(sigs []oci.Signature) ([]map[string]interface{}, string, e
 	return decodedStatements, digest, nil
 }
 
-func decodeStatement(sig oci.Signature) (map[string]interface{}, string, error) {
+func decodeStatement(sig oci.Signature) (map[string]any, string, error) {
 	var digest string
 
 	pld, err := sig.Payload()
@@ -415,7 +415,7 @@ func decodeStatement(sig oci.Signature) (map[string]interface{}, string, error) 
 		digest = d
 	}
 
-	data := make(map[string]interface{})
+	data := make(map[string]any)
 	if err := json.Unmarshal(pld, &data); err != nil {
 		return nil, "", fmt.Errorf("failed to unmarshal JSON payload: %v: %w", sig, err)
 	}
@@ -433,7 +433,7 @@ func decodeStatement(sig oci.Signature) (map[string]interface{}, string, error) 
 	}
 }
 
-func decodePayload(payloadBase64 string) (map[string]interface{}, error) {
+func decodePayload(payloadBase64 string) (map[string]any, error) {
 	statementRaw, err := base64.StdEncoding.DecodeString(payloadBase64)
 	if err != nil {
 		return nil, fmt.Errorf("failed to base64 decode payload for %v: %w", statementRaw, err)
@@ -456,12 +456,12 @@ func decodePayload(payloadBase64 string) (map[string]interface{}, error) {
 	return decodeCosignCustomProvenanceV01(statement)
 }
 
-func decodeCosignCustomProvenanceV01(statement in_toto.Statement) (map[string]interface{}, error) { //nolint:staticcheck
+func decodeCosignCustomProvenanceV01(statement in_toto.Statement) (map[string]any, error) { //nolint:staticcheck
 	if statement.Type != attestation.CosignCustomProvenanceV01 {
 		return nil, fmt.Errorf("invalid statement type %s", attestation.CosignCustomProvenanceV01)
 	}
 
-	predicate, ok := statement.Predicate.(map[string]interface{})
+	predicate, ok := statement.Predicate.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("failed to decode CosignCustomProvenanceV01")
 	}
@@ -481,13 +481,13 @@ func decodeCosignCustomProvenanceV01(statement in_toto.Statement) (map[string]in
 	return datautils.ToMap(statement)
 }
 
-func stringToJSONMap(i interface{}) (map[string]interface{}, error) {
+func stringToJSONMap(i any) (map[string]any, error) {
 	s, ok := i.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string type")
 	}
 
-	data := map[string]interface{}{}
+	data := map[string]any{}
 	if err := json.Unmarshal([]byte(s), &data); err != nil {
 		return nil, fmt.Errorf("failed to marshal JSON: %w", err)
 	}

--- a/pkg/image/verifiers/cpol/cosign/cosign_unit_test.go
+++ b/pkg/image/verifiers/cpol/cosign/cosign_unit_test.go
@@ -478,7 +478,7 @@ func TestBuildVerifyOptions(t *testing.T) {
 func TestDecodeStatementsFromBundles(t *testing.T) {
 	tests := []struct {
 		name    string
-		bundles []*VerificationResult
+		bundles []*verificationResult
 		wantLen int
 		wantErr bool
 	}{
@@ -490,7 +490,7 @@ func TestDecodeStatementsFromBundles(t *testing.T) {
 		},
 		{
 			name:    "empty bundles",
-			bundles: []*VerificationResult{},
+			bundles: []*verificationResult{},
 			wantLen: 0,
 			wantErr: false,
 		},

--- a/pkg/image/verifiers/cpol/cosign/sigstore.go
+++ b/pkg/image/verifiers/cpol/cosign/sigstore.go
@@ -26,99 +26,85 @@ var (
 	attestationlimit = 50
 )
 
-type VerificationResult struct {
-	Bundle *Bundle
+type verificationResult struct {
+	Bundle *verificationBundle
 	Result *verify.VerificationResult
 	Desc   *v1.Descriptor
 }
 
-type Bundle struct {
+type verificationBundle struct {
 	ProtoBundle   *bundle.Bundle
 	DSSE_Envelope *in_toto.Statement //nolint:staticcheck
 }
 
-func verifyBundleAndFetchAttestations(ctx context.Context, opts verifiers.Options) ([]*VerificationResult, error) {
+func verifyBundleAndFetchAttestations(ctx context.Context, opts verifiers.Options) ([]*verificationResult, error) {
 	nameOpts := opts.Client.NameOptions()
 	ref, err := name.ParseReference(opts.ImageRef, nameOpts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse image reference: %v", opts.ImageRef)
 	}
-
 	remoteOpts, err := opts.Client.Options(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create remote opts: %v", opts.ImageRef)
 	}
-
 	bundles, desc, err := fetchBundles(ref, attestationlimit, opts.Type, remoteOpts)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to fetch bundles: %v", opts.ImageRef)
 	}
-
 	policy, err := buildPolicy(desc, opts)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to build policy: %v", opts.ImageRef)
 	}
-
 	verifyOpts := buildVerifyOptions(opts)
 	trustedMaterial, err := getTrustedRoot(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get trusted root: %v", opts.ImageRef)
 	}
-
 	results, err := verifyBundles(bundles, desc, trustedMaterial, policy, verifyOpts)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get verify bundles: %v", opts.ImageRef)
 	}
-
 	return results, nil
 }
 
-func verifyBundles(bundles []*Bundle, desc *v1.Descriptor, trustedRoot *root.TrustedRoot, policy verify.PolicyBuilder, verifierOpts []verify.VerifierOption) ([]*VerificationResult, error) {
+func verifyBundles(bundles []*verificationBundle, desc *v1.Descriptor, trustedRoot *root.TrustedRoot, policy verify.PolicyBuilder, verifierOpts []verify.VerifierOption) ([]*verificationResult, error) {
 	verifier, err := verify.NewSignedEntityVerifier(trustedRoot, verifierOpts...)
 	if err != nil {
 		return nil, err
 	}
-
-	verificationResults := make([]*VerificationResult, 0)
+	verificationResults := make([]*verificationResult, 0)
 	for _, bundle := range bundles {
 		result, err := verifier.Verify(bundle.ProtoBundle, policy)
 		if err == nil {
-			verificationResults = append(verificationResults, &VerificationResult{Bundle: bundle, Result: result, Desc: desc})
+			verificationResults = append(verificationResults, &verificationResult{Bundle: bundle, Result: result, Desc: desc})
 		} else {
 			logger.V(4).Info("failed to verify sigstore bundle", "err", err.Error(), "bundle", bundle)
 		}
 	}
-
 	return verificationResults, nil
 }
 
-func fetchBundles(ref name.Reference, limit int, predicateType string, remoteOpts []remote.Option) ([]*Bundle, *v1.Descriptor, error) {
-	bundles := make([]*Bundle, 0)
-
+func fetchBundles(ref name.Reference, limit int, predicateType string, remoteOpts []remote.Option) ([]*verificationBundle, *v1.Descriptor, error) {
+	bundles := make([]*verificationBundle, 0)
 	desc, err := remote.Head(ref, remoteOpts...)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	referrers, err := remote.Referrers(ref.Context().Digest(desc.Digest.String()), remoteOpts...)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	referrersDescs, err := referrers.IndexManifest()
 	if err != nil {
 		return nil, nil, err
 	}
-
 	if len(referrersDescs.Manifests) > limit {
 		return nil, nil, fmt.Errorf("failed to fetch referrers: too many referrers found, max limit is %d", limit)
 	}
-
 	for _, manifestDesc := range referrersDescs.Manifests {
 		if !strings.HasPrefix(manifestDesc.ArtifactType, "application/vnd.dev.sigstore.bundle") {
 			continue
 		}
-
 		refImg, err := remote.Image(ref.Context().Digest(manifestDesc.Digest.String()), remoteOpts...)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to fetch referrer image: %w", err)
@@ -152,11 +138,10 @@ func fetchBundles(ref name.Reference, limit int, predicateType string, remoteOpt
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to unmarshal bundle: %w", err)
 		}
-		bundles = append(bundles, &Bundle{ProtoBundle: b})
+		bundles = append(bundles, &verificationBundle{ProtoBundle: b})
 	}
-
 	if predicateType != "" {
-		filteredBundles := make([]*Bundle, 0)
+		filteredBundles := make([]*verificationBundle, 0)
 		for _, b := range bundles {
 			dsseEnvelope := b.ProtoBundle.Bundle.GetDsseEnvelope()
 			if dsseEnvelope != nil {
@@ -169,7 +154,7 @@ func fetchBundles(ref name.Reference, limit int, predicateType string, remoteOpt
 				}
 
 				if intotoStatement.PredicateType == predicateType {
-					filteredBundles = append(filteredBundles, &Bundle{
+					filteredBundles = append(filteredBundles, &verificationBundle{
 						ProtoBundle:   b.ProtoBundle,
 						DSSE_Envelope: &intotoStatement,
 					})
@@ -178,7 +163,6 @@ func fetchBundles(ref name.Reference, limit int, predicateType string, remoteOpt
 		}
 		return filteredBundles, desc, nil
 	}
-
 	return bundles, desc, nil
 }
 
@@ -190,7 +174,6 @@ func buildPolicy(desc *v1.Descriptor, opts verifiers.Options) (verify.PolicyBuil
 	artifactDigestVerificationOption := verify.WithArtifactDigest(desc.Digest.Algorithm, digest)
 	hasIssuer := opts.Issuer != "" || opts.IssuerRegExp != ""
 	hasSubject := opts.Subject != "" || opts.SubjectRegExp != ""
-
 	if hasIssuer && hasSubject {
 		id, err := verify.NewShortCertificateIdentity(opts.Issuer, opts.IssuerRegExp, opts.Subject, opts.SubjectRegExp)
 		if err != nil {
@@ -198,7 +181,6 @@ func buildPolicy(desc *v1.Descriptor, opts verifiers.Options) (verify.PolicyBuil
 		}
 		return verify.NewPolicy(artifactDigestVerificationOption, verify.WithCertificateIdentity(id)), nil
 	}
-
 	return verify.NewPolicy(artifactDigestVerificationOption), nil
 }
 
@@ -207,11 +189,9 @@ func buildVerifyOptions(opts verifiers.Options) []verify.VerifierOption {
 	if !opts.IgnoreTlog {
 		verifierOptions = append(verifierOptions, verify.WithTransparencyLog(1))
 	}
-
 	if !opts.IgnoreSCT {
 		verifierOptions = append(verifierOptions, verify.WithObserverTimestamps(1))
 	}
-
 	return verifierOptions
 }
 
@@ -228,19 +208,17 @@ func getTrustedRoot(ctx context.Context) (*root.TrustedRoot, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating trusted root: %w", err)
 	}
-
 	return trustedRoot, nil
 }
 
-func decodeStatementsFromBundles(bundles []*VerificationResult) ([]map[string]interface{}, error) {
+func decodeStatementsFromBundles(bundles []*verificationResult) ([]map[string]any, error) {
 	if len(bundles) == 0 {
-		return []map[string]interface{}{}, nil
+		return []map[string]any{}, nil
 	}
-
 	var err error
-	var statement map[string]interface{}
+	var statement map[string]any
 	var intotostatement in_toto.Statement //nolint:staticcheck
-	decodedStatements := make([]map[string]interface{}, len(bundles))
+	decodedStatements := make([]map[string]any, len(bundles))
 	for i, b := range bundles {
 		intotostatement = *b.Bundle.DSSE_Envelope
 		statement, err = data.ToMap(intotostatement)

--- a/pkg/image/verifiers/cpol/notary/log.go
+++ b/pkg/image/verifiers/cpol/notary/log.go
@@ -1,0 +1,5 @@
+package notary
+
+import "github.com/kyverno/kyverno/pkg/logging"
+
+var logger = logging.WithName("Notary")

--- a/pkg/image/verifiers/cpol/notary/notary.go
+++ b/pkg/image/verifiers/cpol/notary/notary.go
@@ -6,13 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	gcrremote "github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/kyverno/kyverno/pkg/image/verifiers"
 	"github.com/kyverno/kyverno/pkg/image/verifiers/ivpol/notary"
-	"github.com/kyverno/kyverno/pkg/logging"
 	_ "github.com/notaryproject/notation-core-go/signature/cose"
 	_ "github.com/notaryproject/notation-core-go/signature/jws"
 	"github.com/notaryproject/notation-go"
@@ -31,18 +29,14 @@ var (
 	maxPayloadSize    = int64(10 * 1000 * 1000) // 10 MB
 )
 
-func NewVerifier() verifiers.ImageVerifier {
-	return &notaryVerifier{
-		log: logging.WithName("Notary"),
-	}
-}
+type notaryVerifier struct{}
 
-type notaryVerifier struct {
-	log logr.Logger
+func NewVerifier() verifiers.ImageVerifier {
+	return &notaryVerifier{}
 }
 
 func (v *notaryVerifier) VerifySignature(ctx context.Context, opts verifiers.Options) (*verifiers.Response, error) {
-	v.log.V(2).Info("verifying image", "reference", opts.ImageRef)
+	logger.V(2).Info("verifying image", "reference", opts.ImageRef)
 
 	certsPEM := combineCerts(opts)
 	certs, err := cryptoutils.LoadCertificatesFromPEM(bytes.NewReader([]byte(certsPEM)))
@@ -50,19 +44,19 @@ func (v *notaryVerifier) VerifySignature(ctx context.Context, opts verifiers.Opt
 		return nil, errors.Wrapf(err, "failed to parse certificates")
 	}
 
-	trustStore := NewTrustStore("kyverno", certs)
+	trustStore := newTrustStore("kyverno", certs)
 	policyDoc := v.buildPolicy()
 	notationVerifier, err := verifier.New(policyDoc, trustStore, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to created verifier")
 	}
 
-	v.log.V(4).Info("creating notation repo", "reference", opts.ImageRef)
+	logger.V(4).Info("creating notation repo", "reference", opts.ImageRef)
 	parsedRef, err := parseReferenceCrane(ctx, opts.ImageRef, opts.Client)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse image reference: %s", opts.ImageRef)
 	}
-	v.log.V(4).Info("created parsedRef", "reference", opts.ImageRef)
+	logger.V(4).Info("created parsedRef", "reference", opts.ImageRef)
 
 	ref := parsedRef.Ref.Name()
 	remoteVerifyOptions := notation.VerifyOptions{
@@ -70,7 +64,7 @@ func (v *notaryVerifier) VerifySignature(ctx context.Context, opts verifiers.Opt
 		MaxSignatureAttempts: 10,
 	}
 
-	targetDesc, outcomes, err := notation.Verify(notationlog.WithLogger(ctx, notary.NotaryLoggerAdapter(v.log.WithName("Notary Verifier Debug"))), notationVerifier, parsedRef.Repo, remoteVerifyOptions)
+	targetDesc, outcomes, err := notation.Verify(notationlog.WithLogger(ctx, notary.NotaryLoggerAdapter(logger.WithName("Notary Verifier Debug"))), notationVerifier, parsedRef.Repo, remoteVerifyOptions)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to verify %s", ref)
 	}
@@ -79,7 +73,7 @@ func (v *notaryVerifier) VerifySignature(ctx context.Context, opts verifiers.Opt
 		return nil, err
 	}
 
-	v.log.V(2).Info("verified image", "type", targetDesc.MediaType, "digest", targetDesc.Digest, "size", targetDesc.Size)
+	logger.V(2).Info("verified image", "type", targetDesc.MediaType, "digest", targetDesc.Digest, "size", targetDesc.Size)
 
 	resp := &verifiers.Response{
 		Digest:     targetDesc.Digest.String(),
@@ -87,6 +81,82 @@ func (v *notaryVerifier) VerifySignature(ctx context.Context, opts verifiers.Opt
 	}
 
 	return resp, nil
+}
+
+func (v *notaryVerifier) FetchAttestations(ctx context.Context, opts verifiers.Options) (*verifiers.Response, error) {
+	logger.V(2).Info("fetching attestations", "reference", opts.ImageRef, "opts", opts)
+
+	nameOpts := opts.Client.NameOptions()
+	ref, err := name.ParseReference(opts.ImageRef, nameOpts...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse image reference: %s", opts.ImageRef)
+	}
+	remoteOpts, err := opts.Client.Options(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.V(4).Info("client setup done", "repo", ref)
+
+	repoDesc, err := gcrremote.Head(ref, remoteOpts...)
+	if err != nil {
+		return nil, err
+	}
+	logger.V(4).Info("fetched repository", "repoDesc", repoDesc)
+
+	referrers, err := gcrremote.Referrers(ref.Context().Digest(repoDesc.Digest.String()), remoteOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	referrersDescs, err := referrers.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	// This check ensures that the manifest does not have an abnormal amount of referrers attached to it to protect against compromised images
+	if len(referrersDescs.Manifests) > maxReferrersCount {
+		return nil, fmt.Errorf("failed to fetch referrers: too many referrers found, max limit is %d", maxReferrersCount)
+	}
+
+	logger.V(4).Info("fetched referrers", "referrers", referrersDescs)
+
+	var statements []map[string]interface{}
+
+	for _, referrer := range referrersDescs.Manifests {
+		match, _, err := matchArtifactType(referrer, opts.Type)
+		if err != nil {
+			return nil, err
+		}
+
+		if !match {
+			logger.V(6).Info("type doesn't match, continue", "expected", opts.Type, "received", referrer.ArtifactType)
+			continue
+		}
+
+		targetDesc, err := verifyAttestators(ctx, v, ref, opts, referrer)
+		if err != nil {
+			logger.V(4).Info("failed to verify referrer", "digest", targetDesc.Digest.String(), "error", err.Error())
+			return nil, err
+		}
+
+		logger.V(4).Info("extracting statements", "desc", referrer, "repo", ref)
+		statements, err = extractStatements(ctx, ref, referrer, remoteOpts, nameOpts)
+		if err != nil {
+			logger.V(4).Info("failed to extract statements", "error", err.Error())
+			return nil, err
+		}
+
+		logger.V(4).Info("verified attestators", "digest", targetDesc.Digest.String())
+
+		if len(statements) == 0 {
+			return nil, fmt.Errorf("failed to fetch attestations")
+		}
+		logger.V(6).Info("sending response")
+		return &verifiers.Response{Digest: repoDesc.Digest.String(), Statements: statements}, nil
+	}
+
+	return nil, fmt.Errorf("no matching attestations found for image %s with type %s", opts.ImageRef, opts.Type)
 }
 
 func combineCerts(opts verifiers.Options) string {
@@ -128,90 +198,14 @@ func (v *notaryVerifier) verifyOutcomes(outcomes []*notation.VerificationOutcome
 		content := outcome.EnvelopeContent.Payload.Content
 		contentType := outcome.EnvelopeContent.Payload.ContentType
 
-		v.log.V(2).Info("content", "type", contentType, "data", content)
+		logger.V(2).Info("content", "type", contentType, "data", content)
 	}
 
 	return multierr.Combine(errs...)
 }
 
-func (v *notaryVerifier) FetchAttestations(ctx context.Context, opts verifiers.Options) (*verifiers.Response, error) {
-	v.log.V(2).Info("fetching attestations", "reference", opts.ImageRef, "opts", opts)
-
-	nameOpts := opts.Client.NameOptions()
-	ref, err := name.ParseReference(opts.ImageRef, nameOpts...)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse image reference: %s", opts.ImageRef)
-	}
-	remoteOpts, err := opts.Client.Options(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	v.log.V(4).Info("client setup done", "repo", ref)
-
-	repoDesc, err := gcrremote.Head(ref, remoteOpts...)
-	if err != nil {
-		return nil, err
-	}
-	v.log.V(4).Info("fetched repository", "repoDesc", repoDesc)
-
-	referrers, err := gcrremote.Referrers(ref.Context().Digest(repoDesc.Digest.String()), remoteOpts...)
-	if err != nil {
-		return nil, err
-	}
-
-	referrersDescs, err := referrers.IndexManifest()
-	if err != nil {
-		return nil, err
-	}
-
-	// This check ensures that the manifest does not have an abnormal amount of referrers attached to it to protect against compromised images
-	if len(referrersDescs.Manifests) > maxReferrersCount {
-		return nil, fmt.Errorf("failed to fetch referrers: too many referrers found, max limit is %d", maxReferrersCount)
-	}
-
-	v.log.V(4).Info("fetched referrers", "referrers", referrersDescs)
-
-	var statements []map[string]interface{}
-
-	for _, referrer := range referrersDescs.Manifests {
-		match, _, err := matchArtifactType(referrer, opts.Type)
-		if err != nil {
-			return nil, err
-		}
-
-		if !match {
-			v.log.V(6).Info("type doesn't match, continue", "expected", opts.Type, "received", referrer.ArtifactType)
-			continue
-		}
-
-		targetDesc, err := verifyAttestators(ctx, v, ref, opts, referrer)
-		if err != nil {
-			v.log.V(4).Info("failed to verify referrer", "digest", targetDesc.Digest.String(), "error", err.Error())
-			return nil, err
-		}
-
-		v.log.V(4).Info("extracting statements", "desc", referrer, "repo", ref)
-		statements, err = extractStatements(ctx, ref, referrer, remoteOpts, nameOpts)
-		if err != nil {
-			v.log.V(4).Info("failed to extract statements", "error", err.Error())
-			return nil, err
-		}
-
-		v.log.V(4).Info("verified attestators", "digest", targetDesc.Digest.String())
-
-		if len(statements) == 0 {
-			return nil, fmt.Errorf("failed to fetch attestations")
-		}
-		v.log.V(6).Info("sending response")
-		return &verifiers.Response{Digest: repoDesc.Digest.String(), Statements: statements}, nil
-	}
-
-	return nil, fmt.Errorf("no matching attestations found for image %s with type %s", opts.ImageRef, opts.Type)
-}
-
 func verifyAttestators(ctx context.Context, v *notaryVerifier, ref name.Reference, opts verifiers.Options, desc v1.Descriptor) (ocispec.Descriptor, error) {
-	v.log.V(2).Info("verifying attestations", "reference", opts.ImageRef, "opts", opts)
+	logger.V(2).Info("verifying attestations", "reference", opts.ImageRef, "opts", opts)
 	if opts.Cert == "" && opts.CertChain == "" {
 		// skips the checks when no attestor is provided
 		v1Desc := ocispec.Descriptor{
@@ -227,36 +221,36 @@ func verifyAttestators(ctx context.Context, v *notaryVerifier, ref name.Referenc
 	certsPEM := combineCerts(opts)
 	certs, err := cryptoutils.LoadCertificatesFromPEM(bytes.NewReader([]byte(certsPEM)))
 	if err != nil {
-		v.log.V(4).Info("failed to parse certificates", "err", err)
+		logger.V(4).Info("failed to parse certificates", "err", err)
 		return ocispec.Descriptor{}, errors.Wrapf(err, "failed to parse certificates")
 	}
 
-	v.log.V(4).Info("parsed certificates")
-	trustStore := NewTrustStore("kyverno", certs)
+	logger.V(4).Info("parsed certificates")
+	trustStore := newTrustStore("kyverno", certs)
 	policyDoc := v.buildPolicy()
 	notationVerifier, err := verifier.New(policyDoc, trustStore, nil)
 	if err != nil {
-		v.log.V(4).Info("failed to created verifier", "err", err)
+		logger.V(4).Info("failed to created verifier", "err", err)
 		return ocispec.Descriptor{}, errors.Wrapf(err, "failed to created verifier")
 	}
 
-	v.log.V(4).Info("created verifier")
+	logger.V(4).Info("created verifier")
 	reference := ref.Context().RegistryStr() + "/" + ref.Context().RepositoryStr() + "@" + desc.Digest.String()
 	parsedRef, err := parseReferenceCrane(ctx, reference, opts.Client)
 	if err != nil {
 		return ocispec.Descriptor{}, errors.Wrapf(err, "failed to parse image reference: %s", opts.ImageRef)
 	}
-	v.log.V(4).Info("created notation repo", "reference", opts.ImageRef)
+	logger.V(4).Info("created notation repo", "reference", opts.ImageRef)
 
 	remoteVerifyOptions := notation.VerifyOptions{
 		ArtifactReference:    reference,
 		MaxSignatureAttempts: 10,
 	}
 
-	v.log.V(4).Info("verification started")
+	logger.V(4).Info("verification started")
 	targetDesc, outcomes, err := notation.Verify(context.TODO(), notationVerifier, parsedRef.Repo, remoteVerifyOptions)
 	if err != nil {
-		v.log.V(4).Info("failed to vefify attestator", "remoteVerifyOptions", remoteVerifyOptions, "repo", parsedRef.Repo)
+		logger.V(4).Info("failed to vefify attestator", "remoteVerifyOptions", remoteVerifyOptions, "repo", parsedRef.Repo)
 		return targetDesc, err
 	}
 	if err := v.verifyOutcomes(outcomes); err != nil {
@@ -264,10 +258,10 @@ func verifyAttestators(ctx context.Context, v *notaryVerifier, ref name.Referenc
 	}
 
 	if targetDesc.Digest.String() != desc.Digest.String() {
-		v.log.V(4).Info("digest mismatch", "expected", desc.Digest.String(), "found", targetDesc.Digest.String())
+		logger.V(4).Info("digest mismatch", "expected", desc.Digest.String(), "found", targetDesc.Digest.String())
 		return targetDesc, errors.Errorf("digest mismatch")
 	}
-	v.log.V(2).Info("attestator verified", "desc", targetDesc.Digest.String())
+	logger.V(2).Info("attestator verified", "desc", targetDesc.Digest.String())
 
 	return targetDesc, nil
 }
@@ -286,7 +280,7 @@ func extractStatements(ctx context.Context, repoRef name.Reference, desc v1.Desc
 	return statements, nil
 }
 
-func extractStatement(ctx context.Context, repoRef name.Reference, desc v1.Descriptor, remoteOpts []gcrremote.Option, nameOpts []name.Option) (map[string]interface{}, error) {
+func extractStatement(_ context.Context, repoRef name.Reference, desc v1.Descriptor, remoteOpts []gcrremote.Option, nameOpts []name.Option) (map[string]interface{}, error) {
 	refStr := repoRef.Context().RegistryStr() + "/" + repoRef.Context().RepositoryStr() + "@" + desc.Digest.String()
 	ref, err := name.ParseReference(refStr, nameOpts...)
 	if err != nil {

--- a/pkg/image/verifiers/cpol/notary/notary_unit_test.go
+++ b/pkg/image/verifiers/cpol/notary/notary_unit_test.go
@@ -257,12 +257,9 @@ func TestNewVerifier(t *testing.T) {
 
 func TestNewVerifierType(t *testing.T) {
 	v := NewVerifier()
-	nv, ok := v.(*notaryVerifier)
+	_, ok := v.(*notaryVerifier)
 	if !ok {
 		t.Fatal("NewVerifier() did not return a *notaryVerifier")
-	}
-	if nv.log.GetSink() == nil {
-		t.Error("NewVerifier() logger sink is nil")
 	}
 }
 

--- a/pkg/image/verifiers/cpol/notary/registry.go
+++ b/pkg/image/verifiers/cpol/notary/registry.go
@@ -43,7 +43,7 @@ func parseReferenceCrane(ctx context.Context, ref string, registryClient verifie
 		}
 	}
 
-	repository := NewRepository(remoteOpts, nameRef)
+	repository := newRepository(remoteOpts, nameRef)
 	err = resolveDigestCrane(repository, remoteOpts, nameRef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to resolve digest")

--- a/pkg/image/verifiers/cpol/notary/repository.go
+++ b/pkg/image/verifiers/cpol/notary/repository.go
@@ -19,7 +19,7 @@ type repositoryClient struct {
 	remoteOpts []remote.Option
 }
 
-func NewRepository(remoteOpts []remote.Option, ref name.Reference) notationregistry.Repository {
+func newRepository(remoteOpts []remote.Option, ref name.Reference) notationregistry.Repository {
 	return &repositoryClient{
 		remoteOpts: remoteOpts,
 		ref:        ref,

--- a/pkg/image/verifiers/cpol/notary/repository_test.go
+++ b/pkg/image/verifiers/cpol/notary/repository_test.go
@@ -25,7 +25,7 @@ func TestResolve(t *testing.T) {
 	ref, err := name.ParseReference(imageRef)
 	assert.NilError(t, err)
 
-	repositoryClient := NewRepository(nil, ref)
+	repositoryClient := newRepository(nil, ref)
 
 	desc, err := repositoryClient.Resolve(ctx, repoDesc.Digest.String())
 	assert.NilError(t, err)
@@ -45,7 +45,7 @@ func TestListSignatures(t *testing.T) {
 	ref, err := name.ParseReference(imageRef)
 	assert.NilError(t, err)
 
-	repositoryClient := NewRepository(nil, ref)
+	repositoryClient := newRepository(nil, ref)
 	fn := func(_ []ocispec.Descriptor) error {
 		return nil
 	}
@@ -66,7 +66,7 @@ func TestFetchSignatureBlob(t *testing.T) {
 	ref, err := name.ParseReference(imageRef)
 	assert.NilError(t, err)
 
-	repositoryClient := NewRepository(nil, ref)
+	repositoryClient := newRepository(nil, ref)
 
 	referrers, err := remote.Referrers(ref.Context().Digest(ociDesc.Digest.String()))
 	assert.NilError(t, err)

--- a/pkg/image/verifiers/cpol/notary/truststore.go
+++ b/pkg/image/verifiers/cpol/notary/truststore.go
@@ -14,7 +14,7 @@ type simpleTrustStore struct {
 	certs     []*x509.Certificate
 }
 
-func NewTrustStore(name string, certs []*x509.Certificate) truststore.X509TrustStore {
+func newTrustStore(name string, certs []*x509.Certificate) truststore.X509TrustStore {
 	return &simpleTrustStore{
 		name:      name,
 		storeType: truststore.TypeCA,

--- a/pkg/image/verifiers/cpol/notary/truststore_test.go
+++ b/pkg/image/verifiers/cpol/notary/truststore_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewTrustStore(t *testing.T) {
 	certs := []*x509.Certificate{{}, {}}
-	ts := NewTrustStore("test-store", certs)
+	ts := newTrustStore("test-store", certs)
 
 	if ts == nil {
 		t.Fatal("NewTrustStore returned nil")
@@ -19,7 +19,7 @@ func TestNewTrustStore(t *testing.T) {
 
 func TestSimpleTrustStore_GetCertificates(t *testing.T) {
 	certs := []*x509.Certificate{{}, {}}
-	ts := NewTrustStore("my-store", certs)
+	ts := newTrustStore("my-store", certs)
 
 	tests := []struct {
 		name      string
@@ -48,7 +48,7 @@ func TestSimpleTrustStore_GetCertificates(t *testing.T) {
 }
 
 func TestSimpleTrustStore_EmptyCerts(t *testing.T) {
-	ts := NewTrustStore("empty-store", nil)
+	ts := newTrustStore("empty-store", nil)
 	got, err := ts.GetCertificates(context.Background(), truststore.TypeCA, "empty-store")
 	if err != nil {
 		t.Errorf("GetCertificates() unexpected error = %v", err)

--- a/pkg/image/verifiers/response.go
+++ b/pkg/image/verifiers/response.go
@@ -2,5 +2,5 @@ package verifiers
 
 type Response struct {
 	Digest     string
-	Statements []map[string]interface{}
+	Statements []map[string]any
 }


### PR DESCRIPTION
## Explanation

Make everything in cpol image verifiers private.
