### PR TITLE
feat: add 'create network-policy' command to CLI

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/create/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/create/command.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/command"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/create/exception"
 	metricsconfig "github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/create/metrics-config"
+	networkpolicy "github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/create/network-policy"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/create/role"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/create/test"
 	userinfo "github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/create/user-info"
@@ -30,6 +31,7 @@ func Command() *cobra.Command {
 		userinfo.Command(),
 		values.Command(),
 		role.Command(),
+		networkpolicy.Command(),
 	)
 	return cmd
 }

--- a/cmd/cli/kubectl-kyverno/commands/create/network-policy/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/create/network-policy/command.go
@@ -1,0 +1,63 @@
+package networkpolicy
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/command"
+	"github.com/spf13/cobra"
+)
+
+const netPolTemplate = `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: admission-controller
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: "<API_SERVER_CIDR>"
+    ports:
+    - protocol: TCP
+      port: 9443
+`
+
+func Command() *cobra.Command {
+	var path string
+	var namespace string
+	var name string
+
+	cmd := &cobra.Command{
+		Use:          "network-policy",
+		Short:        command.FormatDescription(true, websiteUrl, false, description...),
+		Long:         command.FormatDescription(false, websiteUrl, false, description...),
+		Example:      command.FormatExamples(examples...),
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			output := cmd.OutOrStdout()
+			if path != "" {
+				file, err := os.Create(path)
+				if err != nil {
+					return err
+				}
+				defer file.Close()
+				output = file
+			}
+			_, err := fmt.Fprintf(output, netPolTemplate, name, namespace)
+			return err
+		},
+	}
+
+	cmd.Flags().StringVarP(&path, "output", "o", "", "Output path (uses standard console output if not set)")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "kyverno", "namespace for the network policy")
+	cmd.Flags().StringVar(&name, "name", "kyverno-admission-controller", "name of the network policy resource")
+
+	return cmd
+}

--- a/cmd/cli/kubectl-kyverno/commands/create/network-policy/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/create/network-policy/command_test.go
@@ -1,0 +1,43 @@
+package networkpolicy
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommand(t *testing.T) {
+	cmd := Command()
+	assert.NotNil(t, cmd)
+	b := bytes.NewBufferString("")
+	cmd.SetOut(b)
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	out, err := io.ReadAll(b)
+	assert.NoError(t, err)
+	assert.True(t, strings.Contains(string(out), "kind: NetworkPolicy"))
+}
+
+func TestCommandWithArgs(t *testing.T) {
+	cmd := Command()
+	assert.NotNil(t, cmd)
+	cmd.SetArgs([]string{"foo"})
+	err := cmd.Execute()
+	assert.Error(t, err)
+}
+
+func TestCommandHelp(t *testing.T) {
+	cmd := Command()
+	assert.NotNil(t, cmd)
+	b := bytes.NewBufferString("")
+	cmd.SetOut(b)
+	cmd.SetArgs([]string{"--help"})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	out, err := io.ReadAll(b)
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(out), cmd.Long))
+}

--- a/cmd/cli/kubectl-kyverno/commands/create/network-policy/doc.go
+++ b/cmd/cli/kubectl-kyverno/commands/create/network-policy/doc.go
@@ -1,0 +1,19 @@
+package networkpolicy
+
+var websiteUrl = `https://kyverno.io/docs/kyverno-cli/#create`
+
+var description = []string{
+	`Create a default NetworkPolicy for Kyverno.`,
+	`This generates the default network policy manifest for Kyverno.`,
+}
+
+var examples = [][]string{
+	{
+		"# Create a network policy and save it to a file",
+		"kyverno create network-policy > kyverno-netpol.yaml",
+	},
+	{
+		"# Print the network policy to stdout",
+		"kyverno create network-policy",
+	},
+}


### PR DESCRIPTION
This PR introduces the create network-policy subcommand to the Kyverno CLI. This feature allows users to easily generate a structured Kubernetes NetworkPolicy specifically tailored to harden and protect the Kyverno admission controller.

The generated policy aligns with the principle of least privilege by restricting incoming ingress traffic strictly to the default Kyverno webhook port (9443) and prompting users to specify their target control plane/API server CIDR block. This addition directly addresses hardening requirements identified in the CNCF security assessment (#15335), providing users with an automated, built-in way to implement recommended network security baselines.

Related Issue
Closes #15335

Documentation
[ ] I have sent the draft PR to update the documentation

What type of PR is this
/kind feature

Proposed Changes
CLI Enhancement: Added network-policy as a new subcommand under the create category.

Dynamic Configuration: Implemented --namespace (default: kyverno) and --name (default: kyverno-admission-controller) flags to allow seamless generation for non-default or custom Kyverno installations.

Workload Target Optimization: Configured the policy's podSelector to match app.kubernetes.io/component: admission-controller. This ensures precise targeting of the admission controller pods and prevents breakages or broad matching across environments deployed via Helm charts.

Inbound Hardening Baseline: Updated the template to reference an explicit <API_SERVER_CIDR> placeholder instead of a permissive 0.0.0.0/0 default, forcing users to explicitly declare secure network baselines.

Testing & Quality: Added unit tests ensuring the subcommand cleanly registers under Cobra, correctly processes or blocks extraneous arguments, and evaluates expected behaviors.

Proof Manifests
CLI Execution
Running the command locally with default flags:

Bash
kubectl-kyverno create network-policy
Generated Output
YAML
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: kyverno-admission-controller
  namespace: kyverno
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/component: admission-controller
  policyTypes:
  - Ingress
  ingress:
  - from:
    - ipBlock:
        cidr: "<API_SERVER_CIDR>"
    ports:
    - protocol: TCP
      port: 9443
Checklist
[x] I have read the contributing guidelines.

[x] I have read the AI Usage Policy. (Assisted-by: Gemini)

[x] This is a feature and I have added CLI tests/unit tests that are applicable.