### PR TITLE
fix: add access to clusterroles and bindings in the standard kyverno config

### DIFF
--- a/scripts/config/standard/kyverno.yaml
+++ b/scripts/config/standard/kyverno.yaml
@@ -43,6 +43,8 @@ backgroundController:
             - secrets
             - roles
             - rolebindings
+            - clusterroles
+            - clusterrolebindings
             - limitranges
             - namespaces
             - nodes


### PR DESCRIPTION
## Explanation

Some of the recently added tests demand mutate access to CRs and CRBs. add that to the standard config along with the other resources