### PR TITLE
fix(engine): replace `context.TODO()` with propagated `context(ctx`) in engine paths

### DIFF
--- a/pkg/engine/background.go
+++ b/pkg/engine/background.go
@@ -69,7 +69,7 @@ func (e *engine) filterRule(
 		return engineapi.RuleError(rule.Name, ruleType, "failed to get exceptions", err, rule.ReportProperties)
 	}
 	// check if there are policy exceptions that match the incoming resource
-	matchedExceptions := engineutils.MatchesException(e.client, exceptions, policyContext, true, logger)
+	matchedExceptions := engineutils.MatchesExceptionWithContext(ctx, e.client, exceptions, policyContext, true, logger)
 	if len(matchedExceptions) > 0 {
 		exceptions := make([]engineapi.GenericException, 0, len(matchedExceptions))
 		var keys []string

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -72,7 +72,7 @@ func (e *engine) Validate(
 	startTime := time.Now()
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext)
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.validate"), policyContext)
-	if internal.MatchPolicyContext(logger, e.client, policyContext, e.configuration) {
+	if internal.MatchPolicyContext(ctx, logger, e.client, policyContext, e.configuration) {
 		policyResponse := e.validate(ctx, logger, policyContext)
 		response = response.WithPolicyResponse(policyResponse)
 	}
@@ -91,7 +91,7 @@ func (e *engine) Mutate(
 	startTime := time.Now()
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext)
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.mutate"), policyContext)
-	if internal.MatchPolicyContext(logger, e.client, policyContext, e.configuration) {
+	if internal.MatchPolicyContext(ctx, logger, e.client, policyContext, e.configuration) {
 		policyResponse, patchedResource := e.mutate(ctx, logger, policyContext)
 		response = response.
 			WithPatchedResource(patchedResource).
@@ -111,7 +111,7 @@ func (e *engine) Generate(
 	startTime := time.Now()
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext)
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.generate"), policyContext)
-	if internal.MatchPolicyContext(logger, e.client, policyContext, e.configuration) {
+	if internal.MatchPolicyContext(ctx, logger, e.client, policyContext, e.configuration) {
 		policyResponse := e.generateResponse(ctx, logger, policyContext)
 		response = response.WithPolicyResponse(policyResponse)
 	}
@@ -130,7 +130,7 @@ func (e *engine) VerifyAndPatchImages(
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext)
 	ivm := engineapi.ImageVerificationMetadata{}
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.verify"), policyContext)
-	if internal.MatchPolicyContext(logger, e.client, policyContext, e.configuration) {
+	if internal.MatchPolicyContext(ctx, logger, e.client, policyContext, e.configuration) {
 		policyResponse, patchedResource, innerIvm := e.verifyAndPatchImages(ctx, logger, policyContext)
 		response, ivm = response.
 			WithPolicyResponse(policyResponse).
@@ -150,7 +150,7 @@ func (e *engine) ApplyBackgroundChecks(
 	startTime := time.Now()
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext)
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.background"), policyContext)
-	if internal.MatchPolicyContext(logger, e.client, policyContext, e.configuration) {
+	if internal.MatchPolicyContext(ctx, logger, e.client, policyContext, e.configuration) {
 		policyResponse := e.applyBackgroundChecks(ctx, logger, policyContext)
 		response = response.WithPolicyResponse(policyResponse)
 	}

--- a/pkg/engine/handlers/mutation/mutate_existing.go
+++ b/pkg/engine/handlers/mutation/mutate_existing.go
@@ -42,7 +42,7 @@ func (h mutateExistingHandler) Process(
 	exceptions []*kyvernov2.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there are policy exceptions that match the incoming resource
-	matchedExceptions := engineutils.MatchesException(h.client, exceptions, policyContext, h.isCluster, logger)
+	matchedExceptions := engineutils.MatchesExceptionWithContext(ctx, h.client, exceptions, policyContext, h.isCluster, logger)
 	if len(matchedExceptions) > 0 {
 		exceptions := make([]engineapi.GenericException, 0, len(matchedExceptions))
 		var keys []string

--- a/pkg/engine/handlers/mutation/mutate_image.go
+++ b/pkg/engine/handlers/mutation/mutate_image.go
@@ -76,7 +76,7 @@ func (h mutateImageHandler) Process(
 	exceptions []*kyvernov2.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there are policy exceptions that match the incoming resource
-	matchedExceptions := engineutils.MatchesException(h.client, exceptions, policyContext, h.isCluster, logger)
+	matchedExceptions := engineutils.MatchesExceptionWithContext(ctx, h.client, exceptions, policyContext, h.isCluster, logger)
 	if len(matchedExceptions) > 0 {
 		exceptions := make([]engineapi.GenericException, 0, len(matchedExceptions))
 		var keys []string

--- a/pkg/engine/handlers/mutation/mutate_resource.go
+++ b/pkg/engine/handlers/mutation/mutate_resource.go
@@ -38,7 +38,7 @@ func (h mutateResourceHandler) Process(
 	exceptions []*kyvernov2.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there are policy exceptions that match the incoming resource
-	matchedExceptions := engineutils.MatchesException(h.client, exceptions, policyContext, h.isCluster, logger)
+	matchedExceptions := engineutils.MatchesExceptionWithContext(ctx, h.client, exceptions, policyContext, h.isCluster, logger)
 	if len(matchedExceptions) > 0 {
 		exceptions := make([]engineapi.GenericException, 0, len(matchedExceptions))
 		var keys []string

--- a/pkg/engine/handlers/validation/validate_assert.go
+++ b/pkg/engine/handlers/validation/validate_assert.go
@@ -60,7 +60,7 @@ func (h validateAssertHandler) Process(
 	exceptions []*kyvernov2.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there are policy exceptions that match the incoming resource
-	matchedExceptions := engineutils.MatchesException(h.client, exceptions, policyContext, h.isCluster, logger)
+	matchedExceptions := engineutils.MatchesExceptionWithContext(ctx, h.client, exceptions, policyContext, h.isCluster, logger)
 	if len(matchedExceptions) > 0 {
 		exceptions := make([]engineapi.GenericException, 0, len(matchedExceptions))
 		var keys []string

--- a/pkg/engine/handlers/validation/validate_cel.go
+++ b/pkg/engine/handlers/validation/validate_cel.go
@@ -49,7 +49,7 @@ func (h validateCELHandler) Process(
 	exceptions []*kyvernov2.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there are policy exceptions that match the incoming resource
-	matchedExceptions := engineutils.MatchesException(h.client, exceptions, policyContext, h.isCluster, logger)
+	matchedExceptions := engineutils.MatchesExceptionWithContext(ctx, h.client, exceptions, policyContext, h.isCluster, logger)
 	if len(matchedExceptions) > 0 {
 		exceptions := make([]engineapi.GenericException, 0, len(matchedExceptions))
 		var keys []string

--- a/pkg/engine/handlers/validation/validate_image.go
+++ b/pkg/engine/handlers/validation/validate_image.go
@@ -56,7 +56,7 @@ func (h validateImageHandler) Process(
 	exceptions []*kyvernov2.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there are policy exceptions that match the incoming resource
-	matchedExceptions := engineutils.MatchesException(h.client, exceptions, policyContext, h.isCluster, logger)
+	matchedExceptions := engineutils.MatchesExceptionWithContext(ctx, h.client, exceptions, policyContext, h.isCluster, logger)
 	if len(matchedExceptions) > 0 {
 		exceptions := make([]engineapi.GenericException, 0, len(matchedExceptions))
 		var keys []string

--- a/pkg/engine/handlers/validation/validate_manifest.go
+++ b/pkg/engine/handlers/validation/validate_manifest.go
@@ -63,7 +63,7 @@ func (h validateManifestHandler) Process(
 	exceptions []*kyvernov2.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there are policy exceptions that match the incoming resource
-	matchedExceptions := engineutils.MatchesException(h.client, exceptions, policyContext, h.isCluster, logger)
+	matchedExceptions := engineutils.MatchesExceptionWithContext(ctx, h.client, exceptions, policyContext, h.isCluster, logger)
 	if len(matchedExceptions) > 0 {
 		exceptions := make([]engineapi.GenericException, 0, len(matchedExceptions))
 		var keys []string

--- a/pkg/engine/handlers/validation/validate_pss.go
+++ b/pkg/engine/handlers/validation/validate_pss.go
@@ -65,7 +65,7 @@ func (h validatePssHandler) validate(
 	}
 
 	// check if there are policy exceptions that match the incoming resource
-	matchedExceptions := engineutils.MatchesException(h.client, exceptions, policyContext, h.isCluster, logger)
+	matchedExceptions := engineutils.MatchesExceptionWithContext(ctx, h.client, exceptions, policyContext, h.isCluster, logger)
 	if len(matchedExceptions) > 0 {
 		var polex kyvernov2.PolicyException
 		hasPodSecurity := true

--- a/pkg/engine/handlers/validation/validate_resource.go
+++ b/pkg/engine/handlers/validation/validate_resource.go
@@ -45,7 +45,7 @@ func (h validateResourceHandler) Process(
 	exceptions []*kyvernov2.PolicyException,
 ) (unstructured.Unstructured, []engineapi.RuleResponse) {
 	// check if there are policy exceptions that match the incoming resource
-	matchedExceptions := engineutils.MatchesException(h.client, exceptions, policyContext, h.isCluster, logger)
+	matchedExceptions := engineutils.MatchesExceptionWithContext(ctx, h.client, exceptions, policyContext, h.isCluster, logger)
 	if len(matchedExceptions) > 0 {
 		exceptions := make([]engineapi.GenericException, 0, len(matchedExceptions))
 		var keys []string

--- a/pkg/engine/internal/match.go
+++ b/pkg/engine/internal/match.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions"
 )
 
-func MatchPolicyContext(logger logr.Logger, client engineapi.Client, policyContext engineapi.PolicyContext, configuration config.Configuration) bool {
+func MatchPolicyContext(ctx context.Context, logger logr.Logger, client engineapi.Client, policyContext engineapi.PolicyContext, configuration config.Configuration) bool {
 	policy := policyContext.Policy()
 	old := policyContext.OldResource()
 	new := policyContext.NewResource()
@@ -31,7 +31,7 @@ func MatchPolicyContext(logger logr.Logger, client engineapi.Client, policyConte
 	}
 
 	if policy.GetSpec().GetMatchConditions() != nil {
-		if !checkMatchConditions(logger, policyContext, gvk, subresource) {
+		if !checkMatchConditions(ctx, logger, policyContext, gvk, subresource) {
 			logger.V(4).Info("webhookConfiguration.matchConditions doesn't match request")
 			return false
 		}
@@ -69,7 +69,7 @@ func checkNamespacedPolicy(policy kyvernov1.PolicyInterface, resources ...unstru
 	return true
 }
 
-func checkMatchConditions(logger logr.Logger, policyContext engineapi.PolicyContext, gvk schema.GroupVersionKind, subresource string) bool {
+func checkMatchConditions(ctx context.Context, logger logr.Logger, policyContext engineapi.PolicyContext, gvk schema.GroupVersionKind, subresource string) bool {
 	policy := policyContext.Policy()
 	old := policyContext.OldResource()
 	new := policyContext.NewResource()
@@ -95,6 +95,6 @@ func checkMatchConditions(logger logr.Logger, policyContext engineapi.PolicyCont
 	}
 	matchConditionFilter := compiler.CompileMatchConditions(optionalVars)
 	matcher := matchconditions.NewMatcher(matchConditionFilter, nil, policy.GetKind(), "", policy.GetName())
-	result := matcher.Match(context.TODO(), versionedAttr, nil, nil)
+	result := matcher.Match(ctx, versionedAttr, nil, nil)
 	return result.Matches
 }

--- a/pkg/engine/utils/exceptions.go
+++ b/pkg/engine/utils/exceptions.go
@@ -16,9 +16,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// MatchesException takes a list of exceptions and checks if there is an exception applies to the incoming resource.
+// MatchesException takes a list of exceptions and checks if there is an exception that applies to the incoming resource.
 // It returns the matched policy exception.
+// Deprecated: use MatchesExceptionWithContext to provide an explicit context.
 func MatchesException(client engineapi.Client, polexs []*kyvernov2.PolicyException, policyContext engineapi.PolicyContext, isCluster bool, logger logr.Logger) []kyvernov2.PolicyException {
+	return MatchesExceptionWithContext(context.Background(), client, polexs, policyContext, isCluster, logger)
+}
+
+// MatchesExceptionWithContext takes a list of exceptions and checks if there is an exception that applies to the incoming resource.
+// It returns the matched policy exception.
+func MatchesExceptionWithContext(ctx context.Context, client engineapi.Client, polexs []*kyvernov2.PolicyException, policyContext engineapi.PolicyContext, isCluster bool, logger logr.Logger) []kyvernov2.PolicyException {
 	if len(polexs) == 0 {
 		return nil
 	}
@@ -31,7 +38,7 @@ func MatchesException(client engineapi.Client, polexs []*kyvernov2.PolicyExcepti
 	nsLabels := policyContext.NamespaceLabels()
 	if isCluster {
 		if resource.GetNamespace() != "" {
-			namespace, err := client.GetNamespace(context.TODO(), resource.GetNamespace(), metav1.GetOptions{})
+			namespace, err := client.GetNamespace(ctx, resource.GetNamespace(), metav1.GetOptions{})
 			if err != nil {
 				logger.Error(err, "failed to get namespace", "name", resource.GetNamespace())
 				return nil


### PR DESCRIPTION
## Explanation

This PR replaces `context.TODO()` with proper propagation of `context.Context` (usually `ctx`) across the `pkg/engine` scope, particularly replacing usages in matching rules (`MatchPolicyContext`). It also updates exception resolution by adding a context-aware parser `MatchesExceptionWithContext`. 

This resolves an issue where requests could completely ignore admission webhook timeouts, cancellation signals from callers, and distributed tracing spans created by `otel` integration.

## Proposed Changes
- Added a context-aware func `engineutils.MatchesExceptionWithContext` and kept `engineutils.MatchesException` as a deprecated wrapper using `context.Background()` for backward API compatibility.
- Added `ctx context.Context` as a parameter to `engine.MatchPolicyContext` and `checkMatchConditions`.
- Passed `ctx` in place of `context.TODO()` to `client.GetNamespace` inside `pkg/engine/utils/exceptions.go`.
- Passed `ctx` to the CEL `matcher.Match` function in `pkg/engine/internal/match.go`.
- Updated all handler call sites (validation / mutation / background) under `pkg/engine` to use `MatchesExceptionWithContext` and the injected `ctx`.
