### PR TITLE
test(webhook): validate webhook name and path generation

### DIFF
--- a/pkg/controllers/webhook/utils_test.go
+++ b/pkg/controllers/webhook/utils_test.go
@@ -886,3 +886,24 @@ func TestSortedRules(t *testing.T) {
 		})
 	}
 }
+
+func TestWebhookNameAndPath(t *testing.T) {
+	t.Run("default fail policy", func(t *testing.T) {
+		wh := newWebhook(DefaultWebhookTimeout, fail, nil)
+
+		name, path := webhookNameAndPath(*wh, "kyverno-resource", "/validate")
+
+		assert.Equal(t, "kyverno-resource-fail", name)
+		assert.Equal(t, "/validate/fail", path)
+	})
+
+	t.Run("ignore policy with fine-grained key", func(t *testing.T) {
+		wh := newWebhook(DefaultWebhookTimeout, ignore, nil)
+		wh.policyMeta.Name = "restrict-image"
+
+		name, path := webhookNameAndPath(*wh, "kyverno-resource", "/validate")
+
+		assert.Contains(t, name, "kyverno-resource-ignore-finegrained-restrict-image")
+		assert.Equal(t, "/validate/ignore/finegrained/restrict-image", path)
+	})
+}


### PR DESCRIPTION
## Description
Adds unit coverage for webhook name/path generation across fail and ignore policies, including fine-grained webhook naming. This verifies stable webhook endpoint construction and guards against routing/name regressions.