### PR TITLE
fix(cli): treat expected-fail patchedResources diff as a passing test

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -22,6 +22,13 @@ import (
 
 var ansiRegex = regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:[a-zA-Z0-9]*(?:;[a-zA-Z0-9]*)*)?\u0007|(?:\\d{1,4}(?:;\\d{0,4})*)?[0-mG-Z])")
 
+// reasonResourceDiff is the reason returned by checkResult when the actual
+// patched/generated resource does not match the resource declared in the test
+// result. It is distinct from a rule status mismatch ("Want X, got Y") so that
+// callers can treat an intentional resource diff (a negative mutation test with
+// result: fail) as a pass without masking genuine status mismatches.
+const reasonResourceDiff = "Resource diff"
+
 func Command() *cobra.Command {
 	var testCase, outputFormat string
 	var fileName, gitBranch string
@@ -220,7 +227,7 @@ func checkResult(
 				legend = StripANSI(legend)
 				diff = StripANSI(diff)
 			}
-			return false, fmt.Sprintf("Patched resource didn't match the patched resource in the test result\n(%s)\n\n%s", legend, diff), "Resource diff"
+			return false, fmt.Sprintf("Patched resource didn't match the patched resource in the test result\n(%s)\n\n%s", legend, diff), reasonResourceDiff
 		}
 	}
 	if test.GeneratedResource != "" && len(test.GeneratedResources) == 0 {
@@ -235,7 +242,7 @@ func checkResult(
 				legend = StripANSI(legend)
 				diff = StripANSI(diff)
 			}
-			return false, fmt.Sprintf("Patched resource didn't match the generated resource in the test result\n(%s)\n\n%s", legend, diff), "Resource diff"
+			return false, fmt.Sprintf("Patched resource didn't match the generated resource in the test result\n(%s)\n\n%s", legend, diff), reasonResourceDiff
 		}
 	} else if len(test.GeneratedResources) > 0 {
 		matched := false
@@ -263,7 +270,7 @@ func checkResult(
 				legend = StripANSI(legend)
 				lastDiff = StripANSI(lastDiff)
 			}
-			return false, fmt.Sprintf("Generated resource didn't match any of the expected generated resources in the test result\n(%s)\n\n%s", legend, lastDiff), "Resource diff"
+			return false, fmt.Sprintf("Generated resource didn't match any of the expected generated resources in the test result\n(%s)\n\n%s", legend, lastDiff), reasonResourceDiff
 		}
 	}
 	result := report.ComputePolicyReportResult(false, response, rule)

--- a/cmd/cli/kubectl-kyverno/commands/test/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command_test.go
@@ -249,6 +249,62 @@ func TestResultCountsOnMismatch(t *testing.T) {
 	}
 }
 
+// TestIsExpectedFailure covers the regression from #16100: a negative mutation
+// test (patchedResources with result: fail) reports a resource diff, and that
+// intentional diff must be treated as a passing test. A rule status mismatch
+// ("Want X, got Y") must never be rescued, so #15361 / #11519 stays fixed.
+func TestIsExpectedFailure(t *testing.T) {
+	failResult := v1alpha1.TestResult{
+		TestResultBase: v1alpha1.TestResultBase{Result: openreportsv1alpha1.Result(openreports.StatusFail)},
+	}
+	passResult := v1alpha1.TestResult{
+		TestResultBase: v1alpha1.TestResultBase{Result: openreportsv1alpha1.Result(openreports.StatusPass)},
+	}
+
+	tests := []struct {
+		name   string
+		ok     bool
+		reason string
+		test   v1alpha1.TestResult
+		want   bool
+	}{
+		{
+			name:   "resource diff with expected fail is rescued as pass",
+			ok:     false,
+			reason: reasonResourceDiff,
+			test:   failResult,
+			want:   true,
+		},
+		{
+			name:   "resource diff with expected pass is not rescued",
+			ok:     false,
+			reason: reasonResourceDiff,
+			test:   passResult,
+			want:   false,
+		},
+		{
+			name:   "status mismatch with expected fail is not rescued",
+			ok:     false,
+			reason: "Want fail, got pass",
+			test:   failResult,
+			want:   false,
+		},
+		{
+			name:   "matching result is never a rescued failure",
+			ok:     true,
+			reason: "Ok",
+			test:   failResult,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isExpectedFailure(tt.ok, tt.reason, tt.test))
+		})
+	}
+}
+
 func Test_JSONPayload(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err, "Failed to get working directory")

--- a/cmd/cli/kubectl-kyverno/commands/test/output.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/output.go
@@ -267,14 +267,16 @@ func printTestResult(
 								continue
 							}
 
-							resourceRows := createRowsAccordingToResults(test, rc, &testCount, ruleName, ok, message, reason, strings.Replace(resource, ",", "/", -1))
+							success := ok || isExpectedFailure(ok, reason, test)
+							resourceRows := createRowsAccordingToResults(test, rc, &testCount, ruleName, success, message, reason, strings.Replace(resource, ",", "/", -1))
 							rows = append(rows, resourceRows...)
 						} else {
 							generatedResources := rule.GeneratedResources()
 							for _, r := range generatedResources {
 								ok, message, reason := checkResult(test, fs, resourcePath, response, rule, *r, removeColor)
 
-								resourceRows := createRowsAccordingToResults(test, rc, &testCount, ruleName, ok, message, reason, r.GetName())
+								success := ok || isExpectedFailure(ok, reason, test)
+								resourceRows := createRowsAccordingToResults(test, rc, &testCount, ruleName, success, message, reason, r.GetName())
 								rows = append(rows, resourceRows...)
 							}
 						}
@@ -314,7 +316,8 @@ func printTestResult(
 					r, rule := extractPatchedTargetFromEngineResponse(apiVersion, kind, name, ns, response)
 					ok, message, reason := checkResult(test, fs, resourcePath, response, *rule, *r, removeColor)
 
-					resourceRows := createRowsAccordingToResults(test, rc, &testCount, rule.Name(), ok, message, reason, strings.Replace(resource, ",", "/", -1))
+					success := ok || isExpectedFailure(ok, reason, test)
+					resourceRows := createRowsAccordingToResults(test, rc, &testCount, rule.Name(), success, message, reason, strings.Replace(resource, ",", "/", -1))
 					rows = append(rows, resourceRows...)
 				}
 			}
@@ -363,6 +366,17 @@ func printTestResult(
 		}
 	}
 	return nil
+}
+
+// isExpectedFailure reports whether a checkResult failure should be counted as a
+// passing test. A negative mutation/generation test declares result: fail to assert
+// that the patched (or generated) resource intentionally differs from the expected
+// resource. In that case checkResult returns ok=false with reason reasonResourceDiff,
+// and the mismatch is the expected outcome, so it counts as a pass. A rule status
+// mismatch (reason "Want X, got Y") is never rescued, so genuine status mismatches
+// still fail (see #15361 / #11519).
+func isExpectedFailure(ok bool, reason string, test v1alpha1.TestResult) bool {
+	return !ok && reason == reasonResourceDiff && test.Result == openreports.StatusFail
 }
 
 func createRowsAccordingToResults(test v1alpha1.TestResult, rc *resultCounts, globalTestCounter *int, ruleName string, success bool, message string, reason string, resourceGVKAndName string) []table.Row {

--- a/test/cli/test-mutate/patched-resource-negative/kyverno-test.yaml
+++ b/test/cli/test-mutate/patched-resource-negative/kyverno-test.yaml
@@ -1,0 +1,27 @@
+# Negative mutation test (see issue #16100): a patchedResources entry whose
+# expected result is "fail" asserts that the patched resource intentionally
+# differs from the declared result (a guard against undesired mutation changes).
+# The expected-pass case asserts the mutation produces the declared result.
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: patched-resource-negative
+policies:
+- policy.yaml
+resources:
+- resources.yaml
+results:
+- policy: test-mutation
+  rule: add-annotation
+  patchedResources: results.yaml
+  kind: ConfigMap
+  resources:
+  - expected-pass
+  result: pass
+- policy: test-mutation
+  rule: add-annotation
+  patchedResources: results.yaml
+  kind: ConfigMap
+  resources:
+  - expected-fail
+  result: fail

--- a/test/cli/test-mutate/patched-resource-negative/policy.yaml
+++ b/test/cli/test-mutate/patched-resource-negative/policy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: test-mutation
+spec:
+  rules:
+  - name: add-annotation
+    match:
+      all:
+      - resources:
+          kinds:
+          - ConfigMap
+    mutate:
+      patchStrategicMerge:
+        metadata:
+          annotations:
+            test-annotation: "foo"

--- a/test/cli/test-mutate/patched-resource-negative/resources.yaml
+++ b/test/cli/test-mutate/patched-resource-negative/resources.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: expected-pass
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: expected-fail

--- a/test/cli/test-mutate/patched-resource-negative/results.yaml
+++ b/test/cli/test-mutate/patched-resource-negative/results.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: expected-pass
+  annotations:
+    test-annotation: foo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: expected-fail
+  annotations:
+    test-annotation: bar


### PR DESCRIPTION
Fixes #16100

## Problem

A mutation test that declares `patchedResources` with `result: fail` is a negative
example: it asserts that the patched resource intentionally differs from the
declared result (for instance, to guard against an undesired change in ordering or
content). This worked with the CLI up to 1.17 but broke in 1.18: the expected-fail
case is reported as a real failure and fails the whole suite with a non-zero exit
code.

Minimal reproduction from the issue (ConfigMap mutation adding `test-annotation: foo`,
with a `results.yaml` whose `expected-fail` entry deliberately has the wrong value):

```
$ kyverno test --detailed-results --require-tests=true .
...
| 1 | test-mutation | add-annotation | .../expected-pass | Pass | Ok            | ...
| 2 | test-mutation | add-annotation | .../expected-fail | Fail | Resource diff | Patched resource didn't match ...

Test Summary: 1 tests passed and 1 tests failed
Error: 1 tests failed   (exit 1)
```

With 1.17 the second row reported `Pass` (reason `Resource diff`) and the suite
exited 0.

## Root cause

In `printTestResult`, #15361 replaced the per-resource success calculation

```go
success := ok || (!ok && test.Result == openreports.StatusFail)
```

with the raw `checkResult` `ok` value. That blanket rescue was too broad (it also
masked genuine status mismatches, which is what #15361 set out to fix for #11519),
but removing it entirely also dropped the legitimate case: a `patchedResources`
diff mismatch where the test author expects `fail`.

`checkResult` already distinguishes the two failure modes by the reason it returns:
a resource-content mismatch yields reason `Resource diff`, while a rule status
mismatch yields `Want X, got Y`. Only the first should be rescued for an
expected-`fail` test.

## Fix

- Name the resource-diff reason as a constant `reasonResourceDiff` and return it
  from the three diff branches in `checkResult`.
- Add `isExpectedFailure(ok, reason, test)`, which rescues a failure only when it is
  a resource-diff mismatch and the test expects `fail`. A status mismatch is never
  rescued, so the behavior #15361 intended for #11519 is preserved.
- Apply it at the three `printTestResult` call sites that previously used the raw
  `ok`.

## Tests

- New unit test `TestIsExpectedFailure` (alongside the existing
  `TestCheckResultDetectsMismatch` / `TestResultCountsOnMismatch` added in #15361)
  covers all four combinations: resource diff + expected fail (rescued), resource
  diff + expected pass (not rescued), status mismatch + expected fail (not rescued),
  and a matching result.
- New CLI fixture `test/cli/test-mutate/patched-resource-negative/` mirrors the
  issue's reproduction and is picked up by `kyverno test ./test/cli/test-mutate`.

## Before / after

New fixture, before this change:

```
Test Summary: 1 tests passed and 1 tests failed
Error: 1 tests failed   (exit 1)
```

After:

```
| 1 | test-mutation | add-annotation | .../expected-pass | Pass | Ok            |
| 2 | test-mutation | add-annotation | .../expected-fail | Pass | Resource diff |

Test Summary: 2 tests passed and 0 tests failed   (exit 0)
```

A control case confirms #15361 is not regressed: a validation policy that expects
`fail` but passes (no `patchedResources`, so it takes the status-mismatch path)
still reports `Fail` / `Want fail, got pass` and exits 1.

`go test ./cmd/cli/...` passes, and `kyverno test ./test/cli/test-mutate` reports
all tests passing.
