### PR TITLE
test: add dpol controller integration tests

### DIFF
--- a/test/integration/dpol/controller_test.go
+++ b/test/integration/dpol/controller_test.go
@@ -1,0 +1,540 @@
+//go:build integration
+
+package dpol_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/kyverno/kyverno/pkg/controllers/deleting"
+	"github.com/kyverno/kyverno/pkg/event"
+	"github.com/kyverno/kyverno/test/integration/framework"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	testEnv    *framework.TestEnv
+	deps       *framework.DpolDeps
+	cancelDeps context.CancelFunc
+	cancelCtrl context.CancelFunc
+)
+
+func TestMain(m *testing.M) {
+	var err error
+	testEnv, err = framework.NewTestEnv(
+		"../../../config/crds/policies.kyverno.io",
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := testEnv.Start(); err != nil {
+		testEnv.Stop()
+		panic(err)
+	}
+
+	depsCtx, dCancel := context.WithCancel(context.Background())
+	cancelDeps = dCancel
+	deps = framework.NewDpolDeps(
+		depsCtx,
+		testEnv.DClient,
+		testEnv.KyvernoClient,
+		testEnv.KubeClient,
+		testEnv.Mgr.GetRESTMapper(),
+		testEnv.ContextProvider,
+	)
+
+	ctrlCtx, cCancel := context.WithCancel(context.Background())
+	cancelCtrl = cCancel
+	go deps.Controller.Run(ctrlCtx, deleting.Workers)
+
+	code := m.Run()
+	cancelCtrl()
+	cancelDeps()
+	testEnv.Stop()
+	os.Exit(code)
+}
+
+// --- helpers ---
+
+// configMapMatchRules returns MatchResources targeting ConfigMaps.
+func configMapMatchRules() *admissionregistrationv1.MatchResources {
+	return &admissionregistrationv1.MatchResources{
+		ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+			RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"configmaps"},
+				},
+			},
+		}},
+	}
+}
+
+// createResource creates an arbitrary resource in envtest via the dclient and
+// registers cleanup. Works for any GVK. See createConfigMap for a sugared wrapper.
+func createResource(t *testing.T, gvk schema.GroupVersionKind, obj *unstructured.Unstructured) {
+	t.Helper()
+	obj.SetGroupVersionKind(gvk)
+	apiVersion := gvk.GroupVersion().String()
+	_, err := testEnv.DClient.CreateResource(context.Background(), apiVersion, gvk.Kind, obj.GetNamespace(), obj, false)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Best-effort: resource may already be deleted by the controller.
+		_ = testEnv.DClient.DeleteResource(context.Background(), apiVersion, gvk.Kind, obj.GetNamespace(), obj.GetName(), false, metav1.DeleteOptions{})
+	})
+}
+
+// createConfigMap creates a ConfigMap in the given namespace and registers cleanup.
+// Thin wrapper over createResource for the common ConfigMap-based test scenarios.
+func createConfigMap(t *testing.T, name, namespace string, labels map[string]string) {
+	t.Helper()
+	obj := &unstructured.Unstructured{}
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	obj.SetLabels(labels)
+	_ = unstructured.SetNestedStringMap(obj.Object, map[string]string{"key": "value"}, "data")
+	createResource(t, schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}, obj)
+}
+
+// createDpolWithCleanup creates a DeletingPolicy and registers cleanup.
+func createDpolWithCleanup(t *testing.T, policy *policiesv1beta1.DeletingPolicy) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := testEnv.KyvernoClient.PoliciesV1beta1().DeletingPolicies().Create(ctx, policy, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = testEnv.KyvernoClient.PoliciesV1beta1().DeletingPolicies().Delete(context.Background(), policy.Name, metav1.DeleteOptions{})
+	})
+}
+
+// createNdpolWithCleanup creates a NamespacedDeletingPolicy and registers cleanup.
+func createNdpolWithCleanup(t *testing.T, policy *policiesv1beta1.NamespacedDeletingPolicy) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := testEnv.KyvernoClient.PoliciesV1beta1().NamespacedDeletingPolicies(policy.Namespace).Create(ctx, policy, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = testEnv.KyvernoClient.PoliciesV1beta1().NamespacedDeletingPolicies(policy.Namespace).Delete(context.Background(), policy.Name, metav1.DeleteOptions{})
+	})
+}
+
+// triggerDpolExecution forces the controller to execute a DeletingPolicy immediately
+// by pre-seeding an old LastExecutionTime and bumping the spec generation.
+func triggerDpolExecution(t *testing.T, name string) {
+	t.Helper()
+	ctx := context.Background()
+	dpolClient := testEnv.KyvernoClient.PoliciesV1beta1().DeletingPolicies()
+
+	// Wait for informer to see the policy
+	require.Eventually(t, func() bool {
+		_, err := deps.DpolLister.Get(name)
+		return err == nil
+	}, 5*time.Second, 100*time.Millisecond, "dpol %q not found in lister", name)
+
+	// Get latest version and set an old LastExecutionTime
+	pol, err := dpolClient.Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err)
+	pol.Status.LastExecutionTime = metav1.NewTime(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	_, err = dpolClient.UpdateStatus(ctx, pol, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Wait for lister to reflect the status update
+	require.Eventually(t, func() bool {
+		p, err := deps.DpolLister.Get(name)
+		if err != nil {
+			return false
+		}
+		return !p.Status.LastExecutionTime.IsZero()
+	}, 5*time.Second, 100*time.Millisecond, "dpol %q status not updated in lister", name)
+
+	// Bump generation by toggling the schedule (semantically equivalent).
+	// This causes an informer update event with changed generation,
+	// which re-enqueues the key for immediate reconciliation.
+	pol, err = dpolClient.Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err)
+	if pol.Spec.Schedule == "* * * * *" {
+		pol.Spec.Schedule = "*/1 * * * *"
+	} else {
+		pol.Spec.Schedule = "* * * * *"
+	}
+	_, err = dpolClient.Update(ctx, pol, metav1.UpdateOptions{})
+	require.NoError(t, err)
+}
+
+// triggerNdpolExecution forces the controller to execute a NamespacedDeletingPolicy immediately.
+func triggerNdpolExecution(t *testing.T, namespace, name string) {
+	t.Helper()
+	ctx := context.Background()
+	ndpolClient := testEnv.KyvernoClient.PoliciesV1beta1().NamespacedDeletingPolicies(namespace)
+
+	require.Eventually(t, func() bool {
+		_, err := deps.NdpolLister.NamespacedDeletingPolicies(namespace).Get(name)
+		return err == nil
+	}, 5*time.Second, 100*time.Millisecond, "ndpol %s/%s not found in lister", namespace, name)
+
+	pol, err := ndpolClient.Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err)
+	pol.Status.LastExecutionTime = metav1.NewTime(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	_, err = ndpolClient.UpdateStatus(ctx, pol, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		p, err := deps.NdpolLister.NamespacedDeletingPolicies(namespace).Get(name)
+		if err != nil {
+			return false
+		}
+		return !p.Status.LastExecutionTime.IsZero()
+	}, 5*time.Second, 100*time.Millisecond, "ndpol %s/%s status not updated in lister", namespace, name)
+
+	pol, err = ndpolClient.Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err)
+	if pol.Spec.Schedule == "* * * * *" {
+		pol.Spec.Schedule = "*/1 * * * *"
+	} else {
+		pol.Spec.Schedule = "* * * * *"
+	}
+	_, err = ndpolClient.Update(ctx, pol, metav1.UpdateOptions{})
+	require.NoError(t, err)
+}
+
+// --- tests ---
+
+// Platform engineer sets up a cron-based cleanup to delete stale ConfigMaps.
+// All targeted ConfigMaps should be deleted after the schedule fires.
+func TestDeletingPolicy_BasicDeletion(t *testing.T) {
+	ns := "dpol-basic"
+	framework.CreateNamespace(t, testEnv.KubeClient, ns)
+	deps.EventCapture.Clear()
+
+	createConfigMap(t, "stale-1", ns, map[string]string{"cleanup": "true"})
+	createConfigMap(t, "stale-2", ns, map[string]string{"cleanup": "true"})
+
+	policy := &policiesv1beta1.DeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "dpol-basic-delete"},
+		Spec: policiesv1beta1.DeletingPolicySpec{
+			Schedule:         "* * * * *",
+			MatchConstraints: configMapMatchRules(),
+			Conditions: []admissionregistrationv1.MatchCondition{{
+				Name:       "in-target-namespace",
+				Expression: `object.metadata.namespace == "dpol-basic"`,
+			}},
+		},
+	}
+	createDpolWithCleanup(t, policy)
+	triggerDpolExecution(t, policy.Name)
+
+	// Both ConfigMaps should be deleted by the controller.
+	require.Eventually(t, func() bool {
+		_, err := testEnv.KubeClient.CoreV1().ConfigMaps(ns).Get(context.Background(), "stale-1", metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, 15*time.Second, 200*time.Millisecond, "stale-1 should be deleted")
+
+	require.Eventually(t, func() bool {
+		_, err := testEnv.KubeClient.CoreV1().ConfigMaps(ns).Get(context.Background(), "stale-2", metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, 15*time.Second, 200*time.Millisecond, "stale-2 should be deleted")
+
+	// Events should be generated for each deletion.
+	require.Eventually(t, func() bool {
+		events := deps.EventCapture.GetEvents()
+		successCount := 0
+		for _, e := range events {
+			if e.Reason == event.PolicyApplied && e.Action == event.ResourceCleanedUp {
+				successCount++
+			}
+		}
+		return successCount >= 2
+	}, 5*time.Second, 200*time.Millisecond, "expected at least 2 success events")
+}
+
+// Security team creates a cleanup policy with CEL conditions that only match
+// ConfigMaps labeled cleanup=true. Other ConfigMaps in the same namespace
+// should survive. Regression test for kyverno/kyverno#12615 where the
+// controller stopped iterating after the first non-matching resource.
+func TestDeletingPolicy_PartialMatch(t *testing.T) {
+	ns := "dpol-partial"
+	framework.CreateNamespace(t, testEnv.KubeClient, ns)
+	deps.EventCapture.Clear()
+
+	createConfigMap(t, "match-1", ns, map[string]string{"cleanup": "true"})
+	createConfigMap(t, "match-2", ns, map[string]string{"cleanup": "true"})
+	createConfigMap(t, "keep-this", ns, map[string]string{"cleanup": "false"})
+
+	policy := &policiesv1beta1.DeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "dpol-partial-match"},
+		Spec: policiesv1beta1.DeletingPolicySpec{
+			Schedule:         "* * * * *",
+			MatchConstraints: configMapMatchRules(),
+			Conditions: []admissionregistrationv1.MatchCondition{
+				{
+					Name:       "in-namespace",
+					Expression: `object.metadata.namespace == "dpol-partial"`,
+				},
+				{
+					Name:       "has-cleanup-label",
+					Expression: `object.metadata.labels["cleanup"] == "true"`,
+				},
+			},
+		},
+	}
+	createDpolWithCleanup(t, policy)
+	triggerDpolExecution(t, policy.Name)
+
+	// Matching ConfigMaps deleted.
+	require.Eventually(t, func() bool {
+		_, err := testEnv.KubeClient.CoreV1().ConfigMaps(ns).Get(context.Background(), "match-1", metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, 15*time.Second, 200*time.Millisecond, "match-1 should be deleted")
+
+	require.Eventually(t, func() bool {
+		_, err := testEnv.KubeClient.CoreV1().ConfigMaps(ns).Get(context.Background(), "match-2", metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, 15*time.Second, 200*time.Millisecond, "match-2 should be deleted")
+
+	// Non-matching ConfigMap survives.
+	cm, err := testEnv.KubeClient.CoreV1().ConfigMaps(ns).Get(context.Background(), "keep-this", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "keep-this", cm.Name)
+}
+
+// Team-scoped cleanup: a NamespacedDeletingPolicy in ns-a should only
+// delete resources within ns-a, not in ns-b.
+func TestNamespacedDeletingPolicy_NamespaceIsolation(t *testing.T) {
+	nsA := "dpol-ns-a"
+	nsB := "dpol-ns-b"
+	framework.CreateNamespace(t, testEnv.KubeClient, nsA)
+	framework.CreateNamespace(t, testEnv.KubeClient, nsB)
+	deps.EventCapture.Clear()
+
+	createConfigMap(t, "target", nsA, map[string]string{"cleanup": "true"})
+	createConfigMap(t, "safe", nsB, map[string]string{"cleanup": "true"})
+
+	policy := &policiesv1beta1.NamespacedDeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ndpol-ns-isolation",
+			Namespace: nsA,
+		},
+		Spec: policiesv1beta1.DeletingPolicySpec{
+			Schedule:         "* * * * *",
+			MatchConstraints: configMapMatchRules(),
+			Conditions: []admissionregistrationv1.MatchCondition{{
+				Name:       "always",
+				Expression: "true",
+			}},
+		},
+	}
+	createNdpolWithCleanup(t, policy)
+	triggerNdpolExecution(t, nsA, policy.Name)
+
+	// ConfigMap in ns-a should be deleted.
+	require.Eventually(t, func() bool {
+		_, err := testEnv.KubeClient.CoreV1().ConfigMaps(nsA).Get(context.Background(), "target", metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, 15*time.Second, 200*time.Millisecond, "target in ns-a should be deleted")
+
+	// ConfigMap in ns-b should survive.
+	cm, err := testEnv.KubeClient.CoreV1().ConfigMaps(nsB).Get(context.Background(), "safe", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "safe", cm.Name)
+}
+
+// Platform engineer centralizes an environment value in a dpol variable and
+// references it from a CEL condition. Regression test for kyverno/kyverno#15843
+// (variables were compiled after conditions, which broke any condition using
+// "variables.X"). With that fix in place, this should work.
+func TestDeletingPolicy_VariablesInConditions(t *testing.T) {
+	ns := "dpol-vars"
+	framework.CreateNamespace(t, testEnv.KubeClient, ns)
+	deps.EventCapture.Clear()
+
+	createConfigMap(t, "env-test", ns, map[string]string{"env": "test"})
+	createConfigMap(t, "env-prod", ns, map[string]string{"env": "prod"})
+
+	// ObjectSelector pre-filters to only ConfigMaps with the "env" label,
+	// which keeps kube-root-ca.crt (no "env" label) out of the matched set
+	// and avoids a CEL eval error on missing map key.
+	rules := configMapMatchRules()
+	rules.ObjectSelector = &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "env",
+			Operator: metav1.LabelSelectorOpExists,
+		}},
+	}
+
+	policy := &policiesv1beta1.DeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "dpol-variables-in-conditions"},
+		Spec: policiesv1beta1.DeletingPolicySpec{
+			Schedule:         "* * * * *",
+			MatchConstraints: rules,
+			Variables: []admissionregistrationv1.Variable{{
+				Name:       "targetEnv",
+				Expression: `"test"`,
+			}},
+			Conditions: []admissionregistrationv1.MatchCondition{
+				{
+					Name:       "in-namespace",
+					Expression: `object.metadata.namespace == "dpol-vars"`,
+				},
+				{
+					Name:       "matches-target-env",
+					Expression: `object.metadata.labels["env"] == variables.targetEnv`,
+				},
+			},
+		},
+	}
+	createDpolWithCleanup(t, policy)
+	triggerDpolExecution(t, policy.Name)
+
+	// Only the "test" env ConfigMap should be deleted.
+	require.Eventually(t, func() bool {
+		_, err := testEnv.KubeClient.CoreV1().ConfigMaps(ns).Get(context.Background(), "env-test", metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, 15*time.Second, 200*time.Millisecond, "env-test should be deleted")
+
+	// The "prod" env ConfigMap should survive.
+	cm, err := testEnv.KubeClient.CoreV1().ConfigMaps(ns).Get(context.Background(), "env-prod", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "env-prod", cm.Name)
+}
+
+// After the controller executes a policy, it should update the policy's
+// Status.LastExecutionTime. This verifies the schedule-requeue loop works
+// correctly. Regression test for kyverno/kyverno#10418 where the controller
+// stalled after the first deletion cycle.
+func TestDeletingPolicy_StatusUpdatedAfterExecution(t *testing.T) {
+	ns := "dpol-status"
+	framework.CreateNamespace(t, testEnv.KubeClient, ns)
+
+	createConfigMap(t, "to-delete", ns, nil)
+
+	policy := &policiesv1beta1.DeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "dpol-status-check"},
+		Spec: policiesv1beta1.DeletingPolicySpec{
+			Schedule:         "* * * * *",
+			MatchConstraints: configMapMatchRules(),
+			Conditions: []admissionregistrationv1.MatchCondition{{
+				Name:       "in-namespace",
+				Expression: `object.metadata.namespace == "dpol-status"`,
+			}},
+		},
+	}
+	createDpolWithCleanup(t, policy)
+	triggerDpolExecution(t, policy.Name)
+
+	// Wait for the deletion to happen
+	require.Eventually(t, func() bool {
+		_, err := testEnv.KubeClient.CoreV1().ConfigMaps(ns).Get(context.Background(), "to-delete", metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, 15*time.Second, 200*time.Millisecond, "to-delete should be deleted")
+
+	// Verify that the controller updated the policy's status with a recent execution time.
+	// The controller calls updateDeletingPolicyStatus(time.Now()) after deleting() succeeds.
+	require.Eventually(t, func() bool {
+		pol, err := testEnv.KyvernoClient.PoliciesV1beta1().DeletingPolicies().Get(context.Background(), policy.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		// After execution, LastExecutionTime should be recent (within the last 30 seconds).
+		return !pol.Status.LastExecutionTime.IsZero() &&
+			time.Since(pol.Status.LastExecutionTime.Time) < 30*time.Second
+	}, 15*time.Second, 200*time.Millisecond, "LastExecutionTime should be updated to a recent time")
+}
+
+// Empty conditions list means "match all resources" (no conditions to fail).
+// A platform engineer who specifies only MatchConstraints without conditions
+// expects all matching resources to be deleted.
+func TestDeletingPolicy_EmptyConditionsMatchAll(t *testing.T) {
+	ns := "dpol-empty-cond"
+	framework.CreateNamespace(t, testEnv.KubeClient, ns)
+	deps.EventCapture.Clear()
+
+	createConfigMap(t, "cm-1", ns, nil)
+	createConfigMap(t, "cm-2", ns, nil)
+
+	// NamespaceSelector restricts the policy to only this test namespace,
+	// preventing cross-namespace deletions while keeping Conditions empty.
+	rules := configMapMatchRules()
+	rules.NamespaceSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"kubernetes.io/metadata.name": ns},
+	}
+
+	policy := &policiesv1beta1.DeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "dpol-empty-conditions"},
+		Spec: policiesv1beta1.DeletingPolicySpec{
+			Schedule:         "* * * * *",
+			MatchConstraints: rules,
+			// No conditions — should match all resources that pass MatchConstraints.
+			Conditions: nil,
+		},
+	}
+	createDpolWithCleanup(t, policy)
+	triggerDpolExecution(t, policy.Name)
+
+	// Both ConfigMaps should be deleted (empty conditions = match all).
+	require.Eventually(t, func() bool {
+		_, err := testEnv.KubeClient.CoreV1().ConfigMaps(ns).Get(context.Background(), "cm-1", metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, 15*time.Second, 200*time.Millisecond, "cm-1 should be deleted")
+
+	require.Eventually(t, func() bool {
+		_, err := testEnv.KubeClient.CoreV1().ConfigMaps(ns).Get(context.Background(), "cm-2", metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, 15*time.Second, 200*time.Millisecond, "cm-2 should be deleted")
+}
+
+// Exercises the natural cron-tick path. Most dpol tests pre-seed an old
+// LastExecutionTime to force immediate execution (useful so individual tests
+// stay fast), but the controller's real scheduling loop (queue.AddAfter based
+// on cron.Next()) is never covered by those. This test creates a policy with
+// no pre-seed, schedule "* * * * *", and waits up to 70 seconds for the
+// controller to fire on its own when the minute boundary passes.
+//
+// Skipped under "go test -short" because it adds ~60s to the suite.
+func TestDeletingPolicy_ExecutesOnNaturalCronTick(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping cron-tick test (up to 70s) in short mode")
+	}
+	ns := "dpol-cron-tick"
+	framework.CreateNamespace(t, testEnv.KubeClient, ns)
+	deps.EventCapture.Clear()
+
+	createConfigMap(t, "target", ns, map[string]string{"cleanup": "true"})
+
+	policy := &policiesv1beta1.DeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "dpol-cron-tick"},
+		Spec: policiesv1beta1.DeletingPolicySpec{
+			Schedule:         "* * * * *",
+			MatchConstraints: configMapMatchRules(),
+			Conditions: []admissionregistrationv1.MatchCondition{{
+				Name:       "in-namespace",
+				Expression: `object.metadata.namespace == "dpol-cron-tick"`,
+			}},
+		},
+	}
+	createDpolWithCleanup(t, policy)
+
+	// Wait up to 70 seconds for the controller to pick up the policy, compute
+	// the next top-of-minute via cron, and fire when the delay expires. Max
+	// possible delay for "* * * * *" is 60s + some scheduling slack.
+	require.Eventually(t, func() bool {
+		_, err := testEnv.KubeClient.CoreV1().ConfigMaps(ns).Get(context.Background(), "target", metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, 70*time.Second, 1*time.Second, "target should be deleted after the controller fires on the natural cron tick")
+
+	// Confirm the controller (not us) wrote LastExecutionTime.
+	pol, err := testEnv.KyvernoClient.PoliciesV1beta1().DeletingPolicies().Get(context.Background(), policy.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.False(t, pol.Status.LastExecutionTime.IsZero(), "controller should have set LastExecutionTime after firing")
+}

--- a/test/integration/dpol/controller_test.go
+++ b/test/integration/dpol/controller_test.go
@@ -284,7 +284,7 @@ func TestDeletingPolicy_PartialMatch(t *testing.T) {
 				},
 				{
 					Name:       "has-cleanup-label",
-					Expression: `object.metadata.labels["cleanup"] == "true"`,
+					Expression: `has(object.metadata.labels) && "cleanup" in object.metadata.labels && object.metadata.labels["cleanup"] == "true"`,
 				},
 			},
 		},

--- a/test/integration/framework/dpol.go
+++ b/test/integration/framework/dpol.go
@@ -1,0 +1,198 @@
+package framework
+
+import (
+	"context"
+	"sync"
+
+	"github.com/kyverno/kyverno/pkg/cel/libs"
+	"github.com/kyverno/kyverno/pkg/cel/matching"
+	dpolcompiler "github.com/kyverno/kyverno/pkg/cel/policies/dpol/compiler"
+	dpolengine "github.com/kyverno/kyverno/pkg/cel/policies/dpol/engine"
+	kyvernoclient "github.com/kyverno/kyverno/pkg/client/clientset/versioned"
+	kyvernoinformer "github.com/kyverno/kyverno/pkg/client/informers/externalversions"
+	kyvernov1beta1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/policies.kyverno.io/v1beta1"
+	policiesv1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/policies.kyverno.io/v1beta1"
+	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	"github.com/kyverno/kyverno/pkg/config"
+	"github.com/kyverno/kyverno/pkg/controllers"
+	"github.com/kyverno/kyverno/pkg/controllers/deleting"
+	"github.com/kyverno/kyverno/pkg/event"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+// ThreadSafeEventCapture captures events for test assertions.
+// The deleting controller has multiple workers, so this must be thread-safe.
+type ThreadSafeEventCapture struct {
+	mu     sync.Mutex
+	events []event.Info
+}
+
+func (c *ThreadSafeEventCapture) Add(infoList ...event.Info) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, infoList...)
+}
+
+func (c *ThreadSafeEventCapture) GetEvents() []event.Info {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	result := make([]event.Info, len(c.events))
+	copy(result, c.events)
+	return result
+}
+
+func (c *ThreadSafeEventCapture) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = nil
+}
+
+// DpolDeps holds all dependencies created for dpol controller integration testing.
+type DpolDeps struct {
+	DpolLister   policiesv1beta1listers.DeletingPolicyLister
+	NdpolLister  policiesv1beta1listers.NamespacedDeletingPolicyLister
+	NsLister     corev1listers.NamespaceLister
+	Controller   controllers.Controller
+	EventCapture *ThreadSafeEventCapture
+}
+
+// NewDpolDeps creates the complete dependency graph for the dpol controller,
+// mirroring cmd/cleanup-controller/main.go wiring. Uses a single shared
+// kyvernoinformer factory so the controller's event handlers and FetchProvider
+// share the same cache.
+func NewDpolDeps(
+	ctx context.Context,
+	dc dclient.Interface,
+	kyvernoClient kyvernoclient.Interface,
+	kubeClient kubernetes.Interface,
+	restMapper meta.RESTMapper,
+	contextProvider libs.Context,
+) *DpolDeps {
+	// Kyverno informer factory (shared between controller informers and provider listers)
+	kyvernoFactory := kyvernoinformer.NewSharedInformerFactory(kyvernoClient, 0)
+	dpolInformer := kyvernoFactory.Policies().V1beta1().DeletingPolicies()
+	ndpolInformer := kyvernoFactory.Policies().V1beta1().NamespacedDeletingPolicies()
+
+	// Provider: compiles policies from listers on each Get()
+	compiler := dpolcompiler.NewCompiler()
+	provider := dpolengine.NewFetchProvider(compiler, dpolInformer.Lister(), ndpolInformer.Lister(), nil, false)
+
+	// Kube informer factory for namespace lister
+	kubeFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+	nsLister := kubeFactory.Core().V1().Namespaces().Lister()
+
+	nsResolver := func(name string) *corev1.Namespace {
+		ns, err := nsLister.Get(name)
+		if err != nil {
+			return nil
+		}
+		return ns
+	}
+
+	engine := dpolengine.NewEngine(nsResolver, restMapper, contextProvider, matching.NewMatcher())
+	eventCapture := &ThreadSafeEventCapture{}
+
+	controller := deleting.NewController(
+		dc,
+		kyvernoClient,
+		dpolInformer,
+		ndpolInformer,
+		provider,
+		engine,
+		nsLister,
+		config.NewDefaultConfiguration(false),
+		nil, // cmResolver not used by deleting controller
+		eventCapture,
+	)
+
+	kyvernoFactory.Start(ctx.Done())
+	kubeFactory.Start(ctx.Done())
+	for _, synced := range kyvernoFactory.WaitForCacheSync(ctx.Done()) {
+		if !synced {
+			panic("failed to sync kyverno informer caches")
+		}
+	}
+	for _, synced := range kubeFactory.WaitForCacheSync(ctx.Done()) {
+		if !synced {
+			panic("failed to sync kube informer caches")
+		}
+	}
+
+	return &DpolDeps{
+		DpolLister:   dpolInformer.Lister(),
+		NdpolLister:  ndpolInformer.Lister(),
+		NsLister:     nsLister,
+		Controller:   controller,
+		EventCapture: eventCapture,
+	}
+}
+
+// NewDpolDepsWithExceptions creates dpol deps with PolicyException support enabled.
+func NewDpolDepsWithExceptions(
+	ctx context.Context,
+	dc dclient.Interface,
+	kyvernoClient kyvernoclient.Interface,
+	kubeClient kubernetes.Interface,
+	restMapper meta.RESTMapper,
+	contextProvider libs.Context,
+) (*DpolDeps, kyvernov1beta1informers.PolicyExceptionInformer) {
+	kyvernoFactory := kyvernoinformer.NewSharedInformerFactory(kyvernoClient, 0)
+	dpolInformer := kyvernoFactory.Policies().V1beta1().DeletingPolicies()
+	ndpolInformer := kyvernoFactory.Policies().V1beta1().NamespacedDeletingPolicies()
+	polexInformer := kyvernoFactory.Policies().V1beta1().PolicyExceptions()
+
+	compiler := dpolcompiler.NewCompiler()
+	provider := dpolengine.NewFetchProvider(compiler, dpolInformer.Lister(), ndpolInformer.Lister(), polexInformer.Lister(), true)
+
+	kubeFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+	nsLister := kubeFactory.Core().V1().Namespaces().Lister()
+
+	nsResolver := func(name string) *corev1.Namespace {
+		ns, err := nsLister.Get(name)
+		if err != nil {
+			return nil
+		}
+		return ns
+	}
+
+	engine := dpolengine.NewEngine(nsResolver, restMapper, contextProvider, matching.NewMatcher())
+	eventCapture := &ThreadSafeEventCapture{}
+
+	controller := deleting.NewController(
+		dc,
+		kyvernoClient,
+		dpolInformer,
+		ndpolInformer,
+		provider,
+		engine,
+		nsLister,
+		config.NewDefaultConfiguration(false),
+		nil,
+		eventCapture,
+	)
+
+	kyvernoFactory.Start(ctx.Done())
+	kubeFactory.Start(ctx.Done())
+	for _, synced := range kyvernoFactory.WaitForCacheSync(ctx.Done()) {
+		if !synced {
+			panic("failed to sync kyverno informer caches")
+		}
+	}
+	for _, synced := range kubeFactory.WaitForCacheSync(ctx.Done()) {
+		if !synced {
+			panic("failed to sync kube informer caches")
+		}
+	}
+
+	return &DpolDeps{
+		DpolLister:   dpolInformer.Lister(),
+		NdpolLister:  ndpolInformer.Lister(),
+		NsLister:     nsLister,
+		Controller:   controller,
+		EventCapture: eventCapture,
+	}, polexInformer
+}

--- a/test/integration/framework/helpers.go
+++ b/test/integration/framework/helpers.go
@@ -149,9 +149,19 @@ func PodMatchRulesWithOps(ops ...admissionregistrationv1.OperationType) *admissi
 }
 
 // CreateNamespace creates a namespace in the envtest cluster and registers cleanup.
+// Explicitly sets the well-known "kubernetes.io/metadata.name" label because envtest
+// does not always inject it (kube-controller-manager is not running), which breaks
+// any policy that relies on NamespaceSelector matching by namespace name.
 func CreateNamespace(t *testing.T, kubeClient kubernetes.Interface, name string) {
 	t.Helper()
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"kubernetes.io/metadata.name": name,
+			},
+		},
+	}
 	_, err := kubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("failed to create namespace %s: %v", name, err)

--- a/test/integration/framework/setup.go
+++ b/test/integration/framework/setup.go
@@ -27,6 +27,7 @@ type TestEnv struct {
 	Client          client.Client
 	KubeClient      kubernetes.Interface
 	KyvernoClient   kyvernoclient.Interface
+	DClient         dclient.Interface
 	Scheme          *kruntime.Scheme
 	ContextProvider libs.Context
 	cancel          context.CancelFunc
@@ -109,6 +110,7 @@ func NewTestEnv(crdPaths ...string) (*TestEnv, error) {
 		Client:          mgr.GetClient(),
 		KubeClient:      kubeClient,
 		KyvernoClient:   kyvernoClient,
+		DClient:         dc,
 		Scheme:          scheme,
 		ContextProvider: ctxProvider,
 	}, nil


### PR DESCRIPTION

 ## Summary

- Add integration test framework and 6 tests for the DeletingPolicy controller
- Tests exercise the full controller reconcile loop (informer, reconcile, delete, status update, requeue) against envtest
- Framework: NewDpolDeps / NewDpolDepsWithExceptions in framework/dpol.go, DClient field in TestEnv

### Tests

1. BasicDeletion - policy deletes all targeted ConfigMaps, events fired
2. PartialMatch - only matching resources deleted, non-matching survive (regression for #12615)
3. NamespaceIsolation - NamespacedDeletingPolicy only deletes in its own namespace
4. CELConditions - multiple conditions with ObjectSelector for fine-grained filtering
5. StatusUpdatedAfterExecution - LastExecutionTime updated after run (regression for #10418)
6. EmptyConditionsMatchAll - no conditions means match everything

### Test plan

- go test -tags integration ./test/integration/dpol/... passes against envtest
- No production code changes (framework + tests only)