### PR TITLE
fix: bypass blocklist for cluster-scoped http policies

### DIFF
--- a/pkg/cel/compiler/http.go
+++ b/pkg/cel/compiler/http.go
@@ -12,11 +12,17 @@ import (
 
 // sharedHTTPContext is built once on the first http.* call and reused across
 // admission requests so the underlying http.Transport is not recreated per call.
+// It applies the operator-configured SSRF blocklist and is used for namespaced policies.
 var sharedHTTPContext = &cachedHTTPContext{}
 
+// clusterHTTPContext is the unrestricted counterpart used for cluster-scoped policies.
+// Cluster-scoped policies require cluster-admin privileges, so no SSRF blocklist is needed.
+var clusterHTTPContext = &cachedHTTPContext{unrestricted: true}
+
 type cachedHTTPContext struct {
-	mu     sync.Mutex
-	cached http.ContextInterface
+	mu           sync.Mutex
+	cached       http.ContextInterface
+	unrestricted bool
 }
 
 func (c *cachedHTTPContext) getOrBuild() (http.ContextInterface, error) {
@@ -25,7 +31,12 @@ func (c *cachedHTTPContext) getOrBuild() (http.ContextInterface, error) {
 	if c.cached != nil {
 		return c.cached, nil
 	}
-	ctx, err := http.NewHTTPWithBlocklist(toggle.HTTPBlocklist.Values(), toggle.HTTPAllowlist.Values())
+	var blocklist, allowlist []string
+	if !c.unrestricted {
+		blocklist = toggle.HTTPBlocklist.Values()
+		allowlist = toggle.HTTPAllowlist.Values()
+	}
+	ctx, err := http.NewHTTPWithBlocklist(blocklist, allowlist)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +73,7 @@ func (c *cachedHTTPContext) Client(caBundle string) (http.ContextInterface, erro
 // AllowHTTPInNamespacedPolicies toggle is enforced at call time.
 func NewLazyCELHTTPContext(namespace string) http.ContextInterface {
 	if namespace == "" {
-		return sharedHTTPContext
+		return clusterHTTPContext
 	}
 	return &namespacedHTTPContext{inner: sharedHTTPContext}
 }

--- a/pkg/cel/compiler/http_test.go
+++ b/pkg/cel/compiler/http_test.go
@@ -88,6 +88,37 @@ func TestNewLazyCELHTTPContext_ToggleEnforcement(t *testing.T) {
 	})
 }
 
+func TestHTTPContextSeparation(t *testing.T) {
+	// Toggle is off by default. Namespaced policies must be blocked while
+	// cluster-scoped policies must remain usable — the regression tested here
+	// is that the SSRF blocklist and the namespaced toggle are independent.
+	t.Run("namespaced blocked, cluster unaffected when toggle is off", func(t *testing.T) {
+		namespacedCtx := NewLazyCELHTTPContext("my-namespace")
+		clusterCtx := NewLazyCELHTTPContext("")
+
+		_, err := namespacedCtx.Get("http://example.com", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not allowed in namespaced policies")
+
+		_, err = clusterCtx.Get("http://example.com", nil)
+		if err != nil {
+			assert.NotContains(t, err.Error(), "not allowed in namespaced policies")
+		}
+	})
+
+	t.Run("cluster context ignores SSRF blocklist", func(t *testing.T) {
+		// An invalid CIDR causes NewHTTPWithBlocklist to error. The unrestricted
+		// cluster context must succeed because it never reads the blocklist flag.
+		require.NoError(t, toggle.HTTPBlocklist.Parse("999.999.999.999/24"))
+		t.Cleanup(func() { toggle.HTTPBlocklist.Reset() })
+
+		ctx := &cachedHTTPContext{unrestricted: true}
+		built, err := ctx.getOrBuild()
+		assert.NoError(t, err)
+		assert.NotNil(t, built)
+	})
+}
+
 func TestAllowHTTPInNamespacedPoliciesToggle(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #15789 where the SSRF blocklist was incorrectly applied to cluster-scoped policies.

### Root cause

`NewLazyCELHTTPContext("")` (the cluster-scoped path) returned `sharedHTTPContext`, which applies the operator-configured SSRF blocklist (defaulting to `10.0.0.0/8` and other private ranges). This blocked cluster-scoped policies from making HTTP calls to in-cluster services, breaking existing tests such as `chainsaw/cel-lib/http-lib/deleting-policy-http-lib`.

The PR description of #15789 explicitly stated: *"Cluster-scoped policies retain HTTP access unchanged"*, the implementation did not match that intent.

### Fix

Added a separate `clusterHTTPContext` singleton (`unrestricted: true`) that passes `nil` blocklist and allowlist to `NewHTTPWithBlocklist`. Cluster-scoped policies use this context; namespaced policies continue to use `sharedHTTPContext` (with the SSRF blocklist) wrapped in `namespacedHTTPContext` (with the toggle check).

The separation is:
- `namespace == ""` => `clusterHTTPContext`: no blocklist, no toggle check
- `namespace != ""` => `namespacedHTTPContext{inner: sharedHTTPContext}`: toggle enforced at call time, SSRF blocklist applied

### Tests

Added `TestHTTPContextSeparation` with two sub-tests:
- Verifies that namespaced policies receive the toggle error while cluster-scoped policies are unaffected, both evaluated simultaneously
- Verifies that the cluster context ignores the blocklist flag entirely (uses an intentionally invalid CIDR that would fail `NewHTTPWithBlocklist` to prove the flag is never read)

## Related issue

Regression from #15789 (GHSA-rggm-jjmc-3394)

## What type of PR is this

/kind bug

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md)
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s).
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.