### PR TITLE
fix(cli): add generatedResources field for GeneratingPolicy multi-resource tests

### DIFF
--- a/cmd/cli/kubectl-kyverno/_testdata/tests/test-4/generatedLimitRange.yaml
+++ b/cmd/cli/kubectl-kyverno/_testdata/tests/test-4/generatedLimitRange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-limitrange
+  namespace: hello-world-namespace
+spec:
+  limits:
+    - default:
+        cpu: 500m
+        memory: 1Gi
+      defaultRequest:
+        cpu: 200m
+        memory: 256Mi
+      type: Container

--- a/cmd/cli/kubectl-kyverno/_testdata/tests/test-4/generatedResourceQuota.yaml
+++ b/cmd/cli/kubectl-kyverno/_testdata/tests/test-4/generatedResourceQuota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: default-resourcequota
+  namespace: hello-world-namespace
+spec:
+  hard:
+    requests.cpu: '4'
+    requests.memory: '16Gi'
+    limits.cpu: '4'
+    limits.memory: '16Gi'

--- a/cmd/cli/kubectl-kyverno/_testdata/tests/test-4/kyverno-test.yaml
+++ b/cmd/cli/kubectl-kyverno/_testdata/tests/test-4/kyverno-test.yaml
@@ -1,0 +1,18 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: add-quota-gpol
+policies:
+- policy.yaml
+resources:
+- resource.yaml
+results:
+- generatedResources:
+  - generatedLimitRange.yaml
+  - generatedResourceQuota.yaml
+  isGeneratingPolicy: true
+  kind: Namespace
+  policy: add-ns-quota
+  resources:
+  - hello-world-namespace
+  result: pass

--- a/cmd/cli/kubectl-kyverno/_testdata/tests/test-4/policy.yaml
+++ b/cmd/cli/kubectl-kyverno/_testdata/tests/test-4/policy.yaml
@@ -1,0 +1,58 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-ns-quota
+  annotations:
+    policies.kyverno.io/title: Add Quota
+    policies.kyverno.io/category: Multi-Tenancy, EKS Best Practices
+    policies.kyverno.io/subject: ResourceQuota, LimitRange
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      To better control the number of resources that can be created in a given
+      Namespace and provide default resource consumption limits for Pods,
+      ResourceQuota and LimitRange resources are recommended.
+      This policy will generate ResourceQuota and LimitRange resources when
+      a new Namespace is created.
+spec:
+  rules:
+  - name: generate-resourcequota
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+    generate:
+      apiVersion: v1
+      kind: ResourceQuota
+      name: default-resourcequota
+      synchronize: true
+      namespace: "{{request.object.metadata.name}}"
+      data:
+        spec:
+          hard:
+            requests.cpu: '4'
+            requests.memory: '16Gi'
+            limits.cpu: '4'
+            limits.memory: '16Gi'
+  - name: generate-limitrange
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+    generate:
+      apiVersion: v1
+      kind: LimitRange
+      name: default-limitrange
+      synchronize: true
+      namespace: "{{request.object.metadata.name}}"
+      data:
+        spec:
+          limits:
+          - default:
+              cpu: 500m
+              memory: 1Gi
+            defaultRequest:
+              cpu: 200m
+              memory: 256Mi
+            type: Container

--- a/cmd/cli/kubectl-kyverno/_testdata/tests/test-4/resource.yaml
+++ b/cmd/cli/kubectl-kyverno/_testdata/tests/test-4/resource.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hello-world-namespace

--- a/cmd/cli/kubectl-kyverno/apis/v1alpha1/test_result.go
+++ b/cmd/cli/kubectl-kyverno/apis/v1alpha1/test_result.go
@@ -77,6 +77,10 @@ type TestResultData struct {
 
 	// Resources gives us the list of resources on which the policy is going to be applied.
 	ResourceSpecs []TestResourceSpec `json:"resourceSpecs,omitempty"`
+
+	// GeneratedResources takes a list of resource configuration files in yaml format from
+	// the user to compare them against the Kyverno generated resource configurations.
+	GeneratedResources []string `json:"generatedResources,omitempty"`
 }
 
 // TestResult declares a test result

--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -223,7 +223,7 @@ func checkResult(
 			return false, fmt.Sprintf("Patched resource didn't match the patched resource in the test result\n(%s)\n\n%s", legend, diff), "Resource diff"
 		}
 	}
-	if test.GeneratedResource != "" {
+	if test.GeneratedResource != "" && len(test.GeneratedResources) == 0 {
 		equals, diff, err := getAndCompareResource(actualResource, fs, filepath.Join(resourcePath, test.GeneratedResource), "GeneratedResource")
 		if err != nil {
 			return false, err.Error(), "Resource error"
@@ -236,6 +236,34 @@ func checkResult(
 				diff = StripANSI(diff)
 			}
 			return false, fmt.Sprintf("Patched resource didn't match the generated resource in the test result\n(%s)\n\n%s", legend, diff), "Resource diff"
+		}
+	} else if len(test.GeneratedResources) > 0 {
+		matched := false
+		var lastDiff string
+		var lastErr error
+		for _, expectedRes := range test.GeneratedResources {
+			equals, diff, err := getAndCompareResource(actualResource, fs, filepath.Join(resourcePath, expectedRes), "GeneratedResources")
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			if equals {
+				matched = true
+				break
+			}
+			lastDiff = diff
+		}
+		if !matched {
+			if lastDiff == "" && lastErr != nil {
+				return false, lastErr.Error(), "Resource error"
+			}
+			dmp := diffmatchpatch.New()
+			legend := dmp.DiffPrettyText(dmp.DiffMain("only in expected", "only in actual", false))
+			if removeColor {
+				legend = StripANSI(legend)
+				lastDiff = StripANSI(lastDiff)
+			}
+			return false, fmt.Sprintf("Generated resource didn't match any of the expected generated resources in the test result\n(%s)\n\n%s", legend, lastDiff), "Resource diff"
 		}
 	}
 	result := report.ComputePolicyReportResult(false, response, rule)

--- a/cmd/cli/kubectl-kyverno/commands/test/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/memfs"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/apis/v1alpha1"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/output/color"
@@ -504,6 +506,121 @@ func TestLookupRuleResponses(t *testing.T) {
 			result := lookupRuleResponses(tt.testResult, responses...)
 			assert.Len(t, result, tt.wantCount,
 				"lookupRuleResponses returned unexpected number of responses")
+		})
+	}
+}
+
+func TestCheckResultGeneratedResources(t *testing.T) {
+	policy := &kyvernov1.ClusterPolicy{}
+	policy.SetName("test-policy")
+
+	actual := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ResourceQuota",
+			"metadata": map[string]interface{}{
+				"name":      "default-resourcequota",
+				"namespace": "hello-world-namespace",
+			},
+			"spec": map[string]interface{}{
+				"hard": map[string]interface{}{
+					"requests.cpu": "4",
+				},
+			},
+		},
+	}
+
+	matchingYAML := `apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: default-resourcequota
+  namespace: hello-world-namespace
+spec:
+  hard:
+    requests.cpu: "4"
+`
+	nonMatchingYAML := `apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-limitrange
+  namespace: hello-world-namespace
+spec:
+  limits: []
+`
+
+	rule := *engineapi.RulePass("test-rule", engineapi.Generation, "generated", nil)
+	response := engineapi.NewEngineResponse(
+		actual,
+		engineapi.NewKyvernoPolicy(policy),
+		nil,
+	).WithPolicyResponse(engineapi.PolicyResponse{
+		Rules: []engineapi.RuleResponse{rule},
+	})
+
+	makeFS := func(t *testing.T, files map[string]string) billy.Filesystem {
+		t.Helper()
+		fs := memfs.New()
+		for name, content := range files {
+			f, err := fs.Create(name)
+			require.NoError(t, err)
+			_, err = f.Write([]byte(content))
+			require.NoError(t, err)
+			f.Close()
+		}
+		return fs
+	}
+
+	tests := []struct {
+		name               string
+		generatedResources []string
+		fsFiles            map[string]string
+		wantOk             bool
+		wantReason         string
+	}{
+		{
+			name:               "match found in list",
+			generatedResources: []string{"nonmatch.yaml", "match.yaml"},
+			fsFiles: map[string]string{
+				"nonmatch.yaml": nonMatchingYAML,
+				"match.yaml":    matchingYAML,
+			},
+			wantOk:     true,
+			wantReason: "Ok",
+		},
+		{
+			name:               "no match in list",
+			generatedResources: []string{"nonmatch.yaml"},
+			fsFiles: map[string]string{
+				"nonmatch.yaml": nonMatchingYAML,
+			},
+			wantOk:     false,
+			wantReason: "Resource error",
+		},
+		{
+			name:               "all files missing",
+			generatedResources: []string{"missing.yaml"},
+			fsFiles:            map[string]string{},
+			wantOk:             false,
+			wantReason:         "Resource error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := makeFS(t, tt.fsFiles)
+			testResult := v1alpha1.TestResult{
+				TestResultBase: v1alpha1.TestResultBase{
+					Policy: "test-policy",
+					Rule:   "test-rule",
+					Result: openreportsv1alpha1.Result(openreports.StatusPass),
+				},
+				TestResultData: v1alpha1.TestResultData{
+					GeneratedResources: tt.generatedResources,
+				},
+			}
+			ok, _, reason := checkResult(testResult, fs, "", response, rule, actual, true)
+			assert.Equal(t, tt.wantOk, ok)
+			assert.Equal(t, tt.wantReason, reason)
 		})
 	}
 }

--- a/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
@@ -139,6 +139,13 @@ spec:
                     GeneratedResource takes a resource configuration file in yaml format from
                     the user to compare it against the Kyverno generated resource configuration.
                   type: string
+                generatedResources:
+                  description: |-
+                    GeneratedResources takes a list of resource configuration files in yaml format from
+                    the user to compare them against the Kyverno generated resource configurations.
+                  items:
+                    type: string
+                  type: array
                 isDeletingPolicy:
                   description: |-
                     IsDeletingPolicy indicates if the policy is a deleting policy.

--- a/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
@@ -139,6 +139,13 @@ spec:
                     GeneratedResource takes a resource configuration file in yaml format from
                     the user to compare it against the Kyverno generated resource configuration.
                   type: string
+                generatedResources:
+                  description: |-
+                    GeneratedResources takes a list of resource configuration files in yaml format from
+                    the user to compare them against the Kyverno generated resource configurations.
+                  items:
+                    type: string
+                  type: array
                 isDeletingPolicy:
                   description: |-
                     IsDeletingPolicy indicates if the policy is a deleting policy.

--- a/cmd/cli/kubectl-kyverno/fix/test.go
+++ b/cmd/cli/kubectl-kyverno/fix/test.go
@@ -36,6 +36,11 @@ func FixTest(test v1alpha1.Test, compress bool) (v1alpha1.Test, []string, error)
 			messages = append(messages, "test results contains duplicate resources")
 			result.Resources = unique.UnsortedList()
 		}
+		uniqueGenerated := sets.New(result.GeneratedResources...)
+		if len(result.GeneratedResources) != len(uniqueGenerated) {
+			messages = append(messages, "test results contains duplicate generated resources")
+			result.GeneratedResources = uniqueGenerated.UnsortedList()
+		}
 		results = append(results, result)
 	}
 	if compress {
@@ -44,6 +49,7 @@ func FixTest(test v1alpha1.Test, compress bool) (v1alpha1.Test, []string, error)
 			data := compressed[result.TestResultBase]
 			data.Resources = append(data.Resources, result.Resources...)
 			data.ResourceSpecs = append(data.ResourceSpecs, result.ResourceSpecs...)
+			data.GeneratedResources = append(data.GeneratedResources, result.GeneratedResources...)
 			compressed[result.TestResultBase] = data
 		}
 		results = nil
@@ -52,6 +58,11 @@ func FixTest(test v1alpha1.Test, compress bool) (v1alpha1.Test, []string, error)
 			if len(v.Resources) != len(unique) {
 				messages = append(messages, "test results contains duplicate resources")
 				v.Resources = unique.UnsortedList()
+			}
+			uniqueGenerated := sets.New(v.GeneratedResources...)
+			if len(v.GeneratedResources) != len(uniqueGenerated) {
+				messages = append(messages, "test results contains duplicate generated resources")
+				v.GeneratedResources = uniqueGenerated.UnsortedList()
 			}
 			results = append(results, v1alpha1.TestResult{
 				TestResultBase: k,
@@ -86,6 +97,18 @@ func FixTest(test v1alpha1.Test, compress bool) (v1alpha1.Test, []string, error)
 		if len(a.Resources) == len(b.Resources) {
 			for i := range a.Resources {
 				if x := cmp.Compare(a.Resources[i], b.Resources[i]); x != 0 {
+					return x
+				}
+			}
+		}
+		slices.Sort(a.GeneratedResources)
+		slices.Sort(b.GeneratedResources)
+		if x := cmp.Compare(len(a.GeneratedResources), len(b.GeneratedResources)); x != 0 {
+			return x
+		}
+		if len(a.GeneratedResources) == len(b.GeneratedResources) {
+			for i := range a.GeneratedResources {
+				if x := cmp.Compare(a.GeneratedResources[i], b.GeneratedResources[i]); x != 0 {
 					return x
 				}
 			}

--- a/cmd/cli/kubectl-kyverno/test/load_test.go
+++ b/cmd/cli/kubectl-kyverno/test/load_test.go
@@ -244,6 +244,37 @@ func TestLoadTests(t *testing.T) {
 			},
 		}},
 		wantErr: false,
+	}, {
+		name:     "ok - generatedResources",
+		dirPath:  "../_testdata/tests/test-4",
+		fileName: "kyverno-test.yaml",
+		want: []TestCase{{
+			Path: "../_testdata/tests/test-4/kyverno-test.yaml",
+			Test: &v1alpha1.Test{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "cli.kyverno.io/v1alpha1",
+					Kind:       "Test",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "add-quota-gpol",
+				},
+				Policies:  []string{"policy.yaml"},
+				Resources: []string{"resource.yaml"},
+				Results: []v1alpha1.TestResult{{
+					TestResultBase: v1alpha1.TestResultBase{
+						Kind:               "Namespace",
+						Policy:             "add-ns-quota",
+						Result:             openreports.StatusPass,
+						IsGeneratingPolicy: true,
+					},
+					TestResultData: v1alpha1.TestResultData{
+						Resources:          []string{"hello-world-namespace"},
+						GeneratedResources: []string{"generatedLimitRange.yaml", "generatedResourceQuota.yaml"},
+					},
+				}},
+			},
+		}},
+		wantErr: false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/user/cli/crd/index.html
+++ b/docs/user/cli/crd/index.html
@@ -1478,6 +1478,18 @@ bool
 <p>Resources gives us the list of resources on which the policy is going to be applied.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>generatedResources</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>GeneratedResources takes a list of resource configuration files in yaml format from
+the user to compare them against the Kyverno generated resource configurations.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr />

--- a/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
+++ b/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
@@ -3253,6 +3253,36 @@ from the user which is meant to be cloned by the generate rule.</p>
       </tr>
     
   
+    
+    
+      <tr>
+        <td><code>generatedResources</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>GeneratedResources takes a list of resource configuration files in yaml format from
+the user to compare them against the Kyverno generated resource configurations.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
 
 
       </tbody>


### PR DESCRIPTION
## Explanation

When a `ClusterPolicy` with multiple generate rules is converted to a `GeneratingPolicy`, the existing CLI test structure breaks. `GeneratingPolicy` is ruleless — you cannot use the `rule:` field to split test results per generated resource as you can with `ClusterPolicy`. The current `generatedResource` (singular) field only supports verifying one generated resource per result entry, so there is no way to verify all resources generated by a single `GeneratingPolicy` in a single test.

This PR adds a `generatedResources` (plural) field to `TestResultData` that accepts a list of expected resource files. Each actual generated resource is matched against the set, order-independently. The existing `generatedResource` field remains fully backward compatible.

## Related issue

Closes #14280

Ref https://github.com/kyverno/kyverno/issues/15264

Ref https://github.com/kyverno/kyverno/issues/14629

## Milestone of this PR

/milestone 1.17.2

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [[the documentation](https://github.com/kyverno/website)](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

- Added `GeneratedResources []string` field to `TestResultData` in the CLI test API (`apis/v1alpha1/test_result.go`)
- Updated `checkResult` in `commands/test/command.go` to match each actual generated resource against the list of expected resource files
- Updated both CRD schemas (`config/crds/` and `data/crds/`) with the new field
- Updated `fix/test.go` to preserve `GeneratedResources` during compress and include it in the sort
- Added a test fixture in `_testdata/tests/test-4/` demonstrating the new field with the `add-ns-quota` policy that generates both `ResourceQuota` and `LimitRange`

### Proof Manifests

To reproduce the bug and verify the fix, run the following from the repo root after building the CLI:

```bash
go build -o kyverno ./cmd/cli/kubectl-kyverno/
./kyverno test cmd/cli/kubectl-kyverno/_testdata/tests/test-4
```

Expected output:

```
│ ID │ POLICY       │ RULE                   │ RESOURCE               │ RESULT │ REASON │
│ 1  │ add-ns-quota │ generate-resourcequota │ /default-resourcequota │ Pass   │ Ok     │
│ 2  │ add-ns-quota │ generate-limitrange    │ /default-limitrange    │ Pass   │ Ok     │
Test Summary: 2 tests passed and 0 tests failed
```

**Policy** (`cmd/cli/kubectl-kyverno/_testdata/tests/test-4/policy.yaml`) — a `ClusterPolicy` with two generate rules, one for `ResourceQuota` and one for `LimitRange`.

**New test manifest** using the `generatedResources` field:

```yaml
apiVersion: cli.kyverno.io/v1alpha1
kind: Test
metadata:
  name: add-quota-gpol
policies:
- policy.yaml
resources:
- resource.yaml
results:
- generatedResources:
  - generatedLimitRange.yaml
  - generatedResourceQuota.yaml
  isGeneratingPolicy: true
  kind: Namespace
  policy: add-ns-quota
  resources:
  - hello-world-namespace
  result: pass
```

Run the unit tests:

```bash
go test ./cmd/cli/kubectl-kyverno/commands/test/... -run TestCheckResultGeneratedResources -v
```

Expected output:

```
=== RUN   TestCheckResultGeneratedResources/match_found_in_list
=== RUN   TestCheckResultGeneratedResources/no_match_in_list
=== RUN   TestCheckResultGeneratedResources/all_files_missing
--- PASS: TestCheckResultGeneratedResources (0.00s)
```

**Trigger resource** (`resource.yaml`):

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: hello-world-namespace
```

## Checklist

- [x] I have read the [[contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md)](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [[AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md)](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [[PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md)](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments