### PR TITLE
fix: revert 15880 - support httpAllowList and httpBlockList for cluster-scoped policies

### DIFF
--- a/pkg/cel/compiler/http.go
+++ b/pkg/cel/compiler/http.go
@@ -12,17 +12,12 @@ import (
 
 // sharedHTTPContext is built once on the first http.* call and reused across
 // admission requests so the underlying http.Transport is not recreated per call.
-// It applies the operator-configured SSRF blocklist and is used for namespaced policies.
+// It applies the operator-configured SSRF blocklist and allowlist.
 var sharedHTTPContext = &cachedHTTPContext{}
 
-// clusterHTTPContext is the unrestricted counterpart used for cluster-scoped policies.
-// Cluster-scoped policies require cluster-admin privileges, so no SSRF blocklist is needed.
-var clusterHTTPContext = &cachedHTTPContext{unrestricted: true}
-
 type cachedHTTPContext struct {
-	mu           sync.Mutex
-	cached       http.ContextInterface
-	unrestricted bool
+	mu     sync.Mutex
+	cached http.ContextInterface
 }
 
 func (c *cachedHTTPContext) getOrBuild() (http.ContextInterface, error) {
@@ -31,12 +26,7 @@ func (c *cachedHTTPContext) getOrBuild() (http.ContextInterface, error) {
 	if c.cached != nil {
 		return c.cached, nil
 	}
-	var blocklist, allowlist []string
-	if !c.unrestricted {
-		blocklist = toggle.HTTPBlocklist.Values()
-		allowlist = toggle.HTTPAllowlist.Values()
-	}
-	ctx, err := http.NewHTTPWithBlocklist(blocklist, allowlist)
+	ctx, err := http.NewHTTPWithBlocklist(toggle.HTTPBlocklist.Values(), toggle.HTTPAllowlist.Values())
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +63,7 @@ func (c *cachedHTTPContext) Client(caBundle string) (http.ContextInterface, erro
 // AllowHTTPInNamespacedPolicies toggle is enforced at call time.
 func NewLazyCELHTTPContext(namespace string) http.ContextInterface {
 	if namespace == "" {
-		return clusterHTTPContext
+		return sharedHTTPContext
 	}
 	return &namespacedHTTPContext{inner: sharedHTTPContext}
 }

--- a/pkg/cel/compiler/http_test.go
+++ b/pkg/cel/compiler/http_test.go
@@ -90,9 +90,9 @@ func TestNewLazyCELHTTPContext_ToggleEnforcement(t *testing.T) {
 
 func TestHTTPContextSeparation(t *testing.T) {
 	// Toggle is off by default. Namespaced policies must be blocked while
-	// cluster-scoped policies must remain usable — the regression tested here
-	// is that the SSRF blocklist and the namespaced toggle are independent.
-	t.Run("namespaced blocked, cluster unaffected when toggle is off", func(t *testing.T) {
+	// cluster-scoped policies are still allowed to attempt calls (subject to
+	// blocklist/allowlist filtering in the shared HTTP context).
+	t.Run("namespaced blocked, cluster skips namespaced toggle", func(t *testing.T) {
 		namespacedCtx := NewLazyCELHTTPContext("my-namespace")
 		clusterCtx := NewLazyCELHTTPContext("")
 
@@ -106,16 +106,14 @@ func TestHTTPContextSeparation(t *testing.T) {
 		}
 	})
 
-	t.Run("cluster context ignores SSRF blocklist", func(t *testing.T) {
-		// An invalid CIDR causes NewHTTPWithBlocklist to error. The unrestricted
-		// cluster context must succeed because it never reads the blocklist flag.
-		require.NoError(t, toggle.HTTPBlocklist.Parse("999.999.999.999/24"))
-		t.Cleanup(func() { toggle.HTTPBlocklist.Reset() })
+	t.Run("default blocklist applies to cluster policies", func(t *testing.T) {
+		ctx := NewLazyCELHTTPContext("")
+		require.NotNil(t, ctx)
 
-		ctx := &cachedHTTPContext{unrestricted: true}
-		built, err := ctx.getOrBuild()
-		assert.NoError(t, err)
-		assert.NotNil(t, built)
+		_, err := ctx.Get("http://10.1.2.3", nil)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "not allowed in namespaced policies")
+		assert.Contains(t, err.Error(), "blocked")
 	})
 }
 


### PR DESCRIPTION
## Explanation

Revert https://github.com/kyverno/kyverno/pull/15880

HTTP allowList and blockList should be configurable on cluster scoped policies and the default blockList is enabled.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR

1.18

<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
