### PR TITLE
Fix: Silent status overwrite masks generate cleanup failures

### DIFF
--- a/pkg/background/generate/cleanup.go
+++ b/pkg/background/generate/cleanup.go
@@ -30,13 +30,9 @@ func (c *GenerateController) deleteDownstream(policy kyvernov1.PolicyInterface, 
 
 		if len(errs) != 0 {
 			c.log.Error(multierr.Combine(errs...), "failed to clean up downstream resources on policy deletion")
-			_, err = c.statusControl.Failed(ur.GetName(),
-				fmt.Sprintf("failed to clean up downstream resources on policy deletion: %v", multierr.Combine(errs...)),
-				failedDownstreams)
-		} else {
-			_, err = c.statusControl.Success(ur.GetName(), nil)
+			return multierr.Combine(errs...)
 		}
-		return
+		return nil
 	}
 
 	if policy == nil {
@@ -71,25 +67,16 @@ func (c *GenerateController) handleNonPolicyChanges(policy kyvernov1.PolicyInter
 			return nil
 		}
 		var errs []error
-		failedDownstreams := []kyvernov1.ResourceSpec{}
 		for _, downstream := range downstreams {
 			spec := common.ResourceSpecFromUnstructured(downstream)
 			if err := c.client.DeleteResource(context.TODO(), downstream.GetAPIVersion(), downstream.GetKind(), downstream.GetNamespace(), downstream.GetName(), false, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-				failedDownstreams = append(failedDownstreams, spec)
 				errs = append(errs, err)
 			} else {
 				logger.Info("downstream resource deleted", "spec", spec.String())
 			}
 		}
 		if len(errs) != 0 {
-			_, err = c.statusControl.Failed(ur.GetName(),
-				fmt.Sprintf("failed to clean up downstream resources on source deletion: %v", multierr.Combine(errs...)),
-				failedDownstreams)
-		} else {
-			_, err = c.statusControl.Success(ur.GetName(), nil)
-		}
-		if err != nil {
-			logger.Error(err, "failed to update ur status")
+			return multierr.Combine(errs...)
 		}
 	}
 


### PR DESCRIPTION
### What's broken

When a trigger resource gets deleted under a `synchronize: true` generate policy, Kyverno creates an UpdateRequest to clean up downstream resources. If that cleanup fails (finalizer blocking deletion, RBAC gap, transient API error), the UR still ends up in `Success` state , no retry, no alert.

The issue is a double-write race. `handleNonPolicyChanges` calls `statusControl.Failed()` when deletions fail, but then returns `nil`. That nil bubbles up through `applyGenerate` → `ProcessUR`, where `failures` ends up empty and `updateStatus` calls `statusControl.Success()`, overwriting the failure that was just written.

```go
// falls through → returns nil regardless
// controller.go:133 then overwrites whatever cleanup.go wrote
return updateStatus(c.statusControl, *ur, multierr.Combine(failures...), genResources)
// failures is empty → Success overwrites Failed
```



### Potential impact

- Downstream resources blocked by finalizers or RBAC gaps may be left orphaned
- `kubectl get ur` could show `Completed` even when cleanup failed
- Since `ProcessUR` returns nil, the workqueue won't requeue ,  the failure may never get retried



### Fix

I removed the `statusControl` calls from both `deleteDownstream` and `handleNonPolicyChanges` and just returned the error up the chain. `ProcessUR` already owns status writes via `updateStatus` ,  it should be the only place doing this.

```go
if len(errs) != 0 {
    return multierr.Combine(errs...)
}
return nil
```

Now when deletion fails, `ProcessUR` gets a non-nil error, the workqueue retries with backoff, and the UR status actually reflects what happened.