### PR TITLE
fix(metrics): align new policy metrics and add representatives for kyverno_policy_results

### DIFF
--- a/pkg/cel/policies/gpol/engine/metrics.go
+++ b/pkg/cel/policies/gpol/engine/metrics.go
@@ -31,6 +31,7 @@ func (w *metricWrapper) Handle(request engine.EngineRequest, policy Policy, cach
 		}
 
 		w.metrics.RecordDuration(context.TODO(), policy.Result.Stats().ProcessingTime().Seconds(), string(policy.Result.Status()), policy.Policy, response.Trigger, string(request.Request.Operation))
+		w.metrics.RecordResult(context.TODO(), string(policy.Result.Status()), policy.Policy, response.Trigger, string(request.Request.Operation))
 	}
 
 	return response, nil

--- a/pkg/cel/policies/ivpol/engine/metrics.go
+++ b/pkg/cel/policies/ivpol/engine/metrics.go
@@ -22,6 +22,7 @@ func (w *metricWrapper) HandleMutating(ctx context.Context, request EngineReques
 
 	for _, policy := range response.Policies {
 		w.metrics.RecordDuration(ctx, policy.Result.Stats().ProcessingTime().Seconds(), string(policy.Result.Status()), w.ruleExecutionCause, policy.Policy, response.Resource, string(request.Request.Operation))
+		w.metrics.RecordResult(ctx, string(policy.Result.Status()), w.ruleExecutionCause, policy.Policy, response.Resource, string(request.Request.Operation))
 	}
 
 	return response, patch, nil
@@ -35,6 +36,7 @@ func (w *metricWrapper) HandleValidating(ctx context.Context, request EngineRequ
 
 	for _, policy := range response.Policies {
 		w.metrics.RecordDuration(ctx, policy.Result.Stats().ProcessingTime().Seconds(), string(policy.Result.Status()), w.ruleExecutionCause, policy.Policy, response.Resource, string(request.Request.Operation))
+		w.metrics.RecordResult(ctx, string(policy.Result.Status()), w.ruleExecutionCause, policy.Policy, response.Resource, string(request.Request.Operation))
 	}
 
 	return response, nil

--- a/pkg/cel/policies/mpol/engine/metrics.go
+++ b/pkg/cel/policies/mpol/engine/metrics.go
@@ -27,6 +27,10 @@ func (w *metricWrapper) Evaluate(ctx context.Context, attr admission.Attributes,
 		}
 
 		w.metrics.RecordDuration(ctx, policy.Rules[0].Stats().ProcessingTime().Seconds(), string(policy.Rules[0].Status()), w.ruleExecutionCause, policy.Policy, response.Resource, string(request.Operation))
+
+		for _, rule := range policy.Rules {
+			w.metrics.RecordResult(ctx, string(rule.Status()), w.ruleExecutionCause, policy.Policy, response.Resource, string(request.Operation))
+		}
 	}
 
 	return response, nil
@@ -44,6 +48,10 @@ func (w *metricWrapper) Handle(ctx context.Context, request engine.EngineRequest
 		}
 
 		w.metrics.RecordDuration(ctx, policy.Rules[0].Stats().ProcessingTime().Seconds(), string(policy.Rules[0].Status()), w.ruleExecutionCause, policy.Policy, response.Resource, string(request.Request.Operation))
+
+		for _, rule := range policy.Rules {
+			w.metrics.RecordResult(ctx, string(rule.Status()), w.ruleExecutionCause, policy.Policy, response.Resource, string(request.Request.Operation))
+		}
 	}
 
 	return response, nil

--- a/pkg/cel/policies/vpol/engine/metrics.go
+++ b/pkg/cel/policies/vpol/engine/metrics.go
@@ -25,6 +25,10 @@ func (w *metricWrapper) Handle(ctx context.Context, request EngineRequest, predi
 		}
 
 		w.metrics.RecordDuration(ctx, policy.Rules[0].Stats().ProcessingTime().Seconds(), string(policy.Rules[0].Status()), w.ruleExecutionCause, policy.Policy, response.Resource, string(request.Request.Operation))
+
+		for _, rule := range policy.Rules {
+			w.metrics.RecordResult(ctx, string(rule.Status()), w.ruleExecutionCause, policy.Policy, response.Resource, string(request.Request.Operation))
+		}
 	}
 
 	return response, nil

--- a/pkg/metrics/gpol.go
+++ b/pkg/metrics/gpol.go
@@ -21,10 +21,12 @@ func GetGeneratingMetrics() GeneratingMetrics {
 
 type GeneratingMetrics interface {
 	RecordDuration(ctx context.Context, seconds float64, status string, policy v1beta1.GeneratingPolicyLike, resource *unstructured.Unstructured, operation string)
+	RecordResult(ctx context.Context, status string, policy v1beta1.GeneratingPolicyLike, resource *unstructured.Unstructured, operation string)
 }
 
 type generatingMetrics struct {
 	durationHistogram metric.Float64Histogram
+	resultCounter     metric.Int64Counter
 
 	logger logr.Logger
 }
@@ -39,6 +41,14 @@ func (m *generatingMetrics) init(meter metric.Meter) {
 	if err != nil {
 		m.logger.Error(err, "failed to register metric kyverno_generating_policy_execution_duration_seconds")
 	}
+
+	m.resultCounter, err = meter.Int64Counter(
+		"kyverno_generating_policy_results",
+		metric.WithDescription("can be used to track the results associated with the generating policies applied in the user's cluster, at the level from rule to policy to admission requests."),
+	)
+	if err != nil {
+		m.logger.Error(err, "failed to register metric kyverno_generating_policy_results")
+	}
 }
 
 func (m *generatingMetrics) RecordDuration(ctx context.Context, seconds float64, status string, policy v1beta1.GeneratingPolicyLike, resource *unstructured.Unstructured, operation string) {
@@ -47,6 +57,20 @@ func (m *generatingMetrics) RecordDuration(ctx context.Context, seconds float64,
 	}
 
 	m.durationHistogram.Record(ctx, seconds, metric.WithAttributes(
+		attribute.String("policy_name", policy.GetName()),
+		attribute.String("resource_kind", resource.GetKind()),
+		attribute.String("resource_namespace", resource.GetNamespace()),
+		attribute.String("resource_request_operation", strings.ToLower(operation)),
+		attribute.String("result", status),
+	))
+}
+
+func (m *generatingMetrics) RecordResult(ctx context.Context, status string, policy v1beta1.GeneratingPolicyLike, resource *unstructured.Unstructured, operation string) {
+	if m.resultCounter == nil {
+		return
+	}
+
+	m.resultCounter.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("policy_name", policy.GetName()),
 		attribute.String("resource_kind", resource.GetKind()),
 		attribute.String("resource_namespace", resource.GetNamespace()),

--- a/pkg/metrics/ivpol.go
+++ b/pkg/metrics/ivpol.go
@@ -21,10 +21,12 @@ func GetImageValidatingMetrics() ImageValidatingMetrics {
 
 type ImageValidatingMetrics interface {
 	RecordDuration(ctx context.Context, seconds float64, status, ruleExecutionCause string, policy v1beta1.ImageValidatingPolicyLike, resource *unstructured.Unstructured, operation string)
+	RecordResult(ctx context.Context, status, ruleExecutionCause string, policy v1beta1.ImageValidatingPolicyLike, resource *unstructured.Unstructured, operation string)
 }
 
 type imageValidatingMetrics struct {
 	durationHistogram metric.Float64Histogram
+	resultCounter     metric.Int64Counter
 
 	logger logr.Logger
 }
@@ -39,6 +41,14 @@ func (m *imageValidatingMetrics) init(meter metric.Meter) {
 	if err != nil {
 		m.logger.Error(err, "failed to register metric kyverno_image_validating_policy_execution_duration_seconds")
 	}
+
+	m.resultCounter, err = meter.Int64Counter(
+		"kyverno_image_validating_policy_results",
+		metric.WithDescription("can be used to track the results associated with the image validating policies applied in the user's cluster, at the level from rule to policy to admission requests."),
+	)
+	if err != nil {
+		m.logger.Error(err, "failed to register metric kyverno_image_validating_policy_results")
+	}
 }
 
 func (m *imageValidatingMetrics) RecordDuration(ctx context.Context, seconds float64, status, ruleExecutionCause string, policy v1beta1.ImageValidatingPolicyLike, resource *unstructured.Unstructured, operation string) {
@@ -49,6 +59,25 @@ func (m *imageValidatingMetrics) RecordDuration(ctx context.Context, seconds flo
 	name, _, backgroundMode, validationMode := GetCELPolicyInfos(policy)
 
 	m.durationHistogram.Record(ctx, seconds, metric.WithAttributes(
+		attribute.String("policy_validation_mode", string(validationMode)),
+		attribute.String("policy_background_mode", string(backgroundMode)),
+		attribute.String("policy_name", name),
+		attribute.String("resource_kind", resource.GetKind()),
+		attribute.String("resource_namespace", resource.GetNamespace()),
+		attribute.String("resource_request_operation", strings.ToLower(operation)),
+		attribute.String("execution_cause", ruleExecutionCause),
+		attribute.String("result", status),
+	))
+}
+
+func (m *imageValidatingMetrics) RecordResult(ctx context.Context, status, ruleExecutionCause string, policy v1beta1.ImageValidatingPolicyLike, resource *unstructured.Unstructured, operation string) {
+	if m.resultCounter == nil {
+		return
+	}
+
+	name, _, backgroundMode, validationMode := GetCELPolicyInfos(policy)
+
+	m.resultCounter.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("policy_validation_mode", string(validationMode)),
 		attribute.String("policy_background_mode", string(backgroundMode)),
 		attribute.String("policy_name", name),

--- a/pkg/metrics/mpol.go
+++ b/pkg/metrics/mpol.go
@@ -21,10 +21,12 @@ func GetMutatingMetrics() MutatingMetrics {
 
 type MutatingMetrics interface {
 	RecordDuration(ctx context.Context, seconds float64, status, ruleExecutionCause string, policy v1beta1.MutatingPolicyLike, resource *unstructured.Unstructured, operation string)
+	RecordResult(ctx context.Context, status, ruleExecutionCause string, policy v1beta1.MutatingPolicyLike, resource *unstructured.Unstructured, operation string)
 }
 
 type mutatingMetrics struct {
 	durationHistogram metric.Float64Histogram
+	resultCounter     metric.Int64Counter
 
 	logger logr.Logger
 }
@@ -39,6 +41,14 @@ func (m *mutatingMetrics) init(meter metric.Meter) {
 	if err != nil {
 		m.logger.Error(err, "failed to register metric kyverno_mutating_policy_execution_duration_seconds")
 	}
+
+	m.resultCounter, err = meter.Int64Counter(
+		"kyverno_mutating_policy_results",
+		metric.WithDescription("can be used to track the results associated with the mutating policies applied in the user's cluster, at the level from rule to policy to admission requests."),
+	)
+	if err != nil {
+		m.logger.Error(err, "failed to register metric kyverno_mutating_policy_results")
+	}
 }
 
 func (m *mutatingMetrics) RecordDuration(ctx context.Context, seconds float64, status, ruleExecutionCause string, policy v1beta1.MutatingPolicyLike, resource *unstructured.Unstructured, operation string) {
@@ -49,6 +59,24 @@ func (m *mutatingMetrics) RecordDuration(ctx context.Context, seconds float64, s
 	name, _, backgroundMode, _ := GetCELPolicyInfos(policy)
 
 	m.durationHistogram.Record(ctx, seconds, metric.WithAttributes(
+		attribute.String("policy_background_mode", string(backgroundMode)),
+		attribute.String("policy_name", name),
+		attribute.String("resource_kind", resource.GetKind()),
+		attribute.String("resource_namespace", resource.GetNamespace()),
+		attribute.String("resource_request_operation", strings.ToLower(operation)),
+		attribute.String("execution_cause", ruleExecutionCause),
+		attribute.String("result", status),
+	))
+}
+
+func (m *mutatingMetrics) RecordResult(ctx context.Context, status, ruleExecutionCause string, policy v1beta1.MutatingPolicyLike, resource *unstructured.Unstructured, operation string) {
+	if m.resultCounter == nil {
+		return
+	}
+
+	name, _, backgroundMode, _ := GetCELPolicyInfos(policy)
+
+	m.resultCounter.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("policy_background_mode", string(backgroundMode)),
 		attribute.String("policy_name", name),
 		attribute.String("resource_kind", resource.GetKind()),

--- a/pkg/metrics/vpol.go
+++ b/pkg/metrics/vpol.go
@@ -22,10 +22,12 @@ func GetValidatingMetrics() ValidatingMetrics {
 
 type ValidatingMetrics interface {
 	RecordDuration(ctx context.Context, seconds float64, status, ruleExecutionCause string, policy v1beta1.ValidatingPolicyLike, resource *unstructured.Unstructured, operation string)
+	RecordResult(ctx context.Context, status, ruleExecutionCause string, policy v1beta1.ValidatingPolicyLike, resource *unstructured.Unstructured, operation string)
 }
 
 type validatingMetrics struct {
 	durationHistogram metric.Float64Histogram
+	resultCounter     metric.Int64Counter
 
 	logger logr.Logger
 }
@@ -40,6 +42,14 @@ func (m *validatingMetrics) init(meter metric.Meter) {
 	if err != nil {
 		m.logger.Error(err, "failed to register metric kyverno_validating_policy_execution_duration_seconds")
 	}
+
+	m.resultCounter, err = meter.Int64Counter(
+		"kyverno_validating_policy_results",
+		metric.WithDescription("can be used to track the results associated with the validating policies applied in the user's cluster, at the level from rule to policy to admission requests."),
+	)
+	if err != nil {
+		m.logger.Error(err, "failed to register metric kyverno_validating_policy_results")
+	}
 }
 
 func (m *validatingMetrics) RecordDuration(ctx context.Context, seconds float64, status, ruleExecutionCause string, policy v1beta1.ValidatingPolicyLike, resource *unstructured.Unstructured, operation string) {
@@ -52,6 +62,27 @@ func (m *validatingMetrics) RecordDuration(ctx context.Context, seconds float64,
 	validationMode := policy.GetValidatingPolicySpec().EvaluationMode()
 
 	m.durationHistogram.Record(ctx, seconds, metric.WithAttributes(
+		attribute.String("policy_validation_mode", validationMode),
+		attribute.String("policy_background_mode", fmt.Sprintf("%t", backgroundMode)),
+		attribute.String("policy_name", name),
+		attribute.String("resource_kind", resource.GetKind()),
+		attribute.String("resource_namespace", resource.GetNamespace()),
+		attribute.String("resource_request_operation", strings.ToLower(operation)),
+		attribute.String("execution_cause", ruleExecutionCause),
+		attribute.String("result", status),
+	))
+}
+
+func (m *validatingMetrics) RecordResult(ctx context.Context, status, ruleExecutionCause string, policy v1beta1.ValidatingPolicyLike, resource *unstructured.Unstructured, operation string) {
+	if m.resultCounter == nil {
+		return
+	}
+
+	name := policy.GetName()
+	backgroundMode := policy.BackgroundEnabled()
+	validationMode := policy.GetValidatingPolicySpec().EvaluationMode()
+
+	m.resultCounter.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("policy_validation_mode", validationMode),
 		attribute.String("policy_background_mode", fmt.Sprintf("%t", backgroundMode)),
 		attribute.String("policy_name", name),


### PR DESCRIPTION
## Explanation
After migrating policies from ClusterPolicy/Policy to the new ValidatingPolicy format, the `kyverno_policy_results` metric is no longer populated. Only a duration histogram is emitted instead.

Adding `kyverno_generating_policy_results`, `kyverno_image_validating_policy_results`, `kyverno_mutating_policy_results` and `kyverno_validating_policy_results` to close the gap between those two implementations.

## Related issue

Resolves #15821

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

I didnt find any Documentation listing all specific metrics, i i have missed some, please point them out and i will adapt them.

## What type of PR is this

/kind bug

## Proposed Changes

Adding the äquivalent of `kyverno_policy_results` to the new policies.

### Proof Manifests

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-policy and per-rule "result" metrics across generating, validating, mutating, and image-validating policies.
  * Metrics now record outcome status, execution cause, policy name, resource kind/namespace, and lowercased operation alongside existing duration metrics to improve observability.

* **Chores**
  * Metrics interfaces extended and implementations register new result counters (recording is no-op if uninitialized).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->