### PR TITLE
fix: skip report creation for subresources with empty name/UID

### DIFF
--- a/pkg/background/generate/controller.go
+++ b/pkg/background/generate/controller.go
@@ -356,10 +356,8 @@ func (c *GenerateController) createReports(
 	resource unstructured.Unstructured,
 	engineResponses ...engineapi.EngineResponse,
 ) error {
-	// Skip report creation for subresources (e.g., pods/exec) as they have empty name/UID.
-	// Subresources don't have their own resources in Kubernetes, so reports cannot be created for them.
-	if resource.GetName() == "" {
-		c.log.V(3).Info("skipping report creation for subresource with empty name", "gvk", resource.GroupVersionKind())
+	if resource.GetName() == "" || resource.GetUID() == "" {
+		c.log.V(3).Info("skipping report creation for subresource with empty name or uid", "gvk", resource.GroupVersionKind())
 		return nil
 	}
 

--- a/pkg/background/generate/controller.go
+++ b/pkg/background/generate/controller.go
@@ -356,6 +356,13 @@ func (c *GenerateController) createReports(
 	resource unstructured.Unstructured,
 	engineResponses ...engineapi.EngineResponse,
 ) error {
+	// Skip report creation for subresources (e.g., pods/exec) as they have empty name/UID.
+	// Subresources don't have their own resources in Kubernetes, so reports cannot be created for them.
+	if resource.GetName() == "" {
+		c.log.V(3).Info("skipping report creation for subresource with empty name", "gvk", resource.GroupVersionKind())
+		return nil
+	}
+
 	report := reportutils.BuildGenerateReport(resource.GetNamespace(), resource.GroupVersionKind(), resource.GetName(), resource.GetUID(), engineResponses...)
 	if len(report.GetResults()) > 0 {
 		err := breaker.GetReportsBreaker().Do(ctx, func(ctx context.Context) error {

--- a/pkg/background/gpol/generate_controller.go
+++ b/pkg/background/gpol/generate_controller.go
@@ -230,10 +230,8 @@ func (c *CELGenerateController) createReports(
 	resource unstructured.Unstructured,
 	engineResponses ...engineapi.EngineResponse,
 ) error {
-	// Skip report creation for subresources (e.g., pods/exec) as they have empty name/UID.
-	// Subresources don't have their own resources in Kubernetes, so reports cannot be created for them.
-	if resource.GetName() == "" {
-		c.log.V(3).Info("skipping report creation for subresource with empty name", "gvk", resource.GroupVersionKind())
+	if resource.GetName() == "" || resource.GetUID() == "" {
+		c.log.V(3).Info("skipping report creation for subresource with empty name or uid", "gvk", resource.GroupVersionKind())
 		return nil
 	}
 

--- a/pkg/background/gpol/generate_controller.go
+++ b/pkg/background/gpol/generate_controller.go
@@ -230,6 +230,13 @@ func (c *CELGenerateController) createReports(
 	resource unstructured.Unstructured,
 	engineResponses ...engineapi.EngineResponse,
 ) error {
+	// Skip report creation for subresources (e.g., pods/exec) as they have empty name/UID.
+	// Subresources don't have their own resources in Kubernetes, so reports cannot be created for them.
+	if resource.GetName() == "" {
+		c.log.V(3).Info("skipping report creation for subresource with empty name", "gvk", resource.GroupVersionKind())
+		return nil
+	}
+
 	report := reportutils.BuildGenerateReport(resource.GetNamespace(), resource.GroupVersionKind(), resource.GetName(), resource.GetUID(), engineResponses...)
 	if len(report.GetResults()) > 0 {
 		err := breaker.GetReportsBreaker().Do(ctx, func(ctx context.Context) error {

--- a/pkg/background/mpol/processor.go
+++ b/pkg/background/mpol/processor.go
@@ -204,6 +204,12 @@ func (p *processor) audit(object *unstructured.Unstructured, response *mpolengin
 		return nil
 	}
 
+	// Skip report creation for subresources (e.g., pods/exec) as they have empty name/UID.
+	// Subresources don't have their own resources in Kubernetes, so reports cannot be created for them.
+	if object.GetName() == "" {
+		return nil
+	}
+
 	report := reportutils.BuildMutateExistingReport(object.GetNamespace(), object.GroupVersionKind(), object.GetName(), object.GetUID(), reportableEngineResponses...)
 	if len(report.GetResults()) > 0 {
 		err := breaker.GetReportsBreaker().Do(context.TODO(), func(ctx context.Context) error {

--- a/pkg/background/mpol/processor.go
+++ b/pkg/background/mpol/processor.go
@@ -203,6 +203,9 @@ func (p *processor) audit(object *unstructured.Unstructured, response *mpolengin
 	if !reportutils.ReportingCfg.MutateExistingReportsEnabled() {
 		return nil
 	}
+	if object.GetName() == "" || object.GetUID() == "" {
+		return nil
+	}
 
 	// Skip report creation for subresources (e.g., pods/exec) as they have empty name/UID.
 	// Subresources don't have their own resources in Kubernetes, so reports cannot be created for them.

--- a/pkg/background/mutate/mutate.go
+++ b/pkg/background/mutate/mutate.go
@@ -274,10 +274,10 @@ func (c *mutateExistingController) createReports(
 	resource unstructured.Unstructured,
 	engineResponses ...engineapi.EngineResponse,
 ) error {
-	// Skip report creation for subresources (e.g., pods/exec) as they have empty name/UID.
-	// Subresources don't have their own resources in Kubernetes, so reports cannot be created for them.
-	if resource.GetName() == "" {
-		c.log.V(3).Info("skipping report creation for subresource with empty name", "gvk", resource.GroupVersionKind())
+	// Skip report creation for resources with incomplete identity metadata (for example subresources such as pods/exec).
+	// Reports require both name and UID; if either is empty, the generated report would be invalid.
+	if resource.GetName() == "" || resource.GetUID() == "" {
+		c.log.V(3).Info("skipping report creation for resource with empty name or UID", "gvk", resource.GroupVersionKind())
 		return nil
 	}
 

--- a/pkg/background/mutate/mutate.go
+++ b/pkg/background/mutate/mutate.go
@@ -274,6 +274,13 @@ func (c *mutateExistingController) createReports(
 	resource unstructured.Unstructured,
 	engineResponses ...engineapi.EngineResponse,
 ) error {
+	// Skip report creation for subresources (e.g., pods/exec) as they have empty name/UID.
+	// Subresources don't have their own resources in Kubernetes, so reports cannot be created for them.
+	if resource.GetName() == "" {
+		c.log.V(3).Info("skipping report creation for subresource with empty name", "gvk", resource.GroupVersionKind())
+		return nil
+	}
+
 	report := reportutils.BuildMutateExistingReport(resource.GetNamespace(), resource.GroupVersionKind(), resource.GetName(), resource.GetUID(), engineResponses...)
 	if len(report.GetResults()) > 0 {
 		err := breaker.GetReportsBreaker().Do(ctx, func(ctx context.Context) error {

--- a/pkg/background/mutate/mutate.go
+++ b/pkg/background/mutate/mutate.go
@@ -277,7 +277,7 @@ func (c *mutateExistingController) createReports(
 	// Skip report creation for resources with incomplete identity metadata (for example subresources such as pods/exec).
 	// Reports require both name and UID; if either is empty, the generated report would be invalid.
 	if resource.GetName() == "" || resource.GetUID() == "" {
-		c.log.V(3).Info("skipping report creation for resource with empty name or UID", "gvk", resource.GroupVersionKind())
+		c.log.V(3).Info("skipping report creation for subresource with empty name or uid", "gvk", resource.GroupVersionKind())
 		return nil
 	}
 


### PR DESCRIPTION
Closes https://github.com/kyverno/kyverno/issues/16113.

Subresources (e.g., pods/exec, pods/logs) have empty name and UID values, which causes EphemeralReport creation to fail with validation errors:
- Invalid generateName (defaults to "-")
- Invalid ownerReferences (empty name and uid)

This fix adds a validation check in the report creation pipeline to detect subresources with empty names and skip report creation for them gracefully. Subresources cannot own other resources in Kubernetes, so report creation is not applicable for them anyway.

Changes made:
- pkg/background/generate/controller.go: Skip report creation in createReports()
- pkg/background/mutate/mutate.go: Skip report creation in createReports()
- pkg/background/gpol/generate_controller.go: Skip report creation in createReports()
- pkg/background/mpol/processor.go: Skip report creation in createReports()

Fixes the error:
```
  EphemeralReport.reports.kyverno.io "-6vbcl" is invalid: [metadata.generateName: Invalid value: "-"] [metadata.ownerReferences.name: Invalid value: "" must not be empty] [metadata.ownerReferences.uid: Invalid value: "" must not be empty]
```