### PR TITLE
update blocklist to allow in-cluster HTTP calls

### DIFF
--- a/pkg/cel/compiler/http.go
+++ b/pkg/cel/compiler/http.go
@@ -12,7 +12,7 @@ import (
 
 // sharedHTTPContext is built once on the first http.* call and reused across
 // admission requests so the underlying http.Transport is not recreated per call.
-// It applies the operator-configured SSRF blocklist and allowlist.
+// It applies the operator-configured SSRF blocklist and allowlist for all policies.
 var sharedHTTPContext = &cachedHTTPContext{}
 
 type cachedHTTPContext struct {

--- a/pkg/cel/compiler/http_test.go
+++ b/pkg/cel/compiler/http_test.go
@@ -90,8 +90,7 @@ func TestNewLazyCELHTTPContext_ToggleEnforcement(t *testing.T) {
 
 func TestHTTPContextSeparation(t *testing.T) {
 	// Toggle is off by default. Namespaced policies must be blocked while
-	// cluster-scoped policies are still allowed to attempt calls (subject to
-	// blocklist/allowlist filtering in the shared HTTP context).
+	// cluster-scoped policies are allowed to attempt calls.
 	t.Run("namespaced blocked, cluster skips namespaced toggle", func(t *testing.T) {
 		namespacedCtx := NewLazyCELHTTPContext("my-namespace")
 		clusterCtx := NewLazyCELHTTPContext("")
@@ -106,13 +105,39 @@ func TestHTTPContextSeparation(t *testing.T) {
 		}
 	})
 
-	t.Run("default blocklist applies to cluster policies", func(t *testing.T) {
+	t.Run("shared policy blocklist allows in-cluster service CIDRs", func(t *testing.T) {
 		ctx := NewLazyCELHTTPContext("")
 		require.NotNil(t, ctx)
 
+		// In-cluster service CIDRs should not be blocked by default.
 		_, err := ctx.Get("http://10.1.2.3", nil)
+		// Error is expected (no actual server) but NOT due to blocklist
+		if err != nil {
+			assert.NotContains(t, err.Error(), "blocked")
+			assert.NotContains(t, err.Error(), "not allowed in namespaced policies")
+		}
+	})
+
+	t.Run("opted-in namespaced policies allow in-cluster service CIDRs", func(t *testing.T) {
+		t.Setenv("FLAG_ENABLE_HTTP_IN_NAMESPACED_POLICIES", "true")
+
+		ctx := NewLazyCELHTTPContext("my-namespace")
+		require.NotNil(t, ctx)
+
+		_, err := ctx.Get("http://10.1.2.3", nil)
+		if err != nil {
+			assert.NotContains(t, err.Error(), "blocked")
+			assert.NotContains(t, err.Error(), "not allowed in namespaced policies")
+		}
+	})
+
+	t.Run("shared policy blocklist blocks dangerous metadata services", func(t *testing.T) {
+		ctx := NewLazyCELHTTPContext("")
+		require.NotNil(t, ctx)
+
+		// Metadata services should be blocked for all policy scopes.
+		_, err := ctx.Get("http://169.254.169.254", nil)
 		require.Error(t, err)
-		assert.NotContains(t, err.Error(), "not allowed in namespaced policies")
 		assert.Contains(t, err.Error(), "blocked")
 	})
 }

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -7,10 +7,9 @@ import (
 )
 
 var defaultPolicyHTTPBlocklist = []string{
-	"169.254.169.254",          // AWS/GCP metadata service
+	"169.254.169.254",          // AWS/GCP/Azure metadata service
 	"169.254.169.253",          // GCP metadata service alternate
 	"metadata.google.internal", // GCP metadata service hostname
-	"169.254.0.0/16",           // Azure metadata service range
 	"127.0.0.0/8",              // IPv4 loopback
 	"::1/128",                  // IPv6 loopback
 }

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -4,9 +4,16 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
-	sdkhttp "github.com/kyverno/sdk/cel/libs/http"
 )
+
+var defaultPolicyHTTPBlocklist = []string{
+	"169.254.169.254",          // AWS/GCP metadata service
+	"169.254.169.253",          // GCP metadata service alternate
+	"metadata.google.internal", // GCP metadata service hostname
+	"169.254.0.0/16",           // Azure metadata service range
+	"127.0.0.0/8",              // IPv4 loopback
+	"::1/128",                  // IPv6 loopback
+}
 
 const (
 	// protect managed resource
@@ -51,7 +58,7 @@ const (
 	defaultAllowHTTPInNamespacedPolicies     = false
 	// http blocklist / allowlist flag names
 	HTTPBlocklistFlagName    = "httpBlocklist"
-	HTTPBlocklistDescription = "Comma-separated list of CIDR ranges or hostnames blocked from CEL http.Get/Post calls. Overrides the built-in defaults when set. Example: '10.0.0.0/8,metadata.google.internal'."
+	HTTPBlocklistDescription = "Comma-separated list of CIDR ranges or hostnames blocked from CEL http.Get/Post calls. Overrides the built-in defaults when set. Example: '169.254.169.254,metadata.google.internal'."
 	httpBlocklistEnvVar      = "FLAG_HTTP_BLOCKLIST"
 	HTTPAllowlistFlagName    = "httpAllowlist"
 	HTTPAllowlistDescription = "Comma-separated list of URL prefixes (scheme+host[+path]) permitted in CEL http.Get/Post calls. When set, only matching URLs are allowed. Example: 'https://api.example.com,https://webhook.corp/v1/'."
@@ -67,7 +74,7 @@ var (
 	DumpMutatePatches                 = newToggle(defaultDumpMutatePatches, dumpMutatePatchesEnvVar)
 	AutogenV2                         = newToggle(defaultAutogenV2, autogenV2EnvVar)
 	AllowHTTPInNamespacedPolicies     = newToggle(defaultAllowHTTPInNamespacedPolicies, allowHTTPInNamespacedPoliciesEnvVar)
-	HTTPBlocklist                     = newStringSliceFlag(append(append([]string{}, sdkhttp.DefaultBlockedCIDRs...), sdkhttp.DefaultBlockedHosts...), httpBlocklistEnvVar)
+	HTTPBlocklist                     = newStringSliceFlag(append([]string{}, defaultPolicyHTTPBlocklist...), httpBlocklistEnvVar)
 	HTTPAllowlist                     = newStringSliceFlag(nil, httpAllowlistEnvVar)
 )
 


### PR DESCRIPTION
## Explanation

Allow in cluster HTTP calls for all policy types

Namespaced policies still require an opt-in using `--allowHTTPInNamespacedPolicies`

## Related issue



## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
