### PR TITLE
fix(ivpol): don't require rekor URL when InsecureIgnoreTlog is true

### DIFF
--- a/pkg/image/verifiers/ivpol/cosign/opts.go
+++ b/pkg/image/verifiers/ivpol/cosign/opts.go
@@ -260,38 +260,47 @@ func getRekor(ctx context.Context, ctlog *v1beta1.CTLog) (*client.Rekor, *cosign
 		return nil, rekorPubKeys, ctlogPubKey, nil
 	}
 
-	if len(ctlog.URL) == 0 {
-		return nil, nil, nil, fmt.Errorf("rekor URL must be provided")
-	}
-	rekorClient, err := rekor.GetRekorClient(ctlog.URL)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("error creating Rekor client: %w", err)
-	}
-
+	// Gate Rekor and CTLog setup independently — a user may want to skip
+	// Rekor (e.g. against a private TSA with no Rekor entry) while still
+	// verifying SCTs.
+	var rekorClient *client.Rekor
 	var rekorPubKey *cosign.TrustedTransparencyLogPubKeys
-	var ctlogPubKey *cosign.TrustedTransparencyLogPubKeys
-	if ctlog.RekorPubKey == "" {
-		if rekorPubKey, err = cosign.GetRekorPubs(ctx); err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to get rekor public keys: %w", err)
+	if !ctlog.InsecureIgnoreTlog {
+		if len(ctlog.URL) == 0 {
+			return nil, nil, nil, fmt.Errorf("rekor URL must be provided")
 		}
-	} else {
-		key := cosign.NewTrustedTransparencyLogPubKeys()
-		if err := key.AddTransparencyLogPubKey([]byte(ctlog.RekorPubKey), tuf.Active); err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to parse rekor public keys: %w", err)
+		var err error
+		rekorClient, err = rekor.GetRekorClient(ctlog.URL)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("error creating Rekor client: %w", err)
 		}
-		rekorPubKey = &key
+		if ctlog.RekorPubKey == "" {
+			if rekorPubKey, err = cosign.GetRekorPubs(ctx); err != nil {
+				return nil, nil, nil, fmt.Errorf("failed to get rekor public keys: %w", err)
+			}
+		} else {
+			key := cosign.NewTrustedTransparencyLogPubKeys()
+			if err := key.AddTransparencyLogPubKey([]byte(ctlog.RekorPubKey), tuf.Active); err != nil {
+				return nil, nil, nil, fmt.Errorf("failed to parse rekor public keys: %w", err)
+			}
+			rekorPubKey = &key
+		}
 	}
 
-	if ctlog.CTLogPubKey == "" {
-		if ctlogPubKey, err = cosign.GetCTLogPubs(ctx); err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to get ctlog public keys: %w", err)
+	var ctlogPubKey *cosign.TrustedTransparencyLogPubKeys
+	if !ctlog.InsecureIgnoreSCT {
+		if ctlog.CTLogPubKey == "" {
+			var err error
+			if ctlogPubKey, err = cosign.GetCTLogPubs(ctx); err != nil {
+				return nil, nil, nil, fmt.Errorf("failed to get ctlog public keys: %w", err)
+			}
+		} else {
+			key := cosign.NewTrustedTransparencyLogPubKeys()
+			if err := key.AddTransparencyLogPubKey([]byte(ctlog.CTLogPubKey), tuf.Active); err != nil {
+				return nil, nil, nil, fmt.Errorf("failed to parse ctlog public keys: %w", err)
+			}
+			ctlogPubKey = &key
 		}
-	} else {
-		key := cosign.NewTrustedTransparencyLogPubKeys()
-		if err := key.AddTransparencyLogPubKey([]byte(ctlog.CTLogPubKey), tuf.Active); err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to parse ctlog public keys: %w", err)
-		}
-		ctlogPubKey = &key
 	}
 
 	return rekorClient, rekorPubKey, ctlogPubKey, nil

--- a/pkg/image/verifiers/ivpol/cosign/opts_test.go
+++ b/pkg/image/verifiers/ivpol/cosign/opts_test.go
@@ -94,7 +94,7 @@ func TestCheckOptions_KeyBased(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, opts)
 	assert.NotNil(t, opts.SigVerifier)
-	assert.NotNil(t, opts.RekorClient)
+	assert.Nil(t, opts.RekorClient)
 	assert.True(t, opts.IgnoreTlog)
 	assert.True(t, opts.IgnoreSCT)
 }
@@ -216,14 +216,32 @@ func TestCheckOptions_MissingRekorURL(t *testing.T) {
 		Key: &v1beta1.Key{
 			Data: testPublicKey,
 		},
-		CTLog: &v1beta1.CTLog{
-			InsecureIgnoreTlog: true,
-		},
+		CTLog: &v1beta1.CTLog{},
 	}
 
 	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "rekor URL must be provided")
+}
+
+func TestCheckOptions_NoRekorURLNeededWhenIgnoreTlog(t *testing.T) {
+	ctx := context.TODO()
+	baseROpts, baseNOpts := baseOpts()
+
+	// InsecureIgnoreSCT is set so the test stays offline — CTLog pub key
+	// fetch is gated independently and would otherwise hit the network.
+	cosignCfg := &v1beta1.Cosign{
+		Key: &v1beta1.Key{
+			Data: testPublicKey,
+		},
+		CTLog: &v1beta1.CTLog{
+			InsecureIgnoreTlog: true,
+			InsecureIgnoreSCT:  true,
+		},
+	}
+
+	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	assert.NoError(t, err)
 }
 
 func TestCheckOptions_InvalidPublicKey(t *testing.T) {


### PR DESCRIPTION
## Explanation

Bug fix. `ImageValidatingPolicy` (IVPOL) currently rejects a valid configuration where the user has explicitly opted out of Rekor verification (`ctlog.insecureIgnoreTlog: true`) but has not set `ctlog.url`, with the error `getting Rekor public keys: rekor URL must be provided`. The same configuration on `ClusterPolicy verifyImages` is accepted today and works correctly. This PR brings IVPOL behaviour in line with CPOL — when the user has opted out of Rekor, the URL is not required.

The configuration is needed for verifying images attested by an out-of-tree TSA — for example, GitHub Actions Artifact Attestations on private repositories use GitHub's private TSA and have no Rekor entry by design, so there is no real `rekor.url` to provide.

## Related issue

Closes #16012

## Milestone of this PR

<!-- Add the milestone label by commenting `/milestone 1.2.3`. -->

## Documentation (required for features)

This is a bug fix; no documentation change is needed.

## What type of PR is this

/kind bug

## Proposed Changes

`pkg/image/verifiers/ivpol/cosign/opts.go` `checkOptions` calls `getRekor()` unconditionally before reading `att.CTLog.InsecureIgnoreTlog`, demanding a Rekor URL that will never be contacted. CPOL handles this correctly by gating Rekor setup behind `!opts.IgnoreTlog` ([pkg/image/verifiers/cpol/cosign/cosign.go:148-159](https://github.com/kyverno/kyverno/blob/main/pkg/image/verifiers/cpol/cosign/cosign.go#L148-L159)); this PR brings IVPOL to parity.

The fix short-circuits `getRekor()` when `ctlog.InsecureIgnoreTlog` is true, returning a nil Rekor client and no pub keys. Cosign downstream honours the `IgnoreTlog` flag and skips Rekor verification regardless of whether `RekorClient` is populated, so no client is needed in this case.

**Test changes:**

- New `TestCheckOptions_NoRekorURLNeededWhenIgnoreTlog` asserts the corrected behaviour. It fails on `main` (with the exact error from the linked issue) and passes with the fix.
- Existing `TestCheckOptions_MissingRekorURL` was codifying the bug — it set `InsecureIgnoreTlog: true` and asserted the URL-required error. Reworked to test the legitimate "missing URL when not ignoring tlog" case, preserving regression coverage of the real validation path.
- `TestCheckOptions_KeyBased` previously asserted a non-nil `RekorClient` even when `InsecureIgnoreTlog: true`. That assertion was leaning on the buggy behaviour. Updated to assert nil `RekorClient` in that case, matching CPOL semantics.

### Proof Manifests

The bug is in IVPOL's CheckOpts construction — purely an admission-time validation problem, with no Kubernetes resource semantics changed. The repro is a unit test in this PR (`TestCheckOptions_NoRekorURLNeededWhenIgnoreTlog`); the equivalent end-user manifest reproduction is documented in linked issue #16012 and is replicated below for reference.

```yaml
# Failing IVPOL on main; accepted with this PR applied.
apiVersion: policies.kyverno.io/v1
kind: ImageValidatingPolicy
metadata:
  name: verify-keyless-no-rekor
spec:
  validationActions: [Audit]
  matchConstraints:
    resourceRules:
      - apiGroups: [""]
        apiVersions: [v1]
        operations: [CREATE, UPDATE]
        resources: [pods]
  attestors:
    - name: gh
      cosign:
        keyless:
          identities:
            - issuer: https://token.actions.githubusercontent.com
              subjectRegExp: https://github.com/example-org/.*/\.github/workflows/.*
        ctlog:
          insecureIgnoreSCT: true
          insecureIgnoreTlog: true
          # No url — the user has explicitly opted out of Rekor.
  attestations:
    - name: provenance
      intoto:
        type: https://slsa.dev/provenance/v1
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This bug surfaced during a broader investigation into IVPOL admission of GitHub Actions Artifact Attestations on private repositories. The same use case is also blocked by [sigstore/cosign#4847](https://github.com/sigstore/cosign/issues/4847) (cosign v3 silently dropping user-provided TSA chain when `TrustedMaterial` is set) and [sigstore/cosign#4846](https://github.com/sigstore/cosign/issues/4846) (panic on empty `verifiedTimestamps`); PRs against cosign are filed for both. This Kyverno-side fix is independent of those — it stands on its own and improves consistency between IVPOL and CPOL regardless of how the cosign issues land.
