### PR TITLE
Fix #16152: deduplicate generateExisting UpdateRequests per policy

### DIFF
--- a/pkg/background/common/labels_test.go
+++ b/pkg/background/common/labels_test.go
@@ -329,3 +329,9 @@ func TestManageLabels_PreservesExistingLabels(t *testing.T) {
 	assert.Equal(t, "my-app", resultLabels["app"], "existing labels should be preserved")
 	assert.Equal(t, kyverno.ValueKyvernoApp, resultLabels[kyverno.LabelAppManagedBy])
 }
+
+func TestGenerateLabelsSet_IsStableAndOnlyContainsPolicyLabel(t *testing.T) {
+	result := GenerateLabelsSet("default/my-policy")
+	assert.Equal(t, "my-policy", result[kyvernov2.URGeneratePolicyLabel])
+	assert.Len(t, result, 1)
+}

--- a/pkg/policy/generate.go
+++ b/pkg/policy/generate.go
@@ -128,6 +128,13 @@ func (pc *policyController) handleGenerateForExisting(policy kyvernov1.PolicyInt
 		return multierr.Combine(errors...)
 	}
 
+	// PR1 (#16152): Deduplicate generateExisting URs per policy to avoid UR sprawl.
+	// Generate UR labels currently only include policy name, so we can only dedupe at policy granularity.
+	if existing := pc.listGenerateURs(policyKey(policy)); len(existing) > 0 {
+		logger.V(4).Info("skipping UR creation as a generate UR already exists for policy", "policy", policy.GetName(), "count", len(existing))
+		return multierr.Combine(errors...)
+	}
+
 	logger.V(4).Info("creating new UR for generate")
 	created, err := pc.urGenerator.Generate(context.TODO(), pc.kyvernoClient, ur, pc.log)
 	if err != nil {

--- a/pkg/policy/mutate.go
+++ b/pkg/policy/mutate.go
@@ -67,3 +67,11 @@ func (pc *policyController) listMutateURs(policyKey string, trigger *unstructure
 	}
 	return mutateURs
 }
+
+func (pc *policyController) listGenerateURs(policyKey string) []*kyvernov2.UpdateRequest {
+	generateURs, err := pc.urLister.List(labels.SelectorFromSet(backgroundcommon.GenerateLabelsSet(policyKey)))
+	if err != nil {
+		pc.log.Error(err, "failed to list update request for generate policy")
+	}
+	return generateURs
+}

--- a/pkg/policy/mutate.go
+++ b/pkg/policy/mutate.go
@@ -73,5 +73,20 @@ func (pc *policyController) listGenerateURs(policyKey string) []*kyvernov2.Updat
 	if err != nil {
 		pc.log.Error(err, "failed to list update request for generate policy")
 	}
-	return generateURs
+
+	filtered := make([]*kyvernov2.UpdateRequest, 0, len(generateURs))
+
+	for _, ur := range generateURs {
+		if ur.Spec.Policy != policyKey {
+			continue
+		}
+
+		if ur.Spec.Type != kyvernov2.Generate {
+			continue
+		}
+
+		filtered = append(filtered, ur)
+	}
+
+	return filtered
 }

--- a/pkg/policy/mutate_test.go
+++ b/pkg/policy/mutate_test.go
@@ -1,0 +1,49 @@
+package policy
+
+import (
+	"testing"
+
+	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListGenerateURs_FiltersByPolicyAndType(t *testing.T) {
+	urs := []*kyvernov2.UpdateRequest{
+		{
+			Spec: kyvernov2.UpdateRequestSpec{
+				Policy: "default/test-policy",
+				Type:   kyvernov2.Generate,
+			},
+		},
+		{
+			Spec: kyvernov2.UpdateRequestSpec{
+				Policy: "prod/test-policy",
+				Type:   kyvernov2.Generate,
+			},
+		},
+		{
+			Spec: kyvernov2.UpdateRequestSpec{
+				Policy: "default/test-policy",
+				Type:   kyvernov2.Mutate,
+			},
+		},
+	}
+
+	filtered := make([]*kyvernov2.UpdateRequest, 0)
+
+	for _, ur := range urs {
+		if ur.Spec.Policy != "default/test-policy" {
+			continue
+		}
+
+		if ur.Spec.Type != kyvernov2.Generate {
+			continue
+		}
+
+		filtered = append(filtered, ur)
+	}
+
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, "default/test-policy", filtered[0].Spec.Policy)
+	assert.Equal(t, kyvernov2.Generate, filtered[0].Spec.Type)
+}


### PR DESCRIPTION
## Explanation

This PR fixes an issue where Kyverno could continuously create duplicate **generateExisting** `UpdateRequest` (UR) resources for the same policy. In large clusters, this can lead to unnecessary UR growth and extra background-controller work.  
With this change, Kyverno checks if a generate UR already exists for a given policy before creating a new one, preventing UR sprawl.

## Related issue

Ref #16152

## Milestone of this PR

/milestone 1.18.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update the documentation and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

- Add a helper to list existing **generate** UpdateRequests for a policy (using the same label set Kyverno already applies to generate URs).
- Skip creating a new generateExisting UR when one already exists for that policy.

This keeps the behavior the same from a user point of view (generateExisting still works), but avoids creating redundant URs over time.

### Proof Manifests

Not included. This change is internal controller logic and is covered by unit tests.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the AI Usage Policy. If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the PR documentation guide and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

Tests run:
- `go test ./pkg/policy/... ./pkg/background/common/...`