### PR TITLE
fix NPE when validating ClusterPolicy with matchConditions offline

### DIFF
--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -136,7 +136,7 @@ func Validate(policy, oldPolicy kyvernov1.PolicyInterface, client dclient.Interf
 	spec := policy.GetSpec()
 	background := spec.BackgroundProcessingEnabled()
 	if policy.GetSpec().CustomWebhookMatchConditions() &&
-		!kubeutils.HigherThanKubernetesVersion(client.GetKubeClient().Discovery(), logging.GlobalLogger(), 1, 27, 0) {
+		client != nil && !kubeutils.HigherThanKubernetesVersion(client.GetKubeClient().Discovery(), logging.GlobalLogger(), 1, 27, 0) {
 		return warnings, fmt.Errorf("custom webhook configurations are only supported in kubernetes version 1.27.0 and above")
 	}
 

--- a/pkg/validation/policy/validate_test.go
+++ b/pkg/validation/policy/validate_test.go
@@ -3511,6 +3511,53 @@ func Test_isMapStringString(t *testing.T) {
 	}
 }
 
+func Test_Validate_MatchConditions_NilClient(t *testing.T) {
+	rawPolicy := []byte(`{
+  "apiVersion": "kyverno.io/v1",
+  "kind": "ClusterPolicy",
+  "metadata": {
+    "name": "deny-sa-non-dryrun"
+  },
+  "spec": {
+    "background": false,
+    "webhookConfiguration": {
+      "matchConditions": [
+        {
+          "name": "only-my-sa",
+          "expression": "request.userInfo.username == \"system:serviceaccount:default:my-sa\""
+        }
+      ]
+    },
+    "rules": [
+      {
+        "name": "deny-non-dryrun-mutations",
+        "match": {
+          "any": [
+            {
+              "resources": {
+                "kinds": ["*"]
+              }
+            }
+          ]
+        },
+        "validate": {
+          "failureAction": "Enforce",
+          "message": "dry-run only",
+          "deny": {}
+        }
+      }
+    ]
+  }
+}`)
+	var policy *kyverno.ClusterPolicy
+	err := json.Unmarshal(rawPolicy, &policy)
+	assert.Nil(t, err)
+
+	// nil client must not panic
+	_, err = Validate(policy, nil, nil, true, "", "")
+	assert.Nil(t, err)
+}
+
 func Test_Shallow_Variable_Substitution(t *testing.T) {
 	var err error
 	rawPolicy := []byte(`{


### PR DESCRIPTION
## Explanation
Ran into this testing policies in the CLI. The validation code checks if a policy has matchConditions and then tries to verify the Kubernetes version, but it wasn't handling the case where the client is nil. That's what happens in CLI mode, so it'd panic.

## Related issue
Closes #15833

## Milestone
N/A

## Documentation
N/A

## PR Type
/kind bug

## Proposed Changes
Added a nil check for the client before using it. When the client is nil, we can't validate the Kubernetes version anyway, so we skip that check. Also added a test to make sure this doesn't regress.

## Checklist
Tests added and passing locally.