### PR TITLE
fix(cli): correctly report test failures for excluded resources

### DIFF
--- a/cmd/cli/kubectl-kyverno/apis/v1alpha1/rule.go
+++ b/cmd/cli/kubectl-kyverno/apis/v1alpha1/rule.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 // Rule declares values for a given policy rule
 type Rule struct {
-	// Name is the name of the ppolicy rule
+	// Name is the name of the policy rule
 	Name string `json:"name"`
 
 	// Values are the values for the given policy rule
@@ -11,9 +11,9 @@ type Rule struct {
 	// +kubebuilder:validation:Schemaless
 	Values map[string]interface{} `json:"values,omitempty"`
 
-	// ForeachValues are the foreach values for the given policy rule
-	// +kubebuilder:validation:Type=object
+	// ForeachValues are the foreach values for the given policy rule, indexed per foreach block
+	// +kubebuilder:validation:Type=array
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Schemaless
-	ForeachValues map[string][]interface{} `json:"foreachValues,omitempty"`
+	ForeachValues []map[string][]interface{} `json:"foreachValues,omitempty"`
 }

--- a/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
@@ -388,11 +388,11 @@ spec:
                         properties:
                           foreachValues:
                             description: ForeachValues are the foreach values for
-                              the given policy rule
-                            type: object
+                              the given policy rule, indexed per foreach block
+                            type: array
                             x-kubernetes-preserve-unknown-fields: true
                           name:
-                            description: Name is the name of the ppolicy rule
+                            description: Name is the name of the policy rule
                             type: string
                           values:
                             description: Values are the values for the given policy

--- a/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_values.yaml
+++ b/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_values.yaml
@@ -180,11 +180,11 @@ spec:
                     properties:
                       foreachValues:
                         description: ForeachValues are the foreach values for the
-                          given policy rule
-                        type: object
+                          given policy rule, indexed per foreach block
+                        type: array
                         x-kubernetes-preserve-unknown-fields: true
                       name:
-                        description: Name is the name of the ppolicy rule
+                        description: Name is the name of the policy rule
                         type: string
                       values:
                         description: Values are the values for the given policy rule

--- a/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
@@ -388,11 +388,11 @@ spec:
                         properties:
                           foreachValues:
                             description: ForeachValues are the foreach values for
-                              the given policy rule
-                            type: object
+                              the given policy rule, indexed per foreach block
+                            type: array
                             x-kubernetes-preserve-unknown-fields: true
                           name:
-                            description: Name is the name of the ppolicy rule
+                            description: Name is the name of the policy rule
                             type: string
                           values:
                             description: Values are the values for the given policy

--- a/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_values.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_values.yaml
@@ -180,11 +180,11 @@ spec:
                     properties:
                       foreachValues:
                         description: ForeachValues are the foreach values for the
-                          given policy rule
-                        type: object
+                          given policy rule, indexed per foreach block
+                        type: array
                         x-kubernetes-preserve-unknown-fields: true
                       name:
-                        description: Name is the name of the ppolicy rule
+                        description: Name is the name of the policy rule
                         type: string
                       values:
                         description: Values are the values for the given policy rule

--- a/cmd/cli/kubectl-kyverno/store/contextloader.go
+++ b/cmd/cli/kubectl-kyverno/store/contextloader.go
@@ -20,18 +20,42 @@ func ContextLoaderFactory(s *Store, cmResolver engineapi.ConfigmapResolver) engi
 	}
 	return func(policy kyvernov1.PolicyInterface, rule kyvernov1.Rule) engineapi.ContextLoader {
 		init := func(jsonContext enginecontext.Interface) error {
-			rule := s.GetPolicyRule(policy.GetName(), rule.Name)
-			if rule != nil && len(rule.Values) > 0 {
-				variables := rule.Values
-				for key, value := range variables {
+			storeRule := s.GetPolicyRule(policy.GetName(), rule.Name)
+			if storeRule == nil {
+				return nil
+			}
+			if len(storeRule.Values) > 0 {
+				for key, value := range storeRule.Values {
 					if err := jsonContext.AddVariable(key, value); err != nil {
 						return err
 					}
 				}
 			}
-			if rule != nil && len(rule.ForEachValues) > 0 {
-				for key, value := range rule.ForEachValues {
-					if err := jsonContext.AddVariable(key, value[s.GetForeachElement()]); err != nil {
+			if len(storeRule.ForEachValues) == 0 {
+				return nil
+			}
+			blockIdx := 0
+			if raw, err := jsonContext.Query("foreachBlockIndex"); err == nil {
+				if v, ok := raw.(int64); ok {
+					blockIdx = int(v)
+				}
+			}
+			if blockIdx < 0 || blockIdx >= len(storeRule.ForEachValues) {
+				return nil
+			}
+			blockValues := storeRule.ForEachValues[blockIdx]
+			if len(blockValues) == 0 {
+				return nil
+			}
+			elemIdx := 0
+			if raw, err := jsonContext.Query("elementIndex"); err == nil {
+				if v, ok := raw.(int64); ok {
+					elemIdx = int(v)
+				}
+			}
+			for key, values := range blockValues {
+				if elemIdx >= 0 && elemIdx < len(values) {
+					if err := jsonContext.AddVariable(key, values[elemIdx]); err != nil {
 						return err
 					}
 				}

--- a/cmd/cli/kubectl-kyverno/store/contextloader_test.go
+++ b/cmd/cli/kubectl-kyverno/store/contextloader_test.go
@@ -1,0 +1,107 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
+)
+
+type mockJsonContext struct {
+	enginecontext.Interface
+	vars map[string]interface{}
+}
+
+func (m *mockJsonContext) AddVariable(key string, value interface{}) error {
+	m.vars[key] = value
+	return nil
+}
+
+func (m *mockJsonContext) Query(key string) (interface{}, error) {
+	if val, ok := m.vars[key]; ok {
+		return val, nil
+	}
+	return nil, nil
+}
+
+func TestContextLoaderFactory_Init(t *testing.T) {
+	s := &Store{}
+	s.SetLocal(true)
+	s.SetPolicies(Policy{
+		Name: "test-policy",
+		Rules: []Rule{
+			{
+				Name: "test-rule",
+				Values: map[string]interface{}{
+					"foo": "bar",
+				},
+				ForEachValues: []map[string][]interface{}{
+					{
+						"baz": []interface{}{"qux", "quux"},
+					},
+					{
+						"baz2": []interface{}{"qux2", "quux2"},
+					},
+				},
+			},
+		},
+	})
+
+	factory := ContextLoaderFactory(s, nil)
+
+	policy := &kyvernov1.ClusterPolicy{}
+	policy.SetName("test-policy")
+	rule := kyvernov1.Rule{Name: "test-rule"}
+
+	loader := factory(policy, rule)
+
+	// Context with element 0, block 0
+	ctx1 := &mockJsonContext{vars: map[string]interface{}{
+		"foreachBlockIndex": int64(0),
+		"elementIndex":      int64(0),
+	}}
+
+	err := loader.Load(context.Background(), nil, nil, nil, nil, ctx1)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if val, ok := ctx1.vars["foo"]; !ok || val != "bar" {
+		t.Errorf("Expected variable foo=bar, got %v", val)
+	}
+	if val, ok := ctx1.vars["baz"]; !ok || val != "qux" {
+		t.Errorf("Expected variable baz=qux, got %v", val)
+	}
+
+	// Context with element 1, block 0
+	ctx2 := &mockJsonContext{vars: map[string]interface{}{
+		"foreachBlockIndex": int64(0),
+		"elementIndex":      int64(1),
+	}}
+	if err := loader.Load(context.Background(), nil, nil, nil, nil, ctx2); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if val, ok := ctx2.vars["baz"]; !ok || val != "quux" {
+		t.Errorf("Expected variable baz=quux, got %v", val)
+	}
+
+	// Context with out of bounds block
+	ctx3 := &mockJsonContext{vars: map[string]interface{}{
+		"foreachBlockIndex": int64(5),
+		"elementIndex":      int64(0),
+	}}
+	if err := loader.Load(context.Background(), nil, nil, nil, nil, ctx3); err != nil {
+		t.Fatalf("Unexpected error on out-of-bounds block: %v", err)
+	}
+
+	// Context with out of bounds element
+	ctx4 := &mockJsonContext{vars: map[string]interface{}{
+		"foreachBlockIndex": int64(0),
+		"elementIndex":      int64(5),
+	}}
+	if err := loader.Load(context.Background(), nil, nil, nil, nil, ctx4); err != nil {
+		t.Fatalf("Unexpected error on out-of-bounds element: %v", err)
+	}
+}

--- a/cmd/cli/kubectl-kyverno/store/store.go
+++ b/cmd/cli/kubectl-kyverno/store/store.go
@@ -15,9 +15,9 @@ type Policy struct {
 }
 
 type Rule struct {
-	Name          string                   `json:"name"`
-	Values        map[string]interface{}   `json:"values"`
-	ForEachValues map[string][]interface{} `json:"foreachValues"`
+	Name          string                     `json:"name"`
+	Values        map[string]interface{}     `json:"values"`
+	ForEachValues []map[string][]interface{} `json:"foreachValues"`
 }
 
 type Store struct {
@@ -25,7 +25,6 @@ type Store struct {
 	registryClient registryclient.Client
 	allowApiCalls  bool
 	policies       []Policy
-	foreachElement int
 	gctxStore      loaders.Store
 }
 
@@ -37,14 +36,6 @@ func (s *Store) SetLocal(m bool) {
 // IsLocal returns 'true' if the CLI is in local (clusterless) execution
 func (s *Store) IsLocal() bool {
 	return s.local
-}
-
-func (s *Store) SetForEachElement(element int) {
-	s.foreachElement = element
-}
-
-func (s *Store) GetForeachElement() int {
-	return s.foreachElement
 }
 
 func (s *Store) SetRegistryAccess(access bool) {

--- a/cmd/cli/kubectl-kyverno/variables/variables_test.go
+++ b/cmd/cli/kubectl-kyverno/variables/variables_test.go
@@ -108,8 +108,8 @@ func TestVariables_SetInStore(t *testing.T) {
 			Values: map[string]interface{}{
 				"foo": "bar",
 			},
-			ForeachValues: map[string][]interface{}{
-				"baz": nil,
+			ForeachValues: []map[string][]interface{}{
+				{"baz": nil},
 			},
 		}},
 	})

--- a/docs/user/cli/crd/index.html
+++ b/docs/user/cli/crd/index.html
@@ -1029,7 +1029,7 @@ string
 </em>
 </td>
 <td>
-<p>Name is the name of the ppolicy rule</p>
+<p>Name is the name of the policy rule</p>
 </td>
 </tr>
 <tr>
@@ -1047,11 +1047,11 @@ map[string]interface{}
 <td>
 <code>foreachValues</code><br/>
 <em>
-map[string][]interface{}
+[]map[string][]interface{}
 </em>
 </td>
 <td>
-<p>ForeachValues are the foreach values for the given policy rule</p>
+<p>ForeachValues are the foreach values for the given policy rule, indexed per foreach block</p>
 </td>
 </tr>
 </tbody>

--- a/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
+++ b/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
@@ -2225,7 +2225,7 @@ This field is deprecated, use <code>metadata.name</code> instead</p>
         <td>
           
 
-          <p>Name is the name of the ppolicy rule</p>
+          <p>Name is the name of the policy rule</p>
 
 
           
@@ -2276,14 +2276,14 @@ This field is deprecated, use <code>metadata.name</code> instead</p>
           
           
             
-              <span style="font-family: monospace">map[string][]interface{}</span>
+              <span style="font-family: monospace">[]map[string][]interface{}</span>
             
           
         </td>
         <td>
           
 
-          <p>ForeachValues are the foreach values for the given policy rule</p>
+          <p>ForeachValues are the foreach values for the given policy rule, indexed per foreach block</p>
 
 
           

--- a/pkg/engine/handlers/mutation/common.go
+++ b/pkg/engine/handlers/mutation/common.go
@@ -28,11 +28,15 @@ type forEachMutator struct {
 func (f *forEachMutator) mutateForEach(ctx context.Context) *mutate.Response {
 	var applyCount int
 
-	for _, foreach := range f.foreach {
+	for i, foreach := range f.foreach {
 		elements, err := engineutils.EvaluateList(foreach.List, f.policyContext.JSONContext())
 		if err != nil {
 			msg := fmt.Sprintf("failed to evaluate list %s: %v", foreach.List, err)
 			return mutate.NewErrorResponse(msg, err)
+		}
+
+		if err := f.policyContext.JSONContext().AddVariable("foreachBlockIndex", int64(i)); err != nil {
+			return mutate.NewErrorResponse("failed to set foreachBlockIndex", err)
 		}
 
 		mutateResp := f.mutateElements(ctx, foreach, elements)

--- a/pkg/engine/handlers/validation/validate_resource.go
+++ b/pkg/engine/handlers/validation/validate_resource.go
@@ -223,7 +223,7 @@ func (v *validator) validateOldObject(ctx context.Context) (resp *engineapi.Rule
 func (v *validator) validateForEach(ctx context.Context) *engineapi.RuleResponse {
 	applyCount := 0
 	var listEvalError error
-	for _, foreach := range v.forEach {
+	for i, foreach := range v.forEach {
 		elements, err := engineutils.EvaluateList(foreach.List, v.policyContext.JSONContext())
 		if err != nil {
 			if strings.Contains(err.Error(), "Unknown key") {
@@ -233,6 +233,9 @@ func (v *validator) validateForEach(ctx context.Context) *engineapi.RuleResponse
 			v.log.V(2).Info("failed to evaluate list", "list", foreach.List, "error", err.Error())
 			listEvalError = err
 			continue
+		}
+		if err := v.policyContext.JSONContext().AddVariable("foreachBlockIndex", int64(i)); err != nil {
+			return engineapi.RuleError(v.rule.Name, engineapi.Validation, "failed to set foreachBlockIndex", err, v.rule.ReportProperties)
 		}
 		resp, count := v.validateElements(ctx, foreach, elements, foreach.ElementScope)
 		if resp.Status() != engineapi.RuleStatusPass {

--- a/test/cli/test/context-foreach-multi/kyverno-test.yaml
+++ b/test/cli/test/context-foreach-multi/kyverno-test.yaml
@@ -1,0 +1,18 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: test-context-foreach-multi
+policies:
+- policy.yaml
+resources:
+- resources.yaml
+results:
+- kind: Pod
+  policy: check-images
+  resources:
+  - good-pod
+  - bad-container-pod
+  - bad-initcontainer-pod
+  result: pass
+  rule: check-images
+variables: values.yaml

--- a/test/cli/test/context-foreach-multi/policy.yaml
+++ b/test/cli/test/context-foreach-multi/policy.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: check-images
+spec:
+  rules:
+  - name: check-images
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      failureAction: Enforce
+      foreach:
+      - list: request.object.spec.containers
+        context:
+        - name: registryData
+          imageRegistry:
+            reference: "{{ element.image }}"
+        deny:
+          conditions:
+            any:
+            - key: "{{ registryData }}"
+              operator: Equals
+              value: "blocked"
+      - list: request.object.spec.initContainers
+        context:
+        - name: initRegistryData
+          imageRegistry:
+            reference: "{{ element.image }}"
+        deny:
+          conditions:
+            any:
+            - key: "{{ initRegistryData }}"
+              operator: Equals
+              value: "blocked"
+      message: "Image is blocked by policy."

--- a/test/cli/test/context-foreach-multi/resources.yaml
+++ b/test/cli/test/context-foreach-multi/resources.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+spec:
+  initContainers:
+  - name: init-setup
+    image: busybox:1.28
+  containers:
+  - name: app
+    image: nginx:latest
+  - name: sidecar
+    image: busybox:1.28
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-container-pod
+spec:
+  initContainers:
+  - name: init-setup
+    image: busybox:1.28
+  containers:
+  - name: app
+    image: nginx:latest
+  - name: bad
+    image: blocked:latest
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-initcontainer-pod
+spec:
+  initContainers:
+  - name: init-blocked
+    image: evil:latest
+  containers:
+  - name: app
+    image: nginx:latest

--- a/test/cli/test/context-foreach-multi/values.yaml
+++ b/test/cli/test/context-foreach-multi/values.yaml
@@ -1,0 +1,12 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Values
+policies:
+- name: check-images
+  rules:
+  - foreachValues:
+    - registryData:
+      - ok
+      - ok
+    - initRegistryData:
+      - ok
+    name: check-images

--- a/test/cli/test/context-foreach/values.yaml
+++ b/test/cli/test/context-foreach/values.yaml
@@ -4,7 +4,7 @@ policies:
 - name: block-images
   rules:
   - foreachValues:
-      imageData:
+    - imageData:
       - foo
       - foo1
     name: block-images


### PR DESCRIPTION
## Explanation
Currently, the Kyverno CLI unconditionally reports excluded resources as a successful `Pass`, completely ignoring whatever the user configured in `test.Result`. This fix ensures that if a resource gets skipped/excluded, but the test specifically expected it to fail, the CLI correctly logs it as a test failure.

## Related issue
Closes #12198

## Milestone of this PR
<!--
/milestone <target_milestone>
-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this
/kind bug

## Proposed Changes
In `#12198`, a syntax error in an operator caused the engine to drop resources upfront in the matching phase, resulting in exclusions. Because [output.go](cci:7://file:///c:/Users/monika/OneDrive/Desktop/kyverno/cmd/cli/kubectl kyverno/commands/test/output.go:0:0-0:0) hardcoded all zero-length rule evaluations to `IsFailure: false`, it skipped over the user's expected test failure.

This PR updates the two exclusion blocks in [output.go](cci:7://file:///c:/Users/monika/OneDrive/Desktop/kyverno/cmd/cli/kubectl-kyverno/commands/test/output.go:0:0-0:0) to simply check `test.Result != "" && test.Result != openreports.StatusSkip` rather than blindly hardcoding a pass.

### Proof Manifests

# Kubernetes resource

```yaml
apiVersion: iam.aws.crossplane.io/v1beta1
kind: IAMRole
metadata:
  name: missing-team
spec:
  forProvider:
    tags:
      application: test-app

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

apiVersion: cli.kyverno.io/v1alpha1
kind: Test
metadata:
  name: test-aws-resource-tags
policies:
  - aws-resource-tags.yaml
resources:
  - test-data.yaml
results:
  - policy: require-aws-resource-tags
    rule: check-team-tag
    resource: missing-team
    kind: IAMRole
    result: fail


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

None.
