### PR TITLE
Honor stderrthreshold when logtostderr is enabled

### DIFF
--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -50,6 +50,14 @@ func InitFlags(flags *flag.FlagSet) {
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	}
 	klog.InitFlags(flags)
+	// Opt into the new klog behavior where -stderrthreshold is honored even
+	// when -logtostderr=true (see kubernetes/klog#212, kubernetes/klog#432).
+	fs := flags
+	if fs == nil {
+		fs = flag.CommandLine
+	}
+	fs.Set("legacy_stderr_threshold_behavior", "false") //nolint:errcheck
+	fs.Set("stderrthreshold", "INFO")                   //nolint:errcheck
 }
 
 // Setup configures the logger with the supplied log format.


### PR DESCRIPTION
## Summary

- Opt into the new klog behavior by setting `-legacy_stderr_threshold_behavior=false` so that `-stderrthreshold` is honored even when `-logtostderr=true` (the klog default).
- Set `stderrthreshold=INFO` to preserve backward-compatible behavior (all logs still appear on stderr by default). Users can now override `-stderrthreshold` to `WARNING` or `ERROR` to reduce stderr noise.

This project already uses klog v2.140.0 which includes the fix. This PR just enables it.

## Background

When `-logtostderr=true` (klog's default), the `-stderrthreshold` flag was completely ignored — all log levels were written to stderr. Log aggregation systems that infer severity from the output stream (stdout=INFO, stderr=ERROR) would misclassify every log message as an error.

klog v2.140.0 (kubernetes/klog#432) introduced a fix behind the `-legacy_stderr_threshold_behavior` flag. Setting it to `false` enables proper severity-based filtering.

## Test plan

- [ ] Existing tests pass
- [ ] Deploy with default configuration — all logs appear on stderr (backward compatible)
- [ ] Deploy with `-stderrthreshold=WARNING` — only WARNING and above appear on stderr

Ref: kubernetes/klog#212, kubernetes/klog#432