### PR TITLE
fix: wire gpolEngine and gpolProvider into policyController

### DIFF
--- a/cmd/background-controller/main.go
+++ b/cmd/background-controller/main.go
@@ -95,6 +95,8 @@ func createrLeaderControllers(
 		jp,
 		urGenerator,
 		watchManager,
+		gpolEngine,
+		gpolProvider,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/policy/policy_controller.go
+++ b/pkg/policy/policy_controller.go
@@ -13,6 +13,7 @@ import (
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
 	backgroundcommon "github.com/kyverno/kyverno/pkg/background/common"
 	"github.com/kyverno/kyverno/pkg/background/gpol"
+	gpolengine "github.com/kyverno/kyverno/pkg/cel/policies/gpol/engine"
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/scheme"
 	kyvernov1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1"
@@ -106,6 +107,9 @@ type policyController struct {
 
 	watchManager *gpol.WatchManager
 
+	gpolEngine   gpolengine.Engine
+	gpolProvider gpolengine.Provider
+
 	// mapper
 	restMapper meta.RESTMapper
 }
@@ -128,6 +132,8 @@ func NewPolicyController(
 	jp jmespath.Interface,
 	urGenerator generator.UpdateRequestGenerator,
 	watchManager *gpol.WatchManager,
+	gpolEngine gpolengine.Engine,
+	gpolProvider gpolengine.Provider,
 ) (*policyController, error) {
 	// Event broad caster
 	eventInterface := client.GetEventsInterface()
@@ -160,6 +166,8 @@ func NewPolicyController(
 		jp:              jp,
 		urGenerator:     urGenerator,
 		watchManager:    watchManager,
+		gpolEngine:      gpolEngine,
+		gpolProvider:    gpolProvider,
 	}
 	apiGroupResources, _ := restmapper.GetAPIGroupResources(client.GetKubeClient().Discovery())
 	pc.restMapper = restmapper.NewDiscoveryRESTMapper(apiGroupResources)


### PR DESCRIPTION
### Explanation :
While investigating issue #16168 i found that **handleGenerateExisting** in **policyController** cannot perform CEL match pre-checks for **GeneratingPolicy** because the CEL **gpol engine and provider** are not available in the struct. 
Both are already constructed and passed into the same function in **cmd/background-controller/main.go** but never wired into **NewPolicyController**. this PR adds the plumbing as a prerequisite for the actual **generateExisting** fix.

### Related issue :
**Closes** #16168

### What type of PR is this :
/kind bug

### Proposed Changes :

Added gpolEngine and gpolProvider fields to policyController struct
Added both as parameters to NewPolicyController
Passed them through at the call site in cmd/background-controller/main.go

No behavior change in this PR , it's a pure plumbing only

### Further Comments :
This is the first PRs fixing #16168 - The follow-up PR will use these fields to add CEL match pre-checks inside **handleGenerateExisting** before creating **UpdateRequests**.