### PR TITLE
feat(helm): support extraArgs in CRDs migration job

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -275,6 +275,7 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | crds.annotations | object | `{}` | Additional CRDs annotations |
 | crds.customLabels | object | `{}` | Additional CRDs labels |
 | crds.migration.enabled | bool | `true` | Enable CRDs migration using helm post upgrade hook |
+| crds.migration.extraArgs | object | `{}` | Additional CLI flags passed to the migration job |
 | crds.migration.resources | list | `["cleanuppolicies.kyverno.io","clustercleanuppolicies.kyverno.io","clusterpolicies.kyverno.io","globalcontextentries.kyverno.io","policies.kyverno.io","policyexceptions.kyverno.io","updaterequests.kyverno.io","deletingpolicies.policies.kyverno.io","generatingpolicies.policies.kyverno.io","imagevalidatingpolicies.policies.kyverno.io","mutatingpolicies.policies.kyverno.io","namespaceddeletingpolicies.policies.kyverno.io","namespacedgeneratingpolicies.policies.kyverno.io","namespacedimagevalidatingpolicies.policies.kyverno.io","namespacedmutatingpolicies.policies.kyverno.io","namespacedvalidatingpolicies.policies.kyverno.io","policyexceptions.policies.kyverno.io","validatingpolicies.policies.kyverno.io"]` | Resources to migrate |
 | crds.migration.image.registry | string | `nil` | Image registry |
 | crds.migration.image.defaultRegistry | string | `"reg.kyverno.io"` |  |

--- a/charts/kyverno/templates/hooks/post-upgrade-migrate-resources.yaml
+++ b/charts/kyverno/templates/hooks/post-upgrade-migrate-resources.yaml
@@ -117,7 +117,7 @@ spec:
             - {{ . }}
             {{- end }}
             {{- range $key, $value := .Values.crds.migration.extraArgs }}
-            {{- if $value }}
+            {{- if ne $value nil }}
             - --{{ $key }}={{ $value }}
             {{- end }}
             {{- end }}

--- a/charts/kyverno/templates/hooks/post-upgrade-migrate-resources.yaml
+++ b/charts/kyverno/templates/hooks/post-upgrade-migrate-resources.yaml
@@ -116,6 +116,11 @@ spec:
             - --resource
             - {{ . }}
             {{- end }}
+            {{- range $key, $value := .Values.crds.migration.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- end }}
+            {{- end }}
           {{- with .Values.crds.migration.podResources }}
           resources:
             {{- tpl (toYaml .) $ | nindent 12 }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -154,6 +154,10 @@ crds:
     # -- Enable CRDs migration using helm post upgrade hook
     enabled: true
 
+    # -- Additional CLI flags passed to the migration job
+    extraArgs: {}
+      # loggingFormat: json
+
     # -- Resources to migrate
     resources:
       - cleanuppolicies.kyverno.io

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -156,7 +156,6 @@ crds:
 
     # -- Additional CLI flags passed to the migration job
     extraArgs: {}
-      # loggingFormat: json
 
     # -- Resources to migrate
     resources:


### PR DESCRIPTION
## Explanation

This PR adds support for `crds.migration.extraArgs` in the post-upgrade CRDs migration Job.

Previously, the migration Job arguments were hardcoded and users could not pass flags such as `--loggingFormat=json`. This caused the migration Job to emit text logs even when other Kyverno controllers were configured for JSON logging.

## Related issue
Fixes #16098

## Milestone of this PR
N/A

## Documentation (required for features)
This change adds the new Helm value in `charts/kyverno/values.yaml`:

crds:
  migration:
    extraArgs: {}

I have not opened a separate documentation PR because this is a Helm chart values addition documented directly in `values.yaml`.

My PR contains new or altered behavior to Kyverno. 
- [ x] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind feature

## Proposed Changes

- Added `crds.migration.extraArgs` support in `charts/kyverno/templates/hooks/post-upgrade-migrate-resources.yaml`

- Added the documented default value in `charts/kyverno/values.yaml`

- Mirrored the existing `extraArgs` rendering pattern used by other Kyverno controllers

### Proof Manifests
Command used:

helm template kyverno ./charts/kyverno \
  --set crds.migration.enabled=true \
  --set crds.migration.extraArgs.loggingFormat=json \
  --set crds.migration.extraArgs.v=2

Rendered output from the migration Job:
```

args:
  - migrate
  - --resource
  - cleanuppolicies.kyverno.io
  - --resource
  - clustercleanuppolicies.kyverno.io
  - --resource
  - clusterpolicies.kyverno.io
  - --loggingFormat=json
  - --v=2
```
Validation:

helm lint ./charts/kyverno

Result:

1 chart(s) linted, 0 chart(s) failed

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments
This change is chart-only. The `kyverno migrate` command already supports `--loggingFormat`; this PR only exposes a Helm values path to pass that existing flag to the migration Job.
