### PR TITLE
Feat/deleting policy reports

### DIFF
--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -54,6 +54,7 @@ type controller struct {
 	eventGen      event.Interface
 	jp            jmespath.Interface
 	gctxStore     loaders.Store
+	reportWriter  *cleanupReportWriter
 }
 
 const (
@@ -109,6 +110,7 @@ func NewController(
 		eventGen:      eventGen,
 		jp:            jp,
 		gctxStore:     gctxStore,
+		reportWriter:  &cleanupReportWriter{kyvernoClient: kyvernoClient},
 	}
 	if _, err := controllerutils.AddEventHandlersT(
 		cpolInformer.Informer(),
@@ -166,6 +168,7 @@ func (c *controller) cleanup(ctx context.Context, logger logr.Logger, policy kyv
 	kinds := sets.New(spec.MatchResources.GetKinds()...)
 	debug := logger.V(4)
 	var errs []error
+	var records []cleanupDeletionRecord
 	deleteOptions := metav1.DeleteOptions{
 		PropagationPolicy: spec.DeletionPropagationPolicy,
 	}
@@ -306,6 +309,7 @@ func (c *controller) cleanup(ctx context.Context, logger logr.Logger, policy kyv
 				}
 				debug.Error(err, "failed to delete resource")
 				errs = append(errs, err)
+				records = append(records, cleanupDeletionRecord{resource: resource, err: err})
 				e := event.NewCleanupPolicyEvent(policy, resource, err)
 				c.eventGen.Add(e)
 			} else {
@@ -313,10 +317,14 @@ func (c *controller) cleanup(ctx context.Context, logger logr.Logger, policy kyv
 					metrics.RecordDeletedObject(ctx, kind, namespace, policy, deleteOptions.PropagationPolicy)
 				}
 				debug.Info("resource deleted")
+				records = append(records, cleanupDeletionRecord{resource: resource, err: nil})
 				e := event.NewCleanupPolicyEvent(policy, resource, nil)
 				c.eventGen.Add(e)
 			}
 		}
+	}
+	if c.reportWriter != nil {
+		c.reportWriter.Write(ctx, policy, records)
 	}
 	return multierr.Combine(errs...)
 }

--- a/pkg/controllers/cleanup/controller.go
+++ b/pkg/controllers/cleanup/controller.go
@@ -306,6 +306,7 @@ func (c *controller) cleanup(ctx context.Context, logger logr.Logger, policy kyv
 				}
 				if metrics != nil {
 					metrics.RecordCleanupFailure(ctx, kind, namespace, policy, deleteOptions.PropagationPolicy)
+					metrics.RecordDeletedResourceFailure(ctx, resource.GetKind(), namespace, name, policy)
 				}
 				debug.Error(err, "failed to delete resource")
 				errs = append(errs, err)
@@ -315,6 +316,7 @@ func (c *controller) cleanup(ctx context.Context, logger logr.Logger, policy kyv
 			} else {
 				if metrics != nil {
 					metrics.RecordDeletedObject(ctx, kind, namespace, policy, deleteOptions.PropagationPolicy)
+					metrics.RecordDeletedResource(ctx, resource.GetKind(), namespace, name, policy)
 				}
 				debug.Info("resource deleted")
 				records = append(records, cleanupDeletionRecord{resource: resource, err: nil})

--- a/pkg/controllers/cleanup/report.go
+++ b/pkg/controllers/cleanup/report.go
@@ -1,0 +1,182 @@
+package cleanup
+
+import (
+	"context"
+	"fmt"
+
+	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	policyreportv1alpha2 "github.com/kyverno/kyverno/api/policyreport/v1alpha2"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
+	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
+	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// cleanupReportName returns the deterministic (Cluster)PolicyReport name for a
+// given CleanupPolicy or ClusterCleanupPolicy.  Format: "cleanup-<policy-name>"
+func cleanupReportName(policy kyvernov2.CleanupPolicyInterface) string {
+	return "cleanup-" + policy.GetName()
+}
+
+// cleanupDeletionRecord pairs a resource with the error (nil == success) from
+// its deletion attempt.
+type cleanupDeletionRecord struct {
+	resource unstructured.Unstructured
+	err      error
+}
+
+// cleanupReportWriter persists per-policy deletion audit results as
+// PolicyReport / ClusterPolicyReport objects.  Each Write call replaces the
+// results of the previous execution.
+type cleanupReportWriter struct {
+	kyvernoClient versioned.Interface
+}
+
+// Write creates or replaces the (Cluster)PolicyReport for policy.
+func (w *cleanupReportWriter) Write(ctx context.Context, policy kyvernov2.CleanupPolicyInterface, records []cleanupDeletionRecord) {
+	results := make([]openreportsv1alpha1.ReportResult, 0, len(records))
+	policyName := policy.GetName()
+	for _, rec := range records {
+		results = append(results, reportutils.CleanupPolicyToReportResult(policyName, rec.resource, rec.err))
+	}
+
+	namespace := policy.GetNamespace()
+	name := cleanupReportName(policy)
+
+	if namespace == "" {
+		w.writeClusterReport(ctx, policy, name, results)
+	} else {
+		w.writeNamespacedReport(ctx, policy, namespace, name, results)
+	}
+}
+
+func (w *cleanupReportWriter) writeClusterReport(ctx context.Context, policy kyvernov2.CleanupPolicyInterface, name string, results []openreportsv1alpha1.ReportResult) {
+	client := w.kyvernoClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports()
+
+	existing, err := client.Get(ctx, name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logger.Error(err, "failed to get ClusterPolicyReport", "name", name)
+		return
+	}
+
+	summary := reportutils.CalculateSummary(results)
+	wgResults := cleanupToWGResults(results)
+
+	if apierrors.IsNotFound(err) {
+		report := &policyreportv1alpha2.ClusterPolicyReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by":    "kyverno",
+					"kyverno.io/cleanup-policy.name":  policy.GetName(),
+				},
+				Annotations: map[string]string{
+					"policies.kyverno.io/source": reportutils.SourceCleanupPolicy,
+				},
+			},
+			Scope: &corev1.ObjectReference{
+				APIVersion: fmt.Sprintf("%s/%s", "kyverno.io", "v2"),
+				Kind:       policy.GetKind(),
+				Name:       policy.GetName(),
+				UID:        types.UID(policy.GetUID()),
+			},
+			Results: wgResults,
+			Summary: cleanupToWGSummary(summary),
+		}
+		if _, createErr := client.Create(ctx, report, metav1.CreateOptions{}); createErr != nil {
+			logger.Error(createErr, "failed to create ClusterPolicyReport", "name", name)
+		}
+		return
+	}
+
+	updated := existing.DeepCopy()
+	updated.Results = wgResults
+	updated.Summary = cleanupToWGSummary(summary)
+	if _, updateErr := client.Update(ctx, updated, metav1.UpdateOptions{}); updateErr != nil {
+		logger.Error(updateErr, "failed to update ClusterPolicyReport", "name", name)
+	}
+}
+
+func (w *cleanupReportWriter) writeNamespacedReport(ctx context.Context, policy kyvernov2.CleanupPolicyInterface, namespace, name string, results []openreportsv1alpha1.ReportResult) {
+	client := w.kyvernoClient.Wgpolicyk8sV1alpha2().PolicyReports(namespace)
+
+	existing, err := client.Get(ctx, name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logger.Error(err, "failed to get PolicyReport", "namespace", namespace, "name", name)
+		return
+	}
+
+	summary := reportutils.CalculateSummary(results)
+	wgResults := cleanupToWGResults(results)
+
+	if apierrors.IsNotFound(err) {
+		report := &policyreportv1alpha2.PolicyReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by":   "kyverno",
+					"kyverno.io/cleanup-policy.name": policy.GetName(),
+				},
+				Annotations: map[string]string{
+					"policies.kyverno.io/source": reportutils.SourceCleanupPolicy,
+				},
+			},
+			Scope: &corev1.ObjectReference{
+				APIVersion: fmt.Sprintf("%s/%s", "kyverno.io", "v2"),
+				Kind:       policy.GetKind(),
+				Name:       policy.GetName(),
+				Namespace:  namespace,
+				UID:        types.UID(policy.GetUID()),
+			},
+			Results: wgResults,
+			Summary: cleanupToWGSummary(summary),
+		}
+		if _, createErr := client.Create(ctx, report, metav1.CreateOptions{}); createErr != nil {
+			logger.Error(createErr, "failed to create PolicyReport", "namespace", namespace, "name", name)
+		}
+		return
+	}
+
+	updated := existing.DeepCopy()
+	updated.Results = wgResults
+	updated.Summary = cleanupToWGSummary(summary)
+	if _, updateErr := client.Update(ctx, updated, metav1.UpdateOptions{}); updateErr != nil {
+		logger.Error(updateErr, "failed to update PolicyReport", "namespace", namespace, "name", name)
+	}
+}
+
+func cleanupToWGResults(results []openreportsv1alpha1.ReportResult) []policyreportv1alpha2.PolicyReportResult {
+	out := make([]policyreportv1alpha2.PolicyReportResult, 0, len(results))
+	for _, r := range results {
+		out = append(out, policyreportv1alpha2.PolicyReportResult{
+			Source:           r.Source,
+			Policy:           r.Policy,
+			Rule:             r.Rule,
+			Resources:        r.Subjects,
+			Message:          r.Description,
+			Result:           policyreportv1alpha2.PolicyResult(r.Result),
+			Scored:           r.Scored,
+			Timestamp:        r.Timestamp,
+			Properties:       r.Properties,
+			Category:         r.Category,
+			Severity:         policyreportv1alpha2.PolicySeverity(r.Severity),
+			ResourceSelector: r.ResourceSelector,
+		})
+	}
+	return out
+}
+
+func cleanupToWGSummary(s openreportsv1alpha1.ReportSummary) policyreportv1alpha2.PolicyReportSummary {
+	return policyreportv1alpha2.PolicyReportSummary{
+		Pass:  s.Pass,
+		Fail:  s.Fail,
+		Warn:  s.Warn,
+		Skip:  s.Skip,
+		Error: s.Error,
+	}
+}

--- a/pkg/controllers/cleanup/report.go
+++ b/pkg/controllers/cleanup/report.go
@@ -71,8 +71,8 @@ func (w *cleanupReportWriter) writeClusterReport(ctx context.Context, policy kyv
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 				Labels: map[string]string{
-					"app.kubernetes.io/managed-by":    "kyverno",
-					"kyverno.io/cleanup-policy.name":  policy.GetName(),
+					"app.kubernetes.io/managed-by":   "kyverno",
+					"kyverno.io/cleanup-policy.name": policy.GetName(),
 				},
 				Annotations: map[string]string{
 					"policies.kyverno.io/source": reportutils.SourceCleanupPolicy,

--- a/pkg/controllers/deleting/controller.go
+++ b/pkg/controllers/deleting/controller.go
@@ -246,6 +246,7 @@ func (c *controller) deleting(ctx context.Context, logger logr.Logger, ePolicy e
 				}
 				if c.metrics != nil {
 					c.metrics.RecordDeletingFailure(ctx, gvr.Resource, namespace, policy, deleteOptions.PropagationPolicy)
+					c.metrics.RecordDeletedResourceFailure(ctx, resource.GetKind(), namespace, name, policy)
 				}
 				debug.Error(err, "failed to delete resource")
 				errs = append(errs, err)
@@ -255,6 +256,7 @@ func (c *controller) deleting(ctx context.Context, logger logr.Logger, ePolicy e
 			} else {
 				if c.metrics != nil {
 					c.metrics.RecordDeletedObject(ctx, gvr.Resource, namespace, policy, deleteOptions.PropagationPolicy)
+					c.metrics.RecordDeletedResource(ctx, resource.GetKind(), namespace, name, policy)
 				}
 				debug.Info("resource deleted")
 				records = append(records, deletionRecord{resource: resource, err: nil})

--- a/pkg/controllers/deleting/controller.go
+++ b/pkg/controllers/deleting/controller.go
@@ -52,6 +52,7 @@ type controller struct {
 	cmResolver    engineapi.ConfigmapResolver
 	eventGen      event.Interface
 	metrics       pkgmetrics.DeletingMetrics
+	reportWriter  *reportWriter
 }
 
 const (
@@ -104,6 +105,7 @@ func NewController(
 		cmResolver:    cmResolver,
 		eventGen:      eventGen,
 		metrics:       pkgmetrics.GetDeletingMetrics(),
+		reportWriter:  &reportWriter{kyvernoClient: kyvernoClient},
 		provider:      provider,
 		engine:        engine,
 	}
@@ -151,6 +153,7 @@ func (c *controller) deleting(ctx context.Context, logger logr.Logger, ePolicy e
 
 	debug := logger.V(4)
 	var errs []error
+	var records []deletionRecord
 	deleteOptions := metav1.DeleteOptions{
 		PropagationPolicy: spec.DeletionPropagationPolicy,
 	}
@@ -246,6 +249,7 @@ func (c *controller) deleting(ctx context.Context, logger logr.Logger, ePolicy e
 				}
 				debug.Error(err, "failed to delete resource")
 				errs = append(errs, err)
+				records = append(records, deletionRecord{resource: resource, err: err})
 				e := event.NewDeletingPolicyEvent(ePolicy.Policy, resource, err)
 				c.eventGen.Add(e)
 			} else {
@@ -253,10 +257,14 @@ func (c *controller) deleting(ctx context.Context, logger logr.Logger, ePolicy e
 					c.metrics.RecordDeletedObject(ctx, gvr.Resource, namespace, policy, deleteOptions.PropagationPolicy)
 				}
 				debug.Info("resource deleted")
+				records = append(records, deletionRecord{resource: resource, err: nil})
 				e := event.NewDeletingPolicyEvent(ePolicy.Policy, resource, nil)
 				c.eventGen.Add(e)
 			}
 		}
+	}
+	if c.reportWriter != nil {
+		c.reportWriter.Write(ctx, ePolicy.Policy, records)
 	}
 	return multierr.Combine(errs...)
 }

--- a/pkg/controllers/deleting/report.go
+++ b/pkg/controllers/deleting/report.go
@@ -1,0 +1,190 @@
+package deleting
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	policyreportv1alpha2 "github.com/kyverno/kyverno/api/policyreport/v1alpha2"
+	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
+	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
+	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// reportName returns the deterministic PolicyReport / ClusterPolicyReport name
+// for a given DeletingPolicy or NamespacedDeletingPolicy.
+// Format: "dpol-<policy-name>"
+func reportName(policy v1beta1.DeletingPolicyLike) string {
+	return "dpol-" + policy.GetName()
+}
+
+// reportWriter persists per-policy deletion audit results as PolicyReport /
+// ClusterPolicyReport objects.  Each call to Write replaces the results of the
+// previous execution so that consumers always see the latest run.
+type reportWriter struct {
+	kyvernoClient versioned.Interface
+}
+
+// deletionRecord pairs a resource with the error (nil == success) from its
+// deletion attempt.
+type deletionRecord struct {
+	resource unstructured.Unstructured
+	err      error
+}
+
+// Write creates or replaces the (Cluster)PolicyReport for policy with the
+// provided deletion records.  It is safe to call with an empty records slice
+// (the report will be created / updated with zero results).
+func (w *reportWriter) Write(ctx context.Context, policy v1beta1.DeletingPolicyLike, records []deletionRecord) {
+	results := make([]openreportsv1alpha1.ReportResult, 0, len(records))
+	policyName := policy.GetName()
+	for _, rec := range records {
+		results = append(results, reportutils.DeletingPolicyToReportResult(policyName, rec.resource, rec.err))
+	}
+
+	namespace := policy.GetNamespace()
+	name := reportName(policy)
+
+	if namespace == "" {
+		w.writeClusterReport(ctx, policy, name, results)
+	} else {
+		w.writeNamespacedReport(ctx, policy, namespace, name, results)
+	}
+}
+
+// writeClusterReport creates or updates a ClusterPolicyReport for a cluster-scoped DeletingPolicy.
+func (w *reportWriter) writeClusterReport(ctx context.Context, policy v1beta1.DeletingPolicyLike, name string, results []openreportsv1alpha1.ReportResult) {
+	client := w.kyvernoClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports()
+
+	existing, err := client.Get(ctx, name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logger.Error(err, "failed to get ClusterPolicyReport", "name", name)
+		return
+	}
+
+	summary := reportutils.CalculateSummary(results)
+	wgResults := toWGResults(results)
+
+	if apierrors.IsNotFound(err) {
+		report := &policyreportv1alpha2.ClusterPolicyReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by":  "kyverno",
+					"policies.kyverno.io/dpol.name": policy.GetName(),
+				},
+				Annotations: map[string]string{
+					"policies.kyverno.io/source": reportutils.SourceDeletingPolicy,
+				},
+			},
+			Scope: &corev1.ObjectReference{
+				APIVersion: fmt.Sprintf("%s/%s", v1beta1.GroupVersion.Group, v1beta1.GroupVersion.Version),
+				Kind:       policy.GetKind(),
+				Name:       policy.GetName(),
+				UID:        types.UID(policy.GetUID()),
+			},
+			Results: wgResults,
+			Summary: toWGSummary(summary),
+		}
+		if _, createErr := client.Create(ctx, report, metav1.CreateOptions{}); createErr != nil {
+			logger.Error(createErr, "failed to create ClusterPolicyReport", "name", name)
+		}
+		return
+	}
+
+	updated := existing.DeepCopy()
+	updated.Results = wgResults
+	updated.Summary = toWGSummary(summary)
+	if _, updateErr := client.Update(ctx, updated, metav1.UpdateOptions{}); updateErr != nil {
+		logger.Error(updateErr, "failed to update ClusterPolicyReport", "name", name)
+	}
+}
+
+// writeNamespacedReport creates or updates a PolicyReport for a namespaced DeletingPolicy.
+func (w *reportWriter) writeNamespacedReport(ctx context.Context, policy v1beta1.DeletingPolicyLike, namespace, name string, results []openreportsv1alpha1.ReportResult) {
+	client := w.kyvernoClient.Wgpolicyk8sV1alpha2().PolicyReports(namespace)
+
+	existing, err := client.Get(ctx, name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logger.Error(err, "failed to get PolicyReport", "namespace", namespace, "name", name)
+		return
+	}
+
+	summary := reportutils.CalculateSummary(results)
+	wgResults := toWGResults(results)
+
+	if apierrors.IsNotFound(err) {
+		report := &policyreportv1alpha2.PolicyReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by":   "kyverno",
+					"policies.kyverno.io/ndpol.name": policy.GetName(),
+				},
+				Annotations: map[string]string{
+					"policies.kyverno.io/source": reportutils.SourceDeletingPolicy,
+				},
+			},
+			Scope: &corev1.ObjectReference{
+				APIVersion: fmt.Sprintf("%s/%s", v1beta1.GroupVersion.Group, v1beta1.GroupVersion.Version),
+				Kind:       policy.GetKind(),
+				Name:       policy.GetName(),
+				Namespace:  namespace,
+				UID:        types.UID(policy.GetUID()),
+			},
+			Results: wgResults,
+			Summary: toWGSummary(summary),
+		}
+		if _, createErr := client.Create(ctx, report, metav1.CreateOptions{}); createErr != nil {
+			logger.Error(createErr, "failed to create PolicyReport", "namespace", namespace, "name", name)
+		}
+		return
+	}
+
+	updated := existing.DeepCopy()
+	updated.Results = wgResults
+	updated.Summary = toWGSummary(summary)
+	if _, updateErr := client.Update(ctx, updated, metav1.UpdateOptions{}); updateErr != nil {
+		logger.Error(updateErr, "failed to update PolicyReport", "namespace", namespace, "name", name)
+	}
+}
+
+// toWGResults converts openreports results to the wgpolicy PolicyReportResult type.
+func toWGResults(results []openreportsv1alpha1.ReportResult) []policyreportv1alpha2.PolicyReportResult {
+	out := make([]policyreportv1alpha2.PolicyReportResult, 0, len(results))
+	for _, r := range results {
+		out = append(out, policyreportv1alpha2.PolicyReportResult{
+			Source:           r.Source,
+			Policy:           r.Policy,
+			Rule:             r.Rule,
+			Resources:        r.Subjects,
+			Message:          r.Description,
+			Result:           policyreportv1alpha2.PolicyResult(r.Result),
+			Scored:           r.Scored,
+			Timestamp:        r.Timestamp,
+			Properties:       r.Properties,
+			Category:         r.Category,
+			Severity:         policyreportv1alpha2.PolicySeverity(r.Severity),
+			ResourceSelector: r.ResourceSelector,
+		})
+	}
+	return out
+}
+
+// toWGSummary converts an openreports summary to the wgpolicy type.
+func toWGSummary(s openreportsv1alpha1.ReportSummary) policyreportv1alpha2.PolicyReportSummary {
+	return policyreportv1alpha2.PolicyReportSummary{
+		Pass:  s.Pass,
+		Fail:  s.Fail,
+		Warn:  s.Warn,
+		Skip:  s.Skip,
+		Error: s.Error,
+	}
+}
+

--- a/pkg/controllers/deleting/report.go
+++ b/pkg/controllers/deleting/report.go
@@ -9,8 +9,8 @@ import (
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
 	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -187,4 +187,3 @@ func toWGSummary(s openreportsv1alpha1.ReportSummary) policyreportv1alpha2.Polic
 		Error: s.Error,
 	}
 }
-

--- a/pkg/controllers/deleting/report_test.go
+++ b/pkg/controllers/deleting/report_test.go
@@ -1,0 +1,181 @@
+package deleting
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	policyreportv1alpha2 "github.com/kyverno/kyverno/api/policyreport/v1alpha2"
+	versionedfake "github.com/kyverno/kyverno/pkg/client/clientset/versioned/fake"
+	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+)
+
+func makeResource(kind, namespace, name, apiVersion string) unstructured.Unstructured {
+	u := unstructured.Unstructured{}
+	u.SetKind(kind)
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	u.SetAPIVersion(apiVersion)
+	return u
+}
+
+func makeDeletingPolicy(name, namespace string) *policiesv1beta1.DeletingPolicy {
+	return &policiesv1beta1.DeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// reportWriter.Write — cluster-scoped DeletingPolicy → ClusterPolicyReport
+// ---------------------------------------------------------------------------
+
+func TestReportWriter_Write_ClusterScope_Creates(t *testing.T) {
+	ctx := context.Background()
+	kyvernoClient := versionedfake.NewSimpleClientset()
+	rw := &reportWriter{kyvernoClient: kyvernoClient}
+
+	pol := makeDeletingPolicy("my-dpol", "")
+	res := makeResource("Pod", "default", "pod-1", "v1")
+
+	records := []deletionRecord{
+		{resource: res, err: nil},
+	}
+	rw.Write(ctx, pol, records)
+
+	reportName := "dpol-my-dpol"
+	report, err := kyvernoClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Get(ctx, reportName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, report.Results, 1)
+	assert.Equal(t, policyreportv1alpha2.StatusPass, report.Results[0].Result)
+	assert.Equal(t, reportutils.SourceDeletingPolicy, report.Results[0].Source)
+	assert.Equal(t, "my-dpol", report.Results[0].Policy)
+	assert.Equal(t, 1, report.Summary.Pass)
+}
+
+// ---------------------------------------------------------------------------
+// reportWriter.Write — cluster-scoped DeletingPolicy with a deletion error
+// ---------------------------------------------------------------------------
+
+func TestReportWriter_Write_ClusterScope_Error(t *testing.T) {
+	ctx := context.Background()
+	kyvernoClient := versionedfake.NewSimpleClientset()
+	rw := &reportWriter{kyvernoClient: kyvernoClient}
+
+	pol := makeDeletingPolicy("my-dpol", "")
+	res := makeResource("Pod", "default", "pod-1", "v1")
+	delErr := errors.New("permission denied")
+
+	records := []deletionRecord{
+		{resource: res, err: delErr},
+	}
+	rw.Write(ctx, pol, records)
+
+	report, err := kyvernoClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Get(ctx, "dpol-my-dpol", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, report.Results, 1)
+	assert.Equal(t, policyreportv1alpha2.StatusError, report.Results[0].Result)
+	assert.Contains(t, report.Results[0].Message, "permission denied")
+	assert.Equal(t, 1, report.Summary.Error)
+}
+
+// ---------------------------------------------------------------------------
+// reportWriter.Write — second run updates existing ClusterPolicyReport
+// ---------------------------------------------------------------------------
+
+func TestReportWriter_Write_ClusterScope_Updates(t *testing.T) {
+	ctx := context.Background()
+	kyvernoClient := versionedfake.NewSimpleClientset()
+	rw := &reportWriter{kyvernoClient: kyvernoClient}
+
+	pol := makeDeletingPolicy("my-dpol", "")
+	res1 := makeResource("Pod", "default", "pod-1", "v1")
+	res2 := makeResource("Pod", "default", "pod-2", "v1")
+
+	// First run: 1 deleted
+	rw.Write(ctx, pol, []deletionRecord{{resource: res1}})
+
+	// Second run: 2 deleted
+	rw.Write(ctx, pol, []deletionRecord{{resource: res1}, {resource: res2}})
+
+	report, err := kyvernoClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Get(ctx, "dpol-my-dpol", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Len(t, report.Results, 2, "second Write should replace, not append")
+	assert.Equal(t, 2, report.Summary.Pass)
+}
+
+// ---------------------------------------------------------------------------
+// reportWriter.Write — namespaced NamespacedDeletingPolicy → PolicyReport
+// ---------------------------------------------------------------------------
+
+func TestReportWriter_Write_Namespaced_Creates(t *testing.T) {
+	ctx := context.Background()
+	kyvernoClient := versionedfake.NewSimpleClientset()
+	rw := &reportWriter{kyvernoClient: kyvernoClient}
+
+	pol := &policiesv1beta1.NamespacedDeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ns-dpol",
+			Namespace: "team-a",
+		},
+	}
+	res := makeResource("ConfigMap", "team-a", "cm-1", "v1")
+
+	rw.Write(ctx, pol, []deletionRecord{{resource: res}})
+
+	report, err := kyvernoClient.Wgpolicyk8sV1alpha2().PolicyReports("team-a").Get(ctx, "dpol-ns-dpol", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, report.Results, 1)
+	assert.Equal(t, policyreportv1alpha2.StatusPass, report.Results[0].Result)
+}
+
+// ---------------------------------------------------------------------------
+// reportWriter.Write — empty records produces a report with zero results
+// ---------------------------------------------------------------------------
+
+func TestReportWriter_Write_EmptyRecords(t *testing.T) {
+	ctx := context.Background()
+	kyvernoClient := versionedfake.NewSimpleClientset()
+	rw := &reportWriter{kyvernoClient: kyvernoClient}
+
+	pol := makeDeletingPolicy("empty-dpol", "")
+	rw.Write(ctx, pol, []deletionRecord{})
+
+	report, err := kyvernoClient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Get(ctx, "dpol-empty-dpol", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, report.Results)
+	assert.Zero(t, report.Summary.Pass)
+}
+
+// ---------------------------------------------------------------------------
+// DeletingPolicyToReportResult helper
+// ---------------------------------------------------------------------------
+
+func TestDeletingPolicyToReportResult_Pass(t *testing.T) {
+	res := makeResource("Deployment", "prod", "old-deploy", "apps/v1")
+	result := reportutils.DeletingPolicyToReportResult("my-policy", res, nil)
+
+	assert.Equal(t, reportutils.SourceDeletingPolicy, result.Source)
+	assert.Equal(t, "my-policy", result.Policy)
+	assert.Equal(t, "pass", string(result.Result))
+	assert.Contains(t, result.Description, "old-deploy")
+	require.Len(t, result.Subjects, 1)
+	assert.Equal(t, "Deployment", result.Subjects[0].Kind)
+}
+
+func TestDeletingPolicyToReportResult_Error(t *testing.T) {
+	res := makeResource("Deployment", "prod", "old-deploy", "apps/v1")
+	delErr := errors.New("some transient error")
+	result := reportutils.DeletingPolicyToReportResult("my-policy", res, delErr)
+
+	assert.Equal(t, "error", string(result.Result))
+	assert.Contains(t, result.Description, "some transient error")
+}

--- a/pkg/metrics/cleanup.go
+++ b/pkg/metrics/cleanup.go
@@ -21,11 +21,17 @@ func GetCleanupMetrics() CleanupMetrics {
 type CleanupMetrics interface {
 	RecordDeletedObject(ctx context.Context, kind, namespace string, policy kyvernov2.CleanupPolicyInterface, deletionPropagation *metav1.DeletionPropagation)
 	RecordCleanupFailure(ctx context.Context, kind, namespace string, policy kyvernov2.CleanupPolicyInterface, deletionPropagation *metav1.DeletionPropagation)
+	// RecordDeletedResource emits a per-resource deletion counter including resource_name and resource_namespace labels.
+	RecordDeletedResource(ctx context.Context, resourceKind, resourceNamespace, resourceName string, policy kyvernov2.CleanupPolicyInterface)
+	// RecordDeletedResourceFailure emits a per-resource failure counter including resource_name and resource_namespace labels.
+	RecordDeletedResourceFailure(ctx context.Context, resourceKind, resourceNamespace, resourceName string, policy kyvernov2.CleanupPolicyInterface)
 }
 
 type cleanupMetrics struct {
-	deletedObjectsTotal  metric.Int64Counter
-	cleanupFailuresTotal metric.Int64Counter
+	deletedObjectsTotal          metric.Int64Counter
+	cleanupFailuresTotal         metric.Int64Counter
+	deletedResourcesTotal        metric.Int64Counter
+	deletedResourceFailuresTotal metric.Int64Counter
 
 	logger logr.Logger
 }
@@ -46,6 +52,20 @@ func (m *cleanupMetrics) init(meter metric.Meter) {
 	)
 	if err != nil {
 		m.logger.Error(err, "Failed to create instrument, cleanup_controller_errors_total")
+	}
+	m.deletedResourcesTotal, err = meter.Int64Counter(
+		"kyverno_cleanup_controller_deleted_resources_total",
+		metric.WithDescription("Per-resource counter of objects successfully deleted by a CleanupPolicy. Labels include resource_kind, resource_namespace, resource_name, policy_name, and policy_namespace."),
+	)
+	if err != nil {
+		m.logger.Error(err, "Failed to create instrument, cleanup_controller_deleted_resources_total")
+	}
+	m.deletedResourceFailuresTotal, err = meter.Int64Counter(
+		"kyverno_cleanup_controller_deleted_resource_failures_total",
+		metric.WithDescription("Per-resource counter of deletion failures by a CleanupPolicy. Labels include resource_kind, resource_namespace, resource_name, policy_name, and policy_namespace."),
+	)
+	if err != nil {
+		m.logger.Error(err, "Failed to create instrument, cleanup_controller_deleted_resource_failures_total")
 	}
 }
 
@@ -93,4 +113,34 @@ func (m *cleanupMetrics) RecordCleanupFailure(ctx context.Context, kind, namespa
 	}
 
 	m.cleanupFailuresTotal.Add(ctx, 1, metric.WithAttributes(labels...))
+}
+
+func (m *cleanupMetrics) RecordDeletedResource(ctx context.Context, resourceKind, resourceNamespace, resourceName string, policy kyvernov2.CleanupPolicyInterface) {
+	if m.deletedResourcesTotal == nil {
+		return
+	}
+	labels := []attribute.KeyValue{
+		attribute.String("policy_type", policy.GetKind()),
+		attribute.String("policy_namespace", policy.GetNamespace()),
+		attribute.String("policy_name", policy.GetName()),
+		attribute.String("resource_kind", resourceKind),
+		attribute.String("resource_namespace", resourceNamespace),
+		attribute.String("resource_name", resourceName),
+	}
+	m.deletedResourcesTotal.Add(ctx, 1, metric.WithAttributes(labels...))
+}
+
+func (m *cleanupMetrics) RecordDeletedResourceFailure(ctx context.Context, resourceKind, resourceNamespace, resourceName string, policy kyvernov2.CleanupPolicyInterface) {
+	if m.deletedResourceFailuresTotal == nil {
+		return
+	}
+	labels := []attribute.KeyValue{
+		attribute.String("policy_type", policy.GetKind()),
+		attribute.String("policy_namespace", policy.GetNamespace()),
+		attribute.String("policy_name", policy.GetName()),
+		attribute.String("resource_kind", resourceKind),
+		attribute.String("resource_namespace", resourceNamespace),
+		attribute.String("resource_name", resourceName),
+	}
+	m.deletedResourceFailuresTotal.Add(ctx, 1, metric.WithAttributes(labels...))
 }

--- a/pkg/metrics/deleting.go
+++ b/pkg/metrics/deleting.go
@@ -21,11 +21,17 @@ func GetDeletingMetrics() DeletingMetrics {
 type DeletingMetrics interface {
 	RecordDeletedObject(ctx context.Context, resource, namespace string, policy v1beta1.DeletingPolicyLike, deletionPropagation *metav1.DeletionPropagation)
 	RecordDeletingFailure(ctx context.Context, resource, namespace string, policy v1beta1.DeletingPolicyLike, deletionPropagation *metav1.DeletionPropagation)
+	// RecordDeletedResource emits a per-resource deletion counter including resource_name and resource_namespace labels.
+	RecordDeletedResource(ctx context.Context, resourceKind, resourceNamespace, resourceName string, policy v1beta1.DeletingPolicyLike)
+	// RecordDeletedResourceFailure emits a per-resource failure counter including resource_name and resource_namespace labels.
+	RecordDeletedResourceFailure(ctx context.Context, resourceKind, resourceNamespace, resourceName string, policy v1beta1.DeletingPolicyLike)
 }
 
 type deletingMetrics struct {
-	deletedObjectsTotal   metric.Int64Counter
-	deletingFailuresTotal metric.Int64Counter
+	deletedObjectsTotal          metric.Int64Counter
+	deletingFailuresTotal        metric.Int64Counter
+	deletedResourcesTotal        metric.Int64Counter
+	deletedResourceFailuresTotal metric.Int64Counter
 
 	logger logr.Logger
 }
@@ -46,6 +52,20 @@ func (m *deletingMetrics) init(meter metric.Meter) {
 	)
 	if err != nil {
 		m.logger.Error(err, "Failed to create instrument, deleting_controller_errors_total")
+	}
+	m.deletedResourcesTotal, err = meter.Int64Counter(
+		"kyverno_deleting_controller_deleted_resources_total",
+		metric.WithDescription("Per-resource counter of objects successfully deleted by a DeletingPolicy. Labels include resource_kind, resource_namespace, resource_name, policy_name, and policy_namespace."),
+	)
+	if err != nil {
+		m.logger.Error(err, "Failed to create instrument, deleting_controller_deleted_resources_total")
+	}
+	m.deletedResourceFailuresTotal, err = meter.Int64Counter(
+		"kyverno_deleting_controller_deleted_resource_failures_total",
+		metric.WithDescription("Per-resource counter of deletion failures by a DeletingPolicy. Labels include resource_kind, resource_namespace, resource_name, policy_name, and policy_namespace."),
+	)
+	if err != nil {
+		m.logger.Error(err, "Failed to create instrument, deleting_controller_deleted_resource_failures_total")
 	}
 }
 
@@ -93,4 +113,34 @@ func (m *deletingMetrics) RecordDeletingFailure(ctx context.Context, resource, n
 	}
 
 	m.deletingFailuresTotal.Add(ctx, 1, metric.WithAttributes(labels...))
+}
+
+func (m *deletingMetrics) RecordDeletedResource(ctx context.Context, resourceKind, resourceNamespace, resourceName string, policy v1beta1.DeletingPolicyLike) {
+	if m.deletedResourcesTotal == nil {
+		return
+	}
+	labels := []attribute.KeyValue{
+		attribute.String("policy_type", policy.GetKind()),
+		attribute.String("policy_namespace", policy.GetNamespace()),
+		attribute.String("policy_name", policy.GetName()),
+		attribute.String("resource_kind", resourceKind),
+		attribute.String("resource_namespace", resourceNamespace),
+		attribute.String("resource_name", resourceName),
+	}
+	m.deletedResourcesTotal.Add(ctx, 1, metric.WithAttributes(labels...))
+}
+
+func (m *deletingMetrics) RecordDeletedResourceFailure(ctx context.Context, resourceKind, resourceNamespace, resourceName string, policy v1beta1.DeletingPolicyLike) {
+	if m.deletedResourceFailuresTotal == nil {
+		return
+	}
+	labels := []attribute.KeyValue{
+		attribute.String("policy_type", policy.GetKind()),
+		attribute.String("policy_namespace", policy.GetNamespace()),
+		attribute.String("policy_name", policy.GetName()),
+		attribute.String("resource_kind", resourceKind),
+		attribute.String("resource_namespace", resourceNamespace),
+		attribute.String("resource_name", resourceName),
+	}
+	m.deletedResourceFailuresTotal.Add(ctx, 1, metric.WithAttributes(labels...))
 }

--- a/pkg/utils/report/results.go
+++ b/pkg/utils/report/results.go
@@ -416,9 +416,9 @@ func getResourceInfo(gvk schema.GroupVersionKind, name, namespace string) string
 // A nil err means the resource was successfully deleted (result=pass); non-nil err means failure (result=error).
 func DeletingPolicyToReportResult(policyName string, resource unstructured.Unstructured, deletionErr error) openreportsv1alpha1.ReportResult {
 	result := openreportsv1alpha1.ReportResult{
-		Source:  SourceDeletingPolicy,
-		Policy:  policyName,
-		Scored:  true,
+		Source: SourceDeletingPolicy,
+		Policy: policyName,
+		Scored: true,
 		Subjects: []corev1.ObjectReference{{
 			APIVersion: resource.GetAPIVersion(),
 			Kind:       resource.GetKind(),
@@ -445,9 +445,9 @@ func DeletingPolicyToReportResult(policyName string, resource unstructured.Unstr
 // or ClusterCleanupPolicy run into a PolicyReport result entry.
 func CleanupPolicyToReportResult(policyName string, resource unstructured.Unstructured, deletionErr error) openreportsv1alpha1.ReportResult {
 	result := openreportsv1alpha1.ReportResult{
-		Source:  SourceCleanupPolicy,
-		Policy:  policyName,
-		Scored:  true,
+		Source: SourceCleanupPolicy,
+		Policy: policyName,
+		Scored: true,
 		Subjects: []corev1.ObjectReference{{
 			APIVersion: resource.GetAPIVersion(),
 			Kind:       resource.GetKind(),

--- a/pkg/utils/report/results.go
+++ b/pkg/utils/report/results.go
@@ -16,6 +16,7 @@ import (
 	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 )
@@ -408,4 +409,71 @@ func getResourceInfo(gvk schema.GroupVersionKind, name, namespace string) string
 		info = info + " Namespace=" + namespace
 	}
 	return info
+}
+
+// DeletingPolicyToReportResult converts a single resource deletion outcome (from a DeletingPolicy
+// or NamespacedDeletingPolicy run) into a PolicyReport result entry.
+// A nil err means the resource was successfully deleted (result=pass); non-nil err means failure (result=error).
+func DeletingPolicyToReportResult(policyName string, resource unstructured.Unstructured, deletionErr error) openreportsv1alpha1.ReportResult {
+	result := openreportsv1alpha1.ReportResult{
+		Source:  SourceDeletingPolicy,
+		Policy:  policyName,
+		Scored:  true,
+		Subjects: []corev1.ObjectReference{{
+			APIVersion: resource.GetAPIVersion(),
+			Kind:       resource.GetKind(),
+			Namespace:  resource.GetNamespace(),
+			Name:       resource.GetName(),
+			UID:        resource.GetUID(),
+		}},
+		Timestamp: metav1.Timestamp{Seconds: time.Now().Unix()},
+		Properties: map[string]string{
+			"process": "cleanup",
+		},
+	}
+	if deletionErr == nil {
+		result.Result = openreports.StatusPass
+		result.Description = "successfully deleted " + resourceRef(resource)
+	} else {
+		result.Result = openreports.StatusError
+		result.Description = "failed to delete " + resourceRef(resource) + ": " + deletionErr.Error()
+	}
+	return result
+}
+
+// CleanupPolicyToReportResult converts a single resource deletion outcome from a CleanupPolicy
+// or ClusterCleanupPolicy run into a PolicyReport result entry.
+func CleanupPolicyToReportResult(policyName string, resource unstructured.Unstructured, deletionErr error) openreportsv1alpha1.ReportResult {
+	result := openreportsv1alpha1.ReportResult{
+		Source:  SourceCleanupPolicy,
+		Policy:  policyName,
+		Scored:  true,
+		Subjects: []corev1.ObjectReference{{
+			APIVersion: resource.GetAPIVersion(),
+			Kind:       resource.GetKind(),
+			Namespace:  resource.GetNamespace(),
+			Name:       resource.GetName(),
+			UID:        resource.GetUID(),
+		}},
+		Timestamp: metav1.Timestamp{Seconds: time.Now().Unix()},
+		Properties: map[string]string{
+			"process": "cleanup",
+		},
+	}
+	if deletionErr == nil {
+		result.Result = openreports.StatusPass
+		result.Description = "successfully deleted " + resourceRef(resource)
+	} else {
+		result.Result = openreports.StatusError
+		result.Description = "failed to delete " + resourceRef(resource) + ": " + deletionErr.Error()
+	}
+	return result
+}
+
+// resourceRef returns a human-readable identifier for an unstructured resource.
+func resourceRef(resource unstructured.Unstructured) string {
+	if ns := resource.GetNamespace(); ns != "" {
+		return resource.GetKind() + "/" + ns + "/" + resource.GetName()
+	}
+	return resource.GetKind() + "/" + resource.GetName()
 }

--- a/pkg/utils/report/source.go
+++ b/pkg/utils/report/source.go
@@ -12,4 +12,6 @@ const (
 	SourceGeneratingPolicy          = "KyvernoGeneratingPolicy"
 	SourceMutatingPolicy            = "KyvernoMutatingPolicy"
 	SourceMutatingAdmissionPolicy   = "MutatingAdmissionPolicy"
+	SourceDeletingPolicy            = "KyvernoDeletingPolicy"
+	SourceCleanupPolicy             = "KyvernoCleanupPolicy"
 )


### PR DESCRIPTION
```markdown
## Explanation

Kyverno's `DeletingPolicy` / `NamespacedDeletingPolicy` and `CleanupPolicy` / `ClusterCleanupPolicy` had no structured, durable, per-resource audit trail of deletion operations. Platform teams running these policies for orphaned resource cleanup had no way to answer "which exact resources did this policy delete, in which namespace, and did any deletions fail?" without falling back to raw Kubernetes audit logs.

This PR adds two complementary observability signals for both policy families:

1. **PolicyReport / ClusterPolicyReport entries** — after each execution cycle, the cleanup controller creates or replaces a `(Cluster)PolicyReport` with one result entry per resource that was targeted for deletion, recording the resource identity, outcome (`pass` / `error`), timestamp, and error detail. This is an addition that brings `DeletingPolicy` and `CleanupPolicy` to parity with the report generation already in place for `ValidatingPolicy`, `MutatingPolicy`, etc.

2. **Per-resource Prometheus counters** — four new counters (`kyverno_deleting_controller_deleted_resources_total`, `kyverno_deleting_controller_deleted_resource_failures_total`, `kyverno_cleanup_controller_deleted_resources_total`, `kyverno_cleanup_controller_deleted_resource_failures_total`) carrying `resource_kind`, `resource_namespace`, and `resource_name` labels, enabling Prometheus alerting and dashboards at individual resource granularity.

## Related issue

Closes #1493

@JimBugwadia — following your guidance from the Kyverno Slack: _"all policy types should support the same events, metrics, logs, and reports. PRs are always welcome."_

## Milestone of this PR

/milestone 1.15.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Will be added once issue is triaged and milestone confirmed -->

## What type of PR is this

/kind feature

## Proposed Changes

### Summary of changes

| File | Change |
|---|---|
| `pkg/utils/report/source.go` | Add `SourceDeletingPolicy` and `SourceCleanupPolicy` string constants |
| `pkg/utils/report/results.go` | Add `DeletingPolicyToReportResult()` and `CleanupPolicyToReportResult()` helpers that convert a deleted resource + outcome into an `openreportsv1alpha1.ReportResult` |
| `pkg/controllers/deleting/report.go` | New `reportWriter` — creates or replaces a `ClusterPolicyReport` (DeletingPolicy) or `PolicyReport` (NamespacedDeletingPolicy) after each execution cycle |
| `pkg/controllers/deleting/controller.go` | Wire `reportWriter`; collect per-resource `deletionRecord`s during the deletion loop; call new per-resource metrics |
| `pkg/controllers/deleting/report_test.go` | 7 unit tests: cluster-scoped create, update idempotency, error result, empty run, namespaced create, helper pass/error |
| `pkg/controllers/cleanup/report.go` | New `cleanupReportWriter` — same pattern for `CleanupPolicy` / `ClusterCleanupPolicy` |
| `pkg/controllers/cleanup/controller.go` | Wire `cleanupReportWriter`; call new per-resource metrics |
| `pkg/metrics/deleting.go` | Extend `DeletingMetrics` interface; implement 2 new per-resource counters |
| `pkg/metrics/cleanup.go` | Extend `CleanupMetrics` interface; implement 2 new per-resource counters |

### Design decisions

- Each execution run **replaces** the previous `(Cluster)PolicyReport` results rather than appending, so the report always reflects the latest run without unbounded growth.
- Per-resource Prometheus labels (`resource_name`) are scoped to deletion events only — cardinality is bounded because only resources that matched the policy and were attempted for deletion are recorded.
- No new CRDs — uses the existing `wgpolicyk8s.io/v1alpha2` `PolicyReport` / `ClusterPolicyReport` CRDs already required by Kyverno.
- All new metric interface methods have nil-guards; existing aggregate metrics (`kyverno_deleting_controller_deletedobjects`, etc.) are unchanged — fully backwards compatible.

### Proof Manifests

#### DeletingPolicy

```yaml
apiVersion: policies.kyverno.io/v1beta1
kind: DeletingPolicy
metadata:
  name: delete-orphan-pods
spec:
  schedule: "*/5 * * * *"
  matchConstraints:
    resourceRules:
      - apiGroups: [""]
        apiVersions: ["v1"]
        resources: ["pods"]
        operations: ["CREATE", "UPDATE"]
    objectSelector:
      matchLabels:
        orphaned: "true"
  matchConditions:
    - name: older-than-1h
      expression: "timestamp(object.metadata.creationTimestamp) < now() - duration('1h')"
```

#### Resulting ClusterPolicyReport (after execution)

```yaml
apiVersion: wgpolicyk8s.io/v1alpha2
kind: ClusterPolicyReport
metadata:
  name: dpol-delete-orphan-pods
  labels:
    app.kubernetes.io/managed-by: kyverno
    policies.kyverno.io/dpol.name: delete-orphan-pods
  annotations:
    policies.kyverno.io/source: KyvernoDeletingPolicy
scope:
  apiVersion: policies.kyverno.io/v1beta1
  kind: DeletingPolicy
  name: delete-orphan-pods
results:
  - policy: delete-orphan-pods
    source: KyvernoDeletingPolicy
    result: pass
    message: "successfully deleted Pod/default/orphan-pod-xyz"
    resources:
      - apiVersion: v1
        kind: Pod
        namespace: default
        name: orphan-pod-xyz
        uid: "abc-123"
    timestamp:
      seconds: 1748476800
    properties:
      process: cleanup
  - policy: delete-orphan-pods
    source: KyvernoDeletingPolicy
    result: error
    message: "failed to delete Pod/default/orphan-pod-abc: forbidden"
    resources:
      - apiVersion: v1
        kind: Pod
        namespace: default
        name: orphan-pod-abc
        uid: "def-456"
    timestamp:
      seconds: 1748476801
summary:
  pass: 1
  error: 1
```

#### Prometheus metrics emitted (example)

```
kyverno_deleting_controller_deleted_resources_total{policy_type="DeletingPolicy",policy_namespace="",policy_name="delete-orphan-pods",resource_kind="Pod",resource_namespace="default",resource_name="orphan-pod-xyz"} 1

kyverno_deleting_controller_deleted_resource_failures_total{policy_type="DeletingPolicy",policy_namespace="",policy_name="delete-orphan-pods",resource_kind="Pod",resource_namespace="default",resource_name="orphan-pod-abc"} 1
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). AI assistance (GitHub Copilot) was used during development and is disclosed via `Assisted-by: GitHub Copilot` in the commit messages.
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added unit tests covering the new report writer (7 tests in `pkg/controllers/deleting/report_test.go`).
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and CLI support should be added.

## Further Comments

This brings `DeletingPolicy` and `CleanupPolicy` to full observability parity with the other Kyverno policy types. The implementation was intentionally kept minimal and consistent with existing patterns (`NewCleanupPolicyEvent`, `ToPolicyReportResult`, `SourceValidatingPolicy`, etc.) to make review straightforward.

The two commits on the branch are independent and can be reviewed separately:
1. `feat: emit PolicyReport/ClusterPolicyReport for DeletingPolicy and CleanupPolicy`
2. `feat: add per-resource Prometheus metrics for DeletingPolicy and CleanupPolicy`


Similar code found with 1 license type