### PR TITLE
ci: skip framework tests on docs-only and helm-only PRs

### DIFF
--- a/.github/workflows/check-framework.yaml
+++ b/.github/workflows/check-framework.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
       - release-*
+    paths-ignore:
+      - 'docs/**'
+      - 'charts/**'
+      - '**/*.md'
   push:
     branches:
       - main


### PR DESCRIPTION
framework tests don't exercise anything when a PR only changes docs or helm files, so running all 4 legs on those is just burning CI. small `paths-ignore` for `docs/`, `charts/`, and `**/*.md`.

push events to `main`/`release-*` are untouched.