### PR TITLE
feat: Enable Cosign verbosity debugging

### DIFF
--- a/cmd/internal/cosign.go
+++ b/cmd/internal/cosign.go
@@ -1,0 +1,14 @@
+package internal
+
+import (
+	"os"
+
+	"github.com/google/go-containerregistry/pkg/logs"
+)
+
+func setupCosignLogging() {
+	if !enableCosignLogging {
+		return
+	}
+	logs.Debug.SetOutput(os.Stderr)
+}

--- a/cmd/internal/flag.go
+++ b/cmd/internal/flag.go
@@ -50,10 +50,11 @@ var (
 	enableConfigMapCaching bool
 	openreportsEnabled     bool
 	// cosign
-	enableTUF  bool
-	tufMirror  string
-	tufRoot    string
-	tufRootRaw string
+	enableTUF           bool
+	enableCosignLogging bool
+	tufMirror           string
+	tufRoot             string
+	tufRootRaw          string
 	// registry client
 	imagePullSecrets          string
 	allowInsecureRegistry     bool
@@ -149,6 +150,7 @@ func initDeferredLoadingFlags() {
 
 func initCosignFlags() {
 	flag.BoolVar(&enableTUF, "enableTuf", false, "enable tuf for private sigstore deployments")
+	flag.BoolVar(&enableCosignLogging, "enableCosignLogging", false, "enable debug logging for cosign")
 	flag.StringVar(&tufMirror, "tufMirror", tuf.DefaultRemoteRoot, "Alternate TUF mirror for sigstore. If left blank, public sigstore one is used for cosign verification.")
 	flag.StringVar(&tufRoot, "tufRoot", "", "Path to alternate TUF root.json for sigstore (url or env). If left blank, public sigstore one is used for cosign verification.")
 	flag.StringVar(&tufRootRaw, "tufRootRaw", "", "The raw body of alternate TUF root.json for sigstore. If left blank, public sigstore one is used for cosign verification.")

--- a/cmd/internal/setup.go
+++ b/cmd/internal/setup.go
@@ -84,6 +84,7 @@ func Setup(config Configuration, name string, skipResourceFilters bool) (context
 	}
 	if config.UsesCosign() {
 		setupSigstoreTUF(ctx, logger)
+		setupCosignLogging()
 	}
 	var leaderElectionClient kubeclient.UpstreamInterface
 	if config.UsesLeaderElection() {

--- a/pkg/engine/internal/imageverifier.go
+++ b/pkg/engine/internal/imageverifier.go
@@ -507,7 +507,6 @@ func (iv *imageVerifier) buildCosignVerifier(
 	}
 
 	iv.logger.V(4).Info("cosign verifier built", "ignoreTlog", opts.IgnoreTlog, "ignoreSCT", opts.IgnoreSCT, "image", image)
-	// logs.Debug.SetOutput(os.Stderr)
 	return cosign.NewVerifier(), opts, path
 }
 

--- a/pkg/engine/internal/imageverifier.go
+++ b/pkg/engine/internal/imageverifier.go
@@ -507,6 +507,7 @@ func (iv *imageVerifier) buildCosignVerifier(
 	}
 
 	iv.logger.V(4).Info("cosign verifier built", "ignoreTlog", opts.IgnoreTlog, "ignoreSCT", opts.IgnoreSCT, "image", image)
+	// logs.Debug.SetOutput(os.Stderr)
 	return cosign.NewVerifier(), opts, path
 }
 


### PR DESCRIPTION
## Explanation

Currently the verbosity flags describe the verbosity of kyverno logs, and not dependent internal libraries like cosign.
Hence there is no way to debug issues related to verification in cosign - even with verbosity level 6 we don't see logs for cosign.

## Related issue

Fixes #15368 

## Milestone of this PR


## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [x] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

https://github.com/kyverno/website/pull/2056

## What type of PR is this

/kind feature

## Proposed Changes

This PR introduces a new flag called: `enableCosignLogging` which when set to true, enables the cosign debugging by using the same logger being used inside cosign and redirecting its output to `os.Stderr` to appear in logs besides kyverno's loggr. (Logs are separated)

### Proof Manifests

### Kubernetes resource
#### Pod

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
spec:
  containers:
    - name: nginx
      image: ghcr.io/kyverno/test-verify-image:signed
```

#### Policy

```yaml
apiVersion: policies.kyverno.io/v1
kind: ImageValidatingPolicy
metadata:
  name: verify-cosign
spec:
  evaluation:
    background:
      enabled: false
  webhookConfiguration:
    timeoutSeconds: 30
  validationActions:
    - Deny
  matchConstraints:
    resourceRules:
      - apiGroups: [""]
        apiVersions: ["v1"]
        operations: ["CREATE", "UPDATE"]
        resources: ["pods"]
  matchImageReferences:
    - glob: "ghcr.io/kyverno/test-verify-image:*"
  attestors:
    - name: cosignKey
      cosign:
        key:
          data: |-
            -----BEGIN PUBLIC KEY-----
            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
            5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
            -----END PUBLIC KEY-----
        ctlog:
          url: https://rekor.sigstore.dev
          insecureIgnoreTlog: true
  validations:
    - expression: >-
        images.containers.map(image, verifyImageSignatures(image, [attestors.cosignKey])).all(e, e > 0)
      message: failed to verify image with cosign key
```

#### Old policy

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: verify-cosign
spec:
  background: false
  failurePolicy: Fail
  rules:
    - name: verify-signature
      match:
        any:
          - resources:
              kinds:
                - Pod
      verifyImages:
        - imageReferences:
            - "ghcr.io/kyverno/test-verify-image:*"
          attestors:
            - entries:
                - keys:
                    publicKeys: |-
                      -----BEGIN PUBLIC KEY-----
                      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
                      5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
                      -----END PUBLIC KEY-----
                    rekor:
                      ignoreTlog: true
          failureAction: Enforce
```

#### Helm values
```yaml
admissionController:
  container:
    extraArgs:
      enableCosignLogging: true
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments


