### PR TITLE
fix(engine): prevent forEach mutation panic [release-1.17]

### DIFF
--- a/pkg/engine/mutate/mutation.go
+++ b/pkg/engine/mutate/mutation.go
@@ -78,7 +78,8 @@ func ForEach(name string, foreach kyvernov1.ForEachMutation, policyContext engin
 	if err != nil {
 		return NewErrorResponse("variable substitution failed", err)
 	}
-	patcher := NewPatcher(fe["patchStrategicMerge"], fe["patchesJson6902"].(string))
+	jsonPatch, _ := fe["patchesJson6902"].(string)
+	patcher := NewPatcher(fe["patchStrategicMerge"], jsonPatch)
 	if patcher == nil {
 		return NewErrorResponse("empty mutate rule", nil)
 	}

--- a/pkg/engine/mutate/mutation_test.go
+++ b/pkg/engine/mutate/mutation_test.go
@@ -238,6 +238,16 @@ func TestProcessPatches_RemovePathDoesntExist_NotEmptyResult(t *testing.T) {
 	require.Equal(t, resource, patched)
 }
 
+type MockPolicyContext struct {
+	engineapi.PolicyContext
+	mock.Mock
+}
+
+func (m *MockPolicyContext) JSONContext() context.Interface {
+	args := m.Called()
+	return args.Get(0).(context.Interface)
+}
+
 type MockContext struct {
 	context.Interface
 	mock.Mock
@@ -251,6 +261,31 @@ func (m *MockContext) Query(query string) (interface{}, error) {
 func (m *MockContext) QueryOperation() string {
 	args := m.Called()
 	return args.Get(0).(string)
+}
+
+func TestForEach_NilPatchesJSON6902_NoPanic(t *testing.T) {
+	ctx := &MockContext{}
+	// Variable resolves to nil, which caused a bare type assertion panic before the fix
+	ctx.On("Query", mock.Anything).Return(nil, nil)
+	ctx.On("QueryOperation").Return("CREATE")
+
+	foreach := v1.ForEachMutation{
+		PatchesJSON6902: "{{ element.nonexistent }}",
+	}
+
+	var resource unstructured.Unstructured
+	resource.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "test"},
+	})
+
+	policyContext := &MockPolicyContext{}
+	policyContext.On("JSONContext").Return(ctx)
+
+	resp := ForEach("test-rule", foreach, policyContext, resource, nil, logr.Discard())
+	assert.NotNil(t, resp)
+	assert.Equal(t, engineapi.RuleStatusError, resp.Status)
 }
 
 func TestSubstituteAllInForEach_InvalidTypeConversion(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of 2f90ce1d42828d6cef2538879816c4e6c70abfb8 to release-1.17.

When a `forEach` `patchesJson6902` field contains a variable that resolves to nil at runtime, the mutation handler panics and crashes the background controller into a persistent CrashLoopBackOff. The admission controller drops the connection, blocking all matching resource operations.

Use safe type assertion so nil values are handled gracefully as errors instead of panics.

Fixes: security advisory GHSA-fpjq-c37h-cqcv