### PR TITLE
fix: restart dynamic watchers in background reporting on 410

### DIFF
--- a/.github/workflows/check-golangci-lint.yaml
+++ b/.github/workflows/check-golangci-lint.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           version: v2.11.4
           skip-cache: true
+          verify: false
 
   sync-issue:
     if: always() && github.event_name == 'push'

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -222,7 +222,7 @@ func (c *controller) Run(ctx context.Context, workers int) {
 				c.lock.Lock()
 				if old, stillNeeded := c.dynamicWatchers[gvr]; stillNeeded {
 					attempts := 0
-					for attempts < 5 {
+					for attempts <= 5 {
 						w, err := c.startWatcher(ctx, logger, gvr, old.gvk, c.watchDeathChan)
 						if err != nil {
 							attempts++

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -2,7 +2,8 @@ package resource
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"net/http"
 	"slices"
 	"sync"
 	"time"
@@ -27,6 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/dump"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	admissionregistrationv1informers "k8s.io/client-go/informers/admissionregistration/v1"
@@ -107,6 +111,9 @@ type controller struct {
 	lock            sync.RWMutex
 	dynamicWatchers map[schema.GroupVersionResource]*watcher
 	eventHandlers   []EventHandler
+	adminCtx        context.Context
+	adminCancel     context.CancelFunc
+	watchDeathChan  chan (schema.GroupVersionResource)
 }
 
 func NewController(
@@ -203,7 +210,31 @@ func (c *controller) Warmup(ctx context.Context) error {
 }
 
 func (c *controller) Run(ctx context.Context, workers int) {
+	c.adminCtx, c.adminCancel = context.WithCancel(ctx)
+	c.watchDeathChan = make(chan schema.GroupVersionResource, 100)
+	go func() {
+		for {
+			select {
+			case <-c.adminCtx.Done():
+				return
+			case gvr := <-c.watchDeathChan:
+				c.lock.Lock()
+				if old, stillNeeded := c.dynamicWatchers[gvr]; stillNeeded {
+					w, err := c.startWatcher(ctx, logger, gvr, old.gvk, c.watchDeathChan)
+					if err != nil {
+						logger.Error(err, "failed to start watcher")
+					}
+					c.dynamicWatchers[gvr] = w
+				}
+				c.lock.Unlock()
+			}
+		}
+	}()
+
 	controllerutils.Run(ctx, logger, ControllerName, time.Second, c.queue, workers, maxRetries, c.reconcile)
+
+	c.adminCancel()
+	close(c.watchDeathChan)
 	c.stopDynamicWatchers()
 }
 
@@ -256,7 +287,7 @@ func (c *controller) AddEventHandler(eventHandler EventHandler) {
 	}
 }
 
-func (c *controller) startWatcher(ctx context.Context, logger logr.Logger, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind) (*watcher, error) {
+func (c *controller) startWatcher(ctx context.Context, logger logr.Logger, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, errChan chan schema.GroupVersionResource) (*watcher, error) {
 	hashes := map[types.UID]Resource{}
 	var resourceVersion string
 
@@ -323,7 +354,20 @@ func (c *controller) startWatcher(ctx context.Context, logger logr.Logger, gvr s
 			case watch.Deleted:
 				c.deleteHash(event.Object.(*unstructured.Unstructured), gvr)
 			case watch.Error:
-				logger.Error(errors.New("watch error event received"), "watch error event received", "event", event.Object)
+				errObject := apierrors.FromObject(event.Object)
+				statusErr, ok := errObject.(*apierrors.StatusError)
+				if !ok {
+					logger.Error(fmt.Errorf("unknown error object: %s", dump.Pretty(event.Object)), "unexpected watch error type")
+					continue
+				}
+
+				logger.Error(statusErr, fmt.Sprintf("watch error for gvr: %s", gvr))
+				// status gone error will signal for a watcher restart to the admin goroutine
+				if statusErr.ErrStatus.Code == http.StatusGone {
+					logger.V(2).Info(fmt.Sprintf("watcher for gvr %s got resource version too old, restarting", gvr))
+					errChan <- gvr
+					return
+				}
 			}
 		}
 	}(gvr)
@@ -517,7 +561,7 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 			dynamicWatchers[gvr] = c.dynamicWatchers[gvr]
 			delete(c.dynamicWatchers, gvr)
 		} else {
-			if w, err := c.startWatcher(ctx, logger, gvr, gvk); err != nil {
+			if w, err := c.startWatcher(ctx, logger, gvr, gvk, c.watchDeathChan); err != nil {
 				logger.Error(err, "failed to start watcher")
 			} else {
 				dynamicWatchers[gvr] = w

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -221,11 +221,17 @@ func (c *controller) Run(ctx context.Context, workers int) {
 				}
 				c.lock.Lock()
 				if old, stillNeeded := c.dynamicWatchers[gvr]; stillNeeded {
-					w, err := c.startWatcher(ctx, logger, gvr, old.gvk, c.watchDeathChan)
-					if err != nil {
-						logger.Error(err, "failed to start watcher")
-					} else {
-						c.dynamicWatchers[gvr] = w
+					attempts := 0
+					for attempts < 5 {
+						w, err := c.startWatcher(ctx, logger, gvr, old.gvk, c.watchDeathChan)
+						if err != nil {
+							attempts++
+							logger.Error(err, "failed to start watcher, sleeping 2 seconds the retrying")
+							time.Sleep(time.Second * 2)
+						} else {
+							c.dynamicWatchers[gvr] = w
+							break
+						}
 					}
 				}
 				c.lock.Unlock()

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -221,12 +221,10 @@ func (c *controller) Run(ctx context.Context, workers int) {
 				}
 				c.lock.Lock()
 				if old, stillNeeded := c.dynamicWatchers[gvr]; stillNeeded {
-					attempts := 0
-					for attempts <= 5 {
+					for attempts := 0; attempts <= maxRetries; attempts++ {
 						w, err := c.startWatcher(ctx, logger, gvr, old.gvk, c.watchDeathChan)
 						if err != nil {
-							attempts++
-							logger.Error(err, "failed to start watcher, sleeping 2 seconds the retrying")
+							logger.Error(err, "failed to start watcher, sleeping 2 seconds then retrying")
 							time.Sleep(time.Second * 2)
 						} else {
 							c.dynamicWatchers[gvr] = w

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -202,6 +202,8 @@ func NewController(
 	if _, _, err := controllerutils.AddDefaultEventHandlers(logger, cpolInformer.Informer(), c.queue); err != nil {
 		logger.Error(err, "failed to register event handlers")
 	}
+	c.adminCtx, c.adminCancel = context.WithCancel(context.Background())
+	c.watchDeathChan = make(chan schema.GroupVersionResource, 100)
 	return &c
 }
 
@@ -210,21 +212,23 @@ func (c *controller) Warmup(ctx context.Context) error {
 }
 
 func (c *controller) Run(ctx context.Context, workers int) {
-	c.adminCtx, c.adminCancel = context.WithCancel(ctx)
-	c.watchDeathChan = make(chan schema.GroupVersionResource, 100)
 	go func() {
 		for {
 			select {
 			case <-c.adminCtx.Done():
 				return
-			case gvr := <-c.watchDeathChan:
+			case gvr, ok := <-c.watchDeathChan:
+				if !ok {
+					return
+				}
 				c.lock.Lock()
 				if old, stillNeeded := c.dynamicWatchers[gvr]; stillNeeded {
 					w, err := c.startWatcher(ctx, logger, gvr, old.gvk, c.watchDeathChan)
 					if err != nil {
 						logger.Error(err, "failed to start watcher")
+					} else {
+						c.dynamicWatchers[gvr] = w
 					}
-					c.dynamicWatchers[gvr] = w
 				}
 				c.lock.Unlock()
 			}
@@ -234,7 +238,6 @@ func (c *controller) Run(ctx context.Context, workers int) {
 	controllerutils.Run(ctx, logger, ControllerName, time.Second, c.queue, workers, maxRetries, c.reconcile)
 
 	c.adminCancel()
-	close(c.watchDeathChan)
 	c.stopDynamicWatchers()
 }
 
@@ -365,6 +368,7 @@ func (c *controller) startWatcher(ctx context.Context, logger logr.Logger, gvr s
 				// status gone error will signal for a watcher restart to the admin goroutine
 				if statusErr.ErrStatus.Code == http.StatusGone {
 					logger.V(2).Info(fmt.Sprintf("watcher for gvr %s got resource version too old, restarting", gvr))
+					watchInterface.Stop()
 					errChan <- gvr
 					return
 				}

--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -24,13 +24,12 @@ import (
 	restmapper "github.com/kyverno/kyverno/pkg/utils/restmapper"
 	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/dump"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	admissionregistrationv1informers "k8s.io/client-go/informers/admissionregistration/v1"
@@ -111,8 +110,6 @@ type controller struct {
 	lock            sync.RWMutex
 	dynamicWatchers map[schema.GroupVersionResource]*watcher
 	eventHandlers   []EventHandler
-	adminCtx        context.Context
-	adminCancel     context.CancelFunc
 	watchDeathChan  chan (schema.GroupVersionResource)
 }
 
@@ -202,7 +199,6 @@ func NewController(
 	if _, _, err := controllerutils.AddDefaultEventHandlers(logger, cpolInformer.Informer(), c.queue); err != nil {
 		logger.Error(err, "failed to register event handlers")
 	}
-	c.adminCtx, c.adminCancel = context.WithCancel(context.Background())
 	c.watchDeathChan = make(chan schema.GroupVersionResource, 100)
 	return &c
 }
@@ -212,10 +208,12 @@ func (c *controller) Warmup(ctx context.Context) error {
 }
 
 func (c *controller) Run(ctx context.Context, workers int) {
+	adminCtx, adminCancel := context.WithCancel(context.Background())
+	defer adminCancel()
 	go func() {
 		for {
 			select {
-			case <-c.adminCtx.Done():
+			case <-adminCtx.Done():
 				return
 			case gvr, ok := <-c.watchDeathChan:
 				if !ok {
@@ -236,8 +234,6 @@ func (c *controller) Run(ctx context.Context, workers int) {
 	}()
 
 	controllerutils.Run(ctx, logger, ControllerName, time.Second, c.queue, workers, maxRetries, c.reconcile)
-
-	c.adminCancel()
 	c.stopDynamicWatchers()
 }
 


### PR DESCRIPTION
## Explanation

- StatusGone errors on watchers result in a defacto watch death for a given resource. meaning that reports will go stale.
- When we get a 410, we should instead restart the watch by listing first to get the latest rv and call watch with that rv.
- Spin up an admin goroutine that will receive watch death signals for a given gvr when the watch dies. If the gvr is still in the map, try to start a new watch

## Related issue

https://github.com/kyverno/kyverno/issues/13862

