### PR TITLE
fix(webhook): sort fine-grained vpol entries to prevent spurious webhook config PUTs

### DIFF
--- a/pkg/controllers/webhook/validating.go
+++ b/pkg/controllers/webhook/validating.go
@@ -34,13 +34,11 @@ func buildWebhookRules(cfg config.Configuration, server, name, queryPath string,
 			basic = append(basic, policy)
 		}
 	}
-	// Sort fine-grained policies by name so the Webhooks slice is always in the
-	// same order regardless of informer lister iteration order. Without this,
-	// reflect.DeepEqual in the reconcile loop returns false on every 10-second
-	// watchdog cycle (because the order varies), causing a spurious full PUT to
-	// the apiserver and elevating p99 for all webhooks in the config.
 	slices.SortFunc(fineGrained, func(a, b engineapi.GenericPolicy) int {
-		return strings.Compare(extractGenericPolicy(a).GetName(), extractGenericPolicy(b).GetName())
+		if ns := strings.Compare(a.GetNamespace(), b.GetNamespace()); ns != 0 {
+			return ns
+		}
+		return strings.Compare(a.GetName(), b.GetName())
 	})
 	var webhooks []admissionregistrationv1.ValidatingWebhook
 	// process fine grained policies

--- a/pkg/controllers/webhook/validating.go
+++ b/pkg/controllers/webhook/validating.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"path"
 	"slices"
+	"strings"
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/cel/autogen"
@@ -33,6 +34,14 @@ func buildWebhookRules(cfg config.Configuration, server, name, queryPath string,
 			basic = append(basic, policy)
 		}
 	}
+	// Sort fine-grained policies by name so the Webhooks slice is always in the
+	// same order regardless of informer lister iteration order. Without this,
+	// reflect.DeepEqual in the reconcile loop returns false on every 10-second
+	// watchdog cycle (because the order varies), causing a spurious full PUT to
+	// the apiserver and elevating p99 for all webhooks in the config.
+	slices.SortFunc(fineGrained, func(a, b engineapi.GenericPolicy) int {
+		return strings.Compare(extractGenericPolicy(a).GetName(), extractGenericPolicy(b).GetName())
+	})
 	var webhooks []admissionregistrationv1.ValidatingWebhook
 	// process fine grained policies
 	if len(fineGrained) != 0 {

--- a/pkg/controllers/webhook/validating.go
+++ b/pkg/controllers/webhook/validating.go
@@ -1,11 +1,11 @@
 package webhook
 
 import (
+	"cmp"
 	"context"
 	"maps"
 	"path"
 	"slices"
-	"strings"
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/cel/autogen"
@@ -35,10 +35,10 @@ func buildWebhookRules(cfg config.Configuration, server, name, queryPath string,
 		}
 	}
 	slices.SortFunc(fineGrained, func(a, b engineapi.GenericPolicy) int {
-		if ns := strings.Compare(a.GetNamespace(), b.GetNamespace()); ns != 0 {
-			return ns
+		if x := cmp.Compare(a.GetNamespace(), b.GetNamespace()); x != 0 {
+			return x
 		}
-		return strings.Compare(a.GetName(), b.GetName())
+		return cmp.Compare(a.GetName(), b.GetName())
 	})
 	var webhooks []admissionregistrationv1.ValidatingWebhook
 	// process fine grained policies

--- a/pkg/controllers/webhook/validating_test.go
+++ b/pkg/controllers/webhook/validating_test.go
@@ -349,6 +349,82 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 	}
 }
 
+// TestBuildWebhookRules_FineGrained_DeterministicOrdering asserts that calling
+// buildWebhookRules with the same set of 2+ fine-grained ValidatingPolicies
+// (those with matchConditions) always produces the same webhook slice regardless
+// of the order in which policies are supplied.
+//
+// Background: the webhook controller reconciles every ~10 seconds via a watchdog.
+// On each cycle it rebuilds the desired ValidatingWebhookConfiguration and compares
+// it with the observed one using reflect.DeepEqual. If the fine-grained webhook
+// entries appear in a different order across cycles (because the informer lister
+// returns policies in a non-deterministic order), DeepEqual returns false and a
+// spurious full PUT is issued to the apiserver. This causes the apiserver to
+// rebuild its webhook dispatch table, elevating p99 latency for ALL webhooks in
+// the config — including unrelated ones such as validate.kyverno.svc-fail and
+// mutate.kyverno.svc-fail. The problem manifests only with 2+ fine-grained
+// policies; a single fine-grained policy has nothing to reorder.
+func TestBuildWebhookRules_FineGrained_DeterministicOrdering(t *testing.T) {
+	makeFinegrainedVpol := func(name string, resource string) *policiesv1beta1.ValidatingPolicy {
+		return &policiesv1beta1.ValidatingPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: policiesv1beta1.ValidatingPolicySpec{
+				FailurePolicy: ptr.To(admissionregistrationv1.Fail),
+				MatchConstraints: &admissionregistrationv1.MatchResources{
+					ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+						{
+							RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+								Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+								Rule: admissionregistrationv1.Rule{
+									APIGroups:   []string{""},
+									APIVersions: []string{"v1"},
+									Resources:   []string{resource},
+								},
+							},
+						},
+					},
+				},
+				MatchConditions: []admissionregistrationv1.MatchCondition{
+					{Name: "always-true", Expression: "true"},
+				},
+			},
+		}
+	}
+
+	policyA := makeFinegrainedVpol("policy-aardvark", "pods")
+	policyB := makeFinegrainedVpol("policy-zebra", "configmaps")
+	policyC := makeFinegrainedVpol("policy-mango", "services")
+
+	buildWith := func(policies []*policiesv1beta1.ValidatingPolicy) []admissionregistrationv1.ValidatingWebhook {
+		cache := NewExpressionCache()
+		var generic []engineapi.GenericPolicy
+		for _, p := range policies {
+			cache.AddPolicyExpressions(p.GetMatchConditions())
+			generic = append(generic, engineapi.NewValidatingPolicy(p))
+		}
+		return buildWebhookRules(
+			config.NewDefaultConfiguration(false),
+			"", config.ValidatingPolicyWebhookName, "/vpol",
+			0, nil, generic, cache,
+		)
+	}
+
+	// Same three policies, three different input orderings
+	webhooksABC := buildWith([]*policiesv1beta1.ValidatingPolicy{policyA, policyB, policyC})
+	webhooksCBA := buildWith([]*policiesv1beta1.ValidatingPolicy{policyC, policyB, policyA})
+	webhooksBCA := buildWith([]*policiesv1beta1.ValidatingPolicy{policyB, policyC, policyA})
+
+	assert.Equal(t, len(webhooksABC), len(webhooksCBA), "webhook count must be equal regardless of input order")
+	assert.Equal(t, len(webhooksABC), len(webhooksBCA), "webhook count must be equal regardless of input order")
+
+	for i := range webhooksABC {
+		assert.Equal(t, webhooksABC[i].Name, webhooksCBA[i].Name,
+			"webhook[%d] name: ABC order vs CBA order", i)
+		assert.Equal(t, webhooksABC[i].Name, webhooksBCA[i].Name,
+			"webhook[%d] name: ABC order vs BCA order", i)
+	}
+}
+
 func TestBuildWebhookRules_ImageValidatingPolicy(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/pkg/controllers/webhook/validating_test.go
+++ b/pkg/controllers/webhook/validating_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -350,24 +351,22 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 }
 
 func TestBuildWebhookRules_FineGrained_DeterministicOrdering(t *testing.T) {
-	makeFinegrainedVpol := func(name string, resource string) *policiesv1beta1.ValidatingPolicy {
+	makeFinegrainedVpol := func(name, resource string) *policiesv1beta1.ValidatingPolicy {
 		return &policiesv1beta1.ValidatingPolicy{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
 			Spec: policiesv1beta1.ValidatingPolicySpec{
 				FailurePolicy: ptr.To(admissionregistrationv1.Fail),
 				MatchConstraints: &admissionregistrationv1.MatchResources{
-					ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
-						{
-							RuleWithOperations: admissionregistrationv1.RuleWithOperations{
-								Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
-								Rule: admissionregistrationv1.Rule{
-									APIGroups:   []string{""},
-									APIVersions: []string{"v1"},
-									Resources:   []string{resource},
-								},
+					ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{""},
+								APIVersions: []string{"v1"},
+								Resources:   []string{resource},
 							},
 						},
-					},
+					}},
 				},
 				MatchConditions: []admissionregistrationv1.MatchCondition{
 					{Name: "always-true", Expression: "true"},
@@ -375,11 +374,9 @@ func TestBuildWebhookRules_FineGrained_DeterministicOrdering(t *testing.T) {
 			},
 		}
 	}
-
 	policyA := makeFinegrainedVpol("policy-aardvark", "pods")
 	policyB := makeFinegrainedVpol("policy-zebra", "configmaps")
 	policyC := makeFinegrainedVpol("policy-mango", "services")
-
 	buildWith := func(policies []*policiesv1beta1.ValidatingPolicy) []admissionregistrationv1.ValidatingWebhook {
 		cache := NewExpressionCache()
 		var generic []engineapi.GenericPolicy
@@ -393,20 +390,23 @@ func TestBuildWebhookRules_FineGrained_DeterministicOrdering(t *testing.T) {
 			0, nil, generic, cache,
 		)
 	}
-
-	// Same three policies, three different input orderings
-	webhooksABC := buildWith([]*policiesv1beta1.ValidatingPolicy{policyA, policyB, policyC})
-	webhooksCBA := buildWith([]*policiesv1beta1.ValidatingPolicy{policyC, policyB, policyA})
-	webhooksBCA := buildWith([]*policiesv1beta1.ValidatingPolicy{policyB, policyC, policyA})
-
-	assert.Equal(t, len(webhooksABC), len(webhooksCBA), "webhook count must be equal regardless of input order")
-	assert.Equal(t, len(webhooksABC), len(webhooksBCA), "webhook count must be equal regardless of input order")
-
-	for i := range webhooksABC {
-		assert.Equal(t, webhooksABC[i].Name, webhooksCBA[i].Name,
-			"webhook[%d] name: ABC order vs CBA order", i)
-		assert.Equal(t, webhooksABC[i].Name, webhooksBCA[i].Name,
-			"webhook[%d] name: ABC order vs BCA order", i)
+	canonical := buildWith([]*policiesv1beta1.ValidatingPolicy{policyA, policyB, policyC})
+	tests := []struct {
+		name  string
+		input []*policiesv1beta1.ValidatingPolicy
+	}{
+		{name: "CBA order", input: []*policiesv1beta1.ValidatingPolicy{policyC, policyB, policyA}},
+		{name: "BCA order", input: []*policiesv1beta1.ValidatingPolicy{policyB, policyC, policyA}},
+		{name: "BAC order", input: []*policiesv1beta1.ValidatingPolicy{policyB, policyA, policyC}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildWith(tt.input)
+			require.Equal(t, len(canonical), len(result))
+			for i := range canonical {
+				assert.Equal(t, canonical[i].Name, result[i].Name)
+			}
+		})
 	}
 }
 

--- a/pkg/controllers/webhook/validating_test.go
+++ b/pkg/controllers/webhook/validating_test.go
@@ -351,7 +351,7 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 }
 
 func TestBuildWebhookRules_FineGrained_DeterministicOrdering(t *testing.T) {
-	makeFinegrainedVpol := func(name, resource string) *policiesv1beta1.ValidatingPolicy {
+	makeFineGrainedVpol := func(name, resource string) *policiesv1beta1.ValidatingPolicy {
 		return &policiesv1beta1.ValidatingPolicy{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
 			Spec: policiesv1beta1.ValidatingPolicySpec{
@@ -374,9 +374,9 @@ func TestBuildWebhookRules_FineGrained_DeterministicOrdering(t *testing.T) {
 			},
 		}
 	}
-	policyA := makeFinegrainedVpol("policy-aardvark", "pods")
-	policyB := makeFinegrainedVpol("policy-zebra", "configmaps")
-	policyC := makeFinegrainedVpol("policy-mango", "services")
+	policyA := makeFineGrainedVpol("policy-aardvark", "pods")
+	policyB := makeFineGrainedVpol("policy-zebra", "configmaps")
+	policyC := makeFineGrainedVpol("policy-mango", "services")
 	buildWith := func(policies []*policiesv1beta1.ValidatingPolicy) []admissionregistrationv1.ValidatingWebhook {
 		cache := NewExpressionCache()
 		var generic []engineapi.GenericPolicy

--- a/pkg/controllers/webhook/validating_test.go
+++ b/pkg/controllers/webhook/validating_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -371,14 +370,14 @@ func TestBuildWebhookRules_FineGrained_DeterministicOrdering(t *testing.T) {
 			},
 		}
 	}
-	buildWith := func(generic []engineapi.GenericPolicy) []admissionregistrationv1.ValidatingWebhook {
+	buildWith := func(webhookName, queryPath string, generic []engineapi.GenericPolicy) []admissionregistrationv1.ValidatingWebhook {
 		cache := NewExpressionCache()
 		for _, p := range generic {
 			cache.AddPolicyExpressions(extractGenericPolicy(p).GetMatchConditions())
 		}
 		return buildWebhookRules(
 			config.NewDefaultConfiguration(false),
-			"", config.ValidatingPolicyWebhookName, "/vpol",
+			"", webhookName, queryPath,
 			0, nil, generic, cache,
 		)
 	}
@@ -407,39 +406,46 @@ func TestBuildWebhookRules_FineGrained_DeterministicOrdering(t *testing.T) {
 		Spec:       fineGrainedSpec("configmaps"),
 	})
 	tests := []struct {
-		name      string
-		canonical []engineapi.GenericPolicy
-		shuffled  []engineapi.GenericPolicy
+		name        string
+		webhookName string
+		queryPath   string
+		canonical   []engineapi.GenericPolicy
+		shuffled    []engineapi.GenericPolicy
 	}{
 		{
-			name:      "cluster-scoped CBA order",
-			canonical: []engineapi.GenericPolicy{vpolA, vpolB, vpolC},
-			shuffled:  []engineapi.GenericPolicy{vpolC, vpolB, vpolA},
+			name:        "cluster-scoped CBA order",
+			webhookName: config.ValidatingPolicyWebhookName,
+			queryPath:   "/vpol",
+			canonical:   []engineapi.GenericPolicy{vpolA, vpolB, vpolC},
+			shuffled:    []engineapi.GenericPolicy{vpolC, vpolB, vpolA},
 		},
 		{
-			name:      "cluster-scoped BCA order",
-			canonical: []engineapi.GenericPolicy{vpolA, vpolB, vpolC},
-			shuffled:  []engineapi.GenericPolicy{vpolB, vpolC, vpolA},
+			name:        "cluster-scoped BCA order",
+			webhookName: config.ValidatingPolicyWebhookName,
+			queryPath:   "/vpol",
+			canonical:   []engineapi.GenericPolicy{vpolA, vpolB, vpolC},
+			shuffled:    []engineapi.GenericPolicy{vpolB, vpolC, vpolA},
 		},
 		{
-			name:      "namespaced beta-alphaB-alphaA order",
-			canonical: []engineapi.GenericPolicy{nvpolAlphaA, nvpolAlphaB, nvpolBetaA},
-			shuffled:  []engineapi.GenericPolicy{nvpolBetaA, nvpolAlphaB, nvpolAlphaA},
+			name:        "namespaced beta-alphaB-alphaA order",
+			webhookName: config.NamespacedValidatingPolicyWebhookName,
+			queryPath:   "/nvpol",
+			canonical:   []engineapi.GenericPolicy{nvpolAlphaA, nvpolAlphaB, nvpolBetaA},
+			shuffled:    []engineapi.GenericPolicy{nvpolBetaA, nvpolAlphaB, nvpolAlphaA},
 		},
 		{
-			name:      "namespaced alphaB-beta-alphaA order",
-			canonical: []engineapi.GenericPolicy{nvpolAlphaA, nvpolAlphaB, nvpolBetaA},
-			shuffled:  []engineapi.GenericPolicy{nvpolAlphaB, nvpolBetaA, nvpolAlphaA},
+			name:        "namespaced alphaB-beta-alphaA order",
+			webhookName: config.NamespacedValidatingPolicyWebhookName,
+			queryPath:   "/nvpol",
+			canonical:   []engineapi.GenericPolicy{nvpolAlphaA, nvpolAlphaB, nvpolBetaA},
+			shuffled:    []engineapi.GenericPolicy{nvpolAlphaB, nvpolBetaA, nvpolAlphaA},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			expected := buildWith(tt.canonical)
-			result := buildWith(tt.shuffled)
-			require.Equal(t, len(expected), len(result))
-			for i := range expected {
-				assert.Equal(t, expected[i].Name, result[i].Name)
-			}
+			expected := buildWith(tt.webhookName, tt.queryPath, tt.canonical)
+			result := buildWith(tt.webhookName, tt.queryPath, tt.shuffled)
+			assert.Equal(t, expected, result)
 		})
 	}
 }

--- a/pkg/controllers/webhook/validating_test.go
+++ b/pkg/controllers/webhook/validating_test.go
@@ -349,22 +349,6 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 	}
 }
 
-// TestBuildWebhookRules_FineGrained_DeterministicOrdering asserts that calling
-// buildWebhookRules with the same set of 2+ fine-grained ValidatingPolicies
-// (those with matchConditions, matchConstraints.matchPolicy: Exact, or custom
-// timeoutSeconds) always produces the same webhook slice regardless of the order
-// in which policies are supplied.
-//
-// Background: the webhook controller reconciles every ~10 seconds via a watchdog.
-// On each cycle it rebuilds the desired ValidatingWebhookConfiguration and compares
-// it with the observed one using reflect.DeepEqual. If the fine-grained webhook
-// entries appear in a different order across cycles (because the informer lister
-// returns policies in a non-deterministic order), DeepEqual returns false and a
-// spurious full PUT is issued to the apiserver. This causes the apiserver to
-// rebuild its webhook dispatch table, elevating p99 latency for ALL webhooks in
-// the config — including unrelated ones such as validate.kyverno.svc-fail and
-// mutate.kyverno.svc-fail. The problem manifests only with 2+ fine-grained
-// policies; a single fine-grained policy has nothing to reorder.
 func TestBuildWebhookRules_FineGrained_DeterministicOrdering(t *testing.T) {
 	makeFinegrainedVpol := func(name string, resource string) *policiesv1beta1.ValidatingPolicy {
 		return &policiesv1beta1.ValidatingPolicy{

--- a/pkg/controllers/webhook/validating_test.go
+++ b/pkg/controllers/webhook/validating_test.go
@@ -351,8 +351,9 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 
 // TestBuildWebhookRules_FineGrained_DeterministicOrdering asserts that calling
 // buildWebhookRules with the same set of 2+ fine-grained ValidatingPolicies
-// (those with matchConditions) always produces the same webhook slice regardless
-// of the order in which policies are supplied.
+// (those with matchConditions, matchConstraints.matchPolicy: Exact, or custom
+// timeoutSeconds) always produces the same webhook slice regardless of the order
+// in which policies are supplied.
 //
 // Background: the webhook controller reconciles every ~10 seconds via a watchdog.
 // On each cycle it rebuilds the desired ValidatingWebhookConfiguration and compares

--- a/pkg/controllers/webhook/validating_test.go
+++ b/pkg/controllers/webhook/validating_test.go
@@ -351,38 +351,30 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 }
 
 func TestBuildWebhookRules_FineGrained_DeterministicOrdering(t *testing.T) {
-	makeFineGrainedVpol := func(name, resource string) *policiesv1beta1.ValidatingPolicy {
-		return &policiesv1beta1.ValidatingPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
-			Spec: policiesv1beta1.ValidatingPolicySpec{
-				FailurePolicy: ptr.To(admissionregistrationv1.Fail),
-				MatchConstraints: &admissionregistrationv1.MatchResources{
-					ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
-						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
-							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
-							Rule: admissionregistrationv1.Rule{
-								APIGroups:   []string{""},
-								APIVersions: []string{"v1"},
-								Resources:   []string{resource},
-							},
+	fineGrainedSpec := func(resource string) policiesv1beta1.ValidatingPolicySpec {
+		return policiesv1beta1.ValidatingPolicySpec{
+			FailurePolicy: ptr.To(admissionregistrationv1.Fail),
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+					RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+						Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{resource},
 						},
-					}},
-				},
-				MatchConditions: []admissionregistrationv1.MatchCondition{
-					{Name: "always-true", Expression: "true"},
-				},
+					},
+				}},
+			},
+			MatchConditions: []admissionregistrationv1.MatchCondition{
+				{Name: "always-true", Expression: "true"},
 			},
 		}
 	}
-	policyA := makeFineGrainedVpol("policy-aardvark", "pods")
-	policyB := makeFineGrainedVpol("policy-zebra", "configmaps")
-	policyC := makeFineGrainedVpol("policy-mango", "services")
-	buildWith := func(policies []*policiesv1beta1.ValidatingPolicy) []admissionregistrationv1.ValidatingWebhook {
+	buildWith := func(generic []engineapi.GenericPolicy) []admissionregistrationv1.ValidatingWebhook {
 		cache := NewExpressionCache()
-		var generic []engineapi.GenericPolicy
-		for _, p := range policies {
-			cache.AddPolicyExpressions(p.GetMatchConditions())
-			generic = append(generic, engineapi.NewValidatingPolicy(p))
+		for _, p := range generic {
+			cache.AddPolicyExpressions(extractGenericPolicy(p).GetMatchConditions())
 		}
 		return buildWebhookRules(
 			config.NewDefaultConfiguration(false),
@@ -390,21 +382,63 @@ func TestBuildWebhookRules_FineGrained_DeterministicOrdering(t *testing.T) {
 			0, nil, generic, cache,
 		)
 	}
-	canonical := buildWith([]*policiesv1beta1.ValidatingPolicy{policyA, policyB, policyC})
+	vpolA := engineapi.NewValidatingPolicy(&policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-aardvark"},
+		Spec:       fineGrainedSpec("pods"),
+	})
+	vpolB := engineapi.NewValidatingPolicy(&policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-mango"},
+		Spec:       fineGrainedSpec("services"),
+	})
+	vpolC := engineapi.NewValidatingPolicy(&policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-zebra"},
+		Spec:       fineGrainedSpec("configmaps"),
+	})
+	nvpolAlphaA := engineapi.NewNamespacedValidatingPolicy(&policiesv1beta1.NamespacedValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns-alpha", Name: "policy-a"},
+		Spec:       fineGrainedSpec("pods"),
+	})
+	nvpolAlphaB := engineapi.NewNamespacedValidatingPolicy(&policiesv1beta1.NamespacedValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns-alpha", Name: "policy-b"},
+		Spec:       fineGrainedSpec("services"),
+	})
+	nvpolBetaA := engineapi.NewNamespacedValidatingPolicy(&policiesv1beta1.NamespacedValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns-beta", Name: "policy-a"},
+		Spec:       fineGrainedSpec("configmaps"),
+	})
 	tests := []struct {
-		name  string
-		input []*policiesv1beta1.ValidatingPolicy
+		name      string
+		canonical []engineapi.GenericPolicy
+		shuffled  []engineapi.GenericPolicy
 	}{
-		{name: "CBA order", input: []*policiesv1beta1.ValidatingPolicy{policyC, policyB, policyA}},
-		{name: "BCA order", input: []*policiesv1beta1.ValidatingPolicy{policyB, policyC, policyA}},
-		{name: "BAC order", input: []*policiesv1beta1.ValidatingPolicy{policyB, policyA, policyC}},
+		{
+			name:      "cluster-scoped CBA order",
+			canonical: []engineapi.GenericPolicy{vpolA, vpolB, vpolC},
+			shuffled:  []engineapi.GenericPolicy{vpolC, vpolB, vpolA},
+		},
+		{
+			name:      "cluster-scoped BCA order",
+			canonical: []engineapi.GenericPolicy{vpolA, vpolB, vpolC},
+			shuffled:  []engineapi.GenericPolicy{vpolB, vpolC, vpolA},
+		},
+		{
+			name:      "namespaced beta-alphaB-alphaA order",
+			canonical: []engineapi.GenericPolicy{nvpolAlphaA, nvpolAlphaB, nvpolBetaA},
+			shuffled:  []engineapi.GenericPolicy{nvpolBetaA, nvpolAlphaB, nvpolAlphaA},
+		},
+		{
+			name:      "namespaced alphaB-beta-alphaA order",
+			canonical: []engineapi.GenericPolicy{nvpolAlphaA, nvpolAlphaB, nvpolBetaA},
+			shuffled:  []engineapi.GenericPolicy{nvpolAlphaB, nvpolBetaA, nvpolAlphaA},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildWith(tt.input)
-			require.Equal(t, len(canonical), len(result))
-			for i := range canonical {
-				assert.Equal(t, canonical[i].Name, result[i].Name)
+			expected := buildWith(tt.canonical)
+			result := buildWith(tt.shuffled)
+			require.Equal(t, len(expected), len(result))
+			for i := range expected {
+				assert.Equal(t, expected[i].Name, result[i].Name)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

When 2 or more `ValidatingPolicy` resources with `matchConditions` (or `matchConstraints.matchPolicy: Exact`, or custom `timeoutSeconds`) exist simultaneously, the webhook controller's 10-second reconciliation watchdog issues a spurious full PUT to `ValidatingWebhookConfiguration` on nearly every cycle. Each PUT causes the kube-apiserver to rebuild its internal webhook dispatch table, which elevates p99 admission latency for **all** webhooks in the config — including unrelated `ClusterPolicy` webhooks (`validate.kyverno.svc-fail`) and even `MutatingWebhookConfiguration` entries.

### Root cause

`buildWebhookRules` iterated the `fineGrained` slice in informer lister order, which is non-deterministic across reconcile cycles. The update path uses `reflect.DeepEqual` to diff the observed config against the desired one — which is order-sensitive. Two configs containing the same policies in different slice positions are treated as different, triggering a full PUT even when nothing logically changed.

### Causal chain

```
Every 10 seconds
  └─ watchdog calls enqueueResourceWebhooks
       └─ reconcile: rebuild desired ValidatingWebhookConfiguration
            └─ fineGrained slice iterated in non-deterministic informer order
                 └─ reflect.DeepEqual(observed, desired) → false
                      └─ full PUT issued → apiserver writes to etcd, bumps generation
                           └─ apiserver rebuilds webhook dispatch table
                                └─ ALL webhooks in config experience elevated latency
                                     └─ repeat in 10 seconds
```

### Why the threshold is 2+ fine-grained policies

With 0 or 1 fine-grained policies there is nothing to reorder — the rebuilt config is always structurally identical. `DeepEqual` returns true, no PUT is issued, no latency impact.

### Observed in production

Confirmed via multi-cluster experiments (`kyverno_admission_review_duration_seconds_bucket` p99) and `kubectl get validatingwebhookconfiguration -w` showing `.metadata.generation` incrementing every ~10–30 seconds. After removing the second fine-grained policy, the generation stopped incrementing entirely.

## Fix

Sort the `fineGrained` slice by policy name after the classification loop, before iterating to build per-policy webhook entries. This ensures the `Webhooks` slice is always in the same deterministic order regardless of informer lister iteration order, so `reflect.DeepEqual` returns true when nothing logically changed and no spurious PUT is issued.

```go
slices.SortFunc(fineGrained, func(a, b engineapi.GenericPolicy) int {
    return strings.Compare(extractGenericPolicy(a).GetName(), extractGenericPolicy(b).GetName())
})
```

## Test

Adds `TestBuildWebhookRules_FineGrained_DeterministicOrdering` which calls `buildWebhookRules` with the same 3 fine-grained policies in 3 different input orderings and asserts that all produce an identical webhook name sequence. The test fails before this fix and passes after.

```bash
go test ./pkg/controllers/webhook/... -run TestBuildWebhookRules_FineGrained_DeterministicOrdering -v
```

## Test plan
- [x] `TestBuildWebhookRules_FineGrained_DeterministicOrdering` passes
- [x] All existing `pkg/controllers/webhook/...` tests pass
- [ ] Deploy 2+ `ValidatingPolicy` resources with `matchConditions` and verify `ValidatingWebhookConfiguration` generation stops incrementing on every reconcile cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)