### PR TITLE
fix: compile dpol variables before conditions to allow variable references

### DIFF
--- a/pkg/cel/policies/dpol/compiler/compiler.go
+++ b/pkg/cel/policies/dpol/compiler/compiler.go
@@ -67,6 +67,10 @@ func (c *compilerImpl) Compile(policy policiesv1beta1.DeletingPolicyLike, except
 	path := field.NewPath("spec")
 	// append a place holder error to the errors list to be displayed in case the error list was returned
 	allErrs = append(allErrs, field.InternalError(nil, fmt.Errorf(compileError, "failed to compile policy")))
+	variables, errs := compiler.CompileVariables(path.Child("variables"), env, variablesProvider, spec.Variables...)
+	if errs != nil {
+		return nil, append(allErrs, errs...)
+	}
 	conditions := make([]cel.Program, 0, len(spec.Conditions))
 	{
 		path := path.Child("conditions")
@@ -75,10 +79,6 @@ func (c *compilerImpl) Compile(policy policiesv1beta1.DeletingPolicyLike, except
 			return nil, append(allErrs, errs...)
 		}
 		conditions = append(conditions, programs...)
-	}
-	variables, errs := compiler.CompileVariables(path.Child("variables"), env, variablesProvider, spec.Variables...)
-	if errs != nil {
-		return nil, append(allErrs, errs...)
 	}
 	// exceptions' match conditions
 	compiledExceptions := make([]compiler.Exception, 0, len(exceptions))

--- a/pkg/cel/policies/dpol/compiler/compiler_test.go
+++ b/pkg/cel/policies/dpol/compiler/compiler_test.go
@@ -124,6 +124,28 @@ func TestCompile(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "condition references variable",
+			policy: &v1beta1.DeletingPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "cond-refs-var"},
+				Spec: v1beta1.DeletingPolicySpec{
+					Schedule: "* * * * *",
+					Variables: []admissionv1.Variable{
+						{
+							Name:       "targetEnv",
+							Expression: "'test'",
+						},
+					},
+					Conditions: []admissionv1.MatchCondition{
+						{
+							Name:       "check-env",
+							Expression: "variables.targetEnv == 'test'",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "invalid exception",
 			policy: &v1beta1.DeletingPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: "invalid-exception"},


### PR DESCRIPTION
 Fixes #15818  
                                                                
**The dpol compiler was compiling conditions before variables, so any condition referencing variables.X would fail with undefined field. Swapped the compilation order and added a test case.**                                
  