### PR TITLE
feat(helm): add optional PrometheusRule template

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -915,6 +915,11 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | imagePullSecrets | object | `{}` | Image pull secrets for image verification policies, this will define the `--imagePullSecrets` argument |
 | existingImagePullSecrets | list | `[]` | Existing Image pull secrets for image verification policies, this will define the `--imagePullSecrets` argument |
 | customLabels | object | `{}` | Additional labels |
+| prometheusRule.enabled | bool | `false` | Enable PrometheusRule resource creation. Requires prometheus-operator (monitoring.coreos.com/v1 CRD) to be installed — the same prerequisite as serviceMonitor.enabled. The resource is only created when `enabled: true` and `spec` is non-empty. |
+| prometheusRule.namespace | string | `nil` | Namespace to create the PrometheusRule in. If not set, it will be created in the same namespace as the chart. |
+| prometheusRule.additionalAnnotations | object | `{}` | Additional annotations to add to the PrometheusRule. |
+| prometheusRule.additionalLabels | object | `{}` | Additional labels to add to the PrometheusRule. Must match the `ruleSelector` configured on your Prometheus instance (e.g. `release: prometheus` for kube-prometheus-stack). |
+| prometheusRule.spec | list | `[]` | Alert rule groups. Provide your own rules here; the examples below use Kyverno's histogram metrics and can serve as starting points. Thresholds MUST be tuned to your environment's measured baseline — see https://kyverno.io/docs/guides/monitoring/#alerting for guidance. |
 
 ## TLS Configuration
 

--- a/charts/kyverno/ci/monitoring-values.yaml
+++ b/charts/kyverno/ci/monitoring-values.yaml
@@ -29,3 +29,21 @@ reportsController:
 
 grafana:
   enabled: true
+
+prometheusRule:
+  enabled: true
+  additionalLabels:
+    release: prometheus
+  spec:
+    - name: kyverno.admission
+      rules:
+      - alert: KyvernoAdmissionHighLatency
+        expr: |
+          histogram_quantile(0.99,
+            sum(rate(kyverno_admission_review_duration_seconds_bucket[5m])) by (le)
+          ) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Kyverno admission review p99 latency is elevated

--- a/charts/kyverno/ci/monitoring-values.yaml
+++ b/charts/kyverno/ci/monitoring-values.yaml
@@ -37,13 +37,13 @@ prometheusRule:
   spec:
     - name: kyverno.admission
       rules:
-      - alert: KyvernoAdmissionHighLatency
-        expr: |
-          histogram_quantile(0.99,
-            sum(rate(kyverno_admission_review_duration_seconds_bucket[5m])) by (le)
-          ) > 1
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: Kyverno admission review p99 latency is elevated
+        - alert: KyvernoAdmissionHighLatency
+          expr: |
+            histogram_quantile(0.99,
+              sum(rate(kyverno_admission_review_duration_seconds_bucket[5m])) by (le)
+            ) > 1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Kyverno admission review p99 latency is elevated

--- a/charts/kyverno/templates/prometheusrule.yaml
+++ b/charts/kyverno/templates/prometheusrule.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.prometheusRule.enabled .Values.prometheusRule.spec }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "kyverno.fullname" . }}
+  {{- if .Values.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheusRule.namespace }}
+  {{- else }}
+  namespace: {{ template "kyverno.namespace" . }}
+  {{- end }}
+  {{- with .Values.prometheusRule.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "kyverno.labels.common" . | nindent 4 }}
+    {{- with .Values.prometheusRule.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+  {{- toYaml .Values.prometheusRule.spec | nindent 4 }}
+{{- end }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -742,6 +742,78 @@ grafana:
     matchLabels:
       dashboards: "grafana"
 
+prometheusRule:
+  # -- Enable PrometheusRule resource creation.
+  # Requires prometheus-operator (monitoring.coreos.com/v1 CRD) to be installed —
+  # the same prerequisite as serviceMonitor.enabled.
+  # The resource is only created when `enabled: true` and `spec` is non-empty.
+  enabled: false
+
+  # -- (string) Namespace to create the PrometheusRule in.
+  # If not set, it will be created in the same namespace as the chart.
+  namespace: ~
+
+  # -- Additional annotations to add to the PrometheusRule.
+  additionalAnnotations: {}
+
+  # -- Additional labels to add to the PrometheusRule.
+  # Must match the `ruleSelector` configured on your Prometheus instance
+  # (e.g. `release: prometheus` for kube-prometheus-stack).
+  additionalLabels: {}
+
+  # -- Alert rule groups. Provide your own rules here; the examples below use
+  # Kyverno's histogram metrics and can serve as starting points.
+  # Thresholds MUST be tuned to your environment's measured baseline —
+  # see https://kyverno.io/docs/guides/monitoring/#alerting for guidance.
+  spec: []
+  # spec:
+  #   - name: kyverno.admission
+  #     rules:
+  #     - alert: KyvernoAdmissionHighLatency
+  #       expr: |
+  #         histogram_quantile(0.99,
+  #           sum(rate(kyverno_admission_review_duration_seconds_bucket[5m])) by (le)
+  #         ) > 1
+  #       for: 5m
+  #       labels:
+  #         severity: warning
+  #       annotations:
+  #         summary: Kyverno admission review p99 latency is elevated
+  #         description: >-
+  #           Admission review p99 latency is {{ $value | humanizeDuration }},
+  #           above the 1s threshold. Kubernetes webhooks hard-timeout at 10s.
+  #         runbook_url: https://kyverno.io/docs/guides/monitoring/#admission-latency-high
+  #     - alert: KyvernoAdmissionCriticalLatency
+  #       expr: |
+  #         histogram_quantile(0.99,
+  #           sum(rate(kyverno_admission_review_duration_seconds_bucket[5m])) by (le)
+  #         ) > 5
+  #       for: 5m
+  #       labels:
+  #         severity: critical
+  #       annotations:
+  #         summary: Kyverno admission review p99 latency is critically high
+  #         description: >-
+  #           Admission review p99 latency is {{ $value | humanizeDuration }},
+  #           above 5s. Kubernetes webhooks hard-timeout at 10s.
+  #         runbook_url: https://kyverno.io/docs/guides/monitoring/#admission-latency-high
+  #   - name: kyverno.policy
+  #     rules:
+  #     - alert: KyvernoPolicyExecutionHighLatency
+  #       expr: |
+  #         histogram_quantile(0.99,
+  #           sum(rate(kyverno_policy_execution_duration_seconds_bucket[5m])) by (le, rule_type)
+  #         ) > 0.5
+  #       for: 5m
+  #       labels:
+  #         severity: warning
+  #       annotations:
+  #         summary: Kyverno policy execution p99 latency is elevated
+  #         description: >-
+  #           {{ $labels.rule_type }} rule p99 execution latency is
+  #           {{ $value | humanizeDuration }}.
+  #         runbook_url: https://kyverno.io/docs/guides/monitoring/#policy-execution-latency-high
+
 # Features configuration
 features:
   admissionReports:

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -769,50 +769,50 @@ prometheusRule:
   # spec:
   #   - name: kyverno.admission
   #     rules:
-  #     - alert: KyvernoAdmissionHighLatency
-  #       expr: |
-  #         histogram_quantile(0.99,
-  #           sum(rate(kyverno_admission_review_duration_seconds_bucket[5m])) by (le)
-  #         ) > 1
-  #       for: 5m
-  #       labels:
-  #         severity: warning
-  #       annotations:
-  #         summary: Kyverno admission review p99 latency is elevated
-  #         description: >-
-  #           Admission review p99 latency is {{ $value | humanizeDuration }},
-  #           above the 1s threshold. Kubernetes webhooks hard-timeout at 10s.
-  #         runbook_url: https://kyverno.io/docs/guides/monitoring/#admission-latency-high
-  #     - alert: KyvernoAdmissionCriticalLatency
-  #       expr: |
-  #         histogram_quantile(0.99,
-  #           sum(rate(kyverno_admission_review_duration_seconds_bucket[5m])) by (le)
-  #         ) > 5
-  #       for: 5m
-  #       labels:
-  #         severity: critical
-  #       annotations:
-  #         summary: Kyverno admission review p99 latency is critically high
-  #         description: >-
-  #           Admission review p99 latency is {{ $value | humanizeDuration }},
-  #           above 5s. Kubernetes webhooks hard-timeout at 10s.
-  #         runbook_url: https://kyverno.io/docs/guides/monitoring/#admission-latency-high
+  #       - alert: KyvernoAdmissionHighLatency
+  #         expr: |
+  #           histogram_quantile(0.99,
+  #             sum(rate(kyverno_admission_review_duration_seconds_bucket[5m])) by (le)
+  #           ) > 1
+  #         for: 5m
+  #         labels:
+  #           severity: warning
+  #         annotations:
+  #           summary: Kyverno admission review p99 latency is elevated
+  #           description: >-
+  #             Admission review p99 latency is {{ $value | humanizeDuration }},
+  #             above the 1s threshold. Kubernetes webhooks hard-timeout at 10s.
+  #           runbook_url: https://kyverno.io/docs/guides/monitoring/#admission-latency-high
+  #       - alert: KyvernoAdmissionCriticalLatency
+  #         expr: |
+  #           histogram_quantile(0.99,
+  #             sum(rate(kyverno_admission_review_duration_seconds_bucket[5m])) by (le)
+  #           ) > 5
+  #         for: 5m
+  #         labels:
+  #           severity: critical
+  #         annotations:
+  #           summary: Kyverno admission review p99 latency is critically high
+  #           description: >-
+  #             Admission review p99 latency is {{ $value | humanizeDuration }},
+  #             above 5s. Kubernetes webhooks hard-timeout at 10s.
+  #           runbook_url: https://kyverno.io/docs/guides/monitoring/#admission-latency-high
   #   - name: kyverno.policy
   #     rules:
-  #     - alert: KyvernoPolicyExecutionHighLatency
-  #       expr: |
-  #         histogram_quantile(0.99,
-  #           sum(rate(kyverno_policy_execution_duration_seconds_bucket[5m])) by (le, rule_type)
-  #         ) > 0.5
-  #       for: 5m
-  #       labels:
-  #         severity: warning
-  #       annotations:
-  #         summary: Kyverno policy execution p99 latency is elevated
-  #         description: >-
-  #           {{ $labels.rule_type }} rule p99 execution latency is
-  #           {{ $value | humanizeDuration }}.
-  #         runbook_url: https://kyverno.io/docs/guides/monitoring/#policy-execution-latency-high
+  #       - alert: KyvernoPolicyExecutionHighLatency
+  #         expr: |
+  #           histogram_quantile(0.99,
+  #             sum(rate(kyverno_policy_execution_duration_seconds_bucket[5m])) by (le, rule_type)
+  #           ) > 0.5
+  #         for: 5m
+  #         labels:
+  #           severity: warning
+  #         annotations:
+  #           summary: Kyverno policy execution p99 latency is elevated
+  #           description: >-
+  #             {{ $labels.rule_type }} rule p99 execution latency is
+  #             {{ $value | humanizeDuration }}.
+  #           runbook_url: https://kyverno.io/docs/guides/monitoring/#policy-execution-latency-high
 
 # Features configuration
 features:


### PR DESCRIPTION
Adds an opt-in `PrometheusRule` resource to the Helm chart (disabled by default, requires prometheus-operator).

Operators supply their own alert rules via `prometheusRule.spec`; commented-out example rules for admission latency and policy execution latency are provided in `values.yaml` as starting points to tune.

- `charts/kyverno/templates/prometheusrule.yaml` — new template
- `charts/kyverno/values.yaml` — `prometheusRule` section with `enabled`, `namespace`, `additionalAnnotations`, `additionalLabels`, `spec`
- `charts/kyverno/ci/monitoring-values.yaml` — exercises the template in CI
- `charts/kyverno/README.md` — regenerated via `make codegen-helm-docs`