### PR TITLE
fix(cli): support multiple foreach blocks in CLI test values

### DIFF
--- a/cmd/cli/kubectl-kyverno/apis/v1alpha1/rule.go
+++ b/cmd/cli/kubectl-kyverno/apis/v1alpha1/rule.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 // Rule declares values for a given policy rule
 type Rule struct {
-	// Name is the name of the ppolicy rule
+	// Name is the name of the policy rule
 	Name string `json:"name"`
 
 	// Values are the values for the given policy rule
@@ -11,9 +11,10 @@ type Rule struct {
 	// +kubebuilder:validation:Schemaless
 	Values map[string]interface{} `json:"values,omitempty"`
 
-	// ForeachValues are the foreach values for the given policy rule
-	// +kubebuilder:validation:Type=object
+	// ForeachValues are the foreach values for the given policy rule, indexed per foreach block
+	// +kubebuilder:validation:Type=array
+	// +kubebuilder:validation:Items=object
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Schemaless
-	ForeachValues map[string][]interface{} `json:"foreachValues,omitempty"`
+	ForeachValues []map[string][]interface{} `json:"foreachValues,omitempty"`
 }

--- a/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
@@ -489,11 +489,13 @@ spec:
                         properties:
                           foreachValues:
                             description: ForeachValues are the foreach values for
-                              the given policy rule
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
+                              the given policy rule, indexed per foreach block
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
                           name:
-                            description: Name is the name of the ppolicy rule
+                            description: Name is the name of the policy rule
                             type: string
                           values:
                             description: Values are the values for the given policy

--- a/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_values.yaml
+++ b/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_values.yaml
@@ -180,11 +180,13 @@ spec:
                     properties:
                       foreachValues:
                         description: ForeachValues are the foreach values for the
-                          given policy rule
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
+                          given policy rule, indexed per foreach block
+                        items:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        type: array
                       name:
-                        description: Name is the name of the ppolicy rule
+                        description: Name is the name of the policy rule
                         type: string
                       values:
                         description: Values are the values for the given policy rule

--- a/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
@@ -489,11 +489,13 @@ spec:
                         properties:
                           foreachValues:
                             description: ForeachValues are the foreach values for
-                              the given policy rule
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
+                              the given policy rule, indexed per foreach block
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
                           name:
-                            description: Name is the name of the ppolicy rule
+                            description: Name is the name of the policy rule
                             type: string
                           values:
                             description: Values are the values for the given policy

--- a/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_values.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_values.yaml
@@ -180,11 +180,13 @@ spec:
                     properties:
                       foreachValues:
                         description: ForeachValues are the foreach values for the
-                          given policy rule
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
+                          given policy rule, indexed per foreach block
+                        items:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        type: array
                       name:
-                        description: Name is the name of the ppolicy rule
+                        description: Name is the name of the policy rule
                         type: string
                       values:
                         description: Values are the values for the given policy rule

--- a/cmd/cli/kubectl-kyverno/store/contextloader.go
+++ b/cmd/cli/kubectl-kyverno/store/contextloader.go
@@ -26,19 +26,27 @@ func ContextLoaderFactory(s *Store, cmResolver engineapi.ConfigmapResolver) engi
 	}
 	return func(policy kyvernov1.PolicyInterface, rule kyvernov1.Rule) engineapi.ContextLoader {
 		init := func(jsonContext enginecontext.Interface) error {
-			rule := s.GetPolicyRule(policy.GetName(), rule.Name)
-			if rule != nil && len(rule.Values) > 0 {
-				variables := rule.Values
-				for key, value := range variables {
+			storeRule := s.GetPolicyRule(policy.GetName(), rule.Name)
+			if storeRule != nil && len(storeRule.Values) > 0 {
+				for key, value := range storeRule.Values {
 					if err := jsonContext.AddVariable(key, value); err != nil {
 						return err
 					}
 				}
 			}
-			if rule != nil && len(rule.ForEachValues) > 0 {
-				for key, value := range rule.ForEachValues {
-					if err := jsonContext.AddVariable(key, value[s.GetForeachElement()]); err != nil {
-						return err
+			if storeRule != nil && len(storeRule.ForEachValues) > 0 {
+				blockIndex, elementIndex, err := foreachIndices(jsonContext)
+				if err != nil {
+					return err
+				}
+				if blockIndex < len(storeRule.ForEachValues) {
+					blockValues := storeRule.ForEachValues[blockIndex]
+					for key, values := range blockValues {
+						if elementIndex < len(values) {
+							if err := jsonContext.AddVariable(key, values[elementIndex]); err != nil {
+								return err
+							}
+						}
 					}
 				}
 			}
@@ -63,6 +71,28 @@ func ContextLoaderFactory(s *Store, cmResolver engineapi.ConfigmapResolver) engi
 			inner: factory(policy, rule),
 		}
 	}
+}
+
+// foreachIndices reads foreachBlockIndex and elementIndex from the JSON context.
+// These are injected by the engine before each context load during foreach iteration.
+func foreachIndices(jsonContext enginecontext.Interface) (blockIndex int, elementIndex int, err error) {
+	if raw, qErr := jsonContext.Query("foreachBlockIndex"); qErr == nil && raw != nil {
+		switch v := raw.(type) {
+		case int64:
+			blockIndex = int(v)
+		case float64:
+			blockIndex = int(v)
+		}
+	}
+	if raw, qErr := jsonContext.Query("elementIndex"); qErr == nil && raw != nil {
+		switch v := raw.(type) {
+		case int64:
+			elementIndex = int(v)
+		case float64:
+			elementIndex = int(v)
+		}
+	}
+	return blockIndex, elementIndex, nil
 }
 
 type wrapper struct {

--- a/cmd/cli/kubectl-kyverno/store/store.go
+++ b/cmd/cli/kubectl-kyverno/store/store.go
@@ -16,9 +16,9 @@ type Policy struct {
 }
 
 type Rule struct {
-	Name          string                   `json:"name"`
-	Values        map[string]interface{}   `json:"values"`
-	ForEachValues map[string][]interface{} `json:"foreachValues"`
+	Name          string                     `json:"name"`
+	Values        map[string]interface{}     `json:"values"`
+	ForEachValues []map[string][]interface{} `json:"foreachValues"`
 }
 
 type Store struct {
@@ -26,7 +26,6 @@ type Store struct {
 	registryClient       registryclient.Client
 	allowApiCalls        bool
 	policies             []Policy
-	foreachElement       int
 	gctxStore            loaders.Store
 	apiCallResponses     []v1alpha1.APICallResponseEntry
 	globalContextEntries []v1alpha1.GlobalContextEntryValue
@@ -41,14 +40,6 @@ func (s *Store) SetLocal(m bool) {
 // IsLocal returns 'true' if the CLI is in local (clusterless) execution
 func (s *Store) IsLocal() bool {
 	return s.local
-}
-
-func (s *Store) SetForEachElement(element int) {
-	s.foreachElement = element
-}
-
-func (s *Store) GetForeachElement() int {
-	return s.foreachElement
 }
 
 func (s *Store) SetRegistryAccess(access bool) {

--- a/cmd/cli/kubectl-kyverno/variables/variables_test.go
+++ b/cmd/cli/kubectl-kyverno/variables/variables_test.go
@@ -108,9 +108,9 @@ func TestVariables_SetInStore(t *testing.T) {
 			Values: map[string]interface{}{
 				"foo": "bar",
 			},
-			ForeachValues: map[string][]interface{}{
+			ForeachValues: []map[string][]interface{}{{
 				"baz": nil,
-			},
+			}},
 		}},
 	})
 	tests := []struct {

--- a/docs/user/cli/crd/index.html
+++ b/docs/user/cli/crd/index.html
@@ -1288,7 +1288,7 @@ string
 </em>
 </td>
 <td>
-<p>Name is the name of the ppolicy rule</p>
+<p>Name is the name of the policy rule</p>
 </td>
 </tr>
 <tr>
@@ -1306,11 +1306,11 @@ map[string]interface{}
 <td>
 <code>foreachValues</code><br/>
 <em>
-map[string][]interface{}
+[]map[string][]interface{}
 </em>
 </td>
 <td>
-<p>ForeachValues are the foreach values for the given policy rule</p>
+<p>ForeachValues are the foreach values for the given policy rule, indexed per foreach block</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/engine/context/context.go
+++ b/pkg/engine/context/context.go
@@ -24,7 +24,7 @@ import (
 var (
 	logger       = logging.WithName("context")
 	json         = jsoniter.ConfigCompatibleWithStandardLibrary
-	ReservedKeys = regexp.MustCompile(`request|serviceAccountName|serviceAccountNamespace|element|elementIndex|@|images|image|([a-z_0-9]+\()[^{}]`)
+	ReservedKeys = regexp.MustCompile(`request|serviceAccountName|serviceAccountNamespace|element|elementIndex|foreachBlockIndex|@|images|image|([a-z_0-9]+\()[^{}]`)
 )
 
 // EvalInterface is used to query and inspect context data

--- a/pkg/engine/handlers/mutation/common.go
+++ b/pkg/engine/handlers/mutation/common.go
@@ -28,7 +28,10 @@ type forEachMutator struct {
 func (f *forEachMutator) mutateForEach(ctx context.Context) *mutate.Response {
 	var applyCount int
 
-	for _, foreach := range f.foreach {
+	for i, foreach := range f.foreach {
+		if err := f.policyContext.JSONContext().AddVariable("foreachBlockIndex", int64(i)); err != nil {
+			return mutate.NewErrorResponse(fmt.Sprintf("failed to set foreachBlockIndex for foreach[%d]", i), err)
+		}
 		elements, err := engineutils.EvaluateList(foreach.List, f.policyContext.JSONContext())
 		if err != nil {
 			msg := fmt.Sprintf("failed to evaluate list %s: %v", foreach.List, err)

--- a/pkg/engine/handlers/validation/validate_resource.go
+++ b/pkg/engine/handlers/validation/validate_resource.go
@@ -223,7 +223,10 @@ func (v *validator) validateOldObject(ctx context.Context) (resp *engineapi.Rule
 func (v *validator) validateForEach(ctx context.Context) *engineapi.RuleResponse {
 	applyCount := 0
 	var listEvalError error
-	for _, foreach := range v.forEach {
+	for i, foreach := range v.forEach {
+		if err := v.policyContext.JSONContext().AddVariable("foreachBlockIndex", int64(i)); err != nil {
+			return engineapi.RuleError(v.rule.Name, engineapi.Validation, "failed to set foreachBlockIndex", err, v.rule.ReportProperties)
+		}
 		elements, err := engineutils.EvaluateList(foreach.List, v.policyContext.JSONContext())
 		if err != nil {
 			if strings.Contains(err.Error(), "Unknown key") {

--- a/test/cli/test/context-foreach-multi/kyverno-test.yaml
+++ b/test/cli/test/context-foreach-multi/kyverno-test.yaml
@@ -1,0 +1,28 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: test-context-foreach-multi
+policies:
+- policy.yaml
+resources:
+- resources.yaml
+results:
+- kind: Pod
+  policy: check-images
+  resources:
+  - good-pod
+  result: pass
+  rule: check-images
+- kind: Pod
+  policy: check-images
+  resources:
+  - bad-container-pod
+  result: fail
+  rule: check-images
+- kind: Pod
+  policy: check-images
+  resources:
+  - bad-initcontainer-pod
+  result: fail
+  rule: check-images
+variables: values.yaml

--- a/test/cli/test/context-foreach-multi/policy.yaml
+++ b/test/cli/test/context-foreach-multi/policy.yaml
@@ -1,0 +1,38 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: check-images
+spec:
+  admission: true
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: check-images
+    validate:
+      failureAction: Audit
+      foreach:
+      - context:
+        - imageRegistry:
+            reference: '{{ element.name }}'
+          name: data
+        deny:
+          conditions:
+          - key: '{{ data }}'
+            operator: Equals
+            value: blocked
+        list: request.object.spec.containers
+      - context:
+        - imageRegistry:
+            reference: '{{ element.name }}'
+          name: data
+        deny:
+          conditions:
+          - key: '{{ data }}'
+            operator: Equals
+            value: blocked
+        list: request.object.spec.initContainers
+      message: Images are not permitted.

--- a/test/cli/test/context-foreach-multi/resources.yaml
+++ b/test/cli/test/context-foreach-multi/resources.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+spec:
+  initContainers:
+  - image: busybox:1.28
+    name: init1
+  containers:
+  - image: busybox:1.28
+    name: app1
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-container-pod
+spec:
+  initContainers:
+  - image: busybox:1.28
+    name: init1
+  containers:
+  - image: busybox:1.28
+    name: app1
+  - image: busybox:1.28
+    name: app2
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-initcontainer-pod
+spec:
+  initContainers:
+  - image: busybox:1.28
+    name: init1
+  - image: busybox:1.28
+    name: init2
+  containers:
+  - image: busybox:1.28
+    name: app1

--- a/test/cli/test/context-foreach-multi/values.yaml
+++ b/test/cli/test/context-foreach-multi/values.yaml
@@ -1,0 +1,13 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Values
+policies:
+- name: check-images
+  rules:
+  - foreachValues:
+    - data:
+      - ok
+      - blocked
+    - data:
+      - ok
+      - blocked
+    name: check-images

--- a/test/cli/test/context-foreach/values.yaml
+++ b/test/cli/test/context-foreach/values.yaml
@@ -4,7 +4,7 @@ policies:
 - name: block-images
   rules:
   - foreachValues:
-      imageData:
+    - imageData:
       - foo
       - foo1
     name: block-images


### PR DESCRIPTION
## Explanation

The Kyverno CLI's `foreachValues` field in test values files used a flat map (`map[string][]interface{}`), making it impossible to provide separate mock context values for each foreach block in a rule. When a rule has multiple foreach blocks, all blocks shared the same key namespace, so you couldn't distinguish which mock value belonged to which block. This PR changes `foreachValues` to a slice of maps (`[]map[string][]interface{}`), indexed by foreach block position, and injects a `foreachBlockIndex` variable in the engine so the CLI can look up the correct mock values per block.

## Related issue

Closes #4095

## Milestone of this PR

/milestone 1.14.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

- Changed `Rule.ForeachValues` type from `map[string][]interface{}` to `[]map[string][]interface{}` in both the v1alpha1 API and internal store
- Injected `foreachBlockIndex` variable in the engine's validation and mutation foreach loops so the CLI context loader can identify the active block
- Updated the context loader to read `foreachBlockIndex` and `elementIndex` from the JSON context and index into the correct block's mock values
- Added `foreachBlockIndex` to reserved keys in the engine context
- Added a CLI test (`context-foreach-multi`) with a two-block foreach rule using the same context variable name in both blocks
- Regenerated CRDs and updated API docs

### Proof Manifests

**Policy (two foreach blocks, same context variable name `data` in both):**

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: check-images
spec:
  rules:
  - name: check-images
    match:
      any:
      - resources:
          kinds: [Pod]
    validate:
      failureAction: Audit
      foreach:
      - list: request.object.spec.containers
        context:
        - name: data
          imageRegistry:
            reference: '{{ element.name }}'
        deny:
          conditions:
          - key: '{{ data }}'
            operator: Equals
            value: blocked
      - list: request.object.spec.initContainers
        context:
        - name: data
          imageRegistry:
            reference: '{{ element.name }}'
        deny:
          conditions:
          - key: '{{ data }}'
            operator: Equals
            value: blocked
      message: Images are not permitted.


# Values (block 0 = containers, block 1 = initContainers):

```apiVersion: cli.kyverno.io/v1alpha1
kind: Values
policies:
- name: check-images
  rules:
  - name: check-images
    foreachValues:
    - data:
      - ok
      - blocked
    - data:
      - ok
      - blocked
```

# CLI test

```apiVersion: cli.kyverno.io/v1alpha1
kind: Test
metadata:
  name: test-context-foreach-multi
policies:
- policy.yaml
resources:
- resources.yaml
results:
- kind: Pod
  policy: check-images
  rule: check-images
  resources: [good-pod]
  result: pass
- kind: Pod
  policy: check-images
  rule: check-images
  resources: [bad-container-pod]
  result: fail
- kind: Pod
  policy: check-images
  rule: check-images
  resources: [bad-initcontainer-pod]
  result: fail
variables: values.yaml
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

