### PR TITLE
cli: survive fake-discovery OpenAPIV3 panic during kyverno test

### DIFF
--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -967,9 +967,20 @@ func (p *PolicyProcessor) printOutput(resource interface{}, response engineapi.E
 func (p *PolicyProcessor) openAPI() openapi.Client {
 	clients := make([]openapi.Client, 0)
 
+	// p.Cluster is derived from "the test spec declares cluster resources"
+	// (see test.go), not from "we have a live cluster connection". When
+	// `kyverno test` runs against a MutatingPolicy with a custom CRD and
+	// cluster-scoped resources, the PolicyProcessor is wired with a fake
+	// discovery client whose OpenAPIV3 method panics with "unimplemented"
+	// (#15770). Detect the fake client via recover() and fall through to
+	// the on-disk CRD loader so tests continue to work.
 	if p.Cluster {
-		return p.Client.GetKubeClient().Discovery().OpenAPIV3()
-	} else if p.CrdPath != "" {
+		if client, ok := tryOpenAPIV3(p.Client); ok {
+			return client
+		}
+	}
+
+	if p.CrdPath != "" {
 		absPath := getAbsPath(p.CrdPath)
 		diskCrds := os.DirFS(absPath)
 		clients = append(clients, openapiclient.NewLocalCRDFiles(diskCrds))
@@ -982,6 +993,24 @@ func (p *PolicyProcessor) openAPI() openapi.Client {
 	clients = append(clients, openapiclient.NewHardcodedBuiltins("1.32"))
 
 	return openapiclient.NewComposite(clients...)
+}
+
+// tryOpenAPIV3 invokes discovery.OpenAPIV3() under recover(). The fake
+// discovery client used by `kyverno test` panics with "unimplemented"
+// instead of returning a typed error (#15770), so a plain call here
+// crashes the CLI.
+func tryOpenAPIV3(c dclient.Interface) (client openapi.Client, ok bool) {
+	if c == nil || c.GetKubeClient() == nil {
+		return nil, false
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			client, ok = nil, false
+		}
+	}()
+	client = c.GetKubeClient().Discovery().OpenAPIV3()
+	ok = client != nil
+	return
 }
 
 func (p *PolicyProcessor) resolveResource(kind string) (string, error) {


### PR DESCRIPTION
## Summary

`PolicyProcessor.openAPI` always dereferenced the cluster discovery client's `OpenAPIV3` when `p.Cluster` was true. `p.Cluster` is derived from **the presence of `ClusterResources` in the test spec**, not from having a live cluster connection. When `kyverno test` runs against a `MutatingPolicy` with a custom CRD and cluster-scoped resources, the test runner wires a fake discovery client whose `OpenAPIV3` method panics with `unimplemented` (`k8s.io/client-go/discovery/fake/discovery.go`). The CLI then aborted the entire run with `panic: unimplemented`.

## Fix

Call `OpenAPIV3` under `recover()` via a small `tryOpenAPIV3` helper. If it panics or returns nil, fall through to the same on-disk CRD loader the non-cluster branch already uses, so CLI tests keep working against the user's provided CRDs.

Fixes #15770.

## Test

- `go build ./cmd/cli/kubectl-kyverno/...` green.
- `go vet ./cmd/cli/kubectl-kyverno/processor/...` clean.
- `gofmt` clean.

## Special notes for the reviewer

`recover()` is normally discouraged, but the fake discovery client reaches us via an implementation-defined panic rather than a typed error, so recovering is the only safe option short of adding a new "have a real cluster?" flag across the CLI surface. The recover is scoped to the single method call.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
