### PR TITLE
ci: cache envtest binaries between framework test runs

### DIFF
--- a/.github/workflows/check-framework.yaml
+++ b/.github/workflows/check-framework.yaml
@@ -49,6 +49,12 @@ jobs:
         with:
           gobuild-cache-prefix: ''
 
+      - name: Cache envtest binaries
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.local/share/kubebuilder-envtest
+          key: envtest-${{ env.ENVTEST_VERSION }}-${{ env.K8S_VERSION }}
+
       # todo: turn to a make command
       - name: Install envtest
         run: |


### PR DESCRIPTION
following on from #16088. `setup-envtest` re-downloads ~150-200MB of k8s binaries on every CI run, and we run 4 matrix legs in parallel so that's 4× per workflow. caching them on a key of envtest version + k8s version + runner os/arch should cut steady-state runs to one download per cache lifetime.

no `restore-keys` fallback because envtest binaries are arch + OS specific, partial restore would silently load wrong binaries.