### PR TITLE
test: add unit tests for IsGvkSupported (pkg/utils/report)

### DIFF
--- a/pkg/utils/report/support_test.go
+++ b/pkg/utils/report/support_test.go
@@ -1,0 +1,65 @@
+package report
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	eventsv1beta1 "k8s.io/api/events/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestIsGvkSupported(t *testing.T) {
+	tests := []struct {
+		name string
+		gvk  schema.GroupVersionKind
+		want bool
+	}{{
+		name: "core event is not supported",
+		gvk:  corev1.SchemeGroupVersion.WithKind("Event"),
+		want: false,
+	}, {
+		name: "events.k8s.io/v1 Event is not supported",
+		gvk:  eventsv1.SchemeGroupVersion.WithKind("Event"),
+		want: false,
+	}, {
+		name: "events.k8s.io/v1beta1 Event is not supported",
+		gvk:  eventsv1beta1.SchemeGroupVersion.WithKind("Event"),
+		want: false,
+	}, {
+		name: "Pod is supported",
+		gvk:  schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+		want: true,
+	}, {
+		name: "Deployment is supported",
+		gvk:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+		want: true,
+	}, {
+		name: "ConfigMap is supported",
+		gvk:  schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+		want: true,
+	}, {
+		name: "Service is supported",
+		gvk:  schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"},
+		want: true,
+	}, {
+		name: "Namespace is supported",
+		gvk:  schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"},
+		want: true,
+	}, {
+		name: "CRD is supported",
+		gvk:  schema.GroupVersionKind{Group: "custom.example.com", Version: "v1", Kind: "MyResource"},
+		want: true,
+	}, {
+		name: "empty GVK is supported",
+		gvk:  schema.GroupVersionKind{},
+		want: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsGvkSupported(tt.gvk)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds table-driven unit tests for `IsGvkSupported` in `pkg/utils/report/support.go`. This function had **zero test coverage** and determines which Kubernetes GVKs are allowed as report owners — specifically, it filters out Event resources (core/v1, events.k8s.io/v1, events.k8s.io/v1beta1) to prevent circular ownership.

## Changes

- **New file:** `pkg/utils/report/support_test.go`

## Test Cases (10 cases)

| # | Test Case | GVK | Expected |
|---|-----------|-----|----------|
| 1 | core Event is not supported | `v1/Event` | `false` |
| 2 | events.k8s.io/v1 Event is not supported | `events.k8s.io/v1/Event` | `false` |
| 3 | events.k8s.io/v1beta1 Event is not supported | `events.k8s.io/v1beta1/Event` | `false` |
| 4 | Pod is supported | `v1/Pod` | `true` |
| 5 | Deployment is supported | `apps/v1/Deployment` | `true` |
| 6 | ConfigMap is supported | `v1/ConfigMap` | `true` |
| 7 | Service is supported | `v1/Service` | `true` |
| 8 | Namespace is supported | `v1/Namespace` | `true` |
| 9 | CRD is supported | `custom.example.com/v1/MyResource` | `true` |
| 10 | empty GVK is supported | `//` | `true` |

## Coverage Impact

- `IsGvkSupported`: **0% → 100%**

## Type

- [x] Unit tests
- [ ] Bug fix
- [ ] Feature
