### PR TITLE
fix: support cluster-scoped resource generation in GeneratingPolicy

### DIFF
--- a/pkg/background/generate/generator.go
+++ b/pkg/background/generate/generator.go
@@ -181,6 +181,18 @@ func (g *generator) generate() ([]kyvernov1.ResourceSpec, error) {
 				}
 				newGenResources = append(newGenResources, targetMeta)
 			} else {
+				effectiveAPIVersion := targetMeta.GetAPIVersion()
+				if effectiveAPIVersion == "" {
+					effectiveAPIVersion = generatedObj.GetAPIVersion()
+					newResource.SetAPIVersion(effectiveAPIVersion)
+				}
+
+				effectiveNamespace := targetMeta.GetNamespace()
+				if effectiveNamespace == "" && g.isNamespacedResource(effectiveAPIVersion, targetMeta.GetKind()) {
+					effectiveNamespace = "default"
+				}
+				newResource.SetNamespace(effectiveNamespace)
+
 				if !g.rule.Generation.Synchronize {
 					logger.V(4).Info("synchronize disabled, skip syncing changes")
 					continue
@@ -193,18 +205,11 @@ func (g *generator) generate() ([]kyvernov1.ResourceSpec, error) {
 				}
 
 				logger.V(4).Info("updating existing resource")
-				if targetMeta.GetAPIVersion() == "" {
-					generatedResourceAPIVersion := generatedObj.GetAPIVersion()
-					newResource.SetAPIVersion(generatedResourceAPIVersion)
-				}
-				if targetMeta.GetNamespace() == "" && g.isNamespacedResource(targetMeta.GetAPIVersion(), targetMeta.GetKind()) {
-					newResource.SetNamespace("default")
-				}
 
 				if g.policy.GetSpec().UseServerSideApply {
-					_, err = g.client.ApplyResource(context.TODO(), targetMeta.GetAPIVersion(), targetMeta.GetKind(), targetMeta.GetNamespace(), targetMeta.GetName(), newResource, false, "generate")
+					_, err = g.client.ApplyResource(context.TODO(), effectiveAPIVersion, targetMeta.GetKind(), effectiveNamespace, targetMeta.GetName(), newResource, false, "generate")
 				} else {
-					_, err = g.client.UpdateResource(context.TODO(), targetMeta.GetAPIVersion(), targetMeta.GetKind(), targetMeta.GetNamespace(), newResource, false)
+					_, err = g.client.UpdateResource(context.TODO(), effectiveAPIVersion, targetMeta.GetKind(), effectiveNamespace, newResource, false)
 				}
 				if err != nil {
 					logger.Error(err, "failed to update resource")

--- a/pkg/background/generate/generator.go
+++ b/pkg/background/generate/generator.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/multierr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type generator struct {
@@ -196,7 +197,7 @@ func (g *generator) generate() ([]kyvernov1.ResourceSpec, error) {
 					generatedResourceAPIVersion := generatedObj.GetAPIVersion()
 					newResource.SetAPIVersion(generatedResourceAPIVersion)
 				}
-				if targetMeta.GetNamespace() == "" {
+				if targetMeta.GetNamespace() == "" && g.isNamespacedResource(targetMeta.GetAPIVersion(), targetMeta.GetKind()) {
 					newResource.SetNamespace("default")
 				}
 
@@ -287,4 +288,24 @@ func (g *generator) loadContext(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+func (g *generator) isNamespacedResource(apiVersion, kind string) bool {
+	if apiVersion == "" || kind == "" {
+		return true
+	}
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		g.logger.V(4).Info("failed to parse apiVersion for generated resource scope lookup", "apiVersion", apiVersion, "kind", kind, "error", err.Error())
+		return true
+	}
+	resources, err := g.client.Discovery().FindResources(gv.Group, gv.Version, kind, "")
+	if err != nil {
+		g.logger.V(4).Info("failed to discover generated resource scope", "apiVersion", apiVersion, "kind", kind, "error", err.Error())
+		return true
+	}
+	for _, resource := range resources {
+		return resource.Namespaced
+	}
+	return true
 }

--- a/pkg/cel/libs/context.go
+++ b/pkg/cel/libs/context.go
@@ -192,27 +192,32 @@ func (cp *contextProvider) GenerateResources(namespace string, dataList []map[st
 		}
 
 		for _, item := range items {
+			targetNamespace := namespace
+			if !cp.isNamespacedResource(item.GetAPIVersion(), item.GetKind()) {
+				targetNamespace = ""
+			}
+
 			// In CLI evaluation mode, we do not create the resource in the cluster
 			// but just store it in the generated resources list.
 			if cp.cliEvaluation {
 				item.SetUID("")
 				item.SetManagedFields(nil)
 				item.SetAnnotations(nil)
-				item.SetNamespace(namespace)
+				item.SetNamespace(targetNamespace)
 				item.SetResourceVersion("")
 				item.SetCreationTimestamp(metav1.Time{})
 				cp.generatedResources = append(cp.generatedResources, item)
 				continue
 			}
 			cp.addGenerateLabels(item)
-			item.SetNamespace(namespace)
+			item.SetNamespace(targetNamespace)
 			item.SetResourceVersion("")
 			// check if the resource is already generated
 			_, err := cp.client.GetResource(
 				context.TODO(),
 				item.GetAPIVersion(),
 				item.GetKind(),
-				namespace,
+				targetNamespace,
 				item.GetName(),
 			)
 
@@ -223,7 +228,7 @@ func (cp *contextProvider) GenerateResources(namespace string, dataList []map[st
 						context.TODO(),
 						item.GetAPIVersion(),
 						item.GetKind(),
-						namespace,
+						targetNamespace,
 						item,
 						false,
 					)
@@ -293,6 +298,21 @@ func (cp *contextProvider) ToGVR(apiVersion, kind string) (*schema.GroupVersionR
 	}
 
 	return &r.Resource, nil
+}
+
+func (cp *contextProvider) isNamespacedResource(apiVersion, kind string) bool {
+	if cp.restMapper == nil || apiVersion == "" || kind == "" {
+		return true
+	}
+	groupVersion, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return true
+	}
+	r, err := cp.restMapper.RESTMapping(schema.GroupKind{Group: groupVersion.Group, Kind: kind}, groupVersion.Version)
+	if err != nil || r.Scope == nil {
+		return true
+	}
+	return r.Scope.Name() == meta.RESTScopeNameNamespace
 }
 
 func (cp *contextProvider) ClearGeneratedResources() {

--- a/test/conformance/chainsaw/generating-policies/data/sync/generate-clusterrolebinding-from-namespace/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/sync/generate-clusterrolebinding-from-namespace/chainsaw-test.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: generate-clusterrolebinding-from-namespace
+spec:
+  concurrent: false
+  steps:
+  - name: create permissions
+    try:
+    - apply:
+        file: permissions.yaml
+  - name: create policy
+    use:
+      template: ../../../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait-generating-policy-ready
+    use:
+      template: ../../../../_step-templates/generating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: test-user
+  - name: create namespace trigger
+    try:
+    - apply:
+        file: namespace.yaml
+  - name: check that the clusterrolebinding is generated
+    try:
+    - assert:
+        file: clusterrolebinding-assert.yaml
+  - name: cleanup generated clusterrolebinding
+    try:
+    - delete:
+        ref:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          name: test-app-gpol-crb-view

--- a/test/conformance/chainsaw/generating-policies/data/sync/generate-clusterrolebinding-from-namespace/clusterrolebinding-assert.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/sync/generate-clusterrolebinding-from-namespace/clusterrolebinding-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-app-gpol-crb-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: app-gpol-crb

--- a/test/conformance/chainsaw/generating-policies/data/sync/generate-clusterrolebinding-from-namespace/namespace.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/sync/generate-clusterrolebinding-from-namespace/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-gpol-crb

--- a/test/conformance/chainsaw/generating-policies/data/sync/generate-clusterrolebinding-from-namespace/permissions.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/sync/generate-clusterrolebinding-from-namespace/permissions.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:crb:manage
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete

--- a/test/conformance/chainsaw/generating-policies/data/sync/generate-clusterrolebinding-from-namespace/policy.yaml
+++ b/test/conformance/chainsaw/generating-policies/data/sync/generate-clusterrolebinding-from-namespace/policy.yaml
@@ -1,0 +1,40 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: GeneratingPolicy
+metadata:
+  name: test-user
+spec:
+  evaluation:
+    synchronize:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["namespaces"]
+  variables:
+  - name: ns
+    expression: object.metadata.name
+  generate:
+  - expression: |
+      generator.apply(string(variables.ns), [
+        {
+          "kind": dyn("ClusterRoleBinding"),
+          "apiVersion": dyn("rbac.authorization.k8s.io/v1"),
+          "metadata": dyn({
+            "name": dyn("test-" + string(variables.ns) + "-view")
+          }),
+          "roleRef": dyn({
+            "apiGroup": dyn("rbac.authorization.k8s.io"),
+            "kind": dyn("ClusterRole"),
+            "name": dyn("view")
+          }),
+          "subjects": dyn([
+            {
+              "kind": dyn("ServiceAccount"),
+              "name": dyn("default"),
+              "namespace": dyn(string(variables.ns))
+            }
+          ])
+        }
+      ])


### PR DESCRIPTION
## Description
Fixes GeneratingPolicy generation for cluster-scoped resources (for example ClusterRoleBinding/ClusterRole) by avoiding namespace assignment and namespaced API calls for cluster-scoped targets.

## What changed
- Make CEL generate path scope-aware in pkg/cel/libs/context.go
- Make legacy generate sync/update path scope-aware in pkg/background/generate/generator.go
- Add chainsaw test for namespace-triggered ClusterRoleBinding generation

## Testing
- chainsaw test test/conformance/chainsaw/generating-policies/data/sync/generate-clusterrolebinding-from-namespace

Fixes #16017