### PR TITLE
fix: resolve policy mixing in webhook generation (#16131)

### DIFF
--- a/EVIDENCE.md
+++ b/EVIDENCE.md
@@ -1,0 +1,142 @@
+# Issue #16131 - Policies get mixed
+
+## Root Cause Analysis
+
+**Problem**: Multiple `NamespacedValidatingPolicy` resources with different `objectSelector` or `namespaceSelector` constraints were being incorrectly consolidated into a single `ValidatingWebhookConfiguration`. This caused the webhook selectors to reflect only the last policy processed, breaking the matching logic for all other policies.
+
+**Location**: `pkg/controllers/webhook/validating.go:173-300` (function `buildWebhookRules`)
+
+**Root Cause**: 
+- Basic policies (those without fine-grained matching like timeouts, exact match policy, or match conditions) were consolidated into two shared webhooks (`webhookIgnore` and `webhookFail`)
+- For each policy, selector assignments **overwrote** previous values instead of handling each policy separately
+- Lines 199-214 in original code repeatedly assigned selectors to the shared webhooks
+- Rules were appended across policies, but selectors reflected only the last policy
+
+## Solution Design
+
+**Pattern Applied**: Individual Webhook Pattern (similar to fine-grained policies)
+
+**OOP Principles Used**:
+- **Encapsulation**: Each webhook now encapsulates its own rules and selectors
+- **Separation of Concerns**: Each policy gets its own webhook, eliminating selector collision
+- **Consistency**: Matches the pattern already used for fine-grained policies
+
+**Key Changes**:
+1. Create individual webhooks for each basic policy (instead of consolidating into two shared webhooks)
+2. Each webhook gets its own `NamespaceSelector` and `ObjectSelector` from its policy
+3. Each webhook gets a unique name using `generateName()` function with policy name
+4. Each webhook gets its own client config path with the policy name
+
+## Implementation Details
+
+### Before (Broken)
+```go
+// Single webhookIgnore and webhookFail used for ALL basic policies
+webhookIgnore := admissionregistrationv1.ValidatingWebhook{...}
+webhookFail := admissionregistrationv1.ValidatingWebhook{...}
+
+for _, policy := range basic {
+  // Selectors OVERWRITTEN on each iteration
+  webhookIgnore.NamespaceSelector = mergeLabelSelectors(...)
+  webhookIgnore.ObjectSelector = mergeLabelSelectors(...)
+  webhookFail.NamespaceSelector = mergeLabelSelectors(...)
+  webhookFail.ObjectSelector = mergeLabelSelectors(...)
+  
+  // Rules APPENDED
+  webhookIgnore.Rules = append(webhookIgnore.Rules, webhookRules...)
+}
+```
+
+### After (Fixed)
+```go
+// Separate lists for ignore and fail webhooks
+var basicIgnoreList, basicFailList []admissionregistrationv1.ValidatingWebhook
+
+for _, policy := range basic {
+  // Create fresh webhook for EACH policy
+  webhook := admissionregistrationv1.ValidatingWebhook{...}
+  
+  // Selectors set ONCE per policy
+  webhook.NamespaceSelector = mergeLabelSelectors(...)
+  webhook.ObjectSelector = mergeLabelSelectors(...)
+  webhook.Rules = webhookRules
+  
+  // Unique name per policy
+  webhook.Name = generateName(name+"-ignore", p)
+  
+  // Add to appropriate list
+  basicIgnoreList = append(basicIgnoreList, webhook)
+}
+```
+
+## Test Coverage
+
+Added comprehensive test case: `TestBuildWebhookRules_ValidatingPolicy/Multiple_Policies_with_Different_Selectors_(Issue_#16131)`
+
+**Test Scenario**:
+- Two `ValidatingPolicy` resources:
+  1. `deny-app-deletion-by-label` - No object selector
+  2. `deny-intermediate-app-deletion` - Has `objectSelector: definer.myorg.de/type=intermediate`
+- Both target `argoproj.io/v1alpha1` Applications on DELETE
+
+**Expected Behavior** (now validated):
+- Two separate webhooks generated
+- First webhook has no object selector
+- Second webhook has the specific object selector
+- Each webhook has unique name and client config path
+
+## Testing Results
+
+```
+=== RUN   TestBuildWebhookRules_ValidatingPolicy
+=== RUN   TestBuildWebhookRules_ValidatingPolicy/Single_Ignore_Policy
+=== RUN   TestBuildWebhookRules_ValidatingPolicy/Single_Fail_Policy
+=== RUN   TestBuildWebhookRules_ValidatingPolicy/Fine-Grained_Ignore_Policy
+=== RUN   TestBuildWebhookRules_ValidatingPolicy/Fine-Grained_Fail_Policy
+=== RUN   TestBuildWebhookRules_ValidatingPolicy/Multiple_Policies_with_Different_Selectors_(Issue_#16131)
+--- PASS: TestBuildWebhookRules_ValidatingPolicy (0.01s)
+
+=== RUN   TestBuildWebhookRules_ImageValidatingPolicy
+=== RUN   TestBuildWebhookRules_ImageValidatingPolicy/Autogen_Single_Ignore_Policy
+=== RUN   TestBuildWebhookRules_ImageValidatingPolicy/Autogen_Fine-grained_Ignore_Policy
+--- PASS: TestBuildWebhookRules_ImageValidatingPolicy (0.00s)
+
+✓ All webhook tests pass
+✓ New test case validates the fix
+```
+
+## Before/After Behavior
+
+### Before (Issue)
+User creates two NamespacedValidatingPolicy:
+1. `deny-app-deletion-by-label` - Matches all argo apps, denies deletion if labeled
+2. `deny-intermediate-app-deletion` - Matches only intermediate-labeled argo apps, denies deletion
+
+Result:
+- **Single webhook generated** with mixed rules
+- Webhook's `objectSelector` reflects ONLY the last policy
+- First policy's rules are present but won't match correctly due to wrong selector
+- Application that should be protected is not protected
+
+### After (Fixed)
+Result:
+- **Two separate webhooks generated**
+- First webhook: no object selector, applies to all apps (policy 1)
+- Second webhook: object selector for intermediate, applies to intermediate apps (policy 2)
+- Each policy works correctly with its own selector
+- Application protection works as intended
+
+## Code Quality
+
+✓ Minimal changes - only necessary logic restructured
+✓ No breaking changes to public APIs
+✓ Maintains backward compatibility
+✓ Follows existing patterns (matches fine-grained policy approach)
+✓ Self-documenting code with clear variable names
+✓ All existing tests pass after update
+✓ New test covers the issue
+
+## Files Modified
+
+1. `pkg/controllers/webhook/validating.go` - Fixed webhook consolidation logic
+2. `pkg/controllers/webhook/validating_test.go` - Added test case and updated existing test expectations

--- a/pkg/controllers/webhook/validating.go
+++ b/pkg/controllers/webhook/validating.go
@@ -172,46 +172,14 @@ func buildWebhookRules(cfg config.Configuration, server, name, queryPath string,
 	}
 	// process basic policies
 	if len(basic) != 0 {
-		names := make([]string, 0, len(basic))
-		for _, policy := range basic {
-			names = append(names, policy.GetName())
-		}
-		slices.Sort(names)
-		dynamicPath := path.Join(names...)
-		webhookIgnore := admissionregistrationv1.ValidatingWebhook{
-			Name:                    name + "-ignore",
-			ClientConfig:            newClientConfig(server, servicePort, caBundle, path.Join(queryPath, dynamicPath)),
-			FailurePolicy:           ptr.To(admissionregistrationv1.Ignore),
-			SideEffects:             &noneOnDryRun,
-			AdmissionReviewVersions: []string{"v1"},
-		}
-		webhookFail := admissionregistrationv1.ValidatingWebhook{
-			Name:                    name + "-fail",
-			ClientConfig:            newClientConfig(server, servicePort, caBundle, path.Join(queryPath, dynamicPath)),
-			FailurePolicy:           ptr.To(admissionregistrationv1.Fail),
-			SideEffects:             &noneOnDryRun,
-			AdmissionReviewVersions: []string{"v1"},
-		}
-		webhookFail.NamespaceSelector = cfg.GetWebhook().NamespaceSelector
-
+		var basicIgnoreList, basicFailList []admissionregistrationv1.ValidatingWebhook
 		for _, policy := range basic {
 			p := extractGenericPolicy(policy)
-			webhookIgnore.NamespaceSelector = mergeLabelSelectors(
-				p.GetMatchConstraints().NamespaceSelector,
-				cfg.GetWebhook().NamespaceSelector,
-			)
-			webhookIgnore.ObjectSelector = mergeLabelSelectors(
-				p.GetMatchConstraints().ObjectSelector,
-				cfg.GetWebhook().ObjectSelector,
-			)
-			webhookFail.NamespaceSelector = mergeLabelSelectors(
-				p.GetMatchConstraints().NamespaceSelector,
-				cfg.GetWebhook().NamespaceSelector,
-			)
-			webhookFail.ObjectSelector = mergeLabelSelectors(
-				p.GetMatchConstraints().ObjectSelector,
-				cfg.GetWebhook().ObjectSelector,
-			)
+			webhook := admissionregistrationv1.ValidatingWebhook{
+				SideEffects:             &noneOnDryRun,
+				AdmissionReviewVersions: []string{"v1"},
+			}
+
 			var webhookRules []admissionregistrationv1.RuleWithOperations
 			if vpol, ok := p.(*policiesv1beta1.ValidatingPolicy); ok {
 				rules, err := vpolautogen.Autogen(vpol)
@@ -285,17 +253,34 @@ func buildWebhookRules(cfg config.Configuration, server, name, queryPath string,
 					webhookRules = append(webhookRules, match.RuleWithOperations)
 				}
 			}
+
+			webhook.Rules = webhookRules
+			webhook.NamespaceSelector = mergeLabelSelectors(
+				p.GetMatchConstraints().NamespaceSelector,
+				cfg.GetWebhook().NamespaceSelector,
+			)
+			webhook.ObjectSelector = mergeLabelSelectors(
+				p.GetMatchConstraints().ObjectSelector,
+				cfg.GetWebhook().ObjectSelector,
+			)
+
 			if p.GetFailurePolicy(toggle.FromContext(context.TODO()).ForceFailurePolicyIgnore()) == admissionregistrationv1.Ignore {
-				webhookIgnore.Rules = append(webhookIgnore.Rules, webhookRules...)
+				webhook.FailurePolicy = ptr.To(admissionregistrationv1.Ignore)
+				webhook.Name = generateName(name+"-ignore", p)
+				webhook.ClientConfig = newClientConfig(server, servicePort, caBundle, path.Join(queryPath, p.GetName()))
+				basicIgnoreList = append(basicIgnoreList, webhook)
 			} else {
-				webhookFail.Rules = append(webhookFail.Rules, webhookRules...)
+				webhook.FailurePolicy = ptr.To(admissionregistrationv1.Fail)
+				webhook.Name = generateName(name+"-fail", p)
+				webhook.ClientConfig = newClientConfig(server, servicePort, caBundle, path.Join(queryPath, p.GetName()))
+				basicFailList = append(basicFailList, webhook)
 			}
 		}
-		if webhookFail.Rules != nil {
-			webhooks = append(webhooks, webhookFail)
+		if basicFailList != nil {
+			webhooks = append(webhooks, basicFailList...)
 		}
-		if webhookIgnore.Rules != nil {
-			webhooks = append(webhooks, webhookIgnore)
+		if basicIgnoreList != nil {
+			webhooks = append(webhooks, basicIgnoreList...)
 		}
 	}
 	return webhooks

--- a/pkg/controllers/webhook/validating_test.go
+++ b/pkg/controllers/webhook/validating_test.go
@@ -24,6 +24,9 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 			name: "Single Ignore Policy",
 			vpols: []*policiesv1beta1.ValidatingPolicy{
 				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-ignore",
+					},
 					Spec: policiesv1beta1.ValidatingPolicySpec{
 						FailurePolicy: ptr.To(admissionregistrationv1.Ignore),
 						MatchConstraints: &admissionregistrationv1.MatchResources{
@@ -56,7 +59,7 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 			},
 			expectedWebhooks: []admissionregistrationv1.ValidatingWebhook{
 				{
-					Name: config.ValidatingPolicyWebhookName + "-ignore",
+					Name: config.ValidatingPolicyWebhookName + "-ignore-test-ignore",
 					Rules: []admissionregistrationv1.RuleWithOperations{
 						{
 							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
@@ -86,6 +89,9 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 			name: "Single Fail Policy",
 			vpols: []*policiesv1beta1.ValidatingPolicy{
 				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-fail",
+					},
 					Spec: policiesv1beta1.ValidatingPolicySpec{
 						FailurePolicy: ptr.To(admissionregistrationv1.Fail),
 						MatchConstraints: &admissionregistrationv1.MatchResources{
@@ -118,7 +124,7 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 			},
 			expectedWebhooks: []admissionregistrationv1.ValidatingWebhook{
 				{
-					Name: config.ValidatingPolicyWebhookName + "-fail",
+					Name: config.ValidatingPolicyWebhookName + "-fail-test-fail",
 					Rules: []admissionregistrationv1.RuleWithOperations{
 						{
 							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
@@ -300,6 +306,101 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 				},
 			},
 		},
+			{
+				name: "Multiple Policies with Different Selectors (Issue #16131)",
+				vpols: []*policiesv1beta1.ValidatingPolicy{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "deny-app-deletion-by-label",
+						},
+						Spec: policiesv1beta1.ValidatingPolicySpec{
+							FailurePolicy: ptr.To(admissionregistrationv1.Fail),
+							MatchConstraints: &admissionregistrationv1.MatchResources{
+								ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+									{
+										RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+											Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Delete},
+											Rule: admissionregistrationv1.Rule{
+												APIGroups:   []string{"argoproj.io"},
+												APIVersions: []string{"v1alpha1"},
+												Resources:   []string{"applications"},
+												Scope:       ptr.To(admissionregistrationv1.ScopeType("*")),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "deny-intermediate-app-deletion",
+						},
+						Spec: policiesv1beta1.ValidatingPolicySpec{
+							FailurePolicy: ptr.To(admissionregistrationv1.Ignore),
+							MatchConstraints: &admissionregistrationv1.MatchResources{
+								ObjectSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"definer.myorg.de/type": "intermediate",
+									},
+								},
+								ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+									{
+										RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+											Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Delete},
+											Rule: admissionregistrationv1.Rule{
+												APIGroups:   []string{"argoproj.io"},
+												APIVersions: []string{"v1alpha1"},
+												Resources:   []string{"applications"},
+												Scope:       ptr.To(admissionregistrationv1.ScopeType("*")),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				expectedWebhooks: []admissionregistrationv1.ValidatingWebhook{
+					{
+						Name: config.ValidatingPolicyWebhookName + "-fail-deny-app-deletion-by-label",
+						Rules: []admissionregistrationv1.RuleWithOperations{
+							{
+								Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Delete},
+								Rule: admissionregistrationv1.Rule{
+									APIGroups:   []string{"argoproj.io"},
+									APIVersions: []string{"v1alpha1"},
+									Resources:   []string{"applications"},
+									Scope:       ptr.To(admissionregistrationv1.ScopeType("*")),
+								},
+							},
+						},
+						FailurePolicy:     ptr.To(admissionregistrationv1.Fail),
+						NamespaceSelector: nil,
+						ObjectSelector:    nil,
+					},
+					{
+						Name: config.ValidatingPolicyWebhookName + "-ignore-deny-intermediate-app-deletion",
+						Rules: []admissionregistrationv1.RuleWithOperations{
+							{
+								Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Delete},
+								Rule: admissionregistrationv1.Rule{
+									APIGroups:   []string{"argoproj.io"},
+									APIVersions: []string{"v1alpha1"},
+									Resources:   []string{"applications"},
+									Scope:       ptr.To(admissionregistrationv1.ScopeType("*")),
+								},
+							},
+						},
+						FailurePolicy: ptr.To(admissionregistrationv1.Ignore),
+						ObjectSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"definer.myorg.de/type": "intermediate",
+							},
+						},
+					},
+				},
+			},
 	}
 
 	for _, tt := range tests {
@@ -359,6 +460,9 @@ func TestBuildWebhookRules_ImageValidatingPolicy(t *testing.T) {
 			name: "Autogen Single Ignore Policy",
 			ivpols: []*policiesv1beta1.ImageValidatingPolicy{
 				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-ivpol-ignore",
+					},
 					Spec: policiesv1beta1.ImageValidatingPolicySpec{
 						FailurePolicy: ptr.To(admissionregistrationv1.Ignore),
 						MatchConstraints: &admissionregistrationv1.MatchResources{
@@ -381,7 +485,7 @@ func TestBuildWebhookRules_ImageValidatingPolicy(t *testing.T) {
 			},
 			expectedWebhooks: []admissionregistrationv1.ValidatingWebhook{
 				{
-					Name: config.ImageValidatingPolicyValidateWebhookName + "-ignore",
+					Name: config.ImageValidatingPolicyValidateWebhookName + "-ignore-test-ivpol-ignore",
 					Rules: []admissionregistrationv1.RuleWithOperations{
 						{
 							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},


### PR DESCRIPTION
## Summary
- Refactored policy webhook registration to create per-policy webhooks instead of consolidated ones
- Fixes #16131 where multiple policies with different selectors were incorrectly mixed
- Each policy now gets unique webhook with independent selector configuration

## Root Cause
Policy-level selectors were being overwritten instead of preserved per-policy

## Test Plan
- [x] Added comprehensive test for multiple policies with different selectors
- [x] All existing webhook tests pass
- [x] Validates per-policy webhook independence