### PR TITLE
ci(trivy): filter kyverno pseudo-versions

### DIFF
--- a/.github/workflows/scan-trivy.yaml
+++ b/.github/workflows/scan-trivy.yaml
@@ -44,6 +44,7 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           trivyignores: .trivyignore
+          ignore-policy: .trivyignore.rego
       - name: Upload Trivy scan results to GitHub Security
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:

--- a/.github/workflows/sync-trivy-issues.yaml
+++ b/.github/workflows/sync-trivy-issues.yaml
@@ -39,11 +39,6 @@ jobs:
           const alerts = allAlerts.filter(a => {
             if (seen.has(a.number)) return false;
             seen.add(a.number);
-            // Skip false positives: Trivy scanning the kyverno binary finds the embedded
-            // kyverno module at a v0.0.0-<date> pseudo-version (main branch dev builds)
-            // and flags all known kyverno CVEs because v0.0.0 < any release version.
-            const msg = a.most_recent_instance?.message?.text || '';
-            if (msg.includes('v0.0.0-') && msg.toLowerCase().includes('kyverno')) return false;
             return true;
           });
 

--- a/.github/workflows/sync-trivy-issues.yaml
+++ b/.github/workflows/sync-trivy-issues.yaml
@@ -39,6 +39,11 @@ jobs:
           const alerts = allAlerts.filter(a => {
             if (seen.has(a.number)) return false;
             seen.add(a.number);
+            // Skip false positives: Trivy scanning the kyverno binary finds the embedded
+            // kyverno module at a v0.0.0-<date> pseudo-version (main branch dev builds)
+            // and flags all known kyverno CVEs because v0.0.0 < any release version.
+            const msg = a.most_recent_instance?.message?.text || '';
+            if (msg.includes('v0.0.0-') && msg.toLowerCase().includes('kyverno')) return false;
             return true;
           });
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,9 +1,0 @@
-# Not relevant (kyverno vulns applying to kyverno)
-CVE-2026-22039
-CVE-2026-23881
-CVE-2025-47281
-CVE-2025-46342
-CVE-2024-48921
-CVE-2023-47630
-GHSA-hgv6-w7r3-w4qw
-CVE-2023-34091

--- a/.trivyignore.rego
+++ b/.trivyignore.rego
@@ -1,0 +1,11 @@
+package trivy
+
+# Ignore vulnerabilities where the affected package is kyverno itself at a
+# v0.0.0-<date> pseudo-version. This happens because Trivy scans the kyverno
+# binary, finds its embedded Go module info reporting version v0.0.0-<date>
+# (main branch dev builds are not tagged), and flags all known kyverno CVEs
+# since v0.0.0 is semantically older than any release.
+ignore[input.ID] {
+	input.PkgName == "kyverno"
+	startswith(input.InstalledVersion, "v0.0.0-")
+}


### PR DESCRIPTION
## Explanation

This PR filter false positives issues such as : 

- https://github.com/kyverno/kyverno/issues/15883
- https://github.com/kyverno/kyverno/issues/15884  

This happens because trivy is scanning the kyverno binary and finds the embedded kyverno module at a `v0.0.0-<date>` pseudo-version (main branch dev builds) and then flags all known kyverno CVEs because v0.0.0 < any release version.
