### PR TITLE
fix: allow pod-level seccomp in restrict-seccomp-strict vpol

### DIFF
--- a/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.cel.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.cel.yaml
@@ -35,26 +35,51 @@ spec:
   {{ end }}
   validations:
     - expression: >-
-        ((has(object.spec.securityContext) && 
-         has(object.spec.securityContext.seccompProfile) && 
-         has(object.spec.securityContext.seccompProfile.type) && 
-         object.spec.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']) ||
-        (!has(object.spec.securityContext) || !has(object.spec.securityContext.seccompProfile))) &&
-        (!has(object.spec.containers) || object.spec.containers.all(c, 
-          has(c.securityContext) && 
-          has(c.securityContext.seccompProfile) && 
-          has(c.securityContext.seccompProfile.type) && 
-          c.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost'])) &&
-        (!has(object.spec.initContainers) || object.spec.initContainers.all(c, 
-          has(c.securityContext) && 
-          has(c.securityContext.seccompProfile) && 
-          has(c.securityContext.seccompProfile.type) && 
-          c.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost'])) &&
-        (!has(object.spec.ephemeralContainers) || object.spec.ephemeralContainers.all(c, 
-          has(c.securityContext) && 
-          has(c.securityContext.seccompProfile) && 
-          has(c.securityContext.seccompProfile.type) && 
-          c.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']))
+        (!has(object.spec.containers) || object.spec.containers.all(c,
+          (
+            has(c.securityContext) &&
+            has(c.securityContext.seccompProfile) &&
+            has(c.securityContext.seccompProfile.type) &&
+            c.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
+          ) ||
+          (
+            !(has(c.securityContext) && has(c.securityContext.seccompProfile) && has(c.securityContext.seccompProfile.type)) &&
+            has(object.spec.securityContext) &&
+            has(object.spec.securityContext.seccompProfile) &&
+            has(object.spec.securityContext.seccompProfile.type) &&
+            object.spec.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
+          )
+        )) &&
+        (!has(object.spec.initContainers) || object.spec.initContainers.all(c,
+          (
+            has(c.securityContext) &&
+            has(c.securityContext.seccompProfile) &&
+            has(c.securityContext.seccompProfile.type) &&
+            c.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
+          ) ||
+          (
+            !(has(c.securityContext) && has(c.securityContext.seccompProfile) && has(c.securityContext.seccompProfile.type)) &&
+            has(object.spec.securityContext) &&
+            has(object.spec.securityContext.seccompProfile) &&
+            has(object.spec.securityContext.seccompProfile.type) &&
+            object.spec.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
+          )
+        )) &&
+        (!has(object.spec.ephemeralContainers) || object.spec.ephemeralContainers.all(c,
+          (
+            has(c.securityContext) &&
+            has(c.securityContext.seccompProfile) &&
+            has(c.securityContext.seccompProfile.type) &&
+            c.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
+          ) ||
+          (
+            !(has(c.securityContext) && has(c.securityContext.seccompProfile) && has(c.securityContext.seccompProfile.type)) &&
+            has(object.spec.securityContext) &&
+            has(object.spec.securityContext.seccompProfile) &&
+            has(object.spec.securityContext.seccompProfile.type) &&
+            object.spec.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
+          )
+        ))
       message: >-
         Seccomp profile must be explicitly set. The fields
         spec.securityContext.seccompProfile.type,

--- a/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.cel.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.cel.yaml
@@ -35,6 +35,12 @@ spec:
   {{ end }}
   validations:
     - expression: >-
+        (
+          !has(object.spec.securityContext) ||
+          !has(object.spec.securityContext.seccompProfile) ||
+          !has(object.spec.securityContext.seccompProfile.type) ||
+          object.spec.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
+        ) &&
         (!has(object.spec.containers) || object.spec.containers.all(c,
           (
             has(c.securityContext) &&
@@ -81,12 +87,12 @@ spec:
           )
         ))
       message: >-
-        Seccomp profile must be explicitly set. The fields
-        spec.securityContext.seccompProfile.type,
-        spec.containers[*].securityContext.seccompProfile.type,
+        Seccomp profile must be set to `RuntimeDefault` or `Localhost`.
+        The pod-level field spec.securityContext.seccompProfile.type may be used,
+        or the fields spec.containers[*].securityContext.seccompProfile.type,
         spec.initContainers[*].securityContext.seccompProfile.type, and
-        spec.ephemeralContainers[*].securityContext.seccompProfile.type
-        must be set to `RuntimeDefault` or `Localhost`.
+        spec.ephemeralContainers[*].securityContext.seccompProfile.type may be set
+        to an allowed value.
   {{- include "kyverno-policies.policyAuditAnnotations" (dict "name" $name "values" .Values) | nindent 2 }}
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
   validationActions: {{ $actions | nindent 4 }}

--- a/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.cel.yaml
+++ b/charts/kyverno-policies/templates/restricted/restrict-seccomp-strict.cel.yaml
@@ -33,66 +33,30 @@ spec:
     {{- end }}
   {{- include "kyverno-policies.vpolExcludeMatchConditions" . | nindent 2 }}
   {{ end }}
+  variables:
+    - name: allContainers
+      expression: >-
+        object.spec.containers
+        + object.spec.?initContainers.orValue([])
+        + object.spec.?ephemeralContainers.orValue([])
+
   validations:
     - expression: >-
-        (
-          !has(object.spec.securityContext) ||
-          !has(object.spec.securityContext.seccompProfile) ||
-          !has(object.spec.securityContext.seccompProfile.type) ||
-          object.spec.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
-        ) &&
-        (!has(object.spec.containers) || object.spec.containers.all(c,
-          (
-            has(c.securityContext) &&
-            has(c.securityContext.seccompProfile) &&
-            has(c.securityContext.seccompProfile.type) &&
-            c.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
-          ) ||
-          (
-            !(has(c.securityContext) && has(c.securityContext.seccompProfile) && has(c.securityContext.seccompProfile.type)) &&
-            has(object.spec.securityContext) &&
-            has(object.spec.securityContext.seccompProfile) &&
-            has(object.spec.securityContext.seccompProfile.type) &&
-            object.spec.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
-          )
-        )) &&
-        (!has(object.spec.initContainers) || object.spec.initContainers.all(c,
-          (
-            has(c.securityContext) &&
-            has(c.securityContext.seccompProfile) &&
-            has(c.securityContext.seccompProfile.type) &&
-            c.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
-          ) ||
-          (
-            !(has(c.securityContext) && has(c.securityContext.seccompProfile) && has(c.securityContext.seccompProfile.type)) &&
-            has(object.spec.securityContext) &&
-            has(object.spec.securityContext.seccompProfile) &&
-            has(object.spec.securityContext.seccompProfile.type) &&
-            object.spec.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
-          )
-        )) &&
-        (!has(object.spec.ephemeralContainers) || object.spec.ephemeralContainers.all(c,
-          (
-            has(c.securityContext) &&
-            has(c.securityContext.seccompProfile) &&
-            has(c.securityContext.seccompProfile.type) &&
-            c.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
-          ) ||
-          (
-            !(has(c.securityContext) && has(c.securityContext.seccompProfile) && has(c.securityContext.seccompProfile.type)) &&
-            has(object.spec.securityContext) &&
-            has(object.spec.securityContext.seccompProfile) &&
-            has(object.spec.securityContext.seccompProfile.type) &&
-            object.spec.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
-          )
-        ))
+        !object.spec.?securityContext.?seccompProfile.?type.hasValue() ||
+        object.spec.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
       message: >-
-        Seccomp profile must be set to `RuntimeDefault` or `Localhost`.
-        The pod-level field spec.securityContext.seccompProfile.type may be used,
-        or the fields spec.containers[*].securityContext.seccompProfile.type,
-        spec.initContainers[*].securityContext.seccompProfile.type, and
-        spec.ephemeralContainers[*].securityContext.seccompProfile.type may be set
-        to an allowed value.
+        The field spec.securityContext.seccompProfile.type must be unset or
+        set to `RuntimeDefault` or `Localhost`.
+
+    - expression: >-
+        variables.allContainers.all(c,
+          c.?securityContext.?seccompProfile.?type.orValue('') in ['RuntimeDefault', 'Localhost'] ||
+          (!c.?securityContext.?seccompProfile.?type.hasValue() &&
+           object.spec.?securityContext.?seccompProfile.?type.orValue('') in ['RuntimeDefault', 'Localhost']))
+      message: >-
+        Containers must set securityContext.seccompProfile.type to `RuntimeDefault`
+        or `Localhost`, or inherit a valid pod-level
+        spec.securityContext.seccompProfile.type.
   {{- include "kyverno-policies.policyAuditAnnotations" (dict "name" $name "values" .Values) | nindent 2 }}
   {{- $actions := include "kyverno-policies.policyValidationActions" (dict "name" $name "values" .Values) }}
   validationActions: {{ $actions | nindent 4 }}


### PR DESCRIPTION
## Explanation
This PR fixes an issue in the `restrict-seccomp-strict` ValidatingPolicy where Pods using a valid pod-level seccomp profile were incorrectly reported as violations.

According to the Kubernetes Pod Security Standards, containers can inherit a seccomp profile from `spec.securityContext.seccompProfile.type`. However, the current CEL expression requires each container to explicitly define `securityContext.seccompProfile.type`, causing compliant Pods to fail validation.

This change updates the CEL expression to allow containers to inherit a valid pod-level seccomp profile while continuing to reject invalid container-level overrides.


## Related issue
Closes #16224

## Milestone of this PR


## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

 /kind bug

## Proposed Changes

Updated the CEL expression in `restrict-seccomp-strict.cel.yaml` to support pod-level seccomp inheritance.

The new logic:

- Passes when a container explicitly sets `RuntimeDefault` or `Localhost`.
- Passes when a container does not define a seccomp profile and inherits a valid pod-level seccomp profile.
- Fails when a container explicitly overrides the pod-level profile with an invalid value such as `Unconfined`.

This makes the ValidatingPolicy behavior consistent with Kubernetes Pod Security Standards.

### Validation Performed

Tested locally on a Kind cluster with Kyverno Policies installed using:

```bash
helm upgrade --install kyverno-policies ./charts/kyverno-policies \
  --namespace kyverno \
  --create-namespace \
  --set policyType=ValidatingPolicy \
  --set podSecurityStandard=restricted \
  --set validationFailureAction=Audit
```

Verified the following scenarios:

| Scenario | Expected | Result |
|-----------|-----------|---------|
| Pod-level `seccompProfile.type: RuntimeDefault` only (reported issue) | Pass | Pass |
| Container-level `seccompProfile.type: RuntimeDefault` only | Pass | Pass |
| Pod-level `RuntimeDefault` with container-level `Unconfined` override | Fail | Fail |

The deployed `restrict-seccomp-strict` ValidatingPolicy was verified to contain the updated CEL expression before running the tests.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [X] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments
This change fixes the reported issue by allowing valid pod-level seccomp configuration while preserving the existing security checks for invalid container-level overrides.
