### PR TITLE
fix: add the readiness checker to the ci image archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1013,6 +1013,7 @@ docker-save-image-all: image-build-all ## Save docker images in archive
 		$(LOCAL_REGISTRY)/$(LOCAL_REPORTS_REPO):$(GIT_SHA) \
 		$(LOCAL_REGISTRY)/$(LOCAL_BACKGROUND_REPO):$(GIT_SHA) \
 		$(LOCAL_REGISTRY)/$(LOCAL_CLI_REPO):$(GIT_SHA) \
+		$(LOCAL_REGISTRY)/$(LOCAL_READINESS_REPO):$(GIT_SHA) \
 	> kyverno.tar
 
 ########


### PR DESCRIPTION
## Explanation

After the change in https://github.com/kyverno/kyverno/pull/16181, the make command for helm installation uses a local version of the readiness checker. but the step that creates the archive artifact that contains the images wasn't adding the readiness checker image to it