### PR TITLE
fix: upgrade go to 1.26.2 to fix CVE-2026-32283

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/kyverno/kyverno
 
-go 1.26.1
+go 1.26
+
+toolchain go1.26.2
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6

--- a/hack/api-group-resources/go.mod
+++ b/hack/api-group-resources/go.mod
@@ -1,6 +1,8 @@
 module github.com/kyverno/kyverno/hack/api-group-resources
 
-go 1.26.1
+go 1.26
+
+toolchain go1.26.2
 
 require k8s.io/client-go v0.35.3
 

--- a/hack/controller-gen/go.mod
+++ b/hack/controller-gen/go.mod
@@ -1,6 +1,8 @@
 module github.com/kyverno/kyverno/hack/controller-gen
 
-go 1.26.1
+go 1.26
+
+toolchain go1.26.2
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
Bumped Go from 1.26.1 to 1.26.2 across all three go.mod files to patch CVE-2026-32283 (TLS 1.3 DoS via post-handshake key update messages). No other changes needed.

Fixes #15813