### PR TITLE
fix: make unused-package-check fail when go mod tidy changes files (#16091)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,9 +211,13 @@ lint: $(GOLANGCI_LINT)
 
 .PHONY: unused-package-check
 unused-package-check:
-	@tidy=$$(go mod tidy); \
-	if [ -n "$${tidy}" ]; then \
-		echo "go mod tidy checking failed!"; echo "$${tidy}"; echo; \
+	@go mod tidy; \
+	changes=$$(git diff --name-only go.mod go.sum 2>/dev/null); \
+	if [ -n "$${changes}" ]; then \
+		echo "go mod tidy checking failed! The following files have uncommitted changes:"; \
+		echo "$${changes}"; \
+		echo "Run 'go mod tidy' and commit the changes."; \
+		exit 1; \
 	fi
 
 $(BACKGROUND_BIN): fmt


### PR DESCRIPTION
## Summary
- Fixed go mod tidy check to detect actual file changes instead of relying on stdout
- Root cause: go mod tidy modifies files silently without stdout output
- Now uses git diff to detect changes to go.mod and go.sum

## Changes
- Line 215: Changed from checking command stdout to using git diff output
- Properly detects when go mod tidy actually modified dependency files

## Test Plan
- [x] Makefile check now correctly detects dependency changes
- [x] Fails appropriately when go.mod/go.sum are not tidied
- [x] Passes when dependencies are properly managed