### PR TITLE
fix(gctx): correctly track per-loader load state to avoid skipping LoadData

### DIFF
--- a/pkg/engine/context/loaders/globalcontext.go
+++ b/pkg/engine/context/loaders/globalcontext.go
@@ -47,7 +47,7 @@ func NewGCTXLoader(
 }
 
 func (g *gctxLoader) HasLoaded() bool {
-	return false
+	return g.data != nil
 }
 
 func (g *gctxLoader) LoadData() error {


### PR DESCRIPTION
## Explanation

gctxLoader.HasLoaded() previously returned false unconditionally, which forced LoadData() to be re-executed on every variable-substitution access to a globalReference context entry. This worked around a regression but also defeated the deferred-loading fast-path for global context entries.

Track load state via the existing g.data field, mirroring the pattern used by apiLoader / configMapLoader / imageDataLoader / variableLoader (return *.data != nil). HasLoaded() now reports whether THIS loader has actually injected its entry into the per-request engine context, instead of either always returning false or (as in v1.13.3 - v1.13.6) querying the global gctxStore and short-circuiting LoadData() before the entry was added to jsonContext.

## Related issue
#12404 

## What type of PR is this
/kind bug
