### PR TITLE
fix(cli): allow multiple CRDs in to be in the --crd-path file

### DIFF
--- a/cmd/cli/kubectl-kyverno/_testdata/apply/test-4/crd/crds.yml
+++ b/cmd/cli/kubectl-kyverno/_testdata/apply/test-4/crd/crds.yml
@@ -1,0 +1,113 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.example.com
+spec:
+  group: example.com
+  names:
+    plural: foos
+    singular: foo
+    kind: Foo
+    shortNames:
+      - foo
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                containers:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      image:
+                        type: string
+                      resources:
+                        type: object
+                        properties:
+                          limits:
+                            type: object
+                            properties:
+                              memory:
+                                type: string
+                              cpu:
+                                type: string
+                          requests:
+                            type: object
+                            properties:
+                              memory:
+                                type: string
+                              cpu:
+                                type: string
+            status:
+              type: object
+              properties:
+                # Add status fields here if needed
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bars.example.com
+spec:
+  group: example.com
+  names:
+    plural: bars
+    singular: bar
+    kind: Bar
+    shortNames:
+      - foo
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                containers:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      image:
+                        type: string
+                      resources:
+                        type: object
+                        properties:
+                          limits:
+                            type: object
+                            properties:
+                              memory:
+                                type: string
+                              cpu:
+                                type: string
+                          requests:
+                            type: object
+                            properties:
+                              memory:
+                                type: string
+                              cpu:
+                                type: string
+            status:
+              type: object
+              properties:
+                # Add status fields here if needed
+      subresources:
+        status: {}

--- a/cmd/cli/kubectl-kyverno/_testdata/apply/test-4/crd/crds.yml
+++ b/cmd/cli/kubectl-kyverno/_testdata/apply/test-4/crd/crds.yml
@@ -66,7 +66,7 @@ spec:
     singular: bar
     kind: Bar
     shortNames:
-      - foo
+      - bar
   scope: Namespaced
   versions:
     - name: v1

--- a/cmd/cli/kubectl-kyverno/_testdata/apply/test-4/resource-validating-policy/policy.yml
+++ b/cmd/cli/kubectl-kyverno/_testdata/apply/test-4/resource-validating-policy/policy.yml
@@ -1,0 +1,23 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: require-container-resources
+spec:
+  validations:
+    - message: "Resource limits and requests are required for all containers in Foo or Bar"
+      expression: >
+        object.spec.containers.all(c, 
+          has(c.resources) && 
+          has(c.resources.limits) &&
+          has(c.resources.limits.memory) && 
+          has(c.resources.limits.cpu) && 
+          has(c.resources.requests) &&
+          has(c.resources.requests.memory) && 
+          has(c.resources.requests.cpu)
+        )
+  matchConstraints:
+    resourceRules:
+      - operations: ["CREATE", "UPDATE"] # Specify operations
+        apiGroups: ["example.com"]
+        apiVersions: ["v1"]
+        resources: ["foos", "bars"]

--- a/cmd/cli/kubectl-kyverno/_testdata/apply/test-4/resources/bar.yml
+++ b/cmd/cli/kubectl-kyverno/_testdata/apply/test-4/resources/bar.yml
@@ -1,0 +1,14 @@
+apiVersion: "example.com/v1"
+kind: Bar
+metadata:
+  name: test-bar
+spec:
+  containers:
+    - name: foo
+      resources:
+        limits:
+          memory: "128Mi"
+          cpu: "500m"
+        requests:
+          memory: "64Mi"
+          cpu: "250m"

--- a/cmd/cli/kubectl-kyverno/_testdata/apply/test-4/resources/foo.yml
+++ b/cmd/cli/kubectl-kyverno/_testdata/apply/test-4/resources/foo.yml
@@ -1,0 +1,14 @@
+apiVersion: "example.com/v1"
+kind: Foo
+metadata:
+  name: test-foo
+spec:
+  containers:
+    - name: foo
+      resources:
+        limits:
+          memory: "128Mi"
+          cpu: "500m"
+        requests:
+          memory: "64Mi"
+          cpu: "250m"

--- a/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
@@ -1291,7 +1291,8 @@ func verifyTestcase(t *testing.T, tc *TestCase, compareSummary func(*testing.T, 
 			_ = input.Close()
 		}()
 	}
-	desc := fmt.Sprintf("Policies: [%s], / Resources: [%s], JSON payload: [%s]",
+	desc := fmt.Sprintf(
+		"Policies: [%s], / Resources: [%s], JSON payload: [%s]",
 		strings.Join(tc.config.PolicyPaths, ","),
 		strings.Join(tc.config.ResourcePaths, ","),
 		strings.Join(tc.config.JSONPaths, ","),
@@ -1491,6 +1492,34 @@ func Test_Apply_ValidatingPoliciesWithCRD(t *testing.T) {
 	}
 }
 
+func Test_Apply_ValidatingPoliciesWithMultipleCRDS(t *testing.T) {
+	testcases := []*TestCase{
+		{
+			config: ApplyCommandConfig{
+				PolicyPaths:   []string{"../../_testdata/apply/test-4/resource-validating-policy/policy.yml"},
+				ResourcePaths: []string{"../../_testdata/apply/test-4/resources/foo.yml", "../../_testdata/apply/test-4/resources/bar.yml"},
+				CrdPath:       "../../_testdata/apply/test-4/crd/crds.yml",
+				PolicyReport:  true,
+			},
+			expectedReports: []openreportsv1alpha1.Report{{
+				Summary: openreportsv1alpha1.ReportSummary{
+					Pass:  2,
+					Fail:  0,
+					Skip:  0,
+					Error: 0,
+					Warn:  0,
+				},
+			}},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run("", func(t *testing.T) {
+			verifyTestcase(t, tc, compareSummary)
+		})
+	}
+}
+
 func TestCommandCRDKubeEnable(t *testing.T) {
 	cmd := Command()
 	assert.NotNil(t, cmd)
@@ -1591,7 +1620,6 @@ func Test_Apply_AuthzPolicies(t *testing.T) {
 			verifyTestcase(t, tc, compareSummary)
 		})
 	}
-
 }
 
 func Test_Apply_AuthzPolicies_MixedHTTPAndEnvoy(t *testing.T) {

--- a/cmd/cli/kubectl-kyverno/data/data.go
+++ b/cmd/cli/kubectl-kyverno/data/data.go
@@ -33,27 +33,27 @@ func APIGroupResources() ([]*restmapper.APIGroupResources, error) {
 }
 
 type crdProcessor struct {
-	apiGroupResource *restmapper.APIGroupResources
-	mutex            sync.RWMutex
+	apiGroupResources []*restmapper.APIGroupResources
+	mutex             sync.RWMutex
 }
 
-func NewCRDProcessor(resources *restmapper.APIGroupResources) *crdProcessor {
+func NewCRDProcessor(resources []*restmapper.APIGroupResources) *crdProcessor {
 	return &crdProcessor{
-		apiGroupResource: resources,
+		apiGroupResources: resources,
 	}
 }
 
-func (p *crdProcessor) UpdateResourceGroup(resources *restmapper.APIGroupResources) {
+func (p *crdProcessor) UpdateResourceGroups(resources []*restmapper.APIGroupResources) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-	p.apiGroupResource = resources
+	p.apiGroupResources = resources
 }
 
-func (p *crdProcessor) GetResourceGroup() *restmapper.APIGroupResources {
+func (p *crdProcessor) GetResourceGroups() []*restmapper.APIGroupResources {
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
-	if p.apiGroupResource == nil {
+	if p.apiGroupResources == nil {
 		return nil
 	}
-	return p.apiGroupResource
+	return p.apiGroupResources
 }

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -774,7 +774,7 @@ func (p *PolicyProcessor) makePolicyContext(
 		vals, err := p.Variables.ComputeVariables(p.Store, policy.GetName(), resource.GetName(), resource.GetKind(), kindOnwhichPolicyIsApplied /*matches...*/)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"policy `%s` have variables. pass the values for the variables for resource `%s` using set/values_file flag (%w)",
+				"policy `%s` has variables. pass the values for the variables for resource `%s` using set/values_file flag (%w)",
 				policy.GetName(),
 				resource.GetName(),
 				err,

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -130,7 +130,7 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 	}
 	isCluster := false
 	if p.CrdPath != "" {
-		if err := p.loadCrd(); err != nil {
+		if err := p.loadCrds(); err != nil {
 			return nil, err
 		}
 	}
@@ -773,7 +773,8 @@ func (p *PolicyProcessor) makePolicyContext(
 		kindOnwhichPolicyIsApplied := common.GetKindsFromPolicy(p.Out, policy, p.Variables.Subresources(), p.Client)
 		vals, err := p.Variables.ComputeVariables(p.Store, policy.GetName(), resource.GetName(), resource.GetKind(), kindOnwhichPolicyIsApplied /*matches...*/)
 		if err != nil {
-			return nil, fmt.Errorf("policy `%s` have variables. pass the values for the variables for resource `%s` using set/values_file flag (%w)",
+			return nil, fmt.Errorf(
+				"policy `%s` have variables. pass the values for the variables for resource `%s` using set/values_file flag (%w)",
 				policy.GetName(),
 				resource.GetName(),
 				err,
@@ -1248,8 +1249,8 @@ func hasSelector(match *admissionregistrationv1.MatchResources) bool {
 	return true
 }
 
-func (p *PolicyProcessor) loadCrd() error {
-	return common.LoadCrdFromPath(p.CrdPath)
+func (p *PolicyProcessor) loadCrds() error {
+	return common.LoadCrdsFromPath(p.CrdPath)
 }
 
 func getAbsPath(path string) string {

--- a/cmd/cli/kubectl-kyverno/utils/common/common.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common.go
@@ -244,23 +244,29 @@ func LoadYAML[T any](f billy.Filesystem, filepath string, newInstance func() T) 
 	return vals, nil
 }
 
-func LoadCrdFromPath(path string) error {
-	absPath, err := getCrdPath(path)
+func LoadCrdsFromPath(path string) error {
+	absPath, err := getCrdFilePath(path)
 	if err != nil {
 		return err
 	}
-	crd, err := readCRDFromFile(absPath)
+	crds, err := readCRDsFromFile(absPath)
 	if err != nil {
 		return err
 	}
-	apiGroupResource := apiGroupResourcesFromCRD(crd)
-	if err = addResourceGroup(apiGroupResource); err != nil {
+
+	apiGroupResources := []*restmapper.APIGroupResources{}
+	for _, crd := range crds {
+		apiGroupResources = append(apiGroupResources, apiGroupResourcesFromCRD(crd))
+	}
+
+	if err = addResourceGroups(apiGroupResources); err != nil {
 		return err
 	}
+
 	return nil
 }
 
-func getCrdPath(path string) (string, error) {
+func getCrdFilePath(path string) (string, error) {
 	if path[len(path)-1] == '/' {
 		path = path[:len(path)-1]
 	}
@@ -279,26 +285,46 @@ func getCrdPath(path string) (string, error) {
 	return absPath, nil
 }
 
-func readCRDFromFile(path string) (*apiv1.CustomResourceDefinition, error) {
-	data, err := os.ReadFile(path)
+func readCRDsFromFile(path string) ([]*apiv1.CustomResourceDefinition, error) {
+	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	jsonData, err := yaml.ToJSON(data)
-	if err != nil {
-		return nil, err
-	}
+	defer file.Close()
+
+	decoder := yaml.NewYAMLReader(bufio.NewReader(file))
 	crdscheme.Setup()
-	obj, _, err := crdscheme.Decoder.Decode(jsonData, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	crd, ok := obj.(*apiv1.CustomResourceDefinition)
-	if !ok {
-		return nil, fmt.Errorf("decoded object is not a CRD")
+	var crds []*apiv1.CustomResourceDefinition
+
+	for {
+		data, err := decoder.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				return nil, err
+			}
+		}
+
+		jsonData, err := yaml.ToJSON(data)
+		if err != nil {
+			return nil, err
+		}
+
+		obj, _, err := crdscheme.Decoder.Decode(jsonData, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		crd, ok := obj.(*apiv1.CustomResourceDefinition)
+		if !ok {
+			return nil, fmt.Errorf("decoded object is not a CRD")
+		}
+
+		crds = append(crds, crd)
 	}
 
-	return crd, nil
+	return crds, nil
 }
 
 func apiGroupResourcesFromCRD(crd *apiv1.CustomResourceDefinition) *restmapper.APIGroupResources {
@@ -382,11 +408,11 @@ func apiGroupResourcesFromCRD(crd *apiv1.CustomResourceDefinition) *restmapper.A
 	}
 }
 
-func addResourceGroup(resource *restmapper.APIGroupResources) error {
+func addResourceGroups(resources []*restmapper.APIGroupResources) error {
 	processor := data.GetProcessor()
 	if processor == nil {
 		panic("adding a resource group to a nil crd processor. exiting")
 	}
-	processor.UpdateResourceGroup(resource)
+	processor.UpdateResourceGroups(resources)
 	return nil
 }

--- a/cmd/cli/kubectl-kyverno/utils/common/common.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common.go
@@ -12,6 +12,7 @@ import (
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/apis/v1alpha1"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/data"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/log"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/resource"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/source"
 	crdscheme "github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/utils/scheme"
@@ -254,19 +255,25 @@ func LoadCrdsFromPath(path string) error {
 		return err
 	}
 
-	apiGroupResources := []*restmapper.APIGroupResources{}
-	for _, crd := range crds {
-		apiGroupResources = append(apiGroupResources, apiGroupResourcesFromCRD(crd))
-	}
+	if len(crds) > 0 {
+		apiGroupResources := []*restmapper.APIGroupResources{}
+		for _, crd := range crds {
+			apiGroupResources = append(apiGroupResources, apiGroupResourcesFromCRD(crd))
+		}
 
-	if err = addResourceGroups(apiGroupResources); err != nil {
-		return err
+		if err = addResourceGroups(apiGroupResources); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
 func getCrdFilePath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+
 	if path[len(path)-1] == '/' {
 		path = path[:len(path)-1]
 	}
@@ -300,7 +307,8 @@ func readCRDsFromFile(path string) ([]*apiv1.CustomResourceDefinition, error) {
 		data, err := decoder.Read()
 		if err != nil {
 			if err == io.EOF {
-				break
+				// io.EOF means nothing else to read, return immediately
+				return crds, nil
 			} else {
 				return nil, err
 			}
@@ -308,23 +316,24 @@ func readCRDsFromFile(path string) ([]*apiv1.CustomResourceDefinition, error) {
 
 		jsonData, err := yaml.ToJSON(data)
 		if err != nil {
-			return nil, err
+			log.Log.V(3).Info(fmt.Sprintf("could not convert object from --crd-path file to json: %q, skipping", err.Error()))
+			continue
 		}
 
 		obj, _, err := crdscheme.Decoder.Decode(jsonData, nil, nil)
 		if err != nil {
-			return nil, err
+			log.Log.V(3).Info(fmt.Sprintf("could not decode object from --crd-path file: %q, skipping", err.Error()))
+			continue
 		}
 
 		crd, ok := obj.(*apiv1.CustomResourceDefinition)
 		if !ok {
-			return nil, fmt.Errorf("decoded object is not a CRD")
+			log.Log.V(3).Info(fmt.Sprintf("decoded object is not a CRD: %s, skipping", data))
+			continue
 		}
 
 		crds = append(crds, crd)
 	}
-
-	return crds, nil
 }
 
 func apiGroupResourcesFromCRD(crd *apiv1.CustomResourceDefinition) *restmapper.APIGroupResources {
@@ -411,7 +420,7 @@ func apiGroupResourcesFromCRD(crd *apiv1.CustomResourceDefinition) *restmapper.A
 func addResourceGroups(resources []*restmapper.APIGroupResources) error {
 	processor := data.GetProcessor()
 	if processor == nil {
-		panic("adding a resource group to a nil crd processor. exiting")
+		panic("adding resource groups to a nil crd processor. exiting")
 	}
 	processor.UpdateResourceGroups(resources)
 	return nil

--- a/pkg/utils/restmapper/restmapper.go
+++ b/pkg/utils/restmapper/restmapper.go
@@ -30,9 +30,9 @@ func GetRESTMapper(client dclient.Interface) (meta.RESTMapper, error) {
 	} else {
 		processor := data.GetProcessor()
 		if processor != nil {
-			apiGroupResources1 := processor.GetResourceGroup()
-			if apiGroupResources1 != nil {
-				apiGroupResources = append(apiGroupResources, apiGroupResources1)
+			apiGroupResources1 := processor.GetResourceGroups()
+			if len(apiGroupResources1) > 0 {
+				apiGroupResources = append(apiGroupResources, apiGroupResources1...)
 			}
 		}
 		apiGroupResources2, err := data.APIGroupResources()


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

This is a follow-up of #13565 that ensures the file specified via `--crd-path` can contain multiple YAMl documents separated by `---`. This allows to test multiple resources at once using `kyverno apply`.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

Closes #15949

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

`/milestone v1.18.2`

## Documentation (required for features)

As discussed in the linked issue people expected that the file specified via `--crd-path` can contain multiple CRDs, so I'd argue the documentation doesn't need to be changed but the behavior behind it. 

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

Most of the logic introduced by #13565 was already capably of handling multiple CRDs, but the YAML parser wasn't. So I simply switched to another parser in the same YAML library that reads multiple YAML documents from the same file (if there are more than one) and returns a slice instead of a single resource.

### Proof Manifests

Take a policy from the new `kind: ValidationPolicy` like [this one](https://kyverno.io/policies/best-practices-vpol/require-labels/require-labels/) and save it in a file named `policy.yaml`.

I'm using the official [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) helm chart to proof here since it contains **multiple** CRDs and CRs in the default chart.

Create a filed named `crds.yaml` with the CRDs from the chart:

```console
helm template --include-crds oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack |  yq e '. | select(.kind == "CustomResourceDefinition")' > crds.yaml
```

Apply the policy to the rendered output of the chart (which includes a number of CRs):

```console
helm template oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack | kyverno apply policy.yaml --resource - --crd-path crds.yaml
```

Without the fix, Kyverno CLI exits with exit code 1, because the manifests contain CRs whose CRDs the CLI doesn't know about and that aren't read from the `crds.yaml` because it contains more than one CRD. 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is `v1.18`.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

