### PR TITLE
fix(release): set explicit cosign bundle path

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,6 +38,7 @@ signs:
     certificate: "${artifact}.pem"
     args:
       - sign-blob
+      - --bundle=${artifact}.sigstore.json
       - --output-certificate=${certificate}
       - --output-signature=${signature}
       - ${artifact}


### PR DESCRIPTION
This fixes release signing failures seen in tag workflow runs (e.g. v1.17.2-rc.1) where GoReleaser/cosign fails with:\n\n- signing dist/...: create bundle file: open : no such file or directory\n\nRoot cause: cosign expects a bundle output path during sign-blob for this flow.\n\nChange:\n- Add explicit bundle output argument in .goreleaser.yml signs args:\n  - --bundle=.sigstore.json\n\nThis keeps existing signature and certificate outputs and makes signing deterministic.