### PR TITLE
feat: add observedGeneration in status

### DIFF
--- a/pkg/controllers/policystatus/controller.go
+++ b/pkg/controllers/policystatus/controller.go
@@ -314,18 +314,18 @@ func (c controller) reconcileConditions(ctx context.Context, policy engineapi.Ge
 
 	if !backgroundOnly {
 		if ready, ok := c.polStateRecorder.Ready(key); ready {
-			status.SetReadyByCondition(policiesv1beta1.PolicyConditionTypeWebhookConfigured, metav1.ConditionTrue, "Webhook configured.")
+			status.SetReadyByConditionAndObservedGeneration(policiesv1beta1.PolicyConditionTypeWebhookConfigured, metav1.ConditionTrue, "Webhook configured.", policy.GetGeneration())
 		} else if ok {
-			status.SetReadyByCondition(policiesv1beta1.PolicyConditionTypeWebhookConfigured, metav1.ConditionFalse, "Policy is not configured in the webhook.")
+			status.SetReadyByConditionAndObservedGeneration(policiesv1beta1.PolicyConditionTypeWebhookConfigured, metav1.ConditionFalse, "Policy is not configured in the webhook.", policy.GetGeneration())
 		}
 	}
 
 	gvrs := c.resolveGVRs(matchConstraints.ResourceRules)
 	errs := c.permissionsCheck(ctx, gvrs)
 	if errs != nil {
-		status.SetReadyByCondition(policiesv1beta1.PolicyConditionTypeRBACPermissionsGranted, metav1.ConditionFalse, fmt.Sprintf("Policy is not ready for reporting, missing permissions: %v.", multierr.Combine(errs...)))
+		status.SetReadyByConditionAndObservedGeneration(policiesv1beta1.PolicyConditionTypeRBACPermissionsGranted, metav1.ConditionFalse, fmt.Sprintf("Policy is not ready for reporting, missing permissions: %v.", multierr.Combine(errs...)), policy.GetGeneration())
 	} else {
-		status.SetReadyByCondition(policiesv1beta1.PolicyConditionTypeRBACPermissionsGranted, metav1.ConditionTrue, "Policy is ready for reporting.")
+		status.SetReadyByConditionAndObservedGeneration(policiesv1beta1.PolicyConditionTypeRBACPermissionsGranted, metav1.ConditionTrue, "Policy is ready for reporting.", policy.GetGeneration())
 	}
 	return status
 }
@@ -360,20 +360,19 @@ func (c controller) reconcileBeta1Conditions(ctx context.Context, policy enginea
 
 	if !backgroundOnly {
 		if ready, ok := c.polStateRecorder.Ready(key); ready {
-			status.SetReadyByCondition(policiesv1beta1.PolicyConditionTypeWebhookConfigured, metav1.ConditionTrue, "Webhook configured.")
+			status.SetReadyByConditionAndObservedGeneration(policiesv1beta1.PolicyConditionTypeWebhookConfigured, metav1.ConditionTrue, "Webhook configured.", policy.GetGeneration())
 		} else if ok {
-			status.SetReadyByCondition(policiesv1beta1.PolicyConditionTypeWebhookConfigured, metav1.ConditionFalse, "Policy is not configured in the webhook.")
+			status.SetReadyByConditionAndObservedGeneration(policiesv1beta1.PolicyConditionTypeWebhookConfigured, metav1.ConditionFalse, "Policy is not configured in the webhook.", policy.GetGeneration())
 		}
 	}
 
 	gvrs := c.resolveGVRs(matchConstraints.ResourceRules)
 	errs := c.permissionsCheck(ctx, gvrs)
 	if errs != nil {
-		status.SetReadyByCondition(policiesv1beta1.PolicyConditionTypeRBACPermissionsGranted, metav1.ConditionFalse, fmt.Sprintf("Policy is not ready for reporting, missing permissions: %v.", multierr.Combine(errs...)))
+		status.SetReadyByConditionAndObservedGeneration(policiesv1beta1.PolicyConditionTypeRBACPermissionsGranted, metav1.ConditionFalse, fmt.Sprintf("Policy is not ready for reporting, missing permissions: %v.", multierr.Combine(errs...)), policy.GetGeneration())
 	} else {
-		status.SetReadyByCondition(policiesv1beta1.PolicyConditionTypeRBACPermissionsGranted, metav1.ConditionTrue, "Policy is ready for reporting.")
+		status.SetReadyByConditionAndObservedGeneration(policiesv1beta1.PolicyConditionTypeRBACPermissionsGranted, metav1.ConditionTrue, "Policy is ready for reporting.", policy.GetGeneration())
 	}
-
 	return status
 }
 

--- a/pkg/controllers/policystatus/vpol.go
+++ b/pkg/controllers/policystatus/vpol.go
@@ -55,8 +55,8 @@ func (c controller) updateVpolStatus(ctx context.Context, vpol *policiesv1beta1.
 }
 
 func (c controller) updateNVpolStatus(ctx context.Context, nvpol *policiesv1beta1.NamespacedValidatingPolicy) error {
-	updateFunc := func(vpol *policiesv1beta1.NamespacedValidatingPolicy) error {
-		p := engineapi.NewNamespacedValidatingPolicy(vpol)
+	updateFunc := func(nvpol *policiesv1beta1.NamespacedValidatingPolicy) error {
+		p := engineapi.NewNamespacedValidatingPolicy(nvpol)
 		// conditions
 		conditionStatus := c.reconcileBeta1Conditions(ctx, p)
 		ready := true
@@ -70,7 +70,7 @@ func (c controller) updateNVpolStatus(ctx context.Context, nvpol *policiesv1beta
 			conditionStatus.Ready = &ready
 		}
 		// autogen
-		rules, err := vpolautogen.Autogen(vpol)
+		rules, err := vpolautogen.Autogen(nvpol)
 		if err != nil {
 			return err
 		}
@@ -78,8 +78,8 @@ func (c controller) updateNVpolStatus(ctx context.Context, nvpol *policiesv1beta
 			Configs: rules,
 		}
 		// assign
-		status := vpol.GetStatus()
-		vpol.Status = policiesv1beta1.ValidatingPolicyStatus{
+		status := nvpol.GetStatus()
+		nvpol.Status = policiesv1beta1.ValidatingPolicyStatus{
 			ConditionStatus: *conditionStatus,
 			Autogen:         autogenStatus,
 			Generated:       status.Generated,

--- a/test/conformance/chainsaw/mutating-policies/status/observed-generation/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/mutating-policies/status/observed-generation/chainsaw-test.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: observed-generation
+spec:
+  concurrent: false
+  steps:
+  - name: create-policy
+    use:
+      template: ../../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait-policy-ready
+    use:
+      template: ../../../_step-templates/mutating-policy-v1-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: test-observed-generation
+  - name: assert-observed-generation-initial
+    try:
+    - assert:
+        resource:
+          apiVersion: policies.kyverno.io/v1
+          kind: MutatingPolicy
+          metadata:
+            name: test-observed-generation
+          status:
+            conditionStatus:
+              (conditions[?type == 'WebhookConfigured']):
+              - observedGeneration: 1
+              (conditions[?type == 'RBACPermissionsGranted']):
+              - observedGeneration: 1
+  - name: update-policy-spec
+    try:
+    - patch:
+        resource:
+          apiVersion: policies.kyverno.io/v1
+          kind: MutatingPolicy
+          metadata:
+            name: test-observed-generation
+          spec:
+            mutations:
+            - patchType: ApplyConfiguration
+              applyConfiguration:
+                expression: |
+                  Object{
+                    metadata: Object.metadata{
+                      labels: {"mutated": "updated"}
+                    }
+                  }
+  - name: wait-policy-ready-after-update
+    use:
+      template: ../../../_step-templates/mutating-policy-v1-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: test-observed-generation
+  - name: assert-observed-generation-updated
+    try:
+    - assert:
+        resource:
+          apiVersion: policies.kyverno.io/v1
+          kind: MutatingPolicy
+          metadata:
+            name: test-observed-generation
+          status:
+            conditionStatus:
+              (conditions[?type == 'WebhookConfigured']):
+              - observedGeneration: 2
+              (conditions[?type == 'RBACPermissionsGranted']):
+              - observedGeneration: 2

--- a/test/conformance/chainsaw/mutating-policies/status/observed-generation/policy.yaml
+++ b/test/conformance/chainsaw/mutating-policies/status/observed-generation/policy.yaml
@@ -1,0 +1,23 @@
+apiVersion: policies.kyverno.io/v1
+kind: MutatingPolicy
+metadata:
+  name: test-observed-generation
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["configmaps"]
+      operations: ["CREATE"]
+  variables:
+  - name: x
+    expression: "'test'"
+  mutations:
+  - patchType: ApplyConfiguration
+    applyConfiguration:
+      expression: |
+        Object{
+          metadata: Object.metadata{
+            labels: {"mutated": variables.x}
+          }
+        }


### PR DESCRIPTION
## Explanation

This change adds the observedGeneration to the status object. This is already part of the CRD (so no CRD change required), but it was just not picked up by the controller. This has been added.

Important: https://github.com/kyverno/api/pull/80 needs to be merged first, to set the correct api version in go.mod. That is why this is a draft.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

2 Related issues:
https://github.com/kyverno/kyverno/issues/12256
https://github.com/argoproj/argo-cd/pull/27354#pullrequestreview-4122188413

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

I do not think docs are needed for this feature.

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
 /kind feature
-->
 /kind feature

## Proposed Changes

This change adds the observedGeneration to the status field to track if the processed generation is the same as in the annotation.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

See the chainsaw tests. You can see that there is a `observedGeneration` field in the status field now. 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
