### PR TITLE
fix(dpol): apply namespaceSelector against Namespace resource own labels

### DIFF
--- a/pkg/cel/policies/dpol/engine/engine.go
+++ b/pkg/cel/policies/dpol/engine/engine.go
@@ -59,7 +59,7 @@ func (e *Engine) Handle(ctx context.Context, policy Policy, resource unstructure
 			resource.GetName(),
 			mapping.Resource,
 			"",
-			"",
+			admission.Create,
 			nil,
 			false,
 			nil,
@@ -67,6 +67,12 @@ func (e *Engine) Handle(ctx context.Context, policy Policy, resource unstructure
 
 		if namespace != "" {
 			ns = e.nsResolver(namespace)
+		} else if resource.GroupVersionKind().Group == "" && resource.GetKind() == "Namespace" {
+			// For Namespace resources (cluster-scoped), use the resource itself as the
+			// namespace context so that namespaceSelector and namespaceObject work correctly.
+			if resolved := e.nsResolver(resource.GetName()); resolved != nil {
+				ns = resolved
+			}
 		}
 
 		if matches, err := e.matchPolicy(spec.MatchConstraints, attr, ns); err != nil {

--- a/pkg/cel/policies/dpol/engine/engine.go
+++ b/pkg/cel/policies/dpol/engine/engine.go
@@ -8,7 +8,9 @@ import (
 	"github.com/kyverno/kyverno/pkg/cel/libs"
 	"github.com/kyverno/kyverno/pkg/cel/matching"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
@@ -68,8 +70,16 @@ func (e *Engine) Handle(ctx context.Context, policy Policy, resource unstructure
 		if namespace != "" {
 			ns = e.nsResolver(namespace)
 		} else if resource.GroupVersionKind().Group == "" && resource.GetKind() == "Namespace" {
-			// For Namespace resources (cluster-scoped), use the resource itself as the
-			// namespace context so that namespaceSelector and namespaceObject work correctly.
+			// For Namespace resources (cluster-scoped), build ns from the resource itself so
+			// that namespaceSelector and namespaceObject work correctly even when the resolver
+			// cannot return the namespace (CLI, cache-miss, or test paths).
+			ns = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   resource.GetName(),
+					Labels: resource.GetLabels(),
+				},
+			}
+			// Prefer the resolver's copy if available (may carry additional metadata).
 			if resolved := e.nsResolver(resource.GetName()); resolved != nil {
 				ns = resolved
 			}

--- a/pkg/cel/policies/dpol/engine/engine_test.go
+++ b/pkg/cel/policies/dpol/engine/engine_test.go
@@ -18,8 +18,13 @@ import (
 )
 
 var (
-	invalidDpol = &policiesv1beta1.DeletingPolicy{}
-	dpol        = &policiesv1beta1.DeletingPolicy{
+	invalidDpol     = &policiesv1beta1.DeletingPolicy{}
+	namespaceMapper = func() meta.RESTMapper {
+		m := meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "", Version: "v1"}})
+		m.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}, meta.RESTScopeRoot)
+		return m
+	}()
+	dpol = &policiesv1beta1.DeletingPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "valid-policy",
 		},
@@ -161,6 +166,66 @@ func TestHandleConstraintsNil(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.False(t, resp.Match)
+}
+
+func TestHandleNamespaceWithNamespaceSelector(t *testing.T) {
+	dpolNs := &policiesv1beta1.DeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "cleanup-namespaces"},
+		Spec: policiesv1beta1.DeletingPolicySpec{
+			MatchConstraints: &v1.MatchResources{
+				ResourceRules: []v1.NamedRuleWithOperations{{
+					RuleWithOperations: v1.RuleWithOperations{
+						Operations: []v1.OperationType{v1.OperationAll},
+						Rule:       v1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"namespaces"}},
+					},
+				}},
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{{
+						Key:      "project-name",
+						Operator: metav1.LabelSelectorOpExists,
+					}},
+				},
+			},
+			Conditions: []v1.MatchCondition{{Name: "always-true", Expression: "true"}},
+		},
+	}
+
+	makeNs := func(name string, labels map[string]string) unstructured.Unstructured {
+		u := unstructured.Unstructured{}
+		u.SetAPIVersion("v1")
+		u.SetKind("Namespace")
+		u.SetName(name)
+		u.SetLabels(labels)
+		return u
+	}
+
+	nsResolverWith := func(name string, labels map[string]string) func(string) *corev1.Namespace {
+		return func(ns string) *corev1.Namespace {
+			if ns == name {
+				return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+			}
+			return nil
+		}
+	}
+
+	compiledDpol, errs := comp.Compile(dpolNs, nil)
+	assert.Empty(t, errs)
+	pol := Policy{Policy: dpolNs, CompiledPolicy: compiledDpol}
+
+	t.Run("namespace with matching label matches", func(t *testing.T) {
+		labels := map[string]string{"project-name": "my-project"}
+		engine := NewEngine(nsResolverWith("my-ns", labels), namespaceMapper, &libs.FakeContextProvider{}, matcher)
+		resp, err := engine.Handle(ctx, pol, makeNs("my-ns", labels))
+		assert.NoError(t, err)
+		assert.True(t, resp.Match)
+	})
+
+	t.Run("namespace without matching label does not match", func(t *testing.T) {
+		engine := NewEngine(nsResolverWith("kube-system", nil), namespaceMapper, &libs.FakeContextProvider{}, matcher)
+		resp, err := engine.Handle(ctx, pol, makeNs("kube-system", nil))
+		assert.NoError(t, err)
+		assert.False(t, resp.Match)
+	})
 }
 
 func TestHandleError(t *testing.T) {

--- a/pkg/cel/policies/dpol/engine/engine_test.go
+++ b/pkg/cel/policies/dpol/engine/engine_test.go
@@ -295,6 +295,10 @@ func TestHandleCleanupIntegrationTestNamespaces(t *testing.T) {
 		"kube-system":           {"kubernetes.io/metadata.name": "kube-system"},
 		"default":               {"kubernetes.io/metadata.name": "default"},
 	})
+
+	// noopResolver simulates CLI/cache-miss paths where the resolver always returns nil.
+	noopResolver := func(string) *corev1.Namespace { return nil }
+
 	engine := NewEngine(nsResolver, namespaceMapper, &libs.FakeContextProvider{}, matcher)
 
 	tests := []struct {
@@ -336,6 +340,20 @@ func TestHandleCleanupIntegrationTestNamespaces(t *testing.T) {
 			assert.Equal(t, tt.wantMatch, resp.Match)
 		})
 	}
+
+	// Verify the fix holds even when the resolver returns nil (CLI / cache-miss paths):
+	// ns must be built from the resource itself so namespaceSelector still works.
+	noopEngine := NewEngine(noopResolver, namespaceMapper, &libs.FakeContextProvider{}, matcher)
+	t.Run("project namespace matches with noop resolver (CLI path)", func(t *testing.T) {
+		resp, err := noopEngine.Handle(ctx, pol, makeNs("acti-bifrost-even-env", map[string]string{"project-name": "acti-bifrost-even-env"}))
+		assert.NoError(t, err)
+		assert.True(t, resp.Match)
+	})
+	t.Run("system namespace not matched with noop resolver (CLI path)", func(t *testing.T) {
+		resp, err := noopEngine.Handle(ctx, pol, makeNs("kube-system", map[string]string{"kubernetes.io/metadata.name": "kube-system"}))
+		assert.NoError(t, err)
+		assert.False(t, resp.Match)
+	})
 }
 
 func TestHandleError(t *testing.T) {

--- a/pkg/cel/policies/dpol/engine/engine_test.go
+++ b/pkg/cel/policies/dpol/engine/engine_test.go
@@ -228,6 +228,116 @@ func TestHandleNamespaceWithNamespaceSelector(t *testing.T) {
 	})
 }
 
+// TestHandleCleanupIntegrationTestNamespaces mirrors the real-world DeletingPolicy:
+//
+//	apiVersion: policies.kyverno.io/v1
+//	kind: DeletingPolicy
+//	metadata:
+//	  name: cleanup-integration-test-namespaces
+//	spec:
+//	  schedule: "*/5 * * * *"
+//	  matchConstraints:
+//	    resourceRules:
+//	      - apiGroups: [""]
+//	        apiVersions: ["v1"]
+//	        resources: ["namespaces"]
+//	    namespaceSelector:
+//	      matchExpressions:
+//	        - key: project-name
+//	          operator: Exists
+func TestHandleCleanupIntegrationTestNamespaces(t *testing.T) {
+	dpol := &policiesv1beta1.DeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "cleanup-integration-test-namespaces"},
+		Spec: policiesv1beta1.DeletingPolicySpec{
+			Schedule: "*/5 * * * *",
+			MatchConstraints: &v1.MatchResources{
+				ResourceRules: []v1.NamedRuleWithOperations{{
+					RuleWithOperations: v1.RuleWithOperations{
+						Operations: []v1.OperationType{v1.OperationAll},
+						Rule:       v1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"namespaces"}},
+					},
+				}},
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{{
+						Key:      "project-name",
+						Operator: metav1.LabelSelectorOpExists,
+					}},
+				},
+			},
+			// No conditions — empty list matches all resources that pass the namespace selector.
+		},
+	}
+
+	compiled, errs := comp.Compile(dpol, nil)
+	assert.Empty(t, errs)
+	pol := Policy{Policy: dpol, CompiledPolicy: compiled}
+
+	makeNs := func(name string, labels map[string]string) unstructured.Unstructured {
+		u := unstructured.Unstructured{}
+		u.SetAPIVersion("v1")
+		u.SetKind("Namespace")
+		u.SetName(name)
+		u.SetLabels(labels)
+		return u
+	}
+
+	resolverFor := func(namespaces map[string]map[string]string) func(string) *corev1.Namespace {
+		return func(name string) *corev1.Namespace {
+			if labels, ok := namespaces[name]; ok {
+				return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+			}
+			return nil
+		}
+	}
+
+	nsResolver := resolverFor(map[string]map[string]string{
+		"acti-bifrost-even-env": {"project-name": "acti-bifrost-even-env"},
+		"kube-system":           {"kubernetes.io/metadata.name": "kube-system"},
+		"default":               {"kubernetes.io/metadata.name": "default"},
+	})
+	engine := NewEngine(nsResolver, namespaceMapper, &libs.FakeContextProvider{}, matcher)
+
+	tests := []struct {
+		name      string
+		nsName    string
+		labels    map[string]string
+		wantMatch bool
+	}{
+		{
+			name:      "project namespace with project-name label is matched for cleanup",
+			nsName:    "acti-bifrost-even-env",
+			labels:    map[string]string{"project-name": "acti-bifrost-even-env"},
+			wantMatch: true,
+		},
+		{
+			name:      "kube-system without project-name label is not matched",
+			nsName:    "kube-system",
+			labels:    map[string]string{"kubernetes.io/metadata.name": "kube-system"},
+			wantMatch: false,
+		},
+		{
+			name:      "default namespace without project-name label is not matched",
+			nsName:    "default",
+			labels:    map[string]string{"kubernetes.io/metadata.name": "default"},
+			wantMatch: false,
+		},
+		{
+			name:      "project namespace with both labels is matched",
+			nsName:    "my-project-ns",
+			labels:    map[string]string{"project-name": "my-project-ns", "kubernetes.io/metadata.name": "my-project-ns"},
+			wantMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := engine.Handle(ctx, pol, makeNs(tt.nsName, tt.labels))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantMatch, resp.Match)
+		})
+	}
+}
+
 func TestHandleError(t *testing.T) {
 	policy := &policiesv1beta1.DeletingPolicy{
 		Spec: policiesv1beta1.DeletingPolicySpec{


### PR DESCRIPTION
## Summary

- When a `DeletingPolicy` targets `Namespace` resources, `namespaceSelector` in `matchConstraints` was silently ignored because `GetNamespaceLabels` fell through to a lister lookup with an empty namespace name, returning a synthetic object with no user-defined labels
- `namespaceObject` in CEL conditions was also broken for the same reason (`ns` was always `nil` for cluster-scoped Namespace resources)

## Root cause

Two issues in `pkg/cel/policies/dpol/engine/engine.go`:

1. `admission.Attributes` were constructed with an empty operation (`""`). `GetNamespaceLabels` (copied from the upstream webhook namespace matcher) only reads the object's own labels when the operation is `Create` or `Update` — otherwise it falls through to a namespace lister lookup using `attr.GetNamespace()`, which returns `""` for cluster-scoped resources, yielding a synthetic namespace with no labels.

2. The `ns` variable was only populated via `nsResolver` when `resource.GetNamespace() != ""`, so it was always `nil` for Namespace resources.

## Fix

- Pass `admission.Create` as the operation, matching the Kubernetes VAP/webhook behavior for Namespace resources on Create/Update (current-object labels are authoritative)
- For core Namespace resources, resolve `ns` using `nsResolver(resource.GetName())` so `namespaceObject` is correctly populated in CEL conditions

## Test plan

- [ ] `go test ./pkg/cel/policies/dpol/engine/...` passes
- [ ] New `TestHandleNamespaceWithNamespaceSelector` covers: namespace with matching label → match, namespace without matching label → no match

🤖 Generated with [Claude Code](https://claude.com/claude-code)