### PR TITLE
fix(helm): reportsServer.enabled=true fails with "Image tags must be strings"

### DIFF
--- a/charts/kyverno/ci/reportsServer-values.yaml
+++ b/charts/kyverno/ci/reportsServer-values.yaml
@@ -1,0 +1,4 @@
+reportsServer:
+  # Test case: reportsServer enabled with waitForReady (the combination that triggered the null-tag bug)
+  enabled: true
+  waitForReady: true

--- a/charts/kyverno/templates/reports-server/_helpers.tpl
+++ b/charts/kyverno/templates/reports-server/_helpers.tpl
@@ -19,7 +19,7 @@ Reports Server readiness init container
 {{- define "kyverno.reportsServer.initContainer" -}}
 {{- if and .Values.reportsServer.enabled .Values.reportsServer.waitForReady }}
 - name: wait-for-reports-server
-  image: {{ include "kyverno.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.test.image "defaultTag" .Values.test.image.tag) | quote }}
+  image: {{ include "kyverno.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.test.image "defaultTag" (default "latest" .Values.test.image.tag)) | quote }}
   imagePullPolicy: {{ .Values.test.image.pullPolicy | default "IfNotPresent" }}
   args:
     - check-endpoints


### PR DESCRIPTION
Setting reportsServer.enabled=true on chart 3.8.x fails at helm template/install with
"Image tags must be strings" across all four controller deployments

The wait-for-reports-server init container passes .Values.test.image.tag directly as
defaultTag to kyverno.image.
In 3.8.x that field was changed from 'v0.1.0' to null so the typeIs "string" guard fails.

**Fix :**
wrap with (default "latest" .Values.test.image.tag) so when test.image.tag is null it falls back to latest, which is what values.yaml says should happen and what kyverno.test.image already does for the same image.

Also adds charts/kyverno/ci/reportsServer-values.yaml so CI catches this path going forward.

Closes #16166