### PR TITLE
fix(gpol,mpol): enforce namespace boundary in generator.apply() (backport GHSA-79gf-7frw-68m9 to release-1.18)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/kyverno/kyverno-authz v0.4.1-0.20260403194244-37d6f8943fa8
 	github.com/kyverno/kyverno-json v0.0.4-0.20240730143747-aade3d42fc0e
 	github.com/kyverno/playground/backend v0.0.0-20251124111549-b7997c02bca2
-	github.com/kyverno/sdk v0.0.0-20260403020150-29a100fa834c
+	github.com/kyverno/sdk v0.0.0-20260529121714-3c70db82e2e4
 	github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7
 	github.com/notaryproject/notation-core-go v1.3.0
 	github.com/notaryproject/notation-go v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -672,8 +672,8 @@ github.com/kyverno/playground/backend v0.0.0-20251124111549-b7997c02bca2 h1:uLTs
 github.com/kyverno/playground/backend v0.0.0-20251124111549-b7997c02bca2/go.mod h1:EumSDUMvIitgwlZBvVYnlgC285mZ0yCjAfoiu8s3o/g=
 github.com/kyverno/pod-security-admission v0.0.0-20251031094455-46f20778634f h1:9u+4QYMLdZPC8qeUB1TnfiUYRrFGYHxjYQsPiHKgJjI=
 github.com/kyverno/pod-security-admission v0.0.0-20251031094455-46f20778634f/go.mod h1:2oJ/wAoh8hld09eMTT1KzlN3dHjKEQn1xJdu1WAZMa0=
-github.com/kyverno/sdk v0.0.0-20260403020150-29a100fa834c h1:xte6C9WfSFZAmpTLv/nQcZpn4O4SXEZ3ChsiAlqeaJk=
-github.com/kyverno/sdk v0.0.0-20260403020150-29a100fa834c/go.mod h1:duWj9TYUzHnKH15v013U33kElDDAnBfQcftK/a3dcHM=
+github.com/kyverno/sdk v0.0.0-20260529121714-3c70db82e2e4 h1:OvfaBZcRpJg3LLpbBWqbx4k+j5ve42BO/1NMIGO6LE4=
+github.com/kyverno/sdk v0.0.0-20260529121714-3c70db82e2e4/go.mod h1:lmMOICE6t6Oks0ufVf3lUCTxcxGbdQqe5J56+EP8Q3Y=
 github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7 h1:k/1ku0yehLCPqERCHkIHMDqDg1R02AcCScRuHbamU3s=
 github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7/go.mod h1:YR/zYthNdWfO8+0IOyHDcIDBBBS2JMnYUIwSsnwmRqU=
 github.com/lestrrat-go/blackmagic v1.0.4 h1:IwQibdnf8l2KoO+qC3uT4OaTWsW7tuRQXy9TRN9QanA=

--- a/pkg/cel/compiler/compiler_test.go
+++ b/pkg/cel/compiler/compiler_test.go
@@ -700,7 +700,7 @@ generator.apply(
 			assert.NoError(t, err)
 			env, err := base.Extend(
 				cel.Variable(GeneratorKey, generator.ContextType),
-				generator.Lib(nil, versions.KyvernoLatest),
+				generator.Lib(nil, "", versions.KyvernoLatest),
 			)
 			assert.NoError(t, err)
 			gotProgs, gotErrs := CompileGenerations(nil, env, tt.generations...)

--- a/pkg/cel/libs/context.go
+++ b/pkg/cel/libs/context.go
@@ -3,6 +3,7 @@ package libs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/kyverno/kyverno/api/kyverno"
@@ -194,6 +195,14 @@ func (cp *contextProvider) GenerateResources(namespace string, dataList []map[st
 		for _, item := range items {
 			targetNamespace := namespace
 			if !cp.isNamespacedResource(item.GetAPIVersion(), item.GetKind()) {
+				// A non-empty namespace means the call is scoped to a single
+				// namespace, which for a namespaced policy is its own namespace
+				// (enforced in the generator lib). Cluster-scoped resources have
+				// no namespace, so generating one would escape that scope. Reject
+				// it instead of silently creating the resource cluster-wide.
+				if namespace != "" {
+					return fmt.Errorf("cross-scope generation denied: a policy scoped to namespace %q cannot generate cluster-scoped resource %s/%s", namespace, item.GetAPIVersion(), item.GetKind())
+				}
 				targetNamespace = ""
 			}
 

--- a/pkg/cel/libs/context_generate_test.go
+++ b/pkg/cel/libs/context_generate_test.go
@@ -1,0 +1,77 @@
+package libs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func generateTestRESTMapper() meta.RESTMapper {
+	gvs := []schema.GroupVersion{
+		{Group: "", Version: "v1"},
+		{Group: "rbac.authorization.k8s.io", Version: "v1"},
+		{Group: "networking.k8s.io", Version: "v1"},
+	}
+	m := meta.NewDefaultRESTMapper(gvs)
+	m.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}, meta.RESTScopeNamespace)
+	m.Add(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"}, meta.RESTScopeRoot)
+	m.Add(schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "IngressClass"}, meta.RESTScopeRoot)
+	return m
+}
+
+func clusterRoleBinding() map[string]any {
+	return map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRoleBinding",
+		"metadata":   map[string]any{"name": "escalate"},
+	}
+}
+
+// A namespaced policy passes its own namespace as the apply() argument, which
+// satisfies the namespace-boundary check, but a cluster-scoped resource still
+// escapes that namespace. It must be rejected.
+func TestGenerateResources_NamespacedPolicyRejectsClusterScoped(t *testing.T) {
+	cp := &contextProvider{
+		cliEvaluation: true,
+		restMapper:    generateTestRESTMapper(),
+	}
+
+	err := cp.GenerateResources("tenant-ns", []map[string]any{clusterRoleBinding()})
+	assert.Error(t, err, "namespaced policy must not generate a cluster-scoped resource")
+	assert.Contains(t, err.Error(), "cross-scope generation denied")
+	assert.Empty(t, cp.GetGeneratedResources())
+}
+
+// A namespaced resource generated into the policy namespace is still allowed.
+func TestGenerateResources_NamespacedPolicyAllowsNamespaced(t *testing.T) {
+	cp := &contextProvider{
+		cliEvaluation: true,
+		restMapper:    generateTestRESTMapper(),
+	}
+
+	cm := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "data", "namespace": "tenant-ns"},
+	}
+	err := cp.GenerateResources("tenant-ns", []map[string]any{cm})
+	assert.NoError(t, err)
+	assert.Len(t, cp.GetGeneratedResources(), 1)
+	assert.Equal(t, "tenant-ns", cp.GetGeneratedResources()[0].GetNamespace())
+}
+
+// A cluster-scoped policy uses an empty namespace argument and may still
+// generate cluster-scoped resources.
+func TestGenerateResources_ClusterPolicyAllowsClusterScoped(t *testing.T) {
+	cp := &contextProvider{
+		cliEvaluation: true,
+		restMapper:    generateTestRESTMapper(),
+	}
+
+	err := cp.GenerateResources("", []map[string]any{clusterRoleBinding()})
+	assert.NoError(t, err)
+	assert.Len(t, cp.GetGeneratedResources(), 1)
+	assert.Empty(t, cp.GetGeneratedResources()[0].GetNamespace())
+}

--- a/pkg/cel/policies/gpol/compiler/compiler.go
+++ b/pkg/cel/policies/gpol/compiler/compiler.go
@@ -78,6 +78,7 @@ func (c *compilerImpl) createBaseGpolEnv(libsctx libs.Context, namespace string)
 		cel.Variable(compiler.ExceptionsKey, types.NewObjectType("libs.Exception")),
 		generator.Lib(
 			generator.Context{ContextInterface: libsctx},
+			namespace,
 			generator.Latest(),
 		),
 		globalcontext.Lib(

--- a/pkg/cel/policies/gpol/engine/engine_test.go
+++ b/pkg/cel/policies/gpol/engine/engine_test.go
@@ -13,6 +13,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -203,6 +204,42 @@ func TestHandle(t *testing.T) {
 		resp, err := eng.Handle(req, pol, false)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
+	})
+
+	t.Run("NamespacedGeneratingPolicy with cross-namespace generator.apply compiles (enforcement is at runtime)", func(t *testing.T) {
+		ngpol := &v1beta1.NamespacedGeneratingPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cross-ns-escalate",
+				Namespace: "tenant-ns",
+			},
+			Spec: v1beta1.GeneratingPolicySpec{
+				MatchConstraints: &admissionregistrationv1.MatchResources{
+					ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+						{
+							RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+								Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+								Rule: admissionregistrationv1.Rule{
+									APIGroups:   []string{""},
+									APIVersions: []string{"v1"},
+									Resources:   []string{"configmaps"},
+								},
+							},
+						},
+					},
+				},
+				Generation: []v1beta1.Generation{
+					{
+						Expression: `generator.apply("kube-system", [{"apiVersion": dyn("v1"), "kind": dyn("ConfigMap")}])`,
+					},
+				},
+			},
+		}
+		comp := compiler.NewCompiler()
+		// The namespace boundary is enforced at evaluation time by the generator
+		// lib's namespacedImpl, so compilation of a namespaced policy that targets
+		// another namespace must still succeed.
+		_, errList := comp.Compile(ngpol, nil)
+		assert.Nil(t, errList)
 	})
 
 	t.Run("should evaluate compiled policy with variable expressions and policy exceptions", func(t *testing.T) {

--- a/pkg/cel/policies/mpol/compiler/compiler.go
+++ b/pkg/cel/policies/mpol/compiler/compiler.go
@@ -158,6 +158,7 @@ func (c *compilerImpl) newExtendedEnv(libCtx libs.Context, namespace string) (*c
 		environment.UnversionedLib(library.JSONPatch), // the kubernetes jsonpatch library to enable escapeKey
 		generator.Lib(
 			generator.Context{ContextInterface: libCtx},
+			namespace,
 			generator.Latest(),
 		),
 		globalcontext.Lib(

--- a/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/chainsaw-test.yaml
@@ -24,7 +24,7 @@ spec:
         - name: name
           value: cross-ns-escalate
         - name: namespace
-          value: test-namespace
+          value: tenant-ns
   - name: create trigger namespace
     try:
     - apply:

--- a/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/chainsaw-test.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cross-namespace-denied
+spec:
+  steps:
+  - name: create namespace
+    try:
+    - create:
+        file: namespace.yaml
+  - name: create policy
+    use:
+      template: ../../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait-namespaced-generating-policy-ready
+    use:
+      template: ../../../_step-templates/namespaced-generating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: cross-ns-escalate
+        - name: namespace
+          value: test-namespace
+  - name: create trigger namespace
+    try:
+    - apply:
+        file: trigger-namespace.yaml
+  - name: sleep
+    try:
+    - sleep:
+        duration: 5s
+  - name: confirm cross-namespace generation is denied
+    try:
+    - error:
+        resource:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: should-not-exist
+            namespace: default

--- a/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/namespace.yaml
+++ b/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-namespace

--- a/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/namespace.yaml
+++ b/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: test-namespace
+  name: tenant-ns

--- a/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/policy.yaml
+++ b/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/policy.yaml
@@ -1,0 +1,34 @@
+# A NamespacedGeneratingPolicy in test-namespace that attempts to generate a
+# ConfigMap into the "default" namespace (a namespace other than its own). The
+# generator lib enforces the namespace boundary at evaluation time, so the
+# cross-namespace ConfigMap must never be created.
+apiVersion: policies.kyverno.io/v1beta1
+kind: NamespacedGeneratingPolicy
+metadata:
+  name: cross-ns-escalate
+  namespace: test-namespace
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["namespaces"]
+  variables:
+    - name: configmap
+      expression: >-
+        [
+          {
+            "kind": dyn("ConfigMap"),
+            "apiVersion": dyn("v1"),
+            "metadata": dyn({
+              "name": "should-not-exist",
+              "namespace": "default",
+            }),
+            "data": dyn({
+              "managed-by": "kyverno"
+            })
+          }
+        ]
+  generate:
+    - expression: generator.apply("default", variables.configmap)

--- a/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/policy.yaml
+++ b/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/policy.yaml
@@ -1,4 +1,4 @@
-# A NamespacedGeneratingPolicy in test-namespace that attempts to generate a
+# A NamespacedGeneratingPolicy in tenant-ns that attempts to generate a
 # ConfigMap into the "default" namespace (a namespace other than its own). The
 # generator lib enforces the namespace boundary at evaluation time, so the
 # cross-namespace ConfigMap must never be created.
@@ -6,7 +6,7 @@ apiVersion: policies.kyverno.io/v1beta1
 kind: NamespacedGeneratingPolicy
 metadata:
   name: cross-ns-escalate
-  namespace: test-namespace
+  namespace: tenant-ns
 spec:
   matchConstraints:
     resourceRules:

--- a/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/trigger-namespace.yaml
+++ b/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/trigger-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: trigger-ns

--- a/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/trigger-namespace.yaml
+++ b/test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/trigger-namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: trigger-ns
+  name: cross-ns-trigger


### PR DESCRIPTION
## Explanation

Backport of **GHSA-79gf-7frw-68m9** to `release-1.18`.

A `NamespacedGeneratingPolicy` / `NamespacedMutatingPolicy` could call
`generator.apply("<arbitrary-namespace>", [...])` to make the background
controller create resources in any namespace it has RBAC on, bypassing the
intended namespace isolation.

### Fix
- `generator.Lib()` now accepts the policy namespace. When non-empty, the SDK
  wires a `namespacedImpl` that rejects, **at evaluation time**, any
  `generator.apply()` whose target namespace differs from the policy's own
  namespace.
- `GenerateResources` additionally rejects cluster-scoped resources whenever a
  namespace is set, so a namespaced policy cannot emit a cluster-scoped resource
  that would escape its namespace.

### Why this is a manual backport (not a cherry-pick)
The `main` fix (`5164bcded`) is entangled with an SDK package migration
(`kyverno/sdk/cel/libs` → `kyverno/sdk/extensions/cel/libs`) plus unrelated
dependency bumps that don't belong on `release-1.18`. This PR pins
`github.com/kyverno/sdk` to the old-layout build that carries the fix
(`ghsa-79gf-7frw-68m9-compat`, `v0.0.0-20260529121714-3c70db82e2e4`).

> **Semantic note:** unlike `main`, enforcement here is a **runtime** check
> inside the CEL binding (the namespace argument can't be removed from the
> signature), so namespaced policies still compile successfully and denial
> happens at evaluation. The unit/conformance tests were adapted accordingly.

## Related issue(s)

Fixes GHSA-79gf-7frw-68m9

## Proof Manifests

Conformance test added at
`test/conformance/chainsaw/namespaced-generating-policies/data/cross-namespace-denied/`:
a `NamespacedGeneratingPolicy` in `test-namespace` attempting to generate a
ConfigMap into `default` — the ConfigMap must never be created.

## Verification done locally
- `go build ./...`
- `go test ./pkg/cel/libs/... ./pkg/cel/policies/gpol/... ./pkg/cel/policies/mpol/... ./pkg/cel/compiler/...` (all pass)
- `go vet` on changed packages
- `make imports-check fmt-check` (pass)

## Checklist

<!--
Please mark any checkboxes that do not apply to this PR as [N/A].
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [N/A] My PR contains new or altered behavior to Kyverno and (select one):
- [x] My PR is a backport of an already-merged security fix; documentation is handled in the main PR.
