### PR TITLE
fix(webhook): avoid repeated webhook updates

### DIFF
--- a/pkg/controllers/webhook/controller.go
+++ b/pkg/controllers/webhook/controller.go
@@ -1269,14 +1269,18 @@ func (c *controller) buildForJSONPoliciesValidation(cfg config.Configuration, ca
 	if err != nil {
 		return err
 	}
-	result.Webhooks = append(result.Webhooks, buildWebhookRules(cfg,
+	nivpolWebhooks := buildWebhookRules(cfg,
 		c.server,
 		config.ImageValidatingPolicyValidateWebhookName,
 		"/nivpol/validate",
 		c.servicePort,
 		caBundle,
 		nivpols,
-		c.celExpressionCache)...)
+		c.celExpressionCache)
+	for i := range nivpolWebhooks {
+		nivpolWebhooks[i].Rules = sortedRules(deDuplicatedRules(nivpolWebhooks[i].Rules))
+	}
+	result.Webhooks = append(result.Webhooks, nivpolWebhooks...)
 
 	policies := append(pols, nvpols...)
 	policies = append(policies, gpols...)

--- a/pkg/controllers/webhook/validating.go
+++ b/pkg/controllers/webhook/validating.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"path"
 	"slices"
+	"strings"
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/cel/autogen"
@@ -20,8 +21,19 @@ import (
 )
 
 func buildWebhookRules(cfg config.Configuration, server, name, queryPath string, servicePort int32, caBundle []byte, policies []engineapi.GenericPolicy, expressionCache *expressionCache) []admissionregistrationv1.ValidatingWebhook {
+	sortedPolicies := slices.Clone(policies)
+	slices.SortFunc(sortedPolicies, func(a, b engineapi.GenericPolicy) int {
+		if x := strings.Compare(a.GetNamespace(), b.GetNamespace()); x != 0 {
+			return x
+		}
+		if x := strings.Compare(a.GetName(), b.GetName()); x != 0 {
+			return x
+		}
+		return strings.Compare(a.GetKind(), b.GetKind())
+	})
+
 	var fineGrained, basic []engineapi.GenericPolicy
-	for _, policy := range policies {
+	for _, policy := range sortedPolicies {
 		p := extractGenericPolicy(policy)
 		if validConditions(expressionCache, p.GetMatchConditions()) != nil {
 			fineGrained = append(fineGrained, policy)

--- a/pkg/controllers/webhook/validating_test.go
+++ b/pkg/controllers/webhook/validating_test.go
@@ -349,6 +349,70 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 	}
 }
 
+func TestBuildWebhookRules_DeterministicOrder(t *testing.T) {
+	newPolicy := func(name string) *policiesv1beta1.ValidatingPolicy {
+		return &policiesv1beta1.ValidatingPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: policiesv1beta1.ValidatingPolicySpec{
+				FailurePolicy: ptr.To(admissionregistrationv1.Fail),
+				WebhookConfiguration: &policiesv1beta1.WebhookConfiguration{
+					TimeoutSeconds: ptr.To(int32(20)),
+				},
+				MatchConstraints: &admissionregistrationv1.MatchResources{
+					ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+						{
+							RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+								Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+								Rule: admissionregistrationv1.Rule{
+									APIGroups:   []string{"*"},
+									APIVersions: []string{"*"},
+									Resources:   []string{"*"},
+									Scope:       ptr.To(admissionregistrationv1.ScopeType("*")),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	policyA := engineapi.NewValidatingPolicy(newPolicy("a-policy"))
+	policyB := engineapi.NewValidatingPolicy(newPolicy("b-policy"))
+
+	webhooksAB := buildWebhookRules(
+		config.NewDefaultConfiguration(false),
+		"",
+		config.ValidatingPolicyWebhookName,
+		"/vpol",
+		0,
+		nil,
+		[]engineapi.GenericPolicy{policyA, policyB},
+		NewExpressionCache(),
+	)
+	webhooksBA := buildWebhookRules(
+		config.NewDefaultConfiguration(false),
+		"",
+		config.ValidatingPolicyWebhookName,
+		"/vpol",
+		0,
+		nil,
+		[]engineapi.GenericPolicy{policyB, policyA},
+		NewExpressionCache(),
+	)
+
+	assert.Equal(t, webhooksAB, webhooksBA)
+	assert.Equal(t, []string{
+		config.ValidatingPolicyWebhookName + "-fail-finegrained-a-policy",
+		config.ValidatingPolicyWebhookName + "-fail-finegrained-b-policy",
+	}, []string{
+		webhooksAB[0].Name,
+		webhooksAB[1].Name,
+	})
+}
+
 func TestBuildWebhookRules_ImageValidatingPolicy(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
## Explanation

This PR updates webhook reconciliation behavior so Kyverno does not keep rewriting the same webhook configuration when policies have not changed.  
It makes webhook generation deterministic and prevents repeated update churn.

## Related issue

Closes #15767

## Milestone of this PR
## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

- Sort policies before building CEL webhook entries to ensure deterministic webhook ordering.
- Normalize NIVPOL webhook rules the same way as other JSON policy webhook paths.
- Add a regression unit test to verify webhook output is identical regardless of input policy order.

### Proof Manifests

`go test ./pkg/controllers/webhook -run TestBuildWebhookRules_DeterministicOrder -count=1`

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and CLI support should be added and my PR doesn't contain that functionality.

## Further Comments
