### PR TITLE
fix:skip unnecessary TUF initialization for static key verification

### DIFF
--- a/pkg/image/verifiers/ivpol/cosign/opts.go
+++ b/pkg/image/verifiers/ivpol/cosign/opts.go
@@ -42,12 +42,37 @@ func countPEMCertBlocks(pem []byte) int {
 	return bytes.Count(pem, pemCertBlockHeader)
 }
 
+func needsTUF(att *v1beta1.Cosign) bool {
+	// Keyless verification always requires TUF
+	if att.Keyless != nil {
+		return true
+	}
+
+	// Certificate verification may require TUF
+	if att.Certificate != nil {
+		return true
+	}
+
+	// Static key verification with ignored tlog/SCT does not require TUF
+	if att.Key != nil &&
+		att.CTLog != nil &&
+		att.CTLog.InsecureIgnoreTlog &&
+		att.CTLog.InsecureIgnoreSCT {
+		return false
+	}
+
+	// Default to requiring TUF
+	return true
+}
+
 func checkOptions(ctx context.Context, att *v1beta1.Cosign, baseROpts []remote.Option, baseNOpts []name.Option, secretLister imagedataloader.SecretInterface) (*cosign.CheckOpts, error) {
 	tufMu.Lock()
 	defer tufMu.Unlock()
 
-	if err := initializeTuf(ctx, att.TUF); err != nil {
-		return nil, err
+	if needsTUF(att) {
+		if err := initializeTuf(ctx, att.TUF); err != nil {
+			return nil, err
+		}
 	}
 	cosignRemoteOpts := []ociremote.Option{}
 
@@ -249,6 +274,7 @@ func sourceRemoteOpts(ctx context.Context, secretLister imagedataloader.SecretIn
 func getRekor(ctx context.Context, ctlog *v1beta1.CTLog) (*client.Rekor, *cosign.TrustedTransparencyLogPubKeys, *cosign.TrustedTransparencyLogPubKeys, error) {
 	// In keyless, if no TrustRoot was defined and CTLog is nil, then default to rekor pub keys as done in cosign
 	if ctlog == nil {
+
 		rekorPubKeys, err := cosign.GetRekorPubs(ctx)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("getting Rekor public keys: %w", err)


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->
## Description
ImageValidatingPolicy initializes TUF unconditionally, even with a static key (with having insecureIgnoreTlog and insecureIgnoreSCT as true) and causing unnecessary access to tuf-repo-cdn.sigstore.dev - this is with static key verification using cosign v2

### Logs

```text
2026-05-07T12:27:15Z ERR github.com/kyverno/kyverno/pkg/imageverification/imageverifiers/cosign/verifier.go:59 > image verification failed
error="failed to initialize TUF"
```

## Related issue
Fixes #16052

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->


## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [x] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->
Skip unnecessary TUF initialization for static-key verification when both `insecureIgnoreTlog` and `insecureIgnoreSCT`
are enabled.

Previously, Kyverno initialized TUF even when verification used a static public key and transparency verification was explicitly disabled, resulting in unnecessary access to Sigstore TUF infrastructure.

This change conditionally skips TUF initialization for that verification flow while preserving existing Rekor handling behavior.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch.
- [ ] My PR contains new or altered behavior to Kyverno and CLI support should be added.

## Further Comments

Package tests were run successfully for:

go test ./pkg/image/verifiers/ivpol/cosign/...
