### PR TITLE
fix(ivpol): remove early return on matchIamgeReference

### DIFF
--- a/pkg/image/verification/evaluator/eval_test.go
+++ b/pkg/image/verification/evaluator/eval_test.go
@@ -98,7 +98,7 @@ uOKpF5rWAruB5PCIrquamOejpXV9aQA/K2JQDuc0mcKz
 func Test_Eval_NonMatchingImage(t *testing.T) {
 	result, err := Evaluate(context.Background(), []*CompiledImageValidatingPolicy{{Policy: ivpol}}, obj(nonMatchingImage), nil, nil, nil)
 	assert.NoError(t, err)
-	assert.Nil(t, result[ivpol.Name])
+	assert.True(t, result[ivpol.Name].Result)
 }
 
 func Test_Eval(t *testing.T) {

--- a/pkg/image/verification/evaluator/policy.go
+++ b/pkg/image/verification/evaluator/policy.go
@@ -139,11 +139,6 @@ func (c *compiledPolicy) Evaluate(ctx context.Context, ictx imagedataloader.Imag
 		}
 	}
 
-	// no image match found, skip
-	if len(c.matchImageReferences) > 0 && len(imgList) == 0 {
-		return nil, nil
-	}
-
 	if err := ictx.AddImages(ctx, imgList, imageverify.GetRemoteOptsFromPolicy(c.creds)...); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
##Description:                                                                                
                                                                                           
PR #15834 correctly fixed images.containers filtering so only images matching               
`matchImageReferences` are exposed in CEL. But it also added an early return that skips the entire policy evaluation when no pod images match the glob.                                                                                            

In hindsight, this was wrong `matchImageReferences` is an image filter, it controls which images undergo signature/attestation verification and appear in images.containers. It is not a resource admission filter; that role belongs to `matchConstraints.resourceRules`.          
                                                                                         
Skipping evaluation when no images match breaks valid use cases, for example a policy enforcing that all container images come from ghcr.io: the whole point is to deny resources that have no matching images.

The fix removes the early return while keeping the filteredImages loop from #15834, so      
images.containers is still correctly scoped to matching images.

#### Affected conformance tests (broken by #15834, restored by this fix):

- image-data: uses image.GetMetadata() with a hardcoded image name, independent of pod images 
- imagereference: denies deployments whose images are not from ghcr.io
- image-data-arch: checks architecture of images not in ghcr.io
- fetch-pod-resource: uses resource.get(), unrelated to image matching