### PR TITLE
test: add test coverage for updaterequest.go

### DIFF
--- a/pkg/policy/updaterequest_test.go
+++ b/pkg/policy/updaterequest_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func makeUR(n int) *kyvernov2.UpdateRequest {
@@ -154,7 +155,7 @@ func Test_newMutateUR(t *testing.T) {
 				Namespace:  "default",
 				Name:       "test-pod",
 				APIVersion: "v1",
-				UID:        "abc-123",
+				UID:        types.UID("abc-123"),
 			},
 		},
 		{

--- a/pkg/policy/updaterequest_test.go
+++ b/pkg/policy/updaterequest_test.go
@@ -183,6 +183,30 @@ func Test_newMutateUR(t *testing.T) {
 					t.Errorf("Labels[%q]: %q, want: %q", k, gotVal, wantLabel)
 				}
 			}
+		    if gotVal, ok := result.Labels[kyvernov2.URMutatePolicyLabel]; !ok {
+				t.Errorf("Labels missing key %q", kyvernov2.URMutatePolicyLabel)
+			} else if gotVal != policyKey(tt.policy) {
+				t.Errorf("Labels[%q]: %q, want: %q", kyvernov2.URMutatePolicyLabel,
+				gotVal, policyKey(tt.policy))
+			}
+			if gotVal, ok := result.Labels[kyvernov2.URMutateTriggerKindLabel]; !ok {
+				t.Errorf("Labels missing key %q", kyvernov2.URMutateTriggerKindLabel)
+			} else if gotVal != tt.trigger.GetKind() {
+				t.Errorf("Labels[%q]: %q, want: %q", kyvernov2.URMutateTriggerKindLabel,
+				gotVal, tt.trigger.GetKind())
+			}
+			if gotVal, ok := result.Labels[kyvernov2.URMutateTriggerNSLabel]; !ok {
+				t.Errorf("Labels missing key %q", kyvernov2.URMutateTriggerNSLabel)
+			} else if gotVal != tt.trigger.GetNamespace() {
+				t.Errorf("Labels[%q]: %q, want: %q", kyvernov2.URMutateTriggerNSLabel,
+				gotVal, tt.trigger.GetNamespace())
+			}
+			if gotVal, ok := result.Labels[kyvernov2.URMutateTriggerNameLabel]; !ok {
+				t.Errorf("Labels missing key %q", kyvernov2.URMutateTriggerNameLabel)
+			} else if gotVal != tt.trigger.GetName() {
+				t.Errorf("Labels[%q]: %q, want: %q", kyvernov2.URMutateTriggerNameLabel,
+				gotVal, tt.trigger.GetName())
+			}
 
 			// every field from trigger
 			res := result.Spec.Resource
@@ -227,13 +251,11 @@ func Test_newGenerateUR(t *testing.T) {
 			assert.Equal(t, tt.wantPolicy, result.Spec.Policy)
 
 			// labels
-			wantLabels := common.GenerateLabelsSet(tt.wantPolicy)
-			for k, wantVal := range wantLabels {
-				if gotVal, ok := result.Labels[k]; !ok {
-					t.Errorf("Labels missing key %q", k)
-				} else if gotVal != wantVal {
-					t.Errorf("Labels[%q]: %q, want: %q", k, gotVal, wantVal)
-				}
+			if gotVal, ok := result.Labels[kyvernov2.URGeneratePolicyLabel]; !ok {
+				t.Errorf("Labels missing key %q", kyvernov2.URGeneratePolicyLabel)
+			} else if gotVal != tt.wantPolicy {
+				t.Errorf("Labels[%q]: %q, want: %q", kyvernov2.URGeneratePolicyLabel,
+				gotVal, tt.wantPolicy)
 			}
 		})
 	}

--- a/pkg/policy/updaterequest_test.go
+++ b/pkg/policy/updaterequest_test.go
@@ -185,27 +185,27 @@ func Test_newMutateUR(t *testing.T) {
 			}
 		    if gotVal, ok := result.Labels[kyvernov2.URMutatePolicyLabel]; !ok {
 				t.Errorf("Labels missing key %q", kyvernov2.URMutatePolicyLabel)
-			} else if gotVal != policyKey(tt.policy) {
+			} else if gotVal != tt.policy.GetName() {
 				t.Errorf("Labels[%q]: %q, want: %q", kyvernov2.URMutatePolicyLabel,
-				gotVal, policyKey(tt.policy))
+					gotVal, tt.policy.GetName())
 			}
 			if gotVal, ok := result.Labels[kyvernov2.URMutateTriggerKindLabel]; !ok {
 				t.Errorf("Labels missing key %q", kyvernov2.URMutateTriggerKindLabel)
 			} else if gotVal != tt.trigger.GetKind() {
 				t.Errorf("Labels[%q]: %q, want: %q", kyvernov2.URMutateTriggerKindLabel,
-				gotVal, tt.trigger.GetKind())
+					gotVal, tt.trigger.GetKind())
 			}
 			if gotVal, ok := result.Labels[kyvernov2.URMutateTriggerNSLabel]; !ok {
 				t.Errorf("Labels missing key %q", kyvernov2.URMutateTriggerNSLabel)
 			} else if gotVal != tt.trigger.GetNamespace() {
 				t.Errorf("Labels[%q]: %q, want: %q", kyvernov2.URMutateTriggerNSLabel,
-				gotVal, tt.trigger.GetNamespace())
+					gotVal, tt.trigger.GetNamespace())
 			}
 			if gotVal, ok := result.Labels[kyvernov2.URMutateTriggerNameLabel]; !ok {
 				t.Errorf("Labels missing key %q", kyvernov2.URMutateTriggerNameLabel)
 			} else if gotVal != tt.trigger.GetName() {
 				t.Errorf("Labels[%q]: %q, want: %q", kyvernov2.URMutateTriggerNameLabel,
-				gotVal, tt.trigger.GetName())
+					gotVal, tt.trigger.GetName())
 			}
 
 			// every field from trigger
@@ -255,7 +255,7 @@ func Test_newGenerateUR(t *testing.T) {
 				t.Errorf("Labels missing key %q", kyvernov2.URGeneratePolicyLabel)
 			} else if gotVal != tt.wantPolicy {
 				t.Errorf("Labels[%q]: %q, want: %q", kyvernov2.URGeneratePolicyLabel,
-				gotVal, tt.wantPolicy)
+					gotVal, tt.wantPolicy)
 			}
 		})
 	}

--- a/pkg/policy/updaterequest_test.go
+++ b/pkg/policy/updaterequest_test.go
@@ -7,6 +7,7 @@ import (
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
 	common "github.com/kyverno/kyverno/pkg/background/common"
+	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -124,4 +125,124 @@ func TestFilterTriggersByNamespace(t *testing.T) {
 	assert.Len(t, filtered, 2)
 	assert.Equal(t, "dep-a", filtered[0].GetName())
 	assert.Equal(t, "team-a", filtered[1].GetName())
+}
+
+func makeClusterPolicyForUR(name string, rules []kyvernov1.Rule) *kyvernov1.ClusterPolicy {
+	return &kyvernov1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: kyvernov1.Spec{
+			Rules: rules,
+		},
+	}
+}
+
+func Test_newMutateUR(t *testing.T) {
+	tests := []struct {
+		name     string
+		policy   kyvernov1.PolicyInterface
+		trigger  kyvernov1.ResourceSpec
+		ruleName string
+	}{
+		{
+			name:     "Successfully creates a mutate UpdateRequest",
+			policy:   makeClusterPolicyForUR("test-policy", nil),
+			ruleName: "check-pod-labels",
+			trigger: kyvernov1.ResourceSpec{
+				Kind:       "Pod",
+				Namespace:  "default",
+				Name:       "test-pod",
+				APIVersion: "v1",
+				UID:        "abc-123",
+			},
+		},
+		{
+			name:     "empty trigger fields enforcing policy without panicking",
+			policy:   makeClusterPolicyForUR("test-policy", nil),
+			ruleName: "check-empty-fields",
+			trigger:  kyvernov1.ResourceSpec{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := newMutateUR(tt.policy, tt.trigger, tt.ruleName)
+
+			assert.Equal(t, kyvernov2.Mutate, result.Spec.Type)
+			assert.Equal(t, tt.ruleName, result.Spec.Rule)
+			assert.Equal(t, policyKey(tt.policy), result.Spec.Policy)
+
+			// labels
+			wantLabels := common.MutateLabelsSet(policyKey(tt.policy), tt.trigger)
+			for k, wantLabel := range wantLabels {
+				if gotVal, ok := result.Labels[k]; !ok {
+					t.Errorf("Labels missing key %q", k)
+				} else if gotVal != wantLabel {
+					t.Errorf("Labels[%q]: %q, want: %q", k, gotVal, wantLabel)
+				}
+			}
+
+			// every field from trigger
+			res := result.Spec.Resource
+			assert.Equal(t, tt.trigger.GetKind(), res.Kind)
+			assert.Equal(t, tt.trigger.GetNamespace(), res.Namespace)
+			assert.Equal(t, tt.trigger.GetName(), res.Name)
+			assert.Equal(t, tt.trigger.GetAPIVersion(), res.APIVersion)
+			assert.Equal(t, tt.trigger.GetUID(), res.UID)
+		})
+	}
+}
+
+func Test_newGenerateUR(t *testing.T) {
+	tests := []struct {
+		name       string
+		policy     engineapi.GenericPolicy
+		wantPolicy string
+		wantType   kyvernov2.RequestType
+	}{
+		{
+			name:       "cluster policy: Spec.Policy is the bare policy name",
+			policy:     engineapi.NewKyvernoPolicy(makeClusterPolicyForUR("my-cluster-policy", nil)),
+			wantPolicy: "my-cluster-policy",
+			wantType:   kyvernov2.Generate,
+		},
+		{
+			name: "generating policy sets Type to CELGenerate",
+			policy: engineapi.NewGeneratingPolicy(&policiesv1beta1.GeneratingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-celpolicy",
+				},
+			}),
+			wantPolicy: "test-celpolicy",
+			wantType:   kyvernov2.CELGenerate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := newGenerateUR(tt.policy)
+			assert.Equal(t, tt.wantType, result.Spec.Type)
+			assert.Equal(t, tt.wantPolicy, result.Spec.Policy)
+
+			// labels
+			wantLabels := common.GenerateLabelsSet(tt.wantPolicy)
+			for k, wantVal := range wantLabels {
+				if gotVal, ok := result.Labels[k]; !ok {
+					t.Errorf("Labels missing key %q", k)
+				} else if gotVal != wantVal {
+					t.Errorf("Labels[%q]: %q, want: %q", k, gotVal, wantVal)
+				}
+			}
+		})
+	}
+}
+
+func Test_newUrMeta(t *testing.T) {
+	result := newUrMeta()
+
+	assert.Equal(t, "UpdateRequest", result.Kind)
+	assert.Equal(t, "ur-", result.GenerateName)
+	assert.Equal(t, config.KyvernoNamespace(), result.Namespace)
+	assert.Equal(t, kyvernov2.SchemeGroupVersion.String(), result.APIVersion)
 }

--- a/pkg/policy/updaterequest_test.go
+++ b/pkg/policy/updaterequest_test.go
@@ -183,7 +183,7 @@ func Test_newMutateUR(t *testing.T) {
 					t.Errorf("Labels[%q]: %q, want: %q", k, gotVal, wantLabel)
 				}
 			}
-		    if gotVal, ok := result.Labels[kyvernov2.URMutatePolicyLabel]; !ok {
+			if gotVal, ok := result.Labels[kyvernov2.URMutatePolicyLabel]; !ok {
 				t.Errorf("Labels missing key %q", kyvernov2.URMutatePolicyLabel)
 			} else if gotVal != tt.policy.GetName() {
 				t.Errorf("Labels[%q]: %q, want: %q", kyvernov2.URMutatePolicyLabel,


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->
This PR introduces unit testing for the functions in `updaterequest.go` file in `pkg/policy`.

## Description

It ensures that the base UR metadata, mutation URs, and generation URs are constructed correctly.

**newUrMeta**: Added baseline tests to verify the default UR template correctly sets `TypeMeta` and `ObjectMeta`

**newMutateUR**: Added unit tests to validate the proper construction of mutation-specific update requests.

**newGenerateUR**: 

1. Verifies `kyvernov1.ClusterPolicy` inputs correctly set the UR Type to `Generate`.
2. Verifies `policiesv1beta1.GeneratingPolicy` inputs correctly set the UR Type to `CELGenerate`.

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

- **Before**: 3.4% coverage in pkg/policy
- **After**  : 6.2% coverage in pkg/policy (+2.8%)

## Testing

> go test ./pkg/policy -v -run "Test_new"

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
