### PR TITLE
fix: update require-run-as-nonroot ValidatingPolicy CEL expression

### DIFF
--- a/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.cel.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.cel.yaml
@@ -27,24 +27,17 @@ spec:
       apiVersions: [v1]
       operations: [CREATE, UPDATE]
       resources: [pods]
+  variables:
+    - name: ctnrs
+      expression: >-
+        object.spec.containers +
+        object.spec.?initContainers.orValue([]) +
+        object.spec.?ephemeralContainers.orValue([])
   validations:
-    - expression: >-
-        ((has(object.spec.securityContext) && 
-         has(object.spec.securityContext.runAsNonRoot) && 
-         object.spec.securityContext.runAsNonRoot == true) ||
-        (!has(object.spec.securityContext) || !has(object.spec.securityContext.runAsNonRoot))) &&
-        (!has(object.spec.containers) || object.spec.containers.all(c, 
-          has(c.securityContext) && 
-          has(c.securityContext.runAsNonRoot) && 
-          c.securityContext.runAsNonRoot == true)) &&
-        (!has(object.spec.initContainers) || object.spec.initContainers.all(c, 
-          has(c.securityContext) && 
-          has(c.securityContext.runAsNonRoot) && 
-          c.securityContext.runAsNonRoot == true)) &&
-        (!has(object.spec.ephemeralContainers) || object.spec.ephemeralContainers.all(c, 
-          has(c.securityContext) && 
-          has(c.securityContext.runAsNonRoot) && 
-          c.securityContext.runAsNonRoot == true))
+    - expression: |-
+        (object.spec.?securityContext.?runAsNonRoot.orValue(false) == true
+        && variables.ctnrs.all(c, c.?securityContext.?runAsNonRoot.orValue(true) == true))
+        || variables.ctnrs.all(c, c.?securityContext.?runAsNonRoot.orValue(false) == true)
       message: >-
         Running as root is not allowed. Either the field spec.securityContext.runAsNonRoot
         must be set to `true`, or the fields spec.containers[*].securityContext.runAsNonRoot,
@@ -53,4 +46,3 @@ spec:
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
   validationActions: {{ $actions | nindent 4 }}
 {{- end }}
-


### PR DESCRIPTION
## What this PR does
Fixes the broken CEL expression in the `require-run-as-nonroot` ValidatingPolicy 
in the kyverno-policies Helm chart.

## Problem
The previous expression required ALL containers to explicitly set 
`runAsNonRoot: true`, completely ignoring the pod-level 
`spec.securityContext.runAsNonRoot` field. This caused valid pods to 
be incorrectly rejected.

## Fix
- Added a `variables` block to collect all containers (including init 
  and ephemeral)
- Updated CEL expression to allow either:
  1. Pod-level `runAsNonRoot: true` with no container override, OR
  2. All containers explicitly setting `runAsNonRoot: true`

## Testing
Tested with Kyverno CLI:
- ✅ Pod with only pod-level `runAsNonRoot: true` now passes (was the bug)
- ✅ Pod with container-level `runAsNonRoot: true` still passes
- ❌ Pod with nothing set still fails correctly

Fixes #15697