### PR TITLE
[codex] Fail CLI tests on messageExpression errors

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/apis/v1alpha1"
@@ -21,6 +22,11 @@ import (
 )
 
 var ansiRegex = regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:[a-zA-Z0-9]*(?:;[a-zA-Z0-9]*)*)?\u0007|(?:\\d{1,4}(?:;\\d{0,4})*)?[0-mG-Z])")
+
+const (
+	messageExpressionEvaluationError = "failed to evaluate message expression:"
+	messageExpressionConversionError = "failed to convert message expression to string:"
+)
 
 func Command() *cobra.Command {
 	var testCase, outputFormat string
@@ -239,10 +245,18 @@ func checkResult(
 		}
 	}
 	result := report.ComputePolicyReportResult(false, response, rule)
+	if isMessageExpressionError(result.Description) {
+		return false, result.Description, "Message expression error"
+	}
 	if result.Result != expected {
 		return false, result.Description, fmt.Sprintf("Want %s, got %s", expected, result.Result)
 	}
 	return true, result.Description, "Ok"
+}
+
+func isMessageExpressionError(message string) bool {
+	return strings.Contains(message, messageExpressionEvaluationError) ||
+		strings.Contains(message, messageExpressionConversionError)
 }
 
 func isRulelessPolicyKind(kind string) bool {

--- a/cmd/cli/kubectl-kyverno/commands/test/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command_test.go
@@ -118,6 +118,7 @@ func TestCheckResultDetectsMismatch(t *testing.T) {
 	tests := []struct {
 		name           string
 		ruleStatus     engineapi.RuleStatus
+		ruleMessage    string
 		expectedResult string
 		wantOk         bool
 		wantReason     string
@@ -125,6 +126,7 @@ func TestCheckResultDetectsMismatch(t *testing.T) {
 		{
 			name:           "expect fail but got pass - should detect mismatch",
 			ruleStatus:     engineapi.RuleStatusPass,
+			ruleMessage:    "msg",
 			expectedResult: openreports.StatusFail,
 			wantOk:         false,
 			wantReason:     "Want fail, got pass",
@@ -132,13 +134,23 @@ func TestCheckResultDetectsMismatch(t *testing.T) {
 		{
 			name:           "expect fail and got fail - should match",
 			ruleStatus:     engineapi.RuleStatusFail,
+			ruleMessage:    "msg",
 			expectedResult: openreports.StatusFail,
 			wantOk:         true,
 			wantReason:     "Ok",
 		},
 		{
+			name:           "expect fail and got message expression error - should fail",
+			ruleStatus:     engineapi.RuleStatusFail,
+			ruleMessage:    "failed to evaluate message expression: no such overload",
+			expectedResult: openreports.StatusFail,
+			wantOk:         false,
+			wantReason:     "Message expression error",
+		},
+		{
 			name:           "expect pass and got pass - should match",
 			ruleStatus:     engineapi.RuleStatusPass,
+			ruleMessage:    "msg",
 			expectedResult: openreports.StatusPass,
 			wantOk:         true,
 			wantReason:     "Ok",
@@ -146,6 +158,7 @@ func TestCheckResultDetectsMismatch(t *testing.T) {
 		{
 			name:           "expect pass but got fail - should detect mismatch",
 			ruleStatus:     engineapi.RuleStatusFail,
+			ruleMessage:    "msg",
 			expectedResult: openreports.StatusPass,
 			wantOk:         false,
 			wantReason:     "Want pass, got fail",
@@ -153,6 +166,7 @@ func TestCheckResultDetectsMismatch(t *testing.T) {
 		{
 			name:           "expect fail but got error - should detect mismatch",
 			ruleStatus:     engineapi.RuleStatusError,
+			ruleMessage:    "msg",
 			expectedResult: openreports.StatusFail,
 			wantOk:         false,
 			wantReason:     "Want fail, got error",
@@ -164,11 +178,11 @@ func TestCheckResultDetectsMismatch(t *testing.T) {
 			var rule engineapi.RuleResponse
 			switch tt.ruleStatus {
 			case engineapi.RuleStatusPass:
-				rule = *engineapi.RulePass("test-rule", engineapi.Validation, "msg", nil)
+				rule = *engineapi.RulePass("test-rule", engineapi.Validation, tt.ruleMessage, nil)
 			case engineapi.RuleStatusFail:
-				rule = *engineapi.RuleFail("test-rule", engineapi.Validation, "msg", nil)
+				rule = *engineapi.RuleFail("test-rule", engineapi.Validation, tt.ruleMessage, nil)
 			case engineapi.RuleStatusError:
-				rule = *engineapi.RuleError("test-rule", engineapi.Validation, "msg", nil, nil)
+				rule = *engineapi.RuleError("test-rule", engineapi.Validation, tt.ruleMessage, nil, nil)
 			}
 
 			response := engineapi.NewEngineResponse(


### PR DESCRIPTION
## Summary
- fail Kyverno CLI test cases when a rule message contains a messageExpression evaluation or conversion error
- add a regression case for expected fail results that previously still counted as passing despite the messageExpression error

Fixes #15350

## Validation
- gofmt on changed Go files
- git diff --check
- attempted: go test ./cmd/cli/kubectl-kyverno/commands/test -run TestCheckResultDetectsMismatch -count=1 -vet=off -p=1

The targeted Go test could not complete locally because the machine ran out of disk space while compiling Kyverno dependencies, even with GOTMPDIR/GOMODCACHE/GOCACHE moved under /tmp.