### PR TITLE
test: add gpol exception and CEL edge case integration tests

### DIFF
--- a/test/integration/framework/gpol.go
+++ b/test/integration/framework/gpol.go
@@ -46,6 +46,32 @@ func NewGpolEngine(
 	return engine, provider
 }
 
+// NewGpolPolexLister creates an informer-backed PolicyException lister from a Kyverno clientset.
+// Mirrors the production wiring in cmd/background-controller/main.go:
+// kyvernoInformer.Policies().V1beta1().PolicyExceptions().Lister()
+func NewGpolPolexLister(ctx context.Context, kyvernoClient kyvernoclient.Interface) celengine.PolicyExceptionLister {
+	factory := kyvernoinformer.NewSharedInformerFactory(kyvernoClient, 0)
+	polexLister := factory.Policies().V1beta1().PolicyExceptions().Lister()
+	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
+	return polexLister
+}
+
+// NewGpolEngineWithExceptions creates a gpol engine and provider with PolicyException support.
+// When no exceptions exist, behavior is identical to NewGpolEngine.
+func NewGpolEngineWithExceptions(
+	gpolLister policiesv1beta1listers.GeneratingPolicyLister,
+	ngpolLister policiesv1beta1listers.NamespacedGeneratingPolicyLister,
+	polexLister celengine.PolicyExceptionLister,
+) (gpolengine.Engine, gpolengine.Provider) {
+	compiler := gpolcompiler.NewCompiler()
+	provider := gpolengine.NewFetchProvider(compiler, gpolLister, ngpolLister, polexLister, true)
+	nsResolver := func(ns string) *corev1.Namespace { return nil }
+	matcher := matching.NewMatcher()
+	engine := gpolengine.NewEngine(nsResolver, matcher)
+	return engine, provider
+}
+
 // NewURProcessor returns a function that processes URSpecs through the gpol engine,
 // creating downstream resources in the envtest cluster. This simulates what the
 // background controller's CELGenerateController.ProcessUR does in production:

--- a/test/integration/gpol/handler_test.go
+++ b/test/integration/gpol/handler_test.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	policiesv1alpha1 "github.com/kyverno/api/api/policies.kyverno.io/v1alpha1"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	celengine "github.com/kyverno/kyverno/pkg/cel/engine"
 	gpolengine "github.com/kyverno/kyverno/pkg/cel/policies/gpol/engine"
 	policiesv1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/policies.kyverno.io/v1beta1"
 	gpol "github.com/kyverno/kyverno/pkg/webhooks/resource/gpol"
@@ -22,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -30,9 +33,11 @@ var (
 	testEnv      *framework.TestEnv
 	gpolLister   policiesv1beta1listers.GeneratingPolicyLister
 	ngpolLister  policiesv1beta1listers.NamespacedGeneratingPolicyLister
+	polexLister  celengine.PolicyExceptionLister
 	gpolEngine   gpolengine.Engine
 	gpolProvider gpolengine.Provider
 	cancelInf    context.CancelFunc
+	cancelPolex  context.CancelFunc
 )
 
 func TestMain(m *testing.M) {
@@ -44,20 +49,29 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	// Start informer factory for gpol listers — mirrors production wiring.
+	// Start informer factories for gpol listers and PolicyException lister.
 	infCtx, cancel := context.WithCancel(context.Background())
 	cancelInf = cancel
 	gpolLister, ngpolLister = framework.NewGpolListers(infCtx, testEnv.KyvernoClient)
-	gpolEngine, gpolProvider = framework.NewGpolEngine(gpolLister, ngpolLister)
+
+	polexInfCtx, polexCancel := context.WithCancel(context.Background())
+	cancelPolex = polexCancel
+	polexLister = framework.NewGpolPolexLister(polexInfCtx, testEnv.KyvernoClient)
+
+	// Use exception-enabled engine so full-flow tests can verify exception behavior.
+	// When no exceptions exist, this behaves identically to NewGpolEngine.
+	gpolEngine, gpolProvider = framework.NewGpolEngineWithExceptions(gpolLister, ngpolLister, polexLister)
 
 	if err := testEnv.Start(); err != nil {
 		cancel()
+		polexCancel()
 		testEnv.Stop()
 		panic(err)
 	}
 
 	code := m.Run()
 	cancelInf()
+	cancelPolex()
 	testEnv.Stop()
 	os.Exit(code)
 }
@@ -660,4 +674,462 @@ func TestGenerateNamespaced_DeleteWithSyncDeletesDownstream(t *testing.T) {
 	assert.Equal(t, "team-cleanup/gen-sync-ns", specs[0].Policy, "namespaced policy key should be namespace/name")
 	assert.True(t, specs[0].RuleContext[0].DeleteDownstream, "should signal downstream deletion")
 	assert.False(t, specs[0].RuleContext[0].Synchronize)
+}
+
+// --- Exception tests: handler → UR processing → exception check → no downstream ---
+//
+// PolicyExceptions for gpol are checked at UR processing time (not at handler time).
+// The handler always creates a UR. The processor's provider.Get() fetches the policy
+// with exceptions compiled in. If an exception matches, the engine skips generation.
+
+// waitForPolexInLister waits until the informer cache has the exception.
+func waitForPolexInLister(t *testing.T, name string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		exceptions, err := polexLister.List(labels.Everything())
+		if err != nil {
+			return false
+		}
+		for _, ex := range exceptions {
+			if ex.Name == name {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 100*time.Millisecond, "exception %q not found in lister", name)
+}
+
+// waitForPolexGone waits until the informer cache no longer has the exception.
+func waitForPolexGone(t *testing.T, name string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		exceptions, err := polexLister.List(labels.Everything())
+		if err != nil {
+			return false
+		}
+		for _, ex := range exceptions {
+			if ex.Name == name {
+				return false
+			}
+		}
+		return true
+	}, 5*time.Second, 100*time.Millisecond, "exception %q still in lister", name)
+}
+
+func TestGenerateFullFlow_ExceptionSkipsGeneration(t *testing.T) {
+	// A platform team's gpol generates a ConfigMap for every pod. The security team
+	// later creates a PolicyException so DB migration pods bypass this policy.
+	// The handler still fires a UR, but when the processor fetches the policy it
+	// finds the exception compiled in and skips generation entirely.
+	policy := &policiesv1beta1.GeneratingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "gen-cm-with-exception"},
+		Spec: policiesv1beta1.GeneratingPolicySpec{
+			MatchConstraints: framework.PodMatchRules(),
+			Variables: []admissionregistrationv1.Variable{
+				{
+					Name: "configmap",
+					Expression: `[{
+						"kind": dyn("ConfigMap"),
+						"apiVersion": dyn("v1"),
+						"metadata": dyn({"name": "gen-for-" + object.metadata.name}),
+						"data": dyn({"trigger": object.metadata.name})
+					}]`,
+				},
+			},
+			Generation: []policiesv1beta1.Generation{
+				{Expression: `generator.Apply(object.metadata.namespace, variables.configmap)`},
+			},
+		},
+	}
+
+	exception := &policiesv1beta1.PolicyException{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "exempt-db-migration",
+			Namespace: "default",
+		},
+		Spec: policiesv1beta1.PolicyExceptionSpec{
+			PolicyRefs: []policiesv1alpha1.PolicyRef{{
+				Name: "gen-cm-with-exception",
+				Kind: "GeneratingPolicy",
+			}},
+		},
+	}
+
+	createGpolWithCleanup(t, policy)
+	waitForGpolInLister(t, "gen-cm-with-exception")
+
+	ctx := context.Background()
+	require.NoError(t, testEnv.Client.Create(ctx, exception))
+	t.Cleanup(func() {
+		testEnv.Client.Delete(context.Background(), exception)
+		waitForPolexGone(t, "exempt-db-migration")
+	})
+	waitForPolexInLister(t, "exempt-db-migration")
+
+	processor := framework.NewURProcessor(gpolEngine, gpolProvider, testEnv.ContextProvider)
+	mock := framework.NewProcessingURGenerator(processor)
+	h := gpol.New(mock, gpolLister, ngpolLister)
+
+	triggerPodJSON := []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {"name": "db-migrate", "namespace": "default", "uid": "pod-uid-ex1"},
+		"spec": {"containers": [{"name": "migrate", "image": "postgres:16"}]}
+	}`)
+
+	policyCtx := framework.ContextWithPolicies(context.Background(), "gen-cm-with-exception")
+	resp := h.Generate(policyCtx, logr.Discard(), framework.PodAdmissionRequestWithOp("db-migrate", "default", admissionv1.Create, triggerPodJSON), "", time.Now())
+	assert.True(t, resp.Allowed)
+
+	require.Eventually(t, func() bool {
+		return len(mock.GetSpecs()) >= 1
+	}, 5*time.Second, 100*time.Millisecond, "UR not processed in time")
+
+	assert.Empty(t, mock.ProcessingErrors(), "exception skip should not produce errors")
+
+	// Exception matched: no ConfigMap should be created.
+	cm := &corev1.ConfigMap{}
+	err := testEnv.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: "default",
+		Name:      "gen-for-db-migrate",
+	}, cm)
+	assert.True(t, apierrors.IsNotFound(err), "exception should prevent ConfigMap generation")
+}
+
+func TestGenerateFullFlow_ExceptionWithMatchCondition(t *testing.T) {
+	// A security team creates a PolicyException that only applies to pods in the
+	// "exempt" namespace. Pods in "exempt" bypass generation, pods in "default"
+	// still get their ConfigMap generated.
+	framework.CreateNamespace(t, testEnv.KubeClient, "exempt")
+
+	policy := &policiesv1beta1.GeneratingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "gen-cm-matchcond-ex"},
+		Spec: policiesv1beta1.GeneratingPolicySpec{
+			MatchConstraints: framework.PodMatchRules(),
+			Variables: []admissionregistrationv1.Variable{
+				{
+					Name: "configmap",
+					Expression: `[{
+						"kind": dyn("ConfigMap"),
+						"apiVersion": dyn("v1"),
+						"metadata": dyn({"name": "gen-mc-" + object.metadata.name}),
+						"data": dyn({"trigger": object.metadata.name})
+					}]`,
+				},
+			},
+			Generation: []policiesv1beta1.Generation{
+				{Expression: `generator.Apply(object.metadata.namespace, variables.configmap)`},
+			},
+		},
+	}
+
+	exception := &policiesv1beta1.PolicyException{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "exempt-ns-only",
+			Namespace: "default",
+		},
+		Spec: policiesv1beta1.PolicyExceptionSpec{
+			PolicyRefs: []policiesv1alpha1.PolicyRef{{
+				Name: "gen-cm-matchcond-ex",
+				Kind: "GeneratingPolicy",
+			}},
+			MatchConditions: []admissionregistrationv1.MatchCondition{{
+				Name:       "only-exempt-namespace",
+				Expression: "object.metadata.namespace == 'exempt'",
+			}},
+		},
+	}
+
+	createGpolWithCleanup(t, policy)
+	waitForGpolInLister(t, "gen-cm-matchcond-ex")
+
+	ctx := context.Background()
+	require.NoError(t, testEnv.Client.Create(ctx, exception))
+	t.Cleanup(func() {
+		testEnv.Client.Delete(context.Background(), exception)
+		waitForPolexGone(t, "exempt-ns-only")
+	})
+	waitForPolexInLister(t, "exempt-ns-only")
+
+	// Pod in "exempt" namespace — exception match condition is true, generation skipped.
+	processor := framework.NewURProcessor(gpolEngine, gpolProvider, testEnv.ContextProvider)
+	mockExempt := framework.NewProcessingURGenerator(processor)
+	hExempt := gpol.New(mockExempt, gpolLister, ngpolLister)
+
+	exemptPodJSON := []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {"name": "exempt-pod", "namespace": "exempt", "uid": "pod-uid-ex2"},
+		"spec": {"containers": [{"name": "app", "image": "nginx"}]}
+	}`)
+
+	policyCtx := framework.ContextWithPolicies(context.Background(), "gen-cm-matchcond-ex")
+	resp := hExempt.Generate(policyCtx, logr.Discard(), framework.PodAdmissionRequestWithOp("exempt-pod", "exempt", admissionv1.Create, exemptPodJSON), "", time.Now())
+	assert.True(t, resp.Allowed)
+
+	require.Eventually(t, func() bool {
+		return len(mockExempt.GetSpecs()) >= 1
+	}, 5*time.Second, 100*time.Millisecond, "exempt UR not processed in time")
+
+	cm := &corev1.ConfigMap{}
+	err := testEnv.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: "exempt",
+		Name:      "gen-mc-exempt-pod",
+	}, cm)
+	assert.True(t, apierrors.IsNotFound(err), "exempt-ns pod should not get a generated ConfigMap")
+
+	// Pod in "default" namespace — exception match condition is false, generation proceeds.
+	mockDefault := framework.NewProcessingURGenerator(framework.NewURProcessor(gpolEngine, gpolProvider, testEnv.ContextProvider))
+	hDefault := gpol.New(mockDefault, gpolLister, ngpolLister)
+
+	defaultPodJSON := []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {"name": "regular-pod", "namespace": "default", "uid": "pod-uid-ex3"},
+		"spec": {"containers": [{"name": "app", "image": "nginx"}]}
+	}`)
+
+	resp = hDefault.Generate(policyCtx, logr.Discard(), framework.PodAdmissionRequestWithOp("regular-pod", "default", admissionv1.Create, defaultPodJSON), "", time.Now())
+	assert.True(t, resp.Allowed)
+
+	require.Eventually(t, func() bool {
+		return len(mockDefault.GetSpecs()) >= 1
+	}, 5*time.Second, 100*time.Millisecond, "default UR not processed in time")
+
+	assert.Empty(t, mockDefault.ProcessingErrors())
+
+	err = testEnv.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: "default",
+		Name:      "gen-mc-regular-pod",
+	}, cm)
+	require.NoError(t, err, "default-ns pod should get a generated ConfigMap")
+	assert.Equal(t, "regular-pod", cm.Data["trigger"])
+
+	t.Cleanup(func() {
+		testEnv.Client.Delete(context.Background(), cm)
+	})
+}
+
+// --- CEL edge case tests ---
+
+func TestGenerateFullFlow_MatchConditionFalse_NoGeneration(t *testing.T) {
+	// A policy has a match condition restricting generation to the "restricted"
+	// namespace. A pod in "default" doesn't match, so the engine skips evaluation
+	// and no downstream resource is created.
+	policy := &policiesv1beta1.GeneratingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "gen-restricted-only"},
+		Spec: policiesv1beta1.GeneratingPolicySpec{
+			MatchConstraints: framework.PodMatchRules(),
+			MatchConditions: []admissionregistrationv1.MatchCondition{{
+				Name:       "restricted-ns-only",
+				Expression: "object.metadata.namespace == 'restricted'",
+			}},
+			Variables: []admissionregistrationv1.Variable{
+				{
+					Name: "configmap",
+					Expression: `[{
+						"kind": dyn("ConfigMap"),
+						"apiVersion": dyn("v1"),
+						"metadata": dyn({"name": "restricted-cm-" + object.metadata.name}),
+						"data": dyn({"trigger": object.metadata.name})
+					}]`,
+				},
+			},
+			Generation: []policiesv1beta1.Generation{
+				{Expression: `generator.Apply(object.metadata.namespace, variables.configmap)`},
+			},
+		},
+	}
+
+	createGpolWithCleanup(t, policy)
+	waitForGpolInLister(t, "gen-restricted-only")
+
+	processor := framework.NewURProcessor(gpolEngine, gpolProvider, testEnv.ContextProvider)
+	mock := framework.NewProcessingURGenerator(processor)
+	h := gpol.New(mock, gpolLister, ngpolLister)
+
+	triggerPodJSON := []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {"name": "wrong-ns-pod", "namespace": "default", "uid": "pod-uid-mc1"},
+		"spec": {"containers": [{"name": "app", "image": "nginx"}]}
+	}`)
+
+	policyCtx := framework.ContextWithPolicies(context.Background(), "gen-restricted-only")
+	resp := h.Generate(policyCtx, logr.Discard(), framework.PodAdmissionRequestWithOp("wrong-ns-pod", "default", admissionv1.Create, triggerPodJSON), "", time.Now())
+	assert.True(t, resp.Allowed)
+
+	require.Eventually(t, func() bool {
+		return len(mock.GetSpecs()) >= 1
+	}, 5*time.Second, 100*time.Millisecond, "UR not processed in time")
+
+	assert.Empty(t, mock.ProcessingErrors())
+
+	cm := &corev1.ConfigMap{}
+	err := testEnv.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: "default",
+		Name:      "restricted-cm-wrong-ns-pod",
+	}, cm)
+	assert.True(t, apierrors.IsNotFound(err), "match condition false should prevent generation")
+}
+
+func TestGenerateFullFlow_GenerationExpressionError_NoDownstream(t *testing.T) {
+	// A developer writes a generation expression that references a nonexistent field.
+	// CEL compiles it (object is DynType) but it fails at eval time. The engine
+	// returns RuleError, and no downstream resource is created.
+	policy := &policiesv1beta1.GeneratingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "gen-broken-expression"},
+		Spec: policiesv1beta1.GeneratingPolicySpec{
+			MatchConstraints: framework.PodMatchRules(),
+			Generation: []policiesv1beta1.Generation{
+				{Expression: `generator.Apply(object.metadata.namespace, object.spec.nonExistentField)`},
+			},
+		},
+	}
+
+	createGpolWithCleanup(t, policy)
+	waitForGpolInLister(t, "gen-broken-expression")
+
+	processor := framework.NewURProcessor(gpolEngine, gpolProvider, testEnv.ContextProvider)
+	mock := framework.NewProcessingURGenerator(processor)
+	h := gpol.New(mock, gpolLister, ngpolLister)
+
+	triggerPodJSON := []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {"name": "error-pod", "namespace": "default", "uid": "pod-uid-err1"},
+		"spec": {"containers": [{"name": "app", "image": "nginx"}]}
+	}`)
+
+	policyCtx := framework.ContextWithPolicies(context.Background(), "gen-broken-expression")
+	resp := h.Generate(policyCtx, logr.Discard(), framework.PodAdmissionRequestWithOp("error-pod", "default", admissionv1.Create, triggerPodJSON), "", time.Now())
+	assert.True(t, resp.Allowed)
+
+	require.Eventually(t, func() bool {
+		return len(mock.GetSpecs()) >= 1
+	}, 5*time.Second, 100*time.Millisecond, "UR not processed in time")
+
+	// The generation expression fails at eval time. engine.Handle() returns the
+	// error in EngineResponse (not as top-level error), so ProcessingErrors may
+	// or may not capture it depending on how the error propagates. The key check
+	// is that no downstream resource was created.
+	cm := &corev1.ConfigMap{}
+	err := testEnv.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: "default",
+		Name:      "generated-for-error-pod",
+	}, cm)
+	assert.True(t, apierrors.IsNotFound(err), "broken generation expression should not create downstream")
+}
+
+func TestGenerateFullFlow_UnusedBrokenVariable_StillGenerates(t *testing.T) {
+	// A policy author adds a variable with a broken CEL expression, but the
+	// generation expression doesn't reference it. CEL variables are lazily
+	// evaluated, so the broken variable's error is deferred and never surfaces.
+	// Generation proceeds normally.
+	policy := &policiesv1beta1.GeneratingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "gen-unused-broken-var"},
+		Spec: policiesv1beta1.GeneratingPolicySpec{
+			MatchConstraints: framework.PodMatchRules(),
+			Variables: []admissionregistrationv1.Variable{
+				{
+					Name:       "broken",
+					Expression: "object.spec.nonExistentField.deeplyNested",
+				},
+				{
+					Name: "configmap",
+					Expression: `[{
+						"kind": dyn("ConfigMap"),
+						"apiVersion": dyn("v1"),
+						"metadata": dyn({"name": "unused-var-" + object.metadata.name}),
+						"data": dyn({"trigger": object.metadata.name})
+					}]`,
+				},
+			},
+			Generation: []policiesv1beta1.Generation{
+				{Expression: `generator.Apply(object.metadata.namespace, variables.configmap)`},
+			},
+		},
+	}
+
+	createGpolWithCleanup(t, policy)
+	waitForGpolInLister(t, "gen-unused-broken-var")
+
+	processor := framework.NewURProcessor(gpolEngine, gpolProvider, testEnv.ContextProvider)
+	mock := framework.NewProcessingURGenerator(processor)
+	h := gpol.New(mock, gpolLister, ngpolLister)
+
+	triggerPodJSON := []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {"name": "lazy-pod", "namespace": "default", "uid": "pod-uid-lz1"},
+		"spec": {"containers": [{"name": "app", "image": "nginx"}]}
+	}`)
+
+	policyCtx := framework.ContextWithPolicies(context.Background(), "gen-unused-broken-var")
+	resp := h.Generate(policyCtx, logr.Discard(), framework.PodAdmissionRequestWithOp("lazy-pod", "default", admissionv1.Create, triggerPodJSON), "", time.Now())
+	assert.True(t, resp.Allowed)
+
+	require.Eventually(t, func() bool {
+		return len(mock.GetSpecs()) >= 1
+	}, 5*time.Second, 100*time.Millisecond, "UR not processed in time")
+
+	assert.Empty(t, mock.ProcessingErrors(), "unused broken variable should not cause errors")
+
+	// Broken variable was never read, so generation proceeded normally.
+	cm := &corev1.ConfigMap{}
+	err := testEnv.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: "default",
+		Name:      "unused-var-lazy-pod",
+	}, cm)
+	require.NoError(t, err, "unused broken variable should not block generation")
+	assert.Equal(t, "lazy-pod", cm.Data["trigger"])
+
+	t.Cleanup(func() {
+		testEnv.Client.Delete(context.Background(), cm)
+	})
+}
+
+func TestGenerateFullFlow_UsedBrokenVariable_NoDownstream(t *testing.T) {
+	// Same as above, but the generation expression actually reads the broken
+	// variable. The deferred error surfaces when variables.broken is accessed,
+	// causing the generation to fail. No downstream resource is created.
+	policy := &policiesv1beta1.GeneratingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "gen-used-broken-var"},
+		Spec: policiesv1beta1.GeneratingPolicySpec{
+			MatchConstraints: framework.PodMatchRules(),
+			Variables: []admissionregistrationv1.Variable{
+				{
+					Name:       "brokenName",
+					Expression: "object.spec.nonExistentField",
+				},
+			},
+			Generation: []policiesv1beta1.Generation{
+				{Expression: `generator.Apply(object.metadata.namespace, [{"kind": dyn("ConfigMap"), "apiVersion": dyn("v1"), "metadata": dyn({"name": variables.brokenName}), "data": dyn({"test": "should-not-exist"})}])`},
+			},
+		},
+	}
+
+	createGpolWithCleanup(t, policy)
+	waitForGpolInLister(t, "gen-used-broken-var")
+
+	processor := framework.NewURProcessor(gpolEngine, gpolProvider, testEnv.ContextProvider)
+	mock := framework.NewProcessingURGenerator(processor)
+	h := gpol.New(mock, gpolLister, ngpolLister)
+
+	triggerPodJSON := []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {"name": "broken-var-pod", "namespace": "default", "uid": "pod-uid-bv1"},
+		"spec": {"containers": [{"name": "app", "image": "nginx"}]}
+	}`)
+
+	policyCtx := framework.ContextWithPolicies(context.Background(), "gen-used-broken-var")
+	resp := h.Generate(policyCtx, logr.Discard(), framework.PodAdmissionRequestWithOp("broken-var-pod", "default", admissionv1.Create, triggerPodJSON), "", time.Now())
+	assert.True(t, resp.Allowed)
+
+	require.Eventually(t, func() bool {
+		return len(mock.GetSpecs()) >= 1
+	}, 5*time.Second, 100*time.Millisecond, "UR not processed in time")
+
+	// The generation expression read variables.brokenName, which triggered the
+	// deferred error. No downstream resource should exist.
+	cm := &corev1.ConfigMap{}
+	err := testEnv.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: "default",
+		Name:      "broken-var-pod",
+	}, cm)
+	assert.True(t, apierrors.IsNotFound(err), "used broken variable should prevent downstream creation")
 }


### PR DESCRIPTION



### Summary

- Adds 6 new full-flow integration tests for gpol covering PolicyException support and CEL runtime edge cases
- Adds framework support for gpol exception testing (NewGpolPolexLister, NewGpolEngineWithExceptions)
- Adds CreateNamespace helper to framework for namespace-scoped tests

### New tests

#### Exception tests:

- TestGenerateFullFlow_ExceptionSkipsGeneration — PolicyException prevents downstream ConfigMap creation
- TestGenerateFullFlow_ExceptionWithMatchCondition — exception with CEL match condition only applies in specific namespace (pods in "exempt" ns bypass, pods in "default" still generate)

#### CEL edge case tests:

- TestGenerateFullFlow_MatchConditionFalse_NoGeneration — policy match condition gates generation (wrong namespace, no downstream)
- TestGenerateFullFlow_GenerationExpressionError_NoDownstream — broken CEL expression (DynType field access) fails at eval, no downstream
- TestGenerateFullFlow_UnusedBrokenVariable_StillGenerates — broken variable that nobody reads gets swallowed (lazy eval), generation proceeds normally
- TestGenerateFullFlow_UsedBrokenVariable_NoDownstream — broken variable that IS read propagates the error, no downstream

### Framework changes

- framework/gpol.go: NewGpolPolexLister (informer-backed exception lister, mirrors cmd/background-controller/main.go wiring) and NewGpolEngineWithExceptions
- framework/helpers.go: CreateNamespace with cleanup
- gpol TestMain switched to exception-enabled engine (no behavior change when no exceptions exist)

### Test plan

- All 15 gpol integration tests pass (9 existing + 6 new)
- golangci-lint clean
- gofmt clean

Related to #15430

