### PR TITLE
[codex] Report skipped policy load errors

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -70,8 +70,14 @@ import (
 )
 
 type SkippedInvalidPolicies struct {
-	skipped []string
-	invalid []string
+	skipped    []string
+	invalid    []string
+	loadErrors []SkippedPolicyLoadError
+}
+
+type SkippedPolicyLoadError struct {
+	path string
+	err  error
 }
 
 type ApplyCommandConfig struct {
@@ -280,7 +286,7 @@ func (c *ApplyCommandConfig) applyCommandHelper(out io.Writer) (*processor.Resul
 	}
 	var store store.Store
 
-	kpols, polexs, celpolexs, vaps, vapBindings, maps, mapBindings, vps, ivps, gps, dps, cps, mps, envoyPols, httpPols, err := c.loadPolicies()
+	kpols, polexs, celpolexs, vaps, vapBindings, maps, mapBindings, vps, ivps, gps, dps, cps, mps, envoyPols, httpPols, skippedInvalidPolicies, err := c.loadPolicies()
 	if err != nil {
 		return nil, nil, skippedInvalidPolicies, nil, err
 	}
@@ -1022,8 +1028,10 @@ func (c *ApplyCommandConfig) loadPolicies() (
 	[]policiesv1beta1.MutatingPolicyLike,
 	[]*policiesv1beta1.ValidatingPolicy, // Envoy policies
 	[]*policiesv1beta1.ValidatingPolicy, // HTTP policies
+	SkippedInvalidPolicies,
 	error,
 ) {
+	var skippedInvalidPolicies SkippedInvalidPolicies
 	// load policies
 	var policies []kyvernov1.PolicyInterface
 	var exceptions []*kyvernov2.PolicyException
@@ -1045,12 +1053,12 @@ func (c *ApplyCommandConfig) loadPolicies() (
 		if isGit {
 			gitSourceURL, err := url.Parse(path)
 			if err != nil {
-				return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to load policies (%w)", err)
+				return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, skippedInvalidPolicies, fmt.Errorf("failed to load policies (%w)", err)
 			}
 			pathElems := strings.Split(gitSourceURL.Path[1:], "/")
 			if len(pathElems) <= 1 {
 				err := fmt.Errorf("invalid URL path %s - expected https://<any_git_source_domain>/:owner/:repository/:branch (without --git-branch flag) OR https://<any_git_source_domain>/:owner/:repository/:directory (with --git-branch flag)", gitSourceURL.Path)
-				return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to parse URL (%w)", err)
+				return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, skippedInvalidPolicies, fmt.Errorf("failed to parse URL (%w)", err)
 			}
 			gitSourceURL.Path = strings.Join([]string{pathElems[0], pathElems[1]}, "/")
 			repoURL := gitSourceURL.String()
@@ -1063,19 +1071,15 @@ func (c *ApplyCommandConfig) loadPolicies() (
 			}
 			if _, err := c.cloneRepo(repoURL, fs, c.GitBranch, *auth); err != nil {
 				log.Log.V(3).Info(fmt.Sprintf("failed to clone repository  %v as it is not valid", repoURL), "error", err)
-				return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to clone repository (%w)", err)
+				return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, skippedInvalidPolicies, fmt.Errorf("failed to clone repository (%w)", err)
 			}
 			policyYamls, err := gitutils.ListYamls(fs, gitPathToYamls)
 			if err != nil {
-				return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to list YAMLs in repository (%w)", err)
+				return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, skippedInvalidPolicies, fmt.Errorf("failed to list YAMLs in repository (%w)", err)
 			}
 			for _, policyYaml := range policyYamls {
 				loaderResults, err := policy.Load(fs, "", policyYaml)
-				if loaderResults != nil && loaderResults.NonFatalErrors != nil {
-					for _, err := range loaderResults.NonFatalErrors {
-						log.Log.Error(err.Error, "Non-fatal parsing error for single document")
-					}
-				}
+				skippedInvalidPolicies.addLoadErrors(policyYaml, loaderResults, err)
 				if err != nil {
 					continue
 				}
@@ -1097,11 +1101,7 @@ func (c *ApplyCommandConfig) loadPolicies() (
 			}
 		} else {
 			loaderResults, err := policy.Load(nil, "", path)
-			if loaderResults != nil && loaderResults.NonFatalErrors != nil {
-				for _, err := range loaderResults.NonFatalErrors {
-					log.Log.Error(err.Error, "Non-fatal parsing error for single document")
-				}
-			}
+			skippedInvalidPolicies.addLoadErrors(path, loaderResults, err)
 			if err != nil {
 				log.Log.V(3).Info("skipping invalid YAML file", "path", path, "error", err)
 			} else {
@@ -1128,7 +1128,25 @@ func (c *ApplyCommandConfig) loadPolicies() (
 			}
 		}
 	}
-	return policies, exceptions, celExceptions, vaps, vapBindings, maps, mapBindings, vps, ivps, gps, dps, cps, mps, envoyPols, httpPols, nil
+	return policies, exceptions, celExceptions, vaps, vapBindings, maps, mapBindings, vps, ivps, gps, dps, cps, mps, envoyPols, httpPols, skippedInvalidPolicies, nil
+}
+
+func (s *SkippedInvalidPolicies) addLoadErrors(path string, loaderResults *policy.LoaderResults, err error) {
+	if loaderResults != nil {
+		for _, nonFatalErr := range loaderResults.NonFatalErrors {
+			log.Log.Error(nonFatalErr.Error, "Non-fatal parsing error for single document")
+			s.loadErrors = append(s.loadErrors, SkippedPolicyLoadError{
+				path: nonFatalErr.Path,
+				err:  nonFatalErr.Error,
+			})
+		}
+	}
+	if err != nil {
+		s.loadErrors = append(s.loadErrors, SkippedPolicyLoadError{
+			path: path,
+			err:  err,
+		})
+	}
 }
 
 func (c *ApplyCommandConfig) initStoreAndClusterClient(store *store.Store, targetResources ...*unstructured.Unstructured) (dclient.Interface, error) {

--- a/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
@@ -1436,6 +1436,25 @@ func Test_ValidatingPolicy_DefaultMessage(t *testing.T) {
 	assert.True(t, found, "Should have at least one failed rule")
 }
 
+func TestLoadPoliciesReportsInvalidPolicyFiles(t *testing.T) {
+	config := ApplyCommandConfig{
+		PolicyPaths: []string{"../../_testdata/policies/invalid-schema.yaml"},
+	}
+
+	policies, _, _, _, _, _, _, _, _, _, _, _, _, _, _, skippedInvalidPolicies, err := config.loadPolicies()
+	assert.NoError(t, err)
+	assert.Empty(t, policies)
+	assert.Len(t, skippedInvalidPolicies.loadErrors, 1)
+	assert.Contains(t, skippedInvalidPolicies.loadErrors[0].path, "invalid-schema.yaml")
+	assert.ErrorContains(t, skippedInvalidPolicies.loadErrors[0].err, "unknown field")
+
+	var out bytes.Buffer
+	printSkippedAndInvalidPolicies(&out, skippedInvalidPolicies)
+	assert.Contains(t, out.String(), "Policy files skipped due to load errors")
+	assert.Contains(t, out.String(), "invalid-schema.yaml")
+	assert.Contains(t, out.String(), "unknown field")
+}
+
 func Test_ImageValidatingPolicy_DefaultMessage(t *testing.T) {
 	config := ApplyCommandConfig{
 		PolicyPaths:   []string{"../../../../../test/cli/test-image-validating-policy/empty-message/policy.yaml"},

--- a/cmd/cli/kubectl-kyverno/commands/apply/print.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/print.go
@@ -24,6 +24,14 @@ import (
 const divider = "----------------------------------------------------------------------"
 
 func printSkippedAndInvalidPolicies(out io.Writer, skipInvalidPolicies SkippedInvalidPolicies) {
+	if len(skipInvalidPolicies.loadErrors) > 0 {
+		fmt.Fprintln(out, divider)
+		fmt.Fprintln(out, "Policy files skipped due to load errors:")
+		for i, loadError := range skipInvalidPolicies.loadErrors {
+			fmt.Fprintf(out, "%d. %s: %v\n", i+1, loadError.path, loadError.err)
+		}
+		fmt.Fprintln(out, divider)
+	}
 	if len(skipInvalidPolicies.skipped) > 0 {
 		fmt.Fprintln(out, divider)
 		fmt.Fprintln(out, "Policies Skipped (as required variables are not provided by the user):")


### PR DESCRIPTION
## Summary
- report policy YAML load errors in normal kyverno apply output instead of only verbose logs
- preserve the existing skip behavior while including the skipped path and error message for troubleshooting
- add regression coverage for invalid schema policy files being surfaced through the skipped policy output

Fixes #10278

## Validation
- gofmt on touched Go files
- git diff --check -- cmd/cli/kubectl-kyverno/commands/apply/command.go cmd/cli/kubectl-kyverno/commands/apply/print.go cmd/cli/kubectl-kyverno/commands/apply/command_test.go
- attempted: GOMODCACHE=/tmp/kyverno-gomodcache GOCACHE=/tmp/kyverno-gocache GOTMPDIR=/tmp go test ./cmd/cli/kubectl-kyverno/commands/apply -run TestLoadPoliciesReportsInvalidPolicyFiles -count=1; failed because the machine ran out of disk space while compiling dependencies
