### PR TITLE
fix: add IVPol image verification logs

### DIFF
--- a/pkg/cel/libs/imageverify/impl.go
+++ b/pkg/cel/libs/imageverify/impl.go
@@ -51,6 +51,7 @@ func ImageVerifyCELFuncs(
 	}
 	return &ivfuncs{
 		Adapter:         adapter,
+		logger:          logger.WithValues("policy", ivpol.GetName(), "namespace", ivpol.GetNamespace()),
 		imgCtx:          imgCtx,
 		creds:           spec.Credentials,
 		imgRules:        imgRules,
@@ -68,9 +69,11 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 		return types.WrapErr(err)
 	} else {
 		count := 0
+		f.logger.V(4).Info("calling verifyImageSignatures", "image", image, "attestors", len(attestors))
 		if match, err := matching.MatchImage(image, f.imgRules...); err != nil {
 			return types.WrapErr(err)
 		} else if !match {
+			f.logger.V(4).Info("image does not match policy image references", "function", "verifyImageSignatures", "image", image, "result", count)
 			return f.NativeToValue(count)
 		}
 		for _, attestor := range attestors {
@@ -82,8 +85,9 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 
 			if attestor.IsCosign() {
 				if err := f.cosignVerifier.VerifyImageSignature(ctx, img, &attestor); err != nil {
-					f.logger.Info("failed to verify image cosign", "error", err)
+					f.logger.V(4).Info("failed to verify image cosign", "image", image, "attestor", attestor.Name, "error", err)
 				} else {
+					f.logger.V(4).Info("image cosign verification succeeded", "image", image, "attestor", attestor.Name)
 					count += 1
 				}
 			} else if attestor.IsNotary() {
@@ -95,12 +99,16 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 					tsaCerts = attestor.Notary.TSACerts.Value
 				}
 				if err := f.notaryVerifier.VerifyImageSignature(ctx, img, certs, tsaCerts); err != nil {
-					f.logger.Info("failed to verify image notary", "error", err)
+					f.logger.V(4).Info("failed to verify image notary", "image", image, "attestor", attestor.Name, "error", err)
 				} else {
+					f.logger.V(4).Info("image notary verification succeeded", "image", image, "attestor", attestor.Name)
 					count += 1
 				}
+			} else {
+				f.logger.V(4).Info("skipping unsupported image attestor", "image", image, "attestor", attestor.Name)
 			}
 		}
+		f.logger.V(4).Info("verifyImageSignatures returned", "image", image, "result", count)
 		return f.NativeToValue(count)
 	}
 }
@@ -118,9 +126,11 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 		return types.WrapErr(err)
 	} else {
 		count := 0
+		f.logger.V(4).Info("calling verifyAttestationSignatures", "image", image, "attestation", attestation, "attestors", len(attestors))
 		if match, err := matching.MatchImage(image, f.imgRules...); err != nil {
 			return types.WrapErr(err)
 		} else if !match {
+			f.logger.V(4).Info("image does not match policy image references", "function", "verifyAttestationSignatures", "image", image, "attestation", attestation, "result", count)
 			return f.NativeToValue(count)
 		}
 		for _, attestor := range attestors {
@@ -135,8 +145,9 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 			}
 			if attestor.IsCosign() {
 				if err := f.cosignVerifier.VerifyAttestationSignature(ctx, img, &attest, &attestor); err != nil {
-					f.logger.Info("failed to verify attestation cosign", "error", err)
+					f.logger.V(4).Info("failed to verify attestation cosign", "image", image, "attestation", attestation, "attestor", attestor.Name, "error", err)
 				} else {
+					f.logger.V(4).Info("attestation cosign verification succeeded", "image", image, "attestation", attestation, "attestor", attestor.Name)
 					count += 1
 				}
 			} else if attestor.IsNotary() {
@@ -151,12 +162,16 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 					tsaCerts = attestor.Notary.TSACerts.Value
 				}
 				if err := f.notaryVerifier.VerifyAttestationSignature(ctx, img, attest.Referrer.Type, certs, tsaCerts); err != nil {
-					f.logger.Info("failed to verify attestation notary", "error", err)
+					f.logger.V(4).Info("failed to verify attestation notary", "image", image, "attestation", attestation, "attestor", attestor.Name, "error", err)
 				} else {
+					f.logger.V(4).Info("attestation notary verification succeeded", "image", image, "attestation", attestation, "attestor", attestor.Name)
 					count += 1
 				}
+			} else {
+				f.logger.V(4).Info("skipping unsupported attestation attestor", "image", image, "attestation", attestation, "attestor", attestor.Name)
 			}
 		}
+		f.logger.V(4).Info("verifyAttestationSignatures returned", "image", image, "attestation", attestation, "result", count)
 		return f.NativeToValue(count)
 	}
 }

--- a/pkg/cel/libs/imageverify/lib.go
+++ b/pkg/cel/libs/imageverify/lib.go
@@ -5,6 +5,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/kyverno/kyverno/pkg/logging"
 	"github.com/kyverno/sdk/cel/libs/versions"
 	"github.com/kyverno/sdk/extensions/imagedataloader"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -29,6 +30,7 @@ func Latest() *version.Version {
 func Lib(v *version.Version, imgCtx imagedataloader.ImageContext, ivpol policiesv1beta1.ImageValidatingPolicyLike, lister k8scorev1.SecretInterface) cel.EnvOption {
 	// create the cel lib env option
 	return cel.Lib(&lib{
+		logger:  logging.WithName("imageverify"),
 		version: v,
 		imgCtx:  imgCtx,
 		ivpol:   ivpol,


### PR DESCRIPTION
## Explanation

This PR fixes missing diagnostic logs for ImageValidatingPolicy image verification. When CEL functions like `verifyImageSignatures()` or `verifyAttestationSignatures()` returned `0`, operators had little visibility into whether the image was skipped, verification failed, or no attestor matched.

The change initializes the IVPol image verification logger and adds verbosity-gated logs for function entry, image-reference skips, verifier success/failure, and the final count returned by the CEL functions.

## Related issue

Closes #16023

## Milestone of this PR

<!-- Add the milestone label by commenting `/milestone 1.2.3`. -->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

This PR updates `pkg/cel/libs/imageverify` to use a real Kyverno logger instead of passing an uninitialized logger into the IVPol CEL image verification implementation.

It also adds debug-level logs around:

- calls to `verifyImageSignatures()`
- calls to `verifyAttestationSignatures()`
- image-reference mismatch skips
- cosign and notary verification success/failure
- unsupported attestor skips
- the final integer result returned by each CEL function

These logs are emitted at `V(4)`, so they are available when running Kyverno with higher verbosity such as `--v=6` without increasing default log noise.

### Proof Manifests

N/A. This PR only adds diagnostic logging for existing IVPol image verification behavior and does not change policy evaluation results.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

