### PR TITLE
Fix basic webhook policies overwriting each other's namespaceSelector and objectSelector

### DIFF
--- a/pkg/controllers/webhook/validating.go
+++ b/pkg/controllers/webhook/validating.go
@@ -192,26 +192,13 @@ func buildWebhookRules(cfg config.Configuration, server, name, queryPath string,
 			SideEffects:             &noneOnDryRun,
 			AdmissionReviewVersions: []string{"v1"},
 		}
+		webhookIgnore.NamespaceSelector = cfg.GetWebhook().NamespaceSelector
+		webhookIgnore.ObjectSelector = cfg.GetWebhook().ObjectSelector
 		webhookFail.NamespaceSelector = cfg.GetWebhook().NamespaceSelector
+		webhookFail.ObjectSelector = cfg.GetWebhook().ObjectSelector
 
 		for _, policy := range basic {
 			p := extractGenericPolicy(policy)
-			webhookIgnore.NamespaceSelector = mergeLabelSelectors(
-				p.GetMatchConstraints().NamespaceSelector,
-				cfg.GetWebhook().NamespaceSelector,
-			)
-			webhookIgnore.ObjectSelector = mergeLabelSelectors(
-				p.GetMatchConstraints().ObjectSelector,
-				cfg.GetWebhook().ObjectSelector,
-			)
-			webhookFail.NamespaceSelector = mergeLabelSelectors(
-				p.GetMatchConstraints().NamespaceSelector,
-				cfg.GetWebhook().NamespaceSelector,
-			)
-			webhookFail.ObjectSelector = mergeLabelSelectors(
-				p.GetMatchConstraints().ObjectSelector,
-				cfg.GetWebhook().ObjectSelector,
-			)
 			var webhookRules []admissionregistrationv1.RuleWithOperations
 			if vpol, ok := p.(*policiesv1beta1.ValidatingPolicy); ok {
 				rules, err := vpolautogen.Autogen(vpol)

--- a/pkg/controllers/webhook/validating_test.go
+++ b/pkg/controllers/webhook/validating_test.go
@@ -10,6 +10,7 @@ import (
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/stretchr/testify/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -68,17 +69,96 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 							},
 						},
 					},
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"environment": "staging",
+					NamespaceSelector: nil,
+					ObjectSelector:    nil,
+					FailurePolicy:     ptr.To(admissionregistrationv1.Ignore),
+				},
+			},
+		},
+		{
+			name: "Multiple Basic Policies with Different Selectors",
+			vpols: []*policiesv1beta1.ValidatingPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "policy-a",
+					},
+					Spec: policiesv1beta1.ValidatingPolicySpec{
+						FailurePolicy: ptr.To(admissionregistrationv1.Ignore),
+						MatchConstraints: &admissionregistrationv1.MatchResources{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"env": "prod"},
+							},
+							ObjectSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "a"},
+							},
+							ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+								{
+									RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+										Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+										Rule: admissionregistrationv1.Rule{
+											APIGroups:   []string{"apps"},
+											APIVersions: []string{"v1"},
+											Resources:   []string{"deployments"},
+										},
+									},
+								},
+							},
 						},
 					},
-					ObjectSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"app": "test",
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "policy-b",
+					},
+					Spec: policiesv1beta1.ValidatingPolicySpec{
+						FailurePolicy: ptr.To(admissionregistrationv1.Ignore),
+						MatchConstraints: &admissionregistrationv1.MatchResources{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"env": "staging"},
+							},
+							ObjectSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "b"},
+							},
+							ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+								{
+									RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+										Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+										Rule: admissionregistrationv1.Rule{
+											APIGroups:   []string{""},
+											APIVersions: []string{"v1"},
+											Resources:   []string{"pods"},
+										},
+									},
+								},
+							},
 						},
 					},
-					FailurePolicy: ptr.To(admissionregistrationv1.Ignore),
+				},
+			},
+			expectedWebhooks: []admissionregistrationv1.ValidatingWebhook{
+				{
+					Name: config.ValidatingPolicyWebhookName + "-ignore",
+					Rules: []admissionregistrationv1.RuleWithOperations{
+						{
+							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{"apps"},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"deployments"},
+							},
+						},
+						{
+							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{""},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"pods"},
+							},
+						},
+					},
+					NamespaceSelector: nil,
+					ObjectSelector:    nil,
+					FailurePolicy:     ptr.To(admissionregistrationv1.Ignore),
 				},
 			},
 		},
@@ -130,17 +210,9 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 							},
 						},
 					},
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"environment": "staging",
-						},
-					},
-					ObjectSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"app": "test",
-						},
-					},
-					FailurePolicy: ptr.To(admissionregistrationv1.Fail),
+					NamespaceSelector: nil,
+					ObjectSelector:    nil,
+					FailurePolicy:     ptr.To(admissionregistrationv1.Fail),
 				},
 			},
 		},
@@ -338,15 +410,94 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 				if expect.ClientConfig.Service != nil {
 					assert.Equal(t, *webhooks[i].ClientConfig.Service.Path, *expect.ClientConfig.Service.Path)
 				}
-				if expect.NamespaceSelector != nil {
-					assert.Equal(t, expect.NamespaceSelector, webhooks[i].NamespaceSelector)
-				}
-				if expect.ObjectSelector != nil {
-					assert.Equal(t, expect.ObjectSelector, webhooks[i].ObjectSelector)
-				}
+				assert.Equal(t, expect.NamespaceSelector, webhooks[i].NamespaceSelector)
+				assert.Equal(t, expect.ObjectSelector, webhooks[i].ObjectSelector)
 			}
 		})
 	}
+}
+
+func TestBuildWebhookRules_BasicWithGlobalSelectors(t *testing.T) {
+	cfg := config.NewDefaultConfiguration(false)
+	cfg.Load(&corev1.ConfigMap{
+		Data: map[string]string{
+			"webhooks": `{
+				"namespaceSelector": {
+					"matchExpressions": [
+						{"key": "kubernetes.io/metadata.name", "operator": "NotIn", "values": ["kyverno"]}
+					]
+				},
+				"objectSelector": {
+					"matchLabels": {"global": "true"}
+				}
+			}`,
+		},
+	})
+
+	vpols := []engineapi.GenericPolicy{
+		engineapi.NewValidatingPolicy(&policiesv1beta1.ValidatingPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "policy-a"},
+			Spec: policiesv1beta1.ValidatingPolicySpec{
+				FailurePolicy: ptr.To(admissionregistrationv1.Ignore),
+				MatchConstraints: &admissionregistrationv1.MatchResources{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "prod"},
+					},
+					ObjectSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "a"},
+					},
+					ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+						{
+							RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+								Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+								Rule: admissionregistrationv1.Rule{
+									APIGroups: []string{""}, APIVersions: []string{"v1"},
+									Resources: []string{"pods"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}),
+		engineapi.NewValidatingPolicy(&policiesv1beta1.ValidatingPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "policy-b"},
+			Spec: policiesv1beta1.ValidatingPolicySpec{
+				FailurePolicy: ptr.To(admissionregistrationv1.Ignore),
+				MatchConstraints: &admissionregistrationv1.MatchResources{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "staging"},
+					},
+					ObjectSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "b"},
+					},
+					ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+						{
+							RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+								Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+								Rule: admissionregistrationv1.Rule{
+									APIGroups: []string{"apps"}, APIVersions: []string{"v1"},
+									Resources: []string{"deployments"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}),
+	}
+
+	webhooks := buildWebhookRules(cfg, "", config.ValidatingPolicyWebhookName, "/vpol", 0, nil, vpols, NewExpressionCache())
+	assert.Equal(t, 1, len(webhooks))
+	assert.Equal(t, config.ValidatingPolicyWebhookName+"-ignore", webhooks[0].Name)
+	assert.Equal(t, &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kyverno"}},
+		},
+	}, webhooks[0].NamespaceSelector)
+	assert.Equal(t, &metav1.LabelSelector{
+		MatchLabels: map[string]string{"global": "true"},
+	}, webhooks[0].ObjectSelector)
 }
 
 func TestBuildWebhookRules_ImageValidatingPolicy(t *testing.T) {
@@ -558,6 +709,346 @@ func TestBuildWebhookRules_ImageValidatingPolicy(t *testing.T) {
 				if expect.ClientConfig.Service != nil {
 					assert.Equal(t, *webhooks[i].ClientConfig.Service.Path, *expect.ClientConfig.Service.Path)
 				}
+			}
+		})
+	}
+}
+
+func TestBuildWebhookRules_MutatingPolicy(t *testing.T) {
+	tests := []struct {
+		name             string
+		mpols            []*policiesv1beta1.MutatingPolicy
+		expectedWebhooks []admissionregistrationv1.ValidatingWebhook
+	}{
+		{
+			name: "Single Basic Mutating Policy with namespaceSelector should not propagate to shared webhook",
+			mpols: []*policiesv1beta1.MutatingPolicy{
+				{
+					Spec: policiesv1beta1.MutatingPolicySpec{
+						FailurePolicy: ptr.To(admissionregistrationv1.Ignore),
+						MatchConstraints: &admissionregistrationv1.MatchResources{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"team": "a"},
+							},
+							ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+								{
+									RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+										Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+										Rule: admissionregistrationv1.Rule{
+											APIGroups:   []string{""},
+											APIVersions: []string{"v1"},
+											Resources:   []string{"pods"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedWebhooks: []admissionregistrationv1.ValidatingWebhook{
+				{
+					Name: config.MutatingPolicyWebhookName + "-ignore",
+					Rules: []admissionregistrationv1.RuleWithOperations{
+						{
+							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{""},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"pods"},
+							},
+						},
+					},
+					NamespaceSelector: nil,
+					ObjectSelector:    nil,
+					FailurePolicy:     ptr.To(admissionregistrationv1.Ignore),
+				},
+			},
+		},
+		{
+			name: "Multiple Basic Mutating Policies with Different namespaceSelectors",
+			mpols: []*policiesv1beta1.MutatingPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mpol-a",
+					},
+					Spec: policiesv1beta1.MutatingPolicySpec{
+						FailurePolicy: ptr.To(admissionregistrationv1.Ignore),
+						MatchConstraints: &admissionregistrationv1.MatchResources{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"team": "a"},
+							},
+							ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+								{
+									RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+										Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+										Rule: admissionregistrationv1.Rule{
+											APIGroups:   []string{""},
+											APIVersions: []string{"v1"},
+											Resources:   []string{"pods"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mpol-b",
+					},
+					Spec: policiesv1beta1.MutatingPolicySpec{
+						FailurePolicy: ptr.To(admissionregistrationv1.Ignore),
+						MatchConstraints: &admissionregistrationv1.MatchResources{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"team": "b"},
+							},
+							ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+								{
+									RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+										Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+										Rule: admissionregistrationv1.Rule{
+											APIGroups:   []string{"apps"},
+											APIVersions: []string{"v1"},
+											Resources:   []string{"deployments"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedWebhooks: []admissionregistrationv1.ValidatingWebhook{
+				{
+					Name: config.MutatingPolicyWebhookName + "-ignore",
+					Rules: []admissionregistrationv1.RuleWithOperations{
+						{
+							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{""},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"pods"},
+							},
+						},
+						{
+							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{"apps"},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"deployments"},
+							},
+						},
+					},
+					NamespaceSelector: nil,
+					ObjectSelector:    nil,
+					FailurePolicy:     ptr.To(admissionregistrationv1.Ignore),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expressionCache := NewExpressionCache()
+			var mpols []engineapi.GenericPolicy
+			for _, mpol := range tt.mpols {
+				mpols = append(mpols, engineapi.NewMutatingPolicy(mpol))
+				expressionCache.AddPolicyExpressions(mpol.GetMatchConditions())
+			}
+			webhooks := buildWebhookRules(
+				config.NewDefaultConfiguration(false),
+				"",
+				config.MutatingPolicyWebhookName,
+				"/mpol",
+				0,
+				nil,
+				mpols,
+				expressionCache,
+			)
+			assert.Equal(t, len(tt.expectedWebhooks), len(webhooks))
+			for i, expect := range tt.expectedWebhooks {
+				assert.Equal(t, expect.Name, webhooks[i].Name)
+				assert.Equal(t, expect.FailurePolicy, webhooks[i].FailurePolicy)
+				assert.Equal(t, len(expect.Rules), len(webhooks[i].Rules))
+				assert.Equal(t, expect.NamespaceSelector, webhooks[i].NamespaceSelector)
+				assert.Equal(t, expect.ObjectSelector, webhooks[i].ObjectSelector)
+			}
+		})
+	}
+}
+
+func TestBuildWebhookRules_GeneratingPolicy(t *testing.T) {
+	tests := []struct {
+		name             string
+		gpols            []*policiesv1beta1.GeneratingPolicy
+		expectedWebhooks []admissionregistrationv1.ValidatingWebhook
+	}{
+		{
+			name: "Single Basic Generating Policy with namespaceSelector should not propagate to shared webhook",
+			gpols: []*policiesv1beta1.GeneratingPolicy{
+				{
+					Spec: policiesv1beta1.GeneratingPolicySpec{
+						MatchConstraints: &admissionregistrationv1.MatchResources{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"team": "a"},
+							},
+							ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+								{
+									RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+										Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+										Rule: admissionregistrationv1.Rule{
+											APIGroups:   []string{""},
+											APIVersions: []string{"v1"},
+											Resources:   []string{"configmaps"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedWebhooks: []admissionregistrationv1.ValidatingWebhook{
+				{
+					Name: config.GeneratingPolicyWebhookName + "-ignore",
+					Rules: []admissionregistrationv1.RuleWithOperations{
+						{
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Connect,
+								admissionregistrationv1.Create,
+								admissionregistrationv1.Delete,
+								admissionregistrationv1.Update,
+							},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{""},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"configmaps"},
+							},
+						},
+					},
+					NamespaceSelector: nil,
+					ObjectSelector:    nil,
+					FailurePolicy:     ptr.To(admissionregistrationv1.Ignore),
+				},
+			},
+		},
+		{
+			name: "Multiple Basic Generating Policies with Different namespaceSelectors",
+			gpols: []*policiesv1beta1.GeneratingPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gpol-a",
+					},
+					Spec: policiesv1beta1.GeneratingPolicySpec{
+						MatchConstraints: &admissionregistrationv1.MatchResources{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"team": "a"},
+							},
+							ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+								{
+									RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+										Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+										Rule: admissionregistrationv1.Rule{
+											APIGroups:   []string{""},
+											APIVersions: []string{"v1"},
+											Resources:   []string{"configmaps"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gpol-b",
+					},
+					Spec: policiesv1beta1.GeneratingPolicySpec{
+						MatchConstraints: &admissionregistrationv1.MatchResources{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"team": "b"},
+							},
+							ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+								{
+									RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+										Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+										Rule: admissionregistrationv1.Rule{
+											APIGroups:   []string{"apps"},
+											APIVersions: []string{"v1"},
+											Resources:   []string{"deployments"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedWebhooks: []admissionregistrationv1.ValidatingWebhook{
+				{
+					Name: config.GeneratingPolicyWebhookName + "-ignore",
+					Rules: []admissionregistrationv1.RuleWithOperations{
+						{
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Connect,
+								admissionregistrationv1.Create,
+								admissionregistrationv1.Delete,
+								admissionregistrationv1.Update,
+							},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{""},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"configmaps"},
+							},
+						},
+						{
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Connect,
+								admissionregistrationv1.Create,
+								admissionregistrationv1.Delete,
+								admissionregistrationv1.Update,
+							},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{"apps"},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"deployments"},
+							},
+						},
+					},
+					NamespaceSelector: nil,
+					ObjectSelector:    nil,
+					FailurePolicy:     ptr.To(admissionregistrationv1.Ignore),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expressionCache := NewExpressionCache()
+			var gpols []engineapi.GenericPolicy
+			for _, gpol := range tt.gpols {
+				gpols = append(gpols, engineapi.NewGeneratingPolicy(gpol))
+				expressionCache.AddPolicyExpressions(gpol.GetMatchConditions())
+			}
+			webhooks := buildWebhookRules(
+				config.NewDefaultConfiguration(false),
+				"",
+				config.GeneratingPolicyWebhookName,
+				"/gpol",
+				0,
+				nil,
+				gpols,
+				expressionCache,
+			)
+			assert.Equal(t, len(tt.expectedWebhooks), len(webhooks))
+			for i, expect := range tt.expectedWebhooks {
+				assert.Equal(t, expect.Name, webhooks[i].Name)
+				assert.Equal(t, expect.FailurePolicy, webhooks[i].FailurePolicy)
+				assert.Equal(t, len(expect.Rules), len(webhooks[i].Rules))
+				assert.Equal(t, expect.NamespaceSelector, webhooks[i].NamespaceSelector)
+				assert.Equal(t, expect.ObjectSelector, webhooks[i].ObjectSelector)
 			}
 		})
 	}

--- a/test/conformance/chainsaw/validating-policies/webhook-configuration/basic/match-labels/webhooks.yaml
+++ b/test/conformance/chainsaw/validating-policies/webhook-configuration/basic/match-labels/webhooks.yaml
@@ -26,11 +26,7 @@ webhooks:
       operator: NotIn
       values:
       - kyverno
-    matchLabels:
-       environment: staging
-  objectSelector: 
-     matchLabels:
-        app: test 
+  objectSelector: {}
   rules:
   - apiGroups:
     - ""


### PR DESCRIPTION
## Explanation

When multiple basic (aggregated) CEL policies each define a
`matchConstraints.namespaceSelector` or `matchConstraints.objectSelector`,
the shared webhook configuration had its selectors overwritten by each
policy in turn. Only the last policy's selectors survived, preventing
earlier policies from ever receiving admission requests that fell outside
the last policy's scope. This caused intermittent behavior where policies
would stop working depending on controller reconciliation order.

The fix ensures that basic aggregated webhooks use only the global config
namespaceSelector/objectSelector. Per-policy selectors are still evaluated
by the Kyverno engine at runtime, so policy enforcement is unaffected.

Fine-grained policies (one webhook per policy) are unchanged -- they
continue to merge their selectors correctly.

## Related issue

Closes #15344

## Milestone of this PR

<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind bug

## Proposed Changes

- Remove per-policy namespaceSelector/objectSelector merging from the
  basic policy loop in `buildWebhookRules()`
- Set the shared webhook's selectors once from the global config before
  the loop
- Add unit tests covering multiple basic policies with different selectors
  for validating, mutating, and generating policies
- Update conformance test expectation for basic validating policy with
  matchLabels

### Proof Manifests

Two MutatingPolicies with different namespaceSelectors:

```yaml
apiVersion: policies.kyverno.io/v1
kind: MutatingPolicy
metadata:
  name: mutate-team-a
spec:
  matchConstraints:
    namespaceSelector:
      matchLabels:
        team: a
    resourceRules:
    - apiGroups: [""]
      apiVersions: [v1]
      operations: [CREATE]
      resources: ["pods"]
  mutations:
    - expression: object
---
apiVersion: policies.kyverno.io/v1
kind: MutatingPolicy
metadata:
  name: mutate-team-b
spec:
  matchConstraints:
    namespaceSelector:
      matchLabels:
        team: b
    resourceRules:
    - apiGroups: [""]
      apiVersions: [v1]
      operations: [CREATE]
      resources: ["pods"]
  mutations:
    - expression: object
```

After the fix, the MutatingWebhookConfiguration has NO per-policy
matchLabels -- only the global namespaceSelector:

```yaml
apiVersion: admissionregistration.k8s.io/v1
kind: MutatingWebhookConfiguration
metadata:
  labels:
    webhook.kyverno.io/managed-by: kyverno
  name: kyverno-resource-mutating-webhook-cfg
webhooks:
- name: mpol.validate.kyverno.svc-ignore
  namespaceSelector:
    matchExpressions:
    - key: kubernetes.io/metadata.name
      operator: NotIn
      values:
      - kube-system
    - key: kubernetes.io/metadata.name
      operator: NotIn
      values:
      - kyverno
  rules:
  - apiGroups: [""]
    apiVersions: [v1]
    operations: [CREATE]
    resources: [pods]
```

Per-policy selectors are still evaluated internally by the Kyverno engine
at runtime -- they just no longer incorrectly narrow the webhook itself.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->