### PR TITLE
fix: upgrade go to 1.26.2 to fix CVE-2026-32281

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyverno/kyverno
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/kyverno/kyverno
 
-go 1.26.2
+go 1.26
+
+toolchain go1.26.2
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6

--- a/hack/api-group-resources/go.mod
+++ b/hack/api-group-resources/go.mod
@@ -1,6 +1,8 @@
 module github.com/kyverno/kyverno/hack/api-group-resources
 
-go 1.26.2
+go 1.26
+
+toolchain go1.26.2
 
 require k8s.io/client-go v0.35.3
 

--- a/hack/api-group-resources/go.mod
+++ b/hack/api-group-resources/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyverno/kyverno/hack/api-group-resources
 
-go 1.26.1
+go 1.26.2
 
 require k8s.io/client-go v0.35.3
 

--- a/hack/controller-gen/go.mod
+++ b/hack/controller-gen/go.mod
@@ -1,6 +1,8 @@
 module github.com/kyverno/kyverno/hack/controller-gen
 
-go 1.26.2
+go 1.26
+
+toolchain go1.26.2
 
 require (
 	github.com/spf13/cobra v1.10.2

--- a/hack/controller-gen/go.mod
+++ b/hack/controller-gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyverno/kyverno/hack/controller-gen
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
we're still on Go 1.26.1 which has CVE-2026-32281, a DoS bug in crypto/x509 where cert chain validation gets really slow if a cert has a ton of policy mappings, which could hang the process.

bumped the go directive to 1.26.2 across all three go.mod files to pick up the fix.

fixes #15815