### PR TITLE
Add mpol handler gap tests (namespaced, exception, failurePolicy, dry-run, backgroundSA)

### DIFF
--- a/test/integration/framework/helpers.go
+++ b/test/integration/framework/helpers.go
@@ -27,21 +27,21 @@ import (
 // the same test can otherwise overlap and race on the underlying slice.
 type MockEventGen struct {
 	mu     sync.Mutex
-	Events []event.Info
+	events []event.Info
 }
 
 func (m *MockEventGen) Add(infoList ...event.Info) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.Events = append(m.Events, infoList...)
+	m.events = append(m.events, infoList...)
 }
 
 // GetEvents returns a snapshot of captured events (thread-safe).
 func (m *MockEventGen) GetEvents() []event.Info {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	out := make([]event.Info, len(m.Events))
-	copy(out, m.Events)
+	out := make([]event.Info, len(m.events))
+	copy(out, m.events)
 	return out
 }
 

--- a/test/integration/framework/helpers.go
+++ b/test/integration/framework/helpers.go
@@ -22,12 +22,27 @@ import (
 )
 
 // MockEventGen captures events for test assertions.
+// Thread-safe because the mpol/vpol handlers spawn an async audit goroutine
+// that calls Add() after the handler returns; back-to-back handler calls in
+// the same test can otherwise overlap and race on the underlying slice.
 type MockEventGen struct {
+	mu     sync.Mutex
 	Events []event.Info
 }
 
 func (m *MockEventGen) Add(infoList ...event.Info) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.Events = append(m.Events, infoList...)
+}
+
+// GetEvents returns a snapshot of captured events (thread-safe).
+func (m *MockEventGen) GetEvents() []event.Info {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]event.Info, len(m.Events))
+	copy(out, m.Events)
+	return out
 }
 
 // PodAdmissionRequest builds a handlers.AdmissionRequest for a Pod CREATE operation.
@@ -159,6 +174,22 @@ func CreateNamespace(t *testing.T, kubeClient kubernetes.Interface, name string)
 	t.Cleanup(func() {
 		_ = kubeClient.CoreV1().Namespaces().Delete(context.Background(), name, metav1.DeleteOptions{})
 	})
+}
+
+// PodAdmissionRequestDryRun builds a handlers.AdmissionRequest for a Pod CREATE with DryRun set to true.
+func PodAdmissionRequestDryRun(name, namespace string, raw []byte) handlers.AdmissionRequest {
+	req := PodAdmissionRequest(name, namespace, raw)
+	dryRun := true
+	req.DryRun = &dryRun
+	return req
+}
+
+// PodAdmissionRequestWithUsername builds a handlers.AdmissionRequest for a Pod CREATE
+// with a custom UserInfo.Username (e.g. for backgroundServiceAccountName tests).
+func PodAdmissionRequestWithUsername(name, namespace, username string, raw []byte) handlers.AdmissionRequest {
+	req := PodAdmissionRequest(name, namespace, raw)
+	req.UserInfo = authenticationv1.UserInfo{Username: username}
+	return req
 }
 
 // PodAdmissionRequestWithOp builds a handlers.AdmissionRequest for a Pod with the given operation.

--- a/test/integration/framework/mpol.go
+++ b/test/integration/framework/mpol.go
@@ -3,10 +3,13 @@ package framework
 import (
 	"context"
 
+	celengine "github.com/kyverno/kyverno/pkg/cel/engine"
 	"github.com/kyverno/kyverno/pkg/cel/libs"
 	"github.com/kyverno/kyverno/pkg/cel/matching"
 	mpolcompiler "github.com/kyverno/kyverno/pkg/cel/policies/mpol/compiler"
 	mpolengine "github.com/kyverno/kyverno/pkg/cel/policies/mpol/engine"
+	kyvernoclient "github.com/kyverno/kyverno/pkg/client/clientset/versioned"
+	kyvernoinformer "github.com/kyverno/kyverno/pkg/client/informers/externalversions"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -16,10 +19,21 @@ import (
 // This mirrors the production wiring in cmd/kyverno/main.go:
 // compiler → KubeProvider(openapi) → engine(typeConverter, contextProvider).
 func NewMpolEngine(ctx context.Context, mgr ctrl.Manager, kubeClient kubernetes.Interface, contextProvider libs.Context) (mpolengine.Engine, mpolengine.Provider, error) {
+	return newMpolEngine(ctx, mgr, kubeClient, contextProvider, nil, false)
+}
+
+// NewMpolEngineWithExceptions creates an mpol engine with PolicyException support enabled.
+// This mirrors production wiring with celExceptionLister passed to NewKubeProvider.
+func NewMpolEngineWithExceptions(ctx context.Context, mgr ctrl.Manager, kubeClient kubernetes.Interface, kyvernoClient kyvernoclient.Interface, contextProvider libs.Context) (mpolengine.Engine, mpolengine.Provider, error) {
+	polexLister := NewPolexLister(ctx, kyvernoClient)
+	return newMpolEngine(ctx, mgr, kubeClient, contextProvider, polexLister, true)
+}
+
+func newMpolEngine(ctx context.Context, mgr ctrl.Manager, kubeClient kubernetes.Interface, contextProvider libs.Context, polexLister celengine.PolicyExceptionLister, polexEnabled bool) (mpolengine.Engine, mpolengine.Provider, error) {
 	compiler := mpolcompiler.NewCompiler()
 	openapiClient := kubeClient.Discovery().OpenAPIV3()
 
-	provider, typeConverter, err := mpolengine.NewKubeProvider(ctx, compiler, contextProvider, mgr, openapiClient, nil, false)
+	provider, typeConverter, err := mpolengine.NewKubeProvider(ctx, compiler, contextProvider, mgr, openapiClient, polexLister, polexEnabled)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -28,4 +42,14 @@ func NewMpolEngine(ctx context.Context, mgr ctrl.Manager, kubeClient kubernetes.
 	matcher := matching.NewMatcher()
 
 	return mpolengine.NewEngine(provider, nsResolver, matcher, typeConverter, contextProvider), provider, nil
+}
+
+// NewPolexLister creates a real informer-backed PolicyException lister,
+// mirroring the production wiring: kyvernoClient → SharedInformerFactory → Lister.
+func NewPolexLister(ctx context.Context, kyvernoClient kyvernoclient.Interface) celengine.PolicyExceptionLister {
+	factory := kyvernoinformer.NewSharedInformerFactory(kyvernoClient, 0)
+	lister := factory.Policies().V1beta1().PolicyExceptions().Lister()
+	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
+	return celengine.NewPolicyExceptionLister(lister, "")
 }

--- a/test/integration/mpol/handler_test.go
+++ b/test/integration/mpol/handler_test.go
@@ -20,7 +20,9 @@ import (
 	"gomodules.xyz/jsonpatch/v2"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -38,7 +40,9 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	engine, provider, err = framework.NewMpolEngine(context.Background(), testEnv.Mgr, testEnv.KubeClient, testEnv.ContextProvider)
+	// Use exception-enabled engine for all tests. When no PolicyExceptions exist,
+	// behavior is identical to the non-exception engine (ListExceptions returns nil).
+	engine, provider, err = framework.NewMpolEngineWithExceptions(context.Background(), testEnv.Mgr, testEnv.KubeClient, testEnv.KyvernoClient, testEnv.ContextProvider)
 	if err != nil {
 		testEnv.Stop()
 		panic(err)
@@ -80,6 +84,28 @@ func createPolicyWithCleanup(t *testing.T, policy *policiesv1beta1.MutatingPolic
 	t.Cleanup(func() {
 		testEnv.Client.Delete(context.Background(), policy)
 		waitForPolicyGone(t)
+	})
+}
+
+// createNamespacedPolicyWithCleanup creates a NamespacedMutatingPolicy and registers cleanup.
+func createNamespacedPolicyWithCleanup(t *testing.T, policy *policiesv1beta1.NamespacedMutatingPolicy) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, testEnv.Client.Create(ctx, policy))
+	t.Cleanup(func() {
+		testEnv.Client.Delete(context.Background(), policy)
+		waitForPolicyGone(t)
+	})
+}
+
+// createNamespace creates a namespace in envtest and registers cleanup.
+func createNamespace(t *testing.T, name string) {
+	t.Helper()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	_, err := testEnv.KubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		testEnv.KubeClient.CoreV1().Namespaces().Delete(context.Background(), name, metav1.DeleteOptions{})
 	})
 }
 
@@ -241,7 +267,7 @@ func TestMutate_EventsGenerated_OnMutation(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	assert.True(t, resp.Allowed, "mutation should allow the resource")
-	assert.NotEmpty(t, eventGen.Events, "mutation should generate events")
+	assert.NotEmpty(t, eventGen.GetEvents(), "mutation should generate events")
 }
 
 func TestMutate_CELVariables_UsedInMutation(t *testing.T) {
@@ -331,4 +357,325 @@ func TestMutate_MultipleMutations_ChainedCorrectly(t *testing.T) {
 	costPatch := findPatch(patches, "/metadata/labels/cost-center")
 	require.NotNil(t, costPatch, "patch for /metadata/labels/cost-center should exist")
 	assert.Equal(t, "engineering", costPatch.Value)
+}
+
+// Test 1: Background controller's service account requests should bypass mutation entirely
+// to prevent infinite loops when the controller itself creates or modifies resources.
+func TestMutate_BackgroundControllerSkipsMutation(t *testing.T) {
+	// The mpol handler short-circuits when UserInfo.Username matches the configured
+	// background service account name, returning before engine evaluation. To prove
+	// the bypass actually fires (and the test would catch the short-circuit being
+	// removed), we register a real mutating policy that would otherwise apply a
+	// patch to every Pod, then verify the bypass discriminates: a normal request
+	// gets the patch, a background-SA request does not.
+	policy := &policiesv1beta1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "bg-controller-skip-mutation"},
+		Spec: policiesv1beta1.MutatingPolicySpec{
+			MatchConstraints: framework.PodMatchRules(),
+			Mutations: []admissionregistrationv1alpha1.Mutation{{
+				PatchType: admissionregistrationv1alpha1.PatchTypeJSONPatch,
+				JSONPatch: &admissionregistrationv1alpha1.JSONPatch{
+					Expression: `[JSONPatch{op: "add", path: "/metadata/labels/bg-controller-skip", value: "true"}]`,
+				},
+			}},
+		},
+	}
+	createPolicyWithCleanup(t, policy)
+	waitForPolicyReady(t, 1)
+
+	bgSA := "system:serviceaccount:kyverno:kyverno-background-controller"
+	eventGen := &framework.MockEventGen{}
+	h := mpol.New(testEnv.ContextProvider, engine, nil, reportutils.ReportingCfg, nil, bgSA, eventGen)
+
+	podJSON := []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {"name": "bg-pod", "namespace": "default", "labels": {}},
+		"spec": {"containers": [{"name": "app", "image": "nginx"}]}
+	}`)
+
+	ctx := framework.ContextWithPolicies(context.Background(), "bg-controller-skip-mutation")
+
+	t.Run("non-background request produces a patch", func(t *testing.T) {
+		resp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("bg-pod", "default", podJSON), "", time.Now())
+		assert.True(t, resp.Allowed, "non-background requests should still be allowed")
+		require.NotNil(t, resp.Patch, "configured mutation should produce a patch for normal requests")
+
+		patches := decodePatches(t, resp.Patch)
+		assert.NotNil(t, findPatch(patches, "/metadata/labels/bg-controller-skip"), "expected the policy's label patch")
+	})
+
+	t.Run("background controller skips mutation", func(t *testing.T) {
+		resp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequestWithUsername("bg-pod", "default", bgSA, podJSON), "", time.Now())
+		assert.True(t, resp.Allowed, "background controller requests should be allowed")
+		assert.Nil(t, resp.Patch, "background controller requests should not produce patches")
+	})
+}
+
+// Test 2: Dry-run requests should evaluate mutations but never create UpdateRequests,
+// honoring the SideEffects: NoneOnDryRun webhook contract.
+func TestMutate_DryRunSkipsUpdateRequestCreation(t *testing.T) {
+	// Mutate-existing policy: has TargetMatchConstraints and MutateExisting enabled.
+	// The handler fires URs for these policies unless it's a dry-run.
+	policy := &policiesv1beta1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "mutate-existing-on-pod"},
+		Spec: policiesv1beta1.MutatingPolicySpec{
+			MatchConstraints: framework.PodMatchRules(),
+			TargetMatchConstraints: &policiesv1beta1.TargetMatchConstraints{
+				MatchResources: *framework.PodMatchRules(),
+			},
+			EvaluationConfiguration: &policiesv1beta1.MutatingPolicyEvaluationConfiguration{
+				MutateExistingConfiguration: &policiesv1beta1.MutateExistingConfiguration{
+					Enabled: ptr.To(true),
+				},
+			},
+			Mutations: []admissionregistrationv1alpha1.Mutation{{
+				PatchType: admissionregistrationv1alpha1.PatchTypeJSONPatch,
+				JSONPatch: &admissionregistrationv1alpha1.JSONPatch{
+					Expression: `[JSONPatch{op: "add", path: "/metadata/labels/mutated", value: "true"}]`,
+				},
+			}},
+		},
+	}
+
+	createPolicyWithCleanup(t, policy)
+	waitForPolicyReady(t, 1)
+
+	urGen := &framework.MockURGenerator{}
+	eventGen := &framework.MockEventGen{}
+	h := mpol.New(testEnv.ContextProvider, engine, nil, reportutils.ReportingCfg, urGen, "", eventGen)
+
+	podJSON := []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {"name": "dryrun-pod", "namespace": "default", "labels": {}},
+		"spec": {"containers": [{"name": "app", "image": "nginx"}]}
+	}`)
+
+	// Non-dry-run should create a UR (proves the setup works)
+	t.Run("non-dry-run creates UR", func(t *testing.T) {
+		ctx := framework.ContextWithPolicies(context.Background(), "mutate-existing-on-pod")
+		resp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("ur-pod", "default", podJSON), "", time.Now())
+
+		assert.True(t, resp.Allowed)
+		// Wait for the async goroutine that fires URs
+		time.Sleep(300 * time.Millisecond)
+		assert.NotEmpty(t, urGen.GetSpecs(), "non-dry-run should create update requests")
+	})
+
+	// Reset UR generator for the dry-run test
+	urGen2 := &framework.MockURGenerator{}
+	h2 := mpol.New(testEnv.ContextProvider, engine, nil, reportutils.ReportingCfg, urGen2, "", eventGen)
+
+	// Dry-run should NOT create URs
+	t.Run("dry-run skips UR creation", func(t *testing.T) {
+		ctx := framework.ContextWithPolicies(context.Background(), "mutate-existing-on-pod")
+		resp := h2.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequestDryRun("dryrun-pod", "default", podJSON), "", time.Now())
+
+		assert.True(t, resp.Allowed)
+		time.Sleep(300 * time.Millisecond)
+		assert.Empty(t, urGen2.GetSpecs(), "dry-run should not create update requests")
+	})
+}
+
+// Test 3: When a CEL expression fails at evaluation time and failurePolicy is Fail,
+// the handler should reject the admission request.
+func TestMutate_FailurePolicy_FailBlocksOnCELError(t *testing.T) {
+	failPolicy := admissionregistrationv1.Fail
+	policy := &policiesv1beta1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "broken-cel-fail"},
+		Spec: policiesv1beta1.MutatingPolicySpec{
+			MatchConstraints: framework.PodMatchRules(),
+			FailurePolicy:    &failPolicy,
+			Mutations: []admissionregistrationv1alpha1.Mutation{{
+				PatchType: admissionregistrationv1alpha1.PatchTypeJSONPatch,
+				JSONPatch: &admissionregistrationv1alpha1.JSONPatch{
+					// Accessing a non-existent field on a dyn-typed object compiles OK
+					// but fails at evaluation time when the actual Pod has no such field.
+					Expression: `[JSONPatch{op: "add", path: "/metadata/labels/x", value: object.spec.nonExistentField}]`,
+				},
+			}},
+		},
+	}
+
+	createPolicyWithCleanup(t, policy)
+	waitForPolicyReady(t, 1)
+
+	eventGen := &framework.MockEventGen{}
+	h := mpol.New(testEnv.ContextProvider, engine, nil, reportutils.ReportingCfg, nil, "", eventGen)
+
+	ctx := framework.ContextWithPolicies(context.Background(), "broken-cel-fail")
+	resp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("fail-pod", "default", []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {"name": "fail-pod", "namespace": "default"},
+		"spec": {"containers": [{"name": "app", "image": "nginx"}]}
+	}`)), "", time.Now())
+
+	assert.False(t, resp.Allowed, "failurePolicy Fail should reject the request on CEL error")
+}
+
+// Test 4: When a CEL expression fails at evaluation time and failurePolicy is Ignore,
+// the handler should allow the request and silently skip the mutation.
+func TestMutate_FailurePolicy_IgnoreAllowsOnCELError(t *testing.T) {
+	ignorePolicy := admissionregistrationv1.Ignore
+	policy := &policiesv1beta1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "broken-cel-ignore"},
+		Spec: policiesv1beta1.MutatingPolicySpec{
+			MatchConstraints: framework.PodMatchRules(),
+			FailurePolicy:    &ignorePolicy,
+			Mutations: []admissionregistrationv1alpha1.Mutation{{
+				PatchType: admissionregistrationv1alpha1.PatchTypeJSONPatch,
+				JSONPatch: &admissionregistrationv1alpha1.JSONPatch{
+					Expression: `[JSONPatch{op: "add", path: "/metadata/labels/x", value: object.spec.nonExistentField}]`,
+				},
+			}},
+		},
+	}
+
+	createPolicyWithCleanup(t, policy)
+	waitForPolicyReady(t, 1)
+
+	eventGen := &framework.MockEventGen{}
+	h := mpol.New(testEnv.ContextProvider, engine, nil, reportutils.ReportingCfg, nil, "", eventGen)
+
+	ctx := framework.ContextWithPolicies(context.Background(), "broken-cel-ignore")
+	resp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("ignore-pod", "default", []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {"name": "ignore-pod", "namespace": "default"},
+		"spec": {"containers": [{"name": "app", "image": "nginx"}]}
+	}`)), "", time.Now())
+
+	assert.True(t, resp.Allowed, "failurePolicy Ignore should allow the request on CEL error")
+	assert.Nil(t, resp.Patch, "failed mutation should not produce patches")
+}
+
+// Test 5: A NamespacedMutatingPolicy in namespace "team-a" should only mutate
+// pods in "team-a", not pods in other namespaces. This is the multi-tenancy isolation
+// guarantee — each team's policies are scoped to their namespace.
+func TestMutateNamespaced_PolicyOnlyAppliesToItsNamespace(t *testing.T) {
+	createNamespace(t, "team-a")
+	createNamespace(t, "team-b")
+
+	policy := &policiesv1beta1.NamespacedMutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a-inject-label",
+			Namespace: "team-a",
+		},
+		Spec: policiesv1beta1.MutatingPolicySpec{
+			MatchConstraints: framework.PodMatchRules(),
+			Mutations: []admissionregistrationv1alpha1.Mutation{{
+				PatchType: admissionregistrationv1alpha1.PatchTypeJSONPatch,
+				JSONPatch: &admissionregistrationv1alpha1.JSONPatch{
+					Expression: `[JSONPatch{op: "add", path: "/metadata/labels/team", value: "frontend"}]`,
+				},
+			}},
+		},
+	}
+
+	createNamespacedPolicyWithCleanup(t, policy)
+	waitForPolicyReady(t, 1)
+
+	eventGen := &framework.MockEventGen{}
+	h := mpol.New(testEnv.ContextProvider, engine, nil, reportutils.ReportingCfg, nil, "", eventGen)
+
+	// Pod in team-a should get mutated
+	t.Run("same namespace gets mutated", func(t *testing.T) {
+		ctx := framework.ContextWithPolicies(context.Background(), "team-a-inject-label")
+		resp := h.MutateNamespaced(ctx, logr.Discard(), framework.PodAdmissionRequest("frontend-pod", "team-a", []byte(`{
+			"apiVersion": "v1", "kind": "Pod",
+			"metadata": {"name": "frontend-pod", "namespace": "team-a", "labels": {}},
+			"spec": {"containers": [{"name": "app", "image": "nginx"}]}
+		}`)), "", time.Now())
+
+		assert.True(t, resp.Allowed)
+		require.NotNil(t, resp.Patch, "pod in team-a should be mutated")
+		patches := decodePatches(t, resp.Patch)
+		p := findPatch(patches, "/metadata/labels/team")
+		require.NotNil(t, p)
+		assert.Equal(t, "frontend", p.Value)
+	})
+
+	// Pod in team-b should NOT get mutated
+	t.Run("different namespace not mutated", func(t *testing.T) {
+		ctx := framework.ContextWithPolicies(context.Background(), "team-a-inject-label")
+		resp := h.MutateNamespaced(ctx, logr.Discard(), framework.PodAdmissionRequest("backend-pod", "team-b", []byte(`{
+			"apiVersion": "v1", "kind": "Pod",
+			"metadata": {"name": "backend-pod", "namespace": "team-b", "labels": {}},
+			"spec": {"containers": [{"name": "app", "image": "nginx"}]}
+		}`)), "", time.Now())
+
+		assert.True(t, resp.Allowed)
+		assert.Nil(t, resp.Patch, "pod in team-b should not be mutated by team-a policy")
+	})
+}
+
+// Test 6: MutateNamespaced should immediately return success for cluster-scoped
+// resources (namespace == ""), since namespaced policies cannot govern them.
+func TestMutateNamespaced_SkipsClusterScopedResources(t *testing.T) {
+	eventGen := &framework.MockEventGen{}
+	h := mpol.New(testEnv.ContextProvider, engine, nil, reportutils.ReportingCfg, nil, "", eventGen)
+
+	// Simulate a cluster-scoped resource (empty namespace)
+	ctx := framework.ContextWithPolicies(context.Background(), "any-policy")
+	resp := h.MutateNamespaced(ctx, logr.Discard(), framework.PodAdmissionRequest("cluster-resource", "", []byte(`{
+		"apiVersion": "v1", "kind": "Node",
+		"metadata": {"name": "cluster-resource"}
+	}`)), "", time.Now())
+
+	assert.True(t, resp.Allowed, "cluster-scoped resources should pass through MutateNamespaced")
+	assert.Nil(t, resp.Patch, "cluster-scoped resources should not be mutated")
+}
+
+// Test 7: A PolicyException referencing a MutatingPolicy should cause the mutation
+// to be skipped for matching resources. This is the break-glass escape hatch:
+// security team enforces policy, but a specific workload gets a temporary exemption.
+func TestMutate_PolicyExceptionSkipsMutation(t *testing.T) {
+	policy := &policiesv1beta1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "require-runasnonroot"},
+		Spec: policiesv1beta1.MutatingPolicySpec{
+			MatchConstraints: framework.PodMatchRules(),
+			Mutations: []admissionregistrationv1alpha1.Mutation{{
+				PatchType: admissionregistrationv1alpha1.PatchTypeJSONPatch,
+				JSONPatch: &admissionregistrationv1alpha1.JSONPatch{
+					Expression: `[JSONPatch{op: "add", path: "/metadata/labels/security", value: "hardened"}]`,
+				},
+			}},
+		},
+	}
+
+	// Exception that exempts the policy
+	exception := &policiesv1beta1.PolicyException{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "exempt-db-migration",
+			Namespace: "default",
+		},
+		Spec: policiesv1beta1.PolicyExceptionSpec{
+			PolicyRefs: []policiesv1beta1.PolicyRef{{
+				Name: "require-runasnonroot",
+				Kind: "MutatingPolicy",
+			}},
+		},
+	}
+
+	// Create exception first, then policy — the provider watches exceptions
+	// and re-queues referenced policies on changes.
+	ctx := context.Background()
+	require.NoError(t, testEnv.Client.Create(ctx, exception))
+	t.Cleanup(func() {
+		testEnv.Client.Delete(context.Background(), exception)
+	})
+
+	createPolicyWithCleanup(t, policy)
+	waitForPolicyReady(t, 1)
+
+	eventGen := &framework.MockEventGen{}
+	h := mpol.New(testEnv.ContextProvider, engine, nil, reportutils.ReportingCfg, nil, "", eventGen)
+
+	ctxWithPolicies := framework.ContextWithPolicies(context.Background(), "require-runasnonroot")
+	resp := h.MutateClustered(ctxWithPolicies, logr.Discard(), framework.PodAdmissionRequest("db-migration-pod", "default", []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {"name": "db-migration-pod", "namespace": "default", "labels": {}},
+		"spec": {"containers": [{"name": "migrate", "image": "postgres:16"}]}
+	}`)), "", time.Now())
+
+	assert.True(t, resp.Allowed, "exception should allow the request")
+	assert.Nil(t, resp.Patch, "exception should skip the mutation (no patches applied)")
 }

--- a/test/integration/mpol/handler_test.go
+++ b/test/integration/mpol/handler_test.go
@@ -453,7 +453,7 @@ func TestMutate_DryRunSkipsUpdateRequestCreation(t *testing.T) {
 	// Non-dry-run should create a UR (proves the setup works)
 	t.Run("non-dry-run creates UR", func(t *testing.T) {
 		ctx := framework.ContextWithPolicies(context.Background(), "mutate-existing-on-pod")
-		resp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("ur-pod", "default", podJSON), "", time.Now())
+		resp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("dryrun-pod", "default", podJSON), "", time.Now())
 
 		assert.True(t, resp.Allowed)
 		// Wait for the async goroutine that fires URs

--- a/test/integration/vpol/handler_test.go
+++ b/test/integration/vpol/handler_test.go
@@ -228,7 +228,7 @@ func TestValidate_EventsGenerated_OnDeny(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	assert.False(t, resp.Allowed, "pod with latest tag should be denied")
-	assert.NotEmpty(t, eventGen.Events, "deny should generate events")
+	assert.NotEmpty(t, eventGen.GetEvents(), "deny should generate events")
 }
 
 func TestValidate_CELVariables_UsedInValidation(t *testing.T) {
@@ -297,7 +297,7 @@ func TestValidate_AuditAction_AllowsNonCompliantButFiresEvents(t *testing.T) {
 
 	// Wait for the async audit goroutine to record the violation.
 	time.Sleep(200 * time.Millisecond)
-	assert.NotEmpty(t, eventGen.Events, "audit policy should still generate events for observability")
+	assert.NotEmpty(t, eventGen.GetEvents(), "audit policy should still generate events for observability")
 }
 
 func TestValidate_MultiplePolicies_DenyAndWarnCombined(t *testing.T) {


### PR DESCRIPTION
## Summary

adds 7 new mpol handler integration tests covering gaps in the existing test suite. also adds framework support for PolicyException testing and NamespacedMutatingPolicy.

### new tests

- background controller SA requests skip mutation (prevents infinite loops)
- dry-run requests don't create UpdateRequests (with baseline non-dry-run subtest to prove setup works)
- failurePolicy Fail rejects on CEL eval error
- failurePolicy Ignore allows on CEL eval error
- NamespacedMutatingPolicy only mutates pods in its own namespace (multi-tenancy isolation)
- MutateNamespaced skips cluster-scoped resources
- PolicyException skips mutation for exempted resources (break-glass scenario)

### framework additions

- NewMpolEngineWithExceptions and NewPolexLister in framework/mpol.go (reusable for vpol/gpol exception tests later)
- PodAdmissionRequestDryRun and PodAdmissionRequestWithUsername helpers
- createNamespacedPolicyWithCleanup and createNamespace test helpers

switched TestMain to use the exception-enabled engine for all tests (no behavior change when no exceptions exist, the lister just returns nil). can't register two controllers for the same CRD on one manager so this was the clean solution.

all 13 tests pass (6 existing + 7 new). vpol and gpol suites verified with no regressions.               