### PR TITLE
fix(engine): checkpoint JSON context in validateOldObject to prevent false pre-existing violation skips

### DIFF
--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -793,8 +793,34 @@ func (p *PolicyProcessor) makePolicyContext(
 		WithPolicy(policy).
 		WithNamespaceLabels(namespaceLabels).
 		WithResourceKind(gvk, subresource)
+	// Two-pass variable injection: dotted-path variables first, then full-object
+	// replacements (request.object / request.oldObject). This guarantees that a
+	// full-object replacement always wins over any dotted-path variable that targets
+	// the same key, regardless of Go map iteration order.
 	for key, value := range resourceValues {
-		err = policyContext.JSONContext().AddVariable(key, value)
+		if key == "request.object" || key == "request.oldObject" {
+			continue
+		}
+		if err := policyContext.JSONContext().AddVariable(key, value); err != nil {
+			log.Log.Error(err, "failed to add variable to context", "key", key, "value", value)
+			return nil, fmt.Errorf("failed to add variable to context %s (%w)", key, err)
+		}
+	}
+	for _, key := range []string{"request.object", "request.oldObject"} {
+		value, ok := resourceValues[key]
+		if !ok {
+			continue
+		}
+		var err error
+		obj, isMap := value.(map[string]interface{})
+		switch {
+		case key == "request.object" && isMap:
+			err = policyContext.JSONContext().AddResource(obj)
+		case key == "request.oldObject" && isMap:
+			err = policyContext.JSONContext().AddOldResource(obj)
+		default:
+			err = policyContext.JSONContext().AddVariable(key, value)
+		}
 		if err != nil {
 			log.Log.Error(err, "failed to add variable to context", "key", key, "value", value)
 			return nil, fmt.Errorf("failed to add variable to context %s (%w)", key, err)

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor_test.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor_test.go
@@ -4,10 +4,17 @@ import (
 	"os"
 	"testing"
 
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	cliapiv1alpha1 "github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/apis/v1alpha1"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/resource"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/store"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/variables"
+	"github.com/kyverno/kyverno/pkg/config"
+	"github.com/kyverno/kyverno/pkg/engine/jmespath"
 	yamlutils "github.com/kyverno/kyverno/pkg/utils/yaml"
 	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var policyNamespaceSelector = []byte(`{
@@ -53,6 +60,94 @@ var policyNamespaceSelector = []byte(`{
 	}
   }
 `)
+
+// Test_makePolicyContext_OldObjectReplaceSemantics verifies that when values supply
+// request.oldObject as a full object map, it replaces (not merges with) the default
+// old resource derived from the new resource, so no fields from the new object leak
+// into request.oldObject.
+func Test_makePolicyContext_OldObjectReplaceSemantics(t *testing.T) {
+	newObj := unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "nginx",
+			"namespace": "test1",
+			// new object has env=prod and an extra label absent from oldObject
+			"labels": map[string]interface{}{"env": "prod", "extra": "new-only"},
+		},
+		"spec": map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{"name": "c", "image": "nginx:latest"},
+			},
+		},
+	}}
+
+	// oldObject intentionally omits "extra" to prove replacement, not merge
+	oldObjectMap := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "nginx",
+			"namespace": "test1",
+			"labels":    map[string]interface{}{"env": "dev"},
+		},
+		"spec": map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{"name": "c", "image": "nginx:latest"},
+			},
+		},
+	}
+
+	valuesSpec := &cliapiv1alpha1.ValuesSpec{
+		Policies: []cliapiv1alpha1.Policy{{
+			Name: "enforce-pod-name",
+			Resources: []cliapiv1alpha1.Resource{{
+				Name: "nginx",
+				Values: map[string]interface{}{
+					"request.operation": "UPDATE",
+					"request.oldObject": oldObjectMap,
+				},
+			}},
+		}},
+	}
+
+	vars, err := variables.New(os.Stdout, nil, "", "", valuesSpec)
+	assert.NilError(t, err)
+
+	policyArray, _, _, _, _, _, _, _ := yamlutils.GetPolicy(policyNamespaceSelector)
+	jp := jmespath.New(config.NewDefaultConfiguration(false))
+	cfg := config.NewDefaultConfiguration(false)
+
+	p := &PolicyProcessor{
+		Store:     &store.Store{},
+		Variables: vars,
+	}
+	ctx, err := p.makePolicyContext(jp, cfg, newObj, policyArray[0], nil,
+		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}, "")
+	assert.NilError(t, err)
+
+	assert.Equal(t, kyvernov1.Update, ctx.Operation())
+
+	// new resource retains its labels
+	newRes := ctx.NewResource()
+	assert.Equal(t, "prod", newRes.GetLabels()["env"])
+	assert.Equal(t, "new-only", newRes.GetLabels()["extra"])
+
+	// old resource must reflect oldObjectMap exactly — env=dev, no "extra"
+	oldRes := ctx.OldResource()
+	assert.Equal(t, "dev", oldRes.GetLabels()["env"])
+	_, hasExtra := oldRes.GetLabels()["extra"]
+	assert.Equal(t, false, hasExtra, "old resource must not retain 'extra' label from new object")
+
+	// JSON context must also reflect replacement
+	retOld, err := ctx.JSONContext().Query("request.oldObject.metadata.labels.env")
+	assert.NilError(t, err)
+	assert.Equal(t, "dev", retOld)
+
+	retNew, err := ctx.JSONContext().Query("request.object.metadata.labels.env")
+	assert.NilError(t, err)
+	assert.Equal(t, "prod", retNew)
+}
 
 func Test_NamespaceSelector(t *testing.T) {
 	type TestCase struct {

--- a/pkg/engine/handlers/validation/validate_resource.go
+++ b/pkg/engine/handlers/validation/validate_resource.go
@@ -210,6 +210,15 @@ func (v *validator) validateOldObject(ctx context.Context) (resp *engineapi.Rule
 		}
 	}()
 
+	// Checkpoint and re-load rule context so variables are evaluated against the old resource,
+	// not the new one, avoiding a false "pre-existing violations" skip.
+	v.policyContext.JSONContext().Checkpoint()
+	defer v.policyContext.JSONContext().Restore()
+
+	if err = v.contextLoader(ctx, v.rule.Context, v.policyContext.JSONContext()); err != nil {
+		return nil, errors.Wrapf(err, "failed to load rule context for old object")
+	}
+
 	if ok := matchResource(v.log, oldResource, v.rule, v.policyContext.NamespaceLabels(), v.policyContext.Policy().GetNamespace(), kyvernov1.Create, v.policyContext.JSONContext()); !ok {
 		resp = engineapi.RuleSkip(v.rule.Name, engineapi.Validation, "resource not matched", nil)
 		return

--- a/pkg/engine/handlers/validation/validate_resource_test.go
+++ b/pkg/engine/handlers/validation/validate_resource_test.go
@@ -9,6 +9,7 @@ import (
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/engine/api"
 	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
+	"github.com/kyverno/kyverno/pkg/engine/factories"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -79,7 +80,6 @@ func Test_validateForEach_ListEvalError_ReturnsError(t *testing.T) {
 		return nil
 	}
 
-	// Use a policy with an invalid list expression that will fail evaluation
 	policyContext := buildTestNamespaceLabelsContext(t, validateForeachInvalidListPolicy, resource, oldResource)
 	rule := policyContext.Policy().GetSpec().Rules[0]
 	v := newValidator(logr.Discard(), mockCL, policyContext, rule)
@@ -87,9 +87,29 @@ func Test_validateForEach_ListEvalError_ReturnsError(t *testing.T) {
 	ctx := context.TODO()
 	resp := v.validateForEach(ctx)
 
-	// Should return error response instead of nil when list evaluation fails
 	assert.NotNil(t, resp, "validateForEach should return error response when list evaluation fails")
 	assert.Equal(t, api.RuleStatusError, resp.Status(), "status should be Error when list evaluation fails")
+}
+
+// Test_validateOldObjectContextReload verifies that rule-level context variables
+// are re-evaluated against the old resource, not reused from the new resource.
+func Test_validateOldObjectContextReload(t *testing.T) {
+	contextLoaderFactory := factories.DefaultContextLoaderFactory(nil)
+	policyContext := buildTestNamespaceLabelsContext(t, validateContextVarPolicy, podWithProdLabel, podWithDevLabel)
+	rule := policyContext.Policy().GetSpec().Rules[0]
+	loader := contextLoaderFactory(policyContext.Policy(), rule)
+
+	engineCL := func(ctx context.Context, contextEntries []kyvernov1.ContextEntry, jsonContext enginecontext.Interface) error {
+		return loader.Load(ctx, jp, nil, nil, contextEntries, jsonContext)
+	}
+
+	// simulate engine pre-loading rule context before calling the handler
+	assert.NoError(t, engineCL(context.TODO(), rule.Context, policyContext.JSONContext()))
+
+	v := newValidator(logr.Discard(), engineCL, policyContext, rule)
+	resp := v.validate(context.TODO())
+	assert.NotNil(t, resp)
+	assert.Equal(t, api.RuleStatusFail, resp.Status())
 }
 
 var (
@@ -318,7 +338,6 @@ var (
 		}
 	}`
 
-	// Policy with forEach + context entries to test per-element error handling
 	validateForeachWithContextPolicy = `{
 		"apiVersion": "kyverno.io/v1",
 		"kind": "ClusterPolicy",
@@ -350,7 +369,6 @@ var (
 		}
 	}`
 
-	// Policy with invalid JMESPath list expression to test error handling
 	validateForeachInvalidListPolicy = `{
 		"apiVersion": "kyverno.io/v1",
 		"kind": "ClusterPolicy",
@@ -367,6 +385,80 @@ var (
 					}]
 				}
 			}]
+		}
+	}`
+
+	validateContextVarPolicy = `{
+		"apiVersion": "kyverno.io/v1",
+		"kind": "ClusterPolicy",
+		"metadata": {
+		  "name": "check-env-label"
+		},
+		"spec": {
+		  "background": false,
+		  "rules": [
+			{
+			  "name": "deny-prod-env",
+			  "context": [
+				{
+				  "name": "currentEnv",
+				  "variable": {
+					"jmesPath": "request.object.metadata.labels.env || ''"
+				  }
+				}
+			  ],
+			  "match": {
+				"any": [
+				  {
+					"resources": {
+					  "kinds": ["Pod"],
+					  "operations": ["UPDATE"]
+					}
+				  }
+				]
+			  },
+			  "validate": {
+				"failureAction": "Enforce",
+				"allowExistingViolations": true,
+				"message": "prod env is not allowed",
+				"deny": {
+				  "conditions": {
+					"all": [
+					  {
+						"key": "{{ currentEnv }}",
+						"operator": "Equals",
+						"value": "prod"
+					  }
+					]
+				  }
+				}
+			  }
+			}
+		  ]
+		}
+	}`
+
+	podWithProdLabel = `{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+		  "name": "test",
+		  "labels": {"env": "prod"}
+		},
+		"spec": {
+		  "containers": [{"name": "c", "image": "nginx"}]
+		}
+	}`
+
+	podWithDevLabel = `{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+		  "name": "test",
+		  "labels": {"env": "dev"}
+		},
+		"spec": {
+		  "containers": [{"name": "c", "image": "nginx"}]
 		}
 	}`
 )

--- a/test/cli/test/allow-existing-violations-context-vars/kyverno-test.yaml
+++ b/test/cli/test/allow-existing-violations-context-vars/kyverno-test.yaml
@@ -1,0 +1,16 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-existing-violations-context-vars
+policies:
+- policy.yaml
+resources:
+- resources.yaml
+results:
+- kind: Pod
+  policy: check-env-label
+  resources:
+  - test-pod
+  result: fail
+  rule: deny-prod-env
+variables: values.yaml

--- a/test/cli/test/allow-existing-violations-context-vars/policy.yaml
+++ b/test/cli/test/allow-existing-violations-context-vars/policy.yaml
@@ -1,0 +1,29 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: check-env-label
+spec:
+  background: false
+  rules:
+    - name: deny-prod-env
+      context:
+        - name: currentEnv
+          variable:
+            jmesPath: "request.object.metadata.labels.env || ''"
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - UPDATE
+      validate:
+        failureAction: Enforce
+        allowExistingViolations: true
+        message: "prod env is not allowed"
+        deny:
+          conditions:
+            all:
+              - key: "{{ currentEnv }}"
+                operator: Equals
+                value: prod

--- a/test/cli/test/allow-existing-violations-context-vars/resources.yaml
+++ b/test/cli/test/allow-existing-violations-context-vars/resources.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    env: prod
+spec:
+  containers:
+    - name: c
+      image: nginx

--- a/test/cli/test/allow-existing-violations-context-vars/values.yaml
+++ b/test/cli/test/allow-existing-violations-context-vars/values.yaml
@@ -1,0 +1,7 @@
+apiVersion: cli.kyverno.io/v1alpha1
+globalValues:
+  request.oldObject.metadata.labels.env: dev
+  request.operation: UPDATE
+kind: Value
+metadata:
+  name: values


### PR DESCRIPTION
## Explanation

When a `ClusterPolicy` with `allowExistingViolations: true` evaluated an UPDATE request, Kyverno incorrectly skipped enforcement even when the *old* (pre-update) resource was valid. This is a bug fix: rule-level context variables (e.g. `jmesPath` bindings) were being reused from the new-object evaluation pass when validating the old object, causing the old object to falsely appear as a violation. Since both old and new appeared to fail, Kyverno concluded a pre-existing violation existed and skipped the rule — allowing an invalid UPDATE through.

## Related issue

Closes #15763

## Milestone of this PR


## What type of PR is this

/kind bug

## Proposed Changes

Two fixes:

**1. Engine (`validate_resource.go`):** `validateOldObject` now checkpoints the JSON context before reloading rule-level context entries against the old resource, and restores it afterward via `defer`. This prevents stale variable bindings from the new-object pass from leaking into the old-object evaluation.

**2. CLI test framework (`policy_processor.go`):** `request.object` and `request.oldObject` values from `values.yaml` are now applied with replace semantics (`AddResource`/`AddOldResource`) instead of merge semantics (`AddVariable`). Previously the old object data was merged on top of the new resource data, contaminating `request.oldObject` with fields from the new resource.

### Proof Manifests

See `test/cli/test/allow-existing-violations-context-vars/` — a CLI test that reproduces the bug: an UPDATE that introduces an invalid label into a previously-valid resource should `fail`, but without this fix it `skip`s.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
