### PR TITLE
fix: do not abort required validation on non-matching images

### DIFF
--- a/pkg/engine/handlers/validation/validate_image.go
+++ b/pkg/engine/handlers/validation/validate_image.go
@@ -85,8 +85,8 @@ func (h validateImageHandler) Process(
 				image := imageInfo.String()
 
 				if !engineutils.ImageMatches(image, imageVerify.ImageReferences) {
-					logger.V(4).Info("image does not match", "imageReferences", imageVerify.ImageReferences)
-					return resource, nil
+					logger.V(4).Info("image does not match, skipping", "image", image, "imageReferences", imageVerify.ImageReferences)
+					continue
 				}
 
 				logger.V(4).Info("validating image", "image", image)

--- a/pkg/engine/handlers/validation/validate_image_test.go
+++ b/pkg/engine/handlers/validation/validate_image_test.go
@@ -1,0 +1,98 @@
+package validation
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/go-logr/logr"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/config"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/kyverno/kyverno/pkg/engine/jmespath"
+	"github.com/kyverno/kyverno/pkg/engine/policycontext"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const verifyImageRequiredPolicy = `{
+	"apiVersion": "kyverno.io/v1",
+	"kind": "ClusterPolicy",
+	"metadata": {
+		"name": "verify-required"
+	},
+	"spec": {
+		"rules": [{
+			"name": "verify-image",
+			"match": {
+				"any": [{
+					"resources": {
+						"kinds": ["Pod"]
+					}
+				}]
+			},
+			"verifyImages": [{
+				"imageReferences": ["ghcr.io/verified/*"],
+				"required": true,
+				"verifyDigest": false
+			}]
+		}]
+	}
+}`
+
+const multiContainerPod = `{
+	"apiVersion": "v1",
+	"kind": "Pod",
+	"metadata": {
+		"name": "test-pod",
+		"namespace": "default"
+	},
+	"spec": {
+		"initContainers": [{
+			"name": "sidecar",
+			"image": "docker.io/busybox:1.36"
+		}],
+		"containers": [{
+			"name": "app",
+			"image": "ghcr.io/verified/app:v1"
+		}]
+	}
+}`
+
+// TestValidateImageHandler_RequiredEnforcedWithNonMatchingImage ensures verifyImages(required)
+// still fails unverified matching images when another container uses a non-matching image.
+// Non-matching images must be skipped, not abort evaluation with an empty response.
+func TestValidateImageHandler_RequiredEnforcedWithNonMatchingImage(t *testing.T) {
+	t.Parallel()
+
+	var cpol kyvernov1.ClusterPolicy
+	require.NoError(t, json.Unmarshal([]byte(verifyImageRequiredPolicy), &cpol))
+
+	resource, err := kubeutils.BytesToUnstructured([]byte(multiContainerPod))
+	require.NoError(t, err)
+
+	cfg := config.NewDefaultConfiguration(false)
+	jp := jmespath.New(cfg)
+
+	policyContext, err := policycontext.NewPolicyContext(jp, *resource, kyvernov1.Create, nil, cfg)
+	require.NoError(t, err)
+	policyContext = policyContext.WithPolicy(&cpol).WithNewResource(*resource)
+
+	rule := cpol.Spec.Rules[0]
+	handler, err := NewValidateImageHandler(policyContext, *resource, rule, cfg, nil, true)
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+
+	h := handler.(validateImageHandler)
+	logger := logr.Discard()
+
+	// Map iteration order is non-deterministic; repeat to cover early-return on non-matching image.
+	for i := 0; i < 32; i++ {
+		_, responses := h.Process(context.Background(), logger, policyContext, *resource, rule, nil, nil)
+		require.NotEmpty(t, responses, "iteration %d: expected a rule response, got none (verifyImages bypass)", i)
+		assert.Equal(t, engineapi.RuleStatusFail, responses[0].Status(), "iteration %d", i)
+		assert.Equal(t, engineapi.ImageVerify, responses[0].RuleType(), "iteration %d", i)
+		assert.Contains(t, responses[0].Message(), "unverified image", "iteration %d", i)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a fail-open path in `verifyImages` validation when `required: true` is set.
If a workload contains multiple container images and one of them does **not** match `imageReferences`, the validate-image handler returned `(resource, nil)` and stopped evaluation. That produced an empty engine response, which the image verification webhook ignores, so admission could succeed even when another container used a matching but **unverified** image.
Non-matching images are now skipped with `continue` so matching images are still enforced.

Fixes [GHSA-m85g-9h78-gj6r](https://github.com/kyverno/kyverno/security/advisories/GHSA-m85g-9h78-gj6r).

## Root cause
In `pkg/engine/handlers/validation/validate_image.go`, the handler iterated all images in the policy context but aborted the whole rule on the first non-matching image:
```go
return resource, nil  // empty RuleResponse → webhook does not block
```
Because image iteration uses Go map order, a non-matching sidecar/init container could be visited before a matching unverified image, making the bypass intermittent on multi-container workloads.

## Fix
- Replace early `return resource, nil` with `continue` for non-matching images.
- Slightly improve debug logging (`image does not match, skipping` + image name).
Behavior is aligned with the minimal fix in the reporter’s `fix.patch`.

## Testing
- [x] Added `TestValidateImageHandler_RequiredEnforcedWithNonMatchingImage` (pod with matching unverified + non-matching images; repeated to cover map iteration order).
- [x] Verified against reporter PoC control test (`TestVerifyImagesRequiredControl`).
- [x] Verified canonical bypass test no longer reproduces (`TestVerifyImagesRequiredBypass` fails with “bypass not observed”).
- [x] Manual Kind test: `verifyImages.required: true` + multi-container pod → consistently denied (`image is not verified`).