### PR TITLE
fix(background-controller): wire MutatingPolicy and NamespacedMutatingPolicy into background scan

### DIFF
--- a/cmd/background-controller/main.go
+++ b/cmd/background-controller/main.go
@@ -87,6 +87,8 @@ func createrLeaderControllers(
 		kyvernoInformer.Kyverno().V1().Policies(),
 		kyvernoInformer.Policies().V1beta1().GeneratingPolicies(),
 		kyvernoInformer.Policies().V1beta1().NamespacedGeneratingPolicies(),
+		kyvernoInformer.Policies().V1beta1().MutatingPolicies(),
+		kyvernoInformer.Policies().V1beta1().NamespacedMutatingPolicies(),
 		kyvernoInformer.Kyverno().V2().UpdateRequests(),
 		configuration,
 		eventGenerator,

--- a/pkg/background/mpol/processor.go
+++ b/pkg/background/mpol/processor.go
@@ -28,11 +28,12 @@ import (
 	webhookutils "github.com/kyverno/kyverno/pkg/webhooks/utils"
 	"github.com/kyverno/sdk/extensions/cel/utils"
 	"go.uber.org/multierr"
+	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -83,6 +84,10 @@ func (p *processor) Process(ur *kyvernov2.UpdateRequest) error {
 		targets  *unstructured.UnstructuredList
 	)
 
+	if ur.Spec.Policy == "" {
+		return updateURStatus(p.statusControl, *ur, fmt.Errorf("update request %s has empty policy key", ur.GetName()), nil)
+	}
+
 	mpol, err := p.GetPolicy(ur)
 	if mpol == nil {
 		return err
@@ -130,13 +135,54 @@ func (p *processor) Process(ur *kyvernov2.UpdateRequest) error {
 		return updateURStatus(p.statusControl, *ur, multierr.Combine(failures...), nil)
 	}
 
-	ar := ur.Spec.Context.AdmissionRequestInfo.AdmissionRequest
+	baseAR := ur.Spec.Context.AdmissionRequestInfo.AdmissionRequest
+	// ParsePolicyKey returns (name, namespace). For cluster-scoped policies the namespace is "".
+	// MatchNames expects just the bare name (not "namespace/name").
+	// The scope predicate is derived from the UR key (not the target's namespace) so that a
+	// cluster-scoped MutatingPolicy with the same name is never matched when the UR is for a
+	// NamespacedMutatingPolicy, and vice versa.
+	policyName, policyNamespace := policy.ParsePolicyKey(ur.Spec.Policy)
+	scopePredicate := mpolengine.ClusteredPolicy()
+	if policyNamespace != "" {
+		scopePredicate = mpolengine.NamespacedPolicy(policyNamespace)
+	}
 	for _, target := range targets.Items {
 		object := &target
 		mapping, err := p.mapper.RESTMapping(target.GroupVersionKind().GroupKind(), target.GroupVersionKind().Version)
 		if err != nil {
 			failures = append(failures, fmt.Errorf("failed to get resource version for mpol %s: %v", ur.Spec.GetPolicyKey(), err))
 			continue
+		}
+
+		// Build the AdmissionRequest for this target. For background-only scans there is no
+		// real admission request, so we construct a synthetic one from the target resource.
+		// Operation is Update (background scans mutate already-existing resources).
+		// Object.Raw, Kind, Resource, Namespace and Name are populated so that request.*
+		// CEL variables (request.object, request.namespace, etc.) reflect the actual target.
+		ar := baseAR
+		if ar == nil {
+			raw, err := json.Marshal(object.Object)
+			if err != nil {
+				failures = append(failures, fmt.Errorf("failed to marshal target object for mpol %s: %v", ur.Spec.GetPolicyKey(), err))
+				continue
+			}
+			gvk := object.GroupVersionKind()
+			ar = &admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				Kind: metav1.GroupVersionKind{
+					Group:   gvk.Group,
+					Version: gvk.Version,
+					Kind:    gvk.Kind,
+				},
+				Resource: metav1.GroupVersionResource{
+					Group:    mapping.Resource.Group,
+					Version:  mapping.Resource.Version,
+					Resource: mapping.Resource.Resource,
+				},
+				Namespace: object.GetNamespace(),
+				Name:      object.GetName(),
+				Object:    runtime.RawExtension{Raw: raw},
+			}
 		}
 
 		attr := admission.NewAttributesRecord(
@@ -147,13 +193,13 @@ func (p *processor) Process(ur *kyvernov2.UpdateRequest) error {
 			object.GetName(),
 			mapping.Resource,
 			"",
-			admission.Operation(""),
+			admission.Operation(ar.Operation),
 			nil,
 			false,
 			admissionpolicy.NewUser(ar.UserInfo),
 		)
 
-		response, err := p.engine.Evaluate(context.TODO(), attr, *ar, mpolengine.And(mpolengine.MatchNames(ur.Spec.Policy), mpolengine.Or(mpolengine.ClusteredPolicy(), mpolengine.NamespacedPolicy(attr.GetNamespace()))))
+		response, err := p.engine.Evaluate(context.TODO(), attr, *ar, mpolengine.And(mpolengine.MatchNames(policyName), scopePredicate))
 		if err != nil {
 			failures = append(failures, fmt.Errorf("failed to evaluate mpol %s: %v", ur.Spec.GetPolicyKey(), err))
 			continue
@@ -293,15 +339,17 @@ func (p *processor) GetPolicy(ur *kyvernov2.UpdateRequest) (v1beta1.MutatingPoli
 	var err error
 
 	failures := make([]error, 0, 1)
-	mpol, err = p.kyvernoClient.PoliciesV1beta1().MutatingPolicies().Get(context.TODO(), ur.Spec.Policy, metav1.GetOptions{})
-	if err == nil {
-		return mpol, nil
-	}
 
-	// Try NamespacedMutatingPolicy
-	if errors.IsNotFound(err) {
-		name, ns := policy.ParsePolicyKey(ur.Spec.Policy)
+	name, ns := policy.ParsePolicyKey(ur.Spec.Policy)
+	if ns != "" {
+		// Namespaced policy: go directly to NamespacedMutatingPolicy lookup.
 		mpol, err = p.kyvernoClient.PoliciesV1beta1().NamespacedMutatingPolicies(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		if err == nil {
+			return mpol, nil
+		}
+	} else {
+		// Cluster-scoped policy: try MutatingPolicy.
+		mpol, err = p.kyvernoClient.PoliciesV1beta1().MutatingPolicies().Get(context.TODO(), name, metav1.GetOptions{})
 		if err == nil {
 			return mpol, nil
 		}

--- a/pkg/background/mpol/processor.go
+++ b/pkg/background/mpol/processor.go
@@ -361,6 +361,7 @@ func (p *processor) GetPolicy(ur *kyvernov2.UpdateRequest) (v1beta1.MutatingPoli
 			if nerr == nil {
 				return nmpol, nil
 			}
+			err = multierr.Combine(err, nerr)
 		}
 	}
 

--- a/pkg/background/mpol/processor.go
+++ b/pkg/background/mpol/processor.go
@@ -136,15 +136,14 @@ func (p *processor) Process(ur *kyvernov2.UpdateRequest) error {
 	}
 
 	baseAR := ur.Spec.Context.AdmissionRequestInfo.AdmissionRequest
-	// ParsePolicyKey returns (name, namespace). For cluster-scoped policies the namespace is "".
-	// MatchNames expects just the bare name (not "namespace/name").
-	// The scope predicate is derived from the UR key (not the target's namespace) so that a
-	// cluster-scoped MutatingPolicy with the same name is never matched when the UR is for a
-	// NamespacedMutatingPolicy, and vice versa.
-	policyName, policyNamespace := policy.ParsePolicyKey(ur.Spec.Policy)
+	// Derive policyName and scopePredicate from the resolved mpol object rather than from the
+	// UR key. Admission-webhook URs store only the bare policy name (reconciler.MatchesMutateExisting
+	// returns GetName(), not namespace/name), so ParsePolicyKey on the UR key would yield an
+	// empty namespace for NamespacedMutatingPolicies, causing the wrong scope predicate to be used.
+	policyName := mpol.GetName()
 	scopePredicate := mpolengine.ClusteredPolicy()
-	if policyNamespace != "" {
-		scopePredicate = mpolengine.NamespacedPolicy(policyNamespace)
+	if ns := mpol.GetNamespace(); ns != "" {
+		scopePredicate = mpolengine.NamespacedPolicy(ns)
 	}
 	for _, target := range targets.Items {
 		object := &target
@@ -348,10 +347,20 @@ func (p *processor) GetPolicy(ur *kyvernov2.UpdateRequest) (v1beta1.MutatingPoli
 			return mpol, nil
 		}
 	} else {
-		// Cluster-scoped policy: try MutatingPolicy.
+		// Cluster-scoped policy: try MutatingPolicy first.
 		mpol, err = p.kyvernoClient.PoliciesV1beta1().MutatingPolicies().Get(context.TODO(), name, metav1.GetOptions{})
 		if err == nil {
 			return mpol, nil
+		}
+		// Fallback: CELMutate URs created from admission webhooks use the bare policy name
+		// (reconciler.MatchesMutateExisting returns GetName(), not namespace/name).
+		// Since NamespacedMutatingPolicies only match resources in their own namespace,
+		// the admission request's namespace equals the policy's namespace.
+		if ar := ur.Spec.Context.AdmissionRequestInfo.AdmissionRequest; ar != nil && ar.Namespace != "" {
+			nmpol, nerr := p.kyvernoClient.PoliciesV1beta1().NamespacedMutatingPolicies(ar.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			if nerr == nil {
+				return nmpol, nil
+			}
 		}
 	}
 

--- a/pkg/background/mpol/processor_test.go
+++ b/pkg/background/mpol/processor_test.go
@@ -343,3 +343,52 @@ func TestProcess_EmptyPolicyKey(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, sc.failedCalled, "expected UR to be marked failed for empty policy key")
 }
+
+// TestGetPolicy_BareNameFallback_NamespacedMutatingPolicy verifies that GetPolicy resolves a
+// NamespacedMutatingPolicy when the UR key is a bare name (no namespace/name format).
+// Admission-webhook URs store only the bare name because reconciler.MatchesMutateExisting
+// returns policy.GetName() instead of namespace/name. The fallback uses AdmissionRequest.Namespace
+// to locate the NamespacedMutatingPolicy (valid because NamespacedMutatingPolicies only match
+// resources in their own namespace, so the admission namespace equals the policy namespace).
+func TestGetPolicy_BareNameFallback_NamespacedMutatingPolicy(t *testing.T) {
+	nmpol := &policiesv1beta1.NamespacedMutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mypol",
+			Namespace: "test-ns",
+		},
+	}
+	kyvernoClient := fake.NewSimpleClientset(nmpol)
+	sc := &fakeStatusControl{}
+
+	p := NewProcessor(
+		dclient.NewEmptyFakeClient(),
+		kyvernoClient,
+		&fakeEngine{},
+		meta.NewDefaultRESTMapper(nil),
+		&libs.FakeContextProvider{},
+		sc,
+		event.NewFake(),
+	)
+
+	// UR uses bare name (as created by webhook handler), with AdmissionRequest carrying the namespace.
+	ur := &kyvernov2.UpdateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "ur-bare", Namespace: "kyverno"},
+		Spec: kyvernov2.UpdateRequestSpec{
+			Policy: "mypol",
+			Context: kyvernov2.UpdateRequestSpecContext{
+				AdmissionRequestInfo: kyvernov2.AdmissionRequestInfoObject{
+					AdmissionRequest: &admissionv1.AdmissionRequest{
+						Namespace: "test-ns",
+					},
+				},
+			},
+		},
+	}
+
+	result, err := p.GetPolicy(ur)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "mypol", result.GetName())
+	assert.Equal(t, "test-ns", result.GetNamespace())
+	assert.False(t, sc.failedCalled, "UR should not be marked failed when policy is found via fallback")
+}

--- a/pkg/background/mpol/processor_test.go
+++ b/pkg/background/mpol/processor_test.go
@@ -5,18 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	policiesv1alpha1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	admissionv1 "k8s.io/api/admission/v1"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apiserver/pkg/admission"
-
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
 	"github.com/kyverno/kyverno/pkg/background/common"
@@ -28,6 +17,17 @@ import (
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/event"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
 )
 
 type fakeContext struct{}
@@ -140,11 +140,11 @@ func TestProcess_NoPolicyFound(t *testing.T) {
 
 func TestProcess_EngineEvaluateError(t *testing.T) {
 	kyvernoClient := fake.NewSimpleClientset(
-		&policiesv1alpha1.MutatingPolicy{
+		&policiesv1beta1.MutatingPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "mypol",
 			},
-			Spec: policiesv1alpha1.MutatingPolicySpec{
+			Spec: policiesv1beta1.MutatingPolicySpec{
 				MatchConstraints: &admissionregistrationv1.MatchResources{
 					ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
 						RuleWithOperations: admissionregistrationv1alpha1.RuleWithOperations{
@@ -189,6 +189,78 @@ func TestProcess_EngineEvaluateError(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestProcess_NilAdmissionRequest_DoesNotPanic(t *testing.T) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMapList"}, &unstructured.UnstructuredList{})
+	cm := &unstructured.Unstructured{}
+	cm.SetAPIVersion("v1")
+	cm.SetKind("ConfigMap")
+	cm.SetNamespace("default")
+	cm.SetName("target-cm")
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "configmaps"}: "ConfigMapList",
+	}
+	fakeClient, err := dclient.NewFakeClient(scheme, gvrToListKind, cm)
+	assert.NoError(t, err)
+	// Wire up the discovery client (pre-registers configmaps) so ListResource can resolve the GVR.
+	fakeClient.SetDiscovery(dclient.NewFakeDiscoveryClient(nil))
+
+	kyvernoClient := fake.NewSimpleClientset(
+		&policiesv1beta1.MutatingPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "bgpol"},
+			Spec: policiesv1beta1.MutatingPolicySpec{
+				MatchConstraints: &admissionregistrationv1.MatchResources{
+					ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+						RuleWithOperations: admissionregistrationv1alpha1.RuleWithOperations{
+							Rule: admissionregistrationv1alpha1.Rule{
+								APIGroups:   []string{""},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"configmaps"},
+							},
+						},
+					}},
+				},
+			},
+		},
+	)
+
+	// Register the ConfigMap GVK in the REST mapper so collectGVK can resolve it.
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "", Version: "v1"}})
+	restMapper.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}, meta.RESTScopeNamespace)
+
+	eng := &fakeEngine{}
+	eng.On("Evaluate").Return(mpolengine.EngineResponse{}, nil)
+
+	p := NewProcessor(
+		fakeClient,
+		kyvernoClient,
+		eng,
+		restMapper,
+		&libs.FakeContextProvider{},
+		&fakeStatusControl{},
+		event.NewFake(),
+	)
+
+	// UR has no AdmissionRequest — this is the background-scan case.
+	ur := &kyvernov2.UpdateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "ur-bg", Namespace: "default"},
+		Spec: kyvernov2.UpdateRequestSpec{
+			Policy: "bgpol",
+			Context: kyvernov2.UpdateRequestSpecContext{
+				AdmissionRequestInfo: kyvernov2.AdmissionRequestInfoObject{
+					AdmissionRequest: nil, // explicitly nil — background scan
+				},
+			},
+		},
+	}
+
+	// Must not panic with nil admission request.
+	assert.NotPanics(t, func() {
+		_ = p.Process(ur)
+	})
+}
+
 func TestCollectGVK_NoNamespaceSelector(t *testing.T) {
 	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "", Version: "v1"}})
 	mapper.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}, meta.RESTScopeNamespace)
@@ -209,4 +281,65 @@ func TestCollectGVK_NoNamespaceSelector(t *testing.T) {
 
 	assert.Contains(t, result, "*")
 	assert.Equal(t, 1, len(result["*"]))
+}
+
+// TestGetPolicy_NamespacedMutatingPolicy verifies that GetPolicy resolves a
+// "namespace/name" UR policy key to a NamespacedMutatingPolicy without hitting
+// the cluster-scoped MutatingPolicy API (which rejects "/" in resource names).
+func TestGetPolicy_NamespacedMutatingPolicy(t *testing.T) {
+	nmpol := &policiesv1beta1.NamespacedMutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-nmpol",
+			Namespace: "my-ns",
+		},
+	}
+	kyvernoClient := fake.NewSimpleClientset(nmpol)
+	sc := &fakeStatusControl{}
+
+	p := NewProcessor(
+		dclient.NewEmptyFakeClient(),
+		kyvernoClient,
+		&fakeEngine{},
+		meta.NewDefaultRESTMapper(nil),
+		&libs.FakeContextProvider{},
+		sc,
+		event.NewFake(),
+	)
+
+	ur := &kyvernov2.UpdateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "ur-nmpol", Namespace: "kyverno"},
+		Spec:       kyvernov2.UpdateRequestSpec{Policy: "my-ns/my-nmpol"},
+	}
+
+	result, err := p.GetPolicy(ur)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "my-nmpol", result.GetName())
+	assert.Equal(t, "my-ns", result.GetNamespace())
+	// Status control must NOT have been called (no failure).
+	assert.False(t, sc.failedCalled)
+}
+
+// TestProcess_EmptyPolicyKey verifies that Process fails the UR and returns no error
+// when the policy key is empty, rather than silently evaluating with an empty name.
+func TestProcess_EmptyPolicyKey(t *testing.T) {
+	sc := &fakeStatusControl{}
+	p := NewProcessor(
+		dclient.NewEmptyFakeClient(),
+		fake.NewSimpleClientset(),
+		&fakeEngine{},
+		meta.NewDefaultRESTMapper(nil),
+		&libs.FakeContextProvider{},
+		sc,
+		event.NewFake(),
+	)
+
+	ur := &kyvernov2.UpdateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "ur-empty", Namespace: "kyverno"},
+		Spec:       kyvernov2.UpdateRequestSpec{Policy: ""},
+	}
+
+	err := p.Process(ur)
+	assert.NoError(t, err)
+	assert.True(t, sc.failedCalled, "expected UR to be marked failed for empty policy key")
 }

--- a/pkg/cel/policies/mpol/engine/reconciler.go
+++ b/pkg/cel/policies/mpol/engine/reconciler.go
@@ -46,12 +46,13 @@ func newReconciler(
 
 func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var policy policiesv1beta1.MutatingPolicyLike
-	mpol := &policiesv1beta1.MutatingPolicy{}
-	err := r.client.Get(ctx, req.NamespacedName, mpol)
-	if err == nil {
-		policy = mpol
-	} else if errors.IsNotFound(err) {
-		// Try NamespacedMutatingPolicy
+	var err error
+
+	if req.NamespacedName.Namespace != "" {
+		// Request has a namespace: this is always a NamespacedMutatingPolicy reconcile.
+		// Do NOT try MutatingPolicy first — for cluster-scoped resources, controller-runtime
+		// ignores the namespace in the request, so Get would silently find a same-named
+		// cluster-scoped policy instead of returning NotFound.
 		nmpol := &policiesv1beta1.NamespacedMutatingPolicy{}
 		err = r.client.Get(ctx, req.NamespacedName, nmpol)
 		if err == nil {
@@ -65,7 +66,19 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, err
 		}
 	} else {
-		return ctrl.Result{}, err
+		// No namespace: this is a MutatingPolicy (cluster-scoped) reconcile.
+		mpol := &policiesv1beta1.MutatingPolicy{}
+		err = r.client.Get(ctx, req.NamespacedName, mpol)
+		if err == nil {
+			policy = mpol
+		} else if errors.IsNotFound(err) {
+			r.lock.Lock()
+			delete(r.policies, req.NamespacedName.String())
+			r.lock.Unlock()
+			return ctrl.Result{}, nil
+		} else {
+			return ctrl.Result{}, err
+		}
 	}
 
 	if policy.GetStatus().Generated {

--- a/pkg/cel/policies/mpol/engine/reconciler_test.go
+++ b/pkg/cel/policies/mpol/engine/reconciler_test.go
@@ -8,7 +8,6 @@ import (
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/cel/policies/mpol/compiler"
-	mpolcompiler "github.com/kyverno/kyverno/pkg/cel/policies/mpol/compiler"
 	"github.com/stretchr/testify/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -274,13 +273,13 @@ func TestMatchesMutateExisting(t *testing.T) {
 		},
 	}
 
-	compiler := mpolcompiler.NewCompiler()
+	comp := compiler.NewCompiler()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, l := range tt.policies {
 				for i, p := range l {
-					c, _ := compiler.Compile(p.Policy, nil)
+					c, _ := comp.Compile(p.Policy, nil)
 					tt.policies[k][i].CompiledPolicy = c
 				}
 			}

--- a/pkg/cel/policies/mpol/engine/reconciler_test.go
+++ b/pkg/cel/policies/mpol/engine/reconciler_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -23,40 +25,59 @@ import (
 type fakeClient struct {
 	client.Client
 	policy *policiesv1beta1.MutatingPolicy
+	nmpol  *policiesv1beta1.NamespacedMutatingPolicy
 	err    error
 }
 
-func (f *fakeClient) Get(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+func (f *fakeClient) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 	if f.err != nil {
 		return f.err
 	}
-	*obj.(*policiesv1beta1.MutatingPolicy) = *f.policy
-	return nil
+	switch o := obj.(type) {
+	case *policiesv1beta1.MutatingPolicy:
+		if f.policy != nil && key.Name == f.policy.Name && key.Namespace == f.policy.Namespace {
+			*o = *f.policy
+			return nil
+		}
+	case *policiesv1beta1.NamespacedMutatingPolicy:
+		if f.nmpol != nil && key.Name == f.nmpol.Name && key.Namespace == f.nmpol.Namespace {
+			*o = *f.nmpol
+			return nil
+		}
+	}
+	return apierrors.NewNotFound(schema.GroupResource{}, "")
 }
 
 func TestReconcile(t *testing.T) {
 	ctx := context.Background()
-	name := types.NamespacedName{Namespace: "default", Name: "test-policy"}
 
-	//t.Run("policy not found", func(t *testing.T) {
-	//	rec := newReconciler(
-	//		&fakeClient{err: errors.ErrUnsupported(policiesv1alpha1.Resource("mutatingpolicies"), "test-policy")},
-	//		compiler.NewCompiler(), nil, false,
-	///	)
-	//	res, err := rec.Reconcile(ctx, reconcile.Request{NamespacedName: name})
-	//	assert.NoError(t, err)
-	//	assert.Equal(t, reconcile.Result{}, res)
-	//})
-
-	t.Run("successful reconciliation", func(t *testing.T) {
+	t.Run("successful reconciliation of cluster-scoped MutatingPolicy", func(t *testing.T) {
 		mp := &policiesv1beta1.MutatingPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test-policy"},
 		}
 		rec := newReconciler(
 			&fakeClient{policy: mp},
 			compiler.NewCompiler(),
 			nil, false,
 		)
+		// Cluster-scoped: no namespace in request.
+		name := types.NamespacedName{Name: "test-policy"}
+		res, err := rec.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+		assert.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+	})
+
+	t.Run("successful reconciliation of NamespacedMutatingPolicy", func(t *testing.T) {
+		nmp := &policiesv1beta1.NamespacedMutatingPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-nmpol", Namespace: "test-ns"},
+		}
+		rec := newReconciler(
+			&fakeClient{nmpol: nmp},
+			compiler.NewCompiler(),
+			nil, false,
+		)
+		// Namespaced: namespace in request.
+		name := types.NamespacedName{Namespace: "test-ns", Name: "test-nmpol"}
 		res, err := rec.Reconcile(ctx, reconcile.Request{NamespacedName: name})
 		assert.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)

--- a/pkg/policy/mpol.go
+++ b/pkg/policy/mpol.go
@@ -1,0 +1,42 @@
+package policy
+
+import (
+	"context"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+)
+
+// newCELMutateUR creates a bare CELMutate UpdateRequest for a MutatingPolicy background scan.
+// There is no admission request context – the processor will fetch all matching resources itself.
+func newCELMutateUR(mpol *policiesv1beta1.MutatingPolicy) *kyvernov2.UpdateRequest {
+	ur := newUrMeta()
+	ur.Spec = kyvernov2.UpdateRequestSpec{
+		Type:   kyvernov2.CELMutate,
+		Policy: mpol.GetName(),
+	}
+	return ur
+}
+
+// newCELMutateURFromNamespacedPolicy creates a bare CELMutate UpdateRequest for a
+// NamespacedMutatingPolicy background scan. The policy key uses namespace/name format.
+func newCELMutateURFromNamespacedPolicy(nmpol *policiesv1beta1.NamespacedMutatingPolicy) *kyvernov2.UpdateRequest {
+	ur := newUrMeta()
+	ur.Spec = kyvernov2.UpdateRequestSpec{
+		Type:   kyvernov2.CELMutate,
+		Policy: nmpol.GetNamespace() + "/" + nmpol.GetName(),
+	}
+	return ur
+}
+
+// createURForMutatingPolicy creates a CELMutate UpdateRequest that causes the background
+// controller to apply this policy to all currently matching resources.
+func (pc *policyController) createURForMutatingPolicy(mpol *policiesv1beta1.MutatingPolicy) error {
+	return pc.submitUR(context.TODO(), newCELMutateUR(mpol))
+}
+
+// createURForNamespacedMutatingPolicy creates a CELMutate UpdateRequest for a
+// NamespacedMutatingPolicy background scan.
+func (pc *policyController) createURForNamespacedMutatingPolicy(nmpol *policiesv1beta1.NamespacedMutatingPolicy) error {
+	return pc.submitUR(context.TODO(), newCELMutateURFromNamespacedPolicy(nmpol))
+}

--- a/pkg/policy/mpol_test.go
+++ b/pkg/policy/mpol_test.go
@@ -1,0 +1,40 @@
+package policy
+
+import (
+	"testing"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewCELMutateUR(t *testing.T) {
+	mpol := &policiesv1beta1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-mpol"},
+	}
+
+	ur := newCELMutateUR(mpol)
+
+	assert.NotNil(t, ur)
+	assert.Equal(t, kyvernov2.CELMutate, ur.Spec.Type)
+	assert.Equal(t, "my-mpol", ur.Spec.Policy)
+	assert.Equal(t, kyvernov2.SchemeGroupVersion.String(), ur.TypeMeta.APIVersion)
+	assert.Equal(t, "UpdateRequest", ur.TypeMeta.Kind)
+	assert.Equal(t, "ur-", ur.GenerateName)
+}
+
+func TestNewCELMutateURFromNamespacedPolicy(t *testing.T) {
+	nmpol := &policiesv1beta1.NamespacedMutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-nmpol", Namespace: "my-ns"},
+	}
+
+	ur := newCELMutateURFromNamespacedPolicy(nmpol)
+
+	assert.NotNil(t, ur)
+	assert.Equal(t, kyvernov2.CELMutate, ur.Spec.Type)
+	assert.Equal(t, "my-ns/my-nmpol", ur.Spec.Policy)
+	assert.Equal(t, kyvernov2.SchemeGroupVersion.String(), ur.TypeMeta.APIVersion)
+	assert.Equal(t, "UpdateRequest", ur.TypeMeta.Kind)
+	assert.Equal(t, "ur-", ur.GenerateName)
+}

--- a/pkg/policy/policy_controller.go
+++ b/pkg/policy/policy_controller.go
@@ -69,6 +69,8 @@ type policyController struct {
 	npInformer    kyvernov1informers.PolicyInformer
 	gpolInformer  policiesv1beta1informers.GeneratingPolicyInformer
 	ngpolInformer policiesv1beta1informers.NamespacedGeneratingPolicyInformer
+	mpolInformer  policiesv1beta1informers.MutatingPolicyInformer
+	nmpolInformer policiesv1beta1informers.NamespacedMutatingPolicyInformer
 
 	eventGen      event.Interface
 	eventRecorder events.EventRecorder
@@ -87,6 +89,12 @@ type policyController struct {
 
 	// ngpolLister can list/get namespaced generating policy from the shared informer's store
 	ngpolLister policiesv1beta1listers.NamespacedGeneratingPolicyLister
+
+	// mpolLister can list/get mutating policy from the shared informer's store
+	mpolLister policiesv1beta1listers.MutatingPolicyLister
+
+	// nmpolLister can list/get namespaced mutating policy from the shared informer's store
+	nmpolLister policiesv1beta1listers.NamespacedMutatingPolicyLister
 
 	// urLister can list/get update request from the shared informer's store
 	urLister kyvernov2listers.UpdateRequestLister
@@ -127,6 +135,8 @@ func NewPolicyController(
 	npInformer kyvernov1informers.PolicyInformer,
 	gpolInformer policiesv1beta1informers.GeneratingPolicyInformer,
 	ngpolInformer policiesv1beta1informers.NamespacedGeneratingPolicyInformer,
+	mpolInformer policiesv1beta1informers.MutatingPolicyInformer,
+	nmpolInformer policiesv1beta1informers.NamespacedMutatingPolicyInformer,
 	urInformer kyvernov2informers.UpdateRequestInformer,
 	configuration config.Configuration,
 	eventGen event.Interface,
@@ -159,6 +169,8 @@ func NewPolicyController(
 		npInformer:    npInformer,
 		gpolInformer:  gpolInformer,
 		ngpolInformer: ngpolInformer,
+		mpolInformer:  mpolInformer,
+		nmpolInformer: nmpolInformer,
 		eventGen:      eventGen,
 		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, "policy_controller"),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -184,8 +196,10 @@ func NewPolicyController(
 	pc.urLister = urInformer.Lister()
 	pc.gpolLister = gpolInformer.Lister()
 	pc.ngpolLister = ngpolInformer.Lister()
+	pc.mpolLister = mpolInformer.Lister()
+	pc.nmpolLister = nmpolInformer.Lister()
 
-	pc.informersSynced = []cache.InformerSynced{pInformer.Informer().HasSynced, npInformer.Informer().HasSynced, gpolInformer.Informer().HasSynced, ngpolInformer.Informer().HasSynced, urInformer.Informer().HasSynced, namespaces.Informer().HasSynced}
+	pc.informersSynced = []cache.InformerSynced{pInformer.Informer().HasSynced, npInformer.Informer().HasSynced, gpolInformer.Informer().HasSynced, ngpolInformer.Informer().HasSynced, mpolInformer.Informer().HasSynced, nmpolInformer.Informer().HasSynced, urInformer.Informer().HasSynced, namespaces.Informer().HasSynced}
 
 	return &pc, nil
 }
@@ -285,6 +299,22 @@ func (pc *policyController) updatePolicy(old, new interface{}) {
 		}
 	}
 
+	oldmpol := oldPolicy.AsMutatingPolicy()
+	newmpol := newPolicy.AsMutatingPolicy()
+	if oldmpol != nil && newmpol != nil {
+		if datautils.DeepEqual(oldmpol.Spec, newmpol.Spec) {
+			return
+		}
+	}
+
+	oldnmpol := oldPolicy.AsNamespacedMutatingPolicy()
+	newnmpol := newPolicy.AsNamespacedMutatingPolicy()
+	if oldnmpol != nil && newnmpol != nil {
+		if datautils.DeepEqual(oldnmpol.Spec, newnmpol.Spec) {
+			return
+		}
+	}
+
 	logger.V(2).Info("updating policy", "name", oldPolicy.GetName())
 	pc.enqueuePolicy(newPolicy)
 }
@@ -325,6 +355,12 @@ func (pc *policyController) deletePolicy(obj interface{}) {
 			pc.watchManager.RemoveWatchersForPolicy(policyKey, true)
 		}
 		p = engineapi.NewNamespacedGeneratingPolicy(ngpol)
+	case *policiesv1beta1.MutatingPolicy:
+		mpol := kubeutils.GetObjectWithTombstone(obj).(*policiesv1beta1.MutatingPolicy)
+		p = engineapi.NewMutatingPolicy(mpol)
+	case *policiesv1beta1.NamespacedMutatingPolicy:
+		nmpol := kubeutils.GetObjectWithTombstone(obj).(*policiesv1beta1.NamespacedMutatingPolicy)
+		p = engineapi.NewNamespacedMutatingPolicy(nmpol)
 	default:
 		logger.Info("Failed to get deleted object", "obj", obj)
 		return
@@ -346,6 +382,10 @@ func (pc *policyController) enqueuePolicy(policy engineapi.GenericPolicy) {
 		pc.queue.Add("gpol/" + key)
 	} else if policy.AsNamespacedGeneratingPolicy() != nil {
 		pc.queue.Add("ngpol/" + key)
+	} else if policy.AsMutatingPolicy() != nil {
+		pc.queue.Add("mpol/" + key)
+	} else if policy.AsNamespacedMutatingPolicy() != nil {
+		pc.queue.Add("nmpol/" + key)
 	}
 }
 
@@ -391,6 +431,24 @@ func (pc *policyController) Run(ctx context.Context, workers int) {
 	}
 
 	if _, err := pc.ngpolInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    pc.addPolicy,
+		UpdateFunc: pc.updatePolicy,
+		DeleteFunc: pc.deletePolicy,
+	}); err != nil {
+		logger.Error(err, "failed to register event handler")
+		return
+	}
+
+	if _, err := pc.mpolInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    pc.addPolicy,
+		UpdateFunc: pc.updatePolicy,
+		DeleteFunc: pc.deletePolicy,
+	}); err != nil {
+		logger.Error(err, "failed to register event handler")
+		return
+	}
+
+	if _, err := pc.nmpolInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    pc.addPolicy,
 		UpdateFunc: pc.updatePolicy,
 		DeleteFunc: pc.deletePolicy,
@@ -530,6 +588,43 @@ func (pc *policyController) syncPolicy(key string) error {
 				errs = append(errs, err)
 			}
 		}
+	case "mpol":
+		mpol, err := pc.mpolLister.Get(polName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if mpol.Spec.MutateExistingEnabled() && mpol.Spec.BackgroundEnabled() &&
+			(mpol.Spec.TargetMatchConstraints == nil || mpol.Spec.TargetMatchConstraints.Expression == "") {
+			logger.V(4).Info("creating UR for mutating policy background scan", "name", mpol.GetName())
+			if err := pc.createURForMutatingPolicy(mpol); err != nil {
+				logger.Error(err, "failed to create UR for mutating policy", "name", mpol.GetName())
+				errs = append(errs, err)
+			}
+		}
+	case "nmpol":
+		ns, name, err := cache.SplitMetaNamespaceKey(polName)
+		if err != nil {
+			return err
+		}
+		nmpol, err := pc.nmpolLister.NamespacedMutatingPolicies(ns).Get(name)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if nmpol.Spec.MutateExistingEnabled() && nmpol.Spec.BackgroundEnabled() &&
+			(nmpol.Spec.TargetMatchConstraints == nil || nmpol.Spec.TargetMatchConstraints.Expression == "") {
+			policyKey := nmpol.GetNamespace() + "/" + nmpol.GetName()
+			logger.V(4).Info("creating UR for namespaced mutating policy background scan", "name", policyKey)
+			if err := pc.createURForNamespacedMutatingPolicy(nmpol); err != nil {
+				logger.Error(err, "failed to create UR for namespaced mutating policy", "name", policyKey)
+				errs = append(errs, err)
+			}
+		}
 	}
 	return multierr.Combine(errs...)
 }
@@ -599,6 +694,26 @@ func (pc *policyController) requeuePolicies() {
 		}
 	} else {
 		logger.Error(err, "unable to list NamespacedGeneratingPolicies")
+	}
+	if mpols, err := pc.mpolLister.List(labels.Everything()); err == nil {
+		for _, mpol := range mpols {
+			if mpol.Spec.MutateExistingEnabled() && mpol.Spec.BackgroundEnabled() &&
+				(mpol.Spec.TargetMatchConstraints == nil || mpol.Spec.TargetMatchConstraints.Expression == "") {
+				pc.enqueuePolicy(engineapi.NewMutatingPolicy(mpol))
+			}
+		}
+	} else {
+		logger.Error(err, "unable to list MutatingPolicies")
+	}
+	if nmpols, err := pc.nmpolLister.List(labels.Everything()); err == nil {
+		for _, nmpol := range nmpols {
+			if nmpol.Spec.MutateExistingEnabled() && nmpol.Spec.BackgroundEnabled() &&
+				(nmpol.Spec.TargetMatchConstraints == nil || nmpol.Spec.TargetMatchConstraints.Expression == "") {
+				pc.enqueuePolicy(engineapi.NewNamespacedMutatingPolicy(nmpol))
+			}
+		}
+	} else {
+		logger.Error(err, "unable to list NamespacedMutatingPolicies")
 	}
 }
 

--- a/pkg/policy/utils.go
+++ b/pkg/policy/utils.go
@@ -63,6 +63,10 @@ func castPolicy(p interface{}) engineapi.GenericPolicy {
 		policy = engineapi.NewGeneratingPolicy(obj)
 	case *policiesv1beta1.NamespacedGeneratingPolicy:
 		policy = engineapi.NewNamespacedGeneratingPolicy(obj)
+	case *policiesv1beta1.MutatingPolicy:
+		policy = engineapi.NewMutatingPolicy(obj)
+	case *policiesv1beta1.NamespacedMutatingPolicy:
+		policy = engineapi.NewNamespacedMutatingPolicy(obj)
 	}
 	return policy
 }

--- a/pkg/policy/utils_test.go
+++ b/pkg/policy/utils_test.go
@@ -3,7 +3,11 @@ package policy
 import (
 	"testing"
 
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -341,4 +345,27 @@ func Test_resourceMatchesWithWildcards(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCastPolicy_MutatingPolicy(t *testing.T) {
+	mpol := &policiesv1beta1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-mpol"},
+	}
+	result := castPolicy(mpol)
+	assert.NotNil(t, result)
+	assert.NotNil(t, result.AsMutatingPolicy())
+	assert.Equal(t, "test-mpol", result.AsMutatingPolicy().GetName())
+	assert.IsType(t, engineapi.NewMutatingPolicy(mpol), result)
+}
+
+func TestCastPolicy_NamespacedMutatingPolicy(t *testing.T) {
+	nmpol := &policiesv1beta1.NamespacedMutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-nmpol", Namespace: "test-ns"},
+	}
+	result := castPolicy(nmpol)
+	assert.NotNil(t, result)
+	assert.NotNil(t, result.AsNamespacedMutatingPolicy())
+	assert.Equal(t, "test-nmpol", result.AsNamespacedMutatingPolicy().GetName())
+	assert.Equal(t, "test-ns", result.AsNamespacedMutatingPolicy().GetNamespace())
+	assert.IsType(t, engineapi.NewNamespacedMutatingPolicy(nmpol), result)
 }

--- a/test/conformance/chainsaw/mutating-policies/existing/background-scan/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/background-scan/chainsaw-test.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: background-scan
+spec:
+  concurrent: false
+  steps:
+  - name: create namespace and configmap
+    try:
+    - create:
+        file: namespace.yaml
+    - assert:
+        file: namespace.yaml
+    - create:
+        file: configmap.yaml
+    - assert:
+        file: configmap.yaml
+  - name: create policy
+    use:
+      template: ..//../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait-mutating-policy-ready
+    description: >
+      Wait for the background-only policy to become ready.
+      Because admission is disabled, only the RBACPermissionsGranted condition is set
+      (no WebhookConfigured condition).
+    try:
+    - assert:
+        timeout: 60s
+        resource:
+          apiVersion: policies.kyverno.io/v1beta1
+          kind: MutatingPolicy
+          metadata:
+            name: test-mpol-background-scan
+          status:
+            conditionStatus:
+              ready: true
+  - name: wait-for-background-scan
+    description: >
+      Wait for the background scan to run and apply the mutation.
+      The background controller periodically scans existing resources and creates
+      CELMutate UpdateRequests for MutatingPolicies with mutateExisting enabled.
+      No admission event is needed — this exercises the background scan code path.
+    try:
+    - assert:
+        file: configmap-assert.yaml
+        timeout: 3m

--- a/test/conformance/chainsaw/mutating-policies/existing/background-scan/configmap-assert.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/background-scan/configmap-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-mpol-background-scan-cm
+  namespace: test-mpol-background-scan-ns
+  labels:
+    background: scan

--- a/test/conformance/chainsaw/mutating-policies/existing/background-scan/configmap.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/background-scan/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-mpol-background-scan-cm
+  namespace: test-mpol-background-scan-ns
+data:
+  key: value

--- a/test/conformance/chainsaw/mutating-policies/existing/background-scan/namespace.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/background-scan/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-mpol-background-scan-ns

--- a/test/conformance/chainsaw/mutating-policies/existing/background-scan/policy.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/background-scan/policy.yaml
@@ -1,0 +1,34 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: MutatingPolicy
+metadata:
+  name: test-mpol-background-scan
+spec:
+  failurePolicy: Fail
+  evaluation:
+    admission:
+      enabled: false
+    background:
+      enabled: true
+    mutateExisting:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [ "" ]
+      apiVersions: [ "v1" ]
+      operations: [ "CREATE", "UPDATE" ]
+      resources: [ "configmaps" ]
+      resourceNames: [ "test-mpol-background-scan-cm" ]
+  matchConditions:
+  - name: target-namespace
+    expression: object.metadata.namespace == 'test-mpol-background-scan-ns'
+  mutations:
+  - patchType: ApplyConfiguration
+    applyConfiguration:
+      expression: >
+        Object{
+          metadata: Object.metadata{
+            labels: Object.metadata.labels{
+              background: "scan"
+            }
+          }
+        }

--- a/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/assert-mpol-cm.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/assert-mpol-cm.yaml
@@ -1,0 +1,11 @@
+---
+# Assert mpol-cm has the cluster policy's label and NOT the namespaced policy's label.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: same-name-pol-mpol-cm
+  namespace: test-same-name-ns
+  labels:
+    bycluster: "true"
+    # Negative assertion: namespaced-policy label must be absent.
+    (bynamespaced): ~

--- a/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/assert-nmpol-cm.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/assert-nmpol-cm.yaml
@@ -1,0 +1,11 @@
+---
+# Assert nmpol-cm has the namespaced policy's label and NOT the cluster policy's label.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: same-name-pol-nmpol-cm
+  namespace: test-same-name-ns
+  labels:
+    bynamespaced: "true"
+    # Negative assertion: cluster-policy label must be absent.
+    (bycluster): ~

--- a/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/chainsaw-test.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: same-name-mpol-nmpol-background-scan
+spec:
+  # Regression test for https://github.com/kyverno/kyverno/issues/16254
+  # Verifies that when a MutatingPolicy and a NamespacedMutatingPolicy share the
+  # same name the background controller applies each policy only to its own target
+  # and does NOT cross-evaluate the other policy's mutations.
+  concurrent: false
+  steps:
+  - name: create-namespace-and-configmaps
+    try:
+    - create:
+        file: namespace.yaml
+    - assert:
+        file: namespace.yaml
+    - create:
+        file: configmaps.yaml
+
+  - name: create-cluster-scoped-mutating-policy
+    use:
+      template: ../../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: mpol.yaml
+
+  - name: wait-mutating-policy-ready
+    try:
+    - assert:
+        timeout: 60s
+        resource:
+          apiVersion: policies.kyverno.io/v1beta1
+          kind: MutatingPolicy
+          metadata:
+            name: same-name-pol
+          status:
+            conditionStatus:
+              ready: true
+
+  - name: create-namespaced-mutating-policy
+    use:
+      template: ../../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: nmpol.yaml
+
+  - name: wait-namespaced-mutating-policy-ready
+    use:
+      template: ../../../_step-templates/namespaced-mutating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: same-name-pol
+        - name: namespace
+          value: test-same-name-ns
+
+  - name: wait-for-background-scan
+    description: >
+      After both policies are ready the background controller creates one
+      UpdateRequest per policy.  Assert that:
+        - same-name-pol-mpol-cm  receives only the cluster-policy label
+        - same-name-pol-nmpol-cm receives only the namespaced-policy label
+      The negative assertions (via JMESPath `~` / null checks) confirm that the
+      scope-predicate fix prevents cross-evaluation between the two policies.
+    try:
+    - assert:
+        file: assert-mpol-cm.yaml
+        timeout: 3m
+    - assert:
+        file: assert-nmpol-cm.yaml
+        timeout: 3m

--- a/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/configmaps.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/configmaps.yaml
@@ -1,0 +1,16 @@
+---
+# Target for the cluster-scoped MutatingPolicy.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: same-name-pol-mpol-cm
+  namespace: test-same-name-ns
+data: {}
+---
+# Target for the NamespacedMutatingPolicy in the same namespace.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: same-name-pol-nmpol-cm
+  namespace: test-same-name-ns
+data: {}

--- a/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/mpol.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/mpol.yaml
@@ -1,0 +1,37 @@
+# Cluster-scoped MutatingPolicy.  Uses a unique label key (bycluster)
+# so that cross-contamination from the NamespacedMutatingPolicy of the same name
+# can be detected unambiguously.
+apiVersion: policies.kyverno.io/v1beta1
+kind: MutatingPolicy
+metadata:
+  name: same-name-pol
+spec:
+  failurePolicy: Fail
+  evaluation:
+    admission:
+      enabled: false
+    background:
+      enabled: true
+    mutateExisting:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["configmaps"]
+      resourceNames: ["same-name-pol-mpol-cm"]
+  matchConditions:
+  - name: target-namespace
+    expression: "object.metadata.namespace == 'test-same-name-ns'"
+  mutations:
+  - patchType: ApplyConfiguration
+    applyConfiguration:
+      expression: >
+        Object{
+          metadata: Object.metadata{
+            labels: Object.metadata.labels{
+              bycluster: "true"
+            }
+          }
+        }

--- a/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/namespace.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-same-name-ns

--- a/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/nmpol.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol/nmpol.yaml
@@ -1,0 +1,38 @@
+# NamespacedMutatingPolicy with the SAME name as the MutatingPolicy above.
+# Uses a distinct label key (bynamespaced) so cross-contamination
+# is detectable.
+apiVersion: policies.kyverno.io/v1beta1
+kind: NamespacedMutatingPolicy
+metadata:
+  name: same-name-pol
+  namespace: test-same-name-ns
+spec:
+  failurePolicy: Fail
+  evaluation:
+    admission:
+      enabled: false
+    background:
+      enabled: true
+    mutateExisting:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["configmaps"]
+      resourceNames: ["same-name-pol-nmpol-cm"]
+  matchConditions:
+  - name: target-namespace
+    expression: "object.metadata.namespace == 'test-same-name-ns'"
+  mutations:
+  - patchType: ApplyConfiguration
+    applyConfiguration:
+      expression: >
+        Object{
+          metadata: Object.metadata{
+            labels: Object.metadata.labels{
+              bynamespaced: "true"
+            }
+          }
+        }

--- a/test/conformance/chainsaw/namespaced-mutating-policies/existing/background-scan/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/namespaced-mutating-policies/existing/background-scan/chainsaw-test.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: background-scan
+spec:
+  concurrent: false
+  steps:
+  - name: create namespace and configmap
+    try:
+    - create:
+        file: namespace.yaml
+    - assert:
+        file: namespace.yaml
+    - create:
+        file: configmap.yaml
+    - assert:
+        file: configmap.yaml
+  - name: create policy
+    use:
+      template: ../../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait-namespaced-mutating-policy-ready
+    description: >
+      Wait for the background-only namespaced mutating policy to become ready.
+      Because admission is disabled, only the RBACPermissionsGranted condition is set
+      (no WebhookConfigured condition).
+    use:
+      template: ../../../_step-templates/namespaced-mutating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: test-nmpol-background-scan
+        - name: namespace
+          value: test-nmpol-background-scan-ns
+  - name: wait-for-background-scan
+    description: >
+      Wait for the background scan to run and apply the mutation.
+      The background controller periodically scans existing resources and creates
+      CELMutate UpdateRequests for NamespacedMutatingPolicies with mutateExisting enabled.
+      No admission event is needed — this exercises the background scan code path.
+    try:
+    - assert:
+        file: configmap-assert.yaml
+        timeout: 3m

--- a/test/conformance/chainsaw/namespaced-mutating-policies/existing/background-scan/configmap-assert.yaml
+++ b/test/conformance/chainsaw/namespaced-mutating-policies/existing/background-scan/configmap-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-nmpol-background-scan-cm
+  namespace: test-nmpol-background-scan-ns
+  labels:
+    background: scan

--- a/test/conformance/chainsaw/namespaced-mutating-policies/existing/background-scan/configmap.yaml
+++ b/test/conformance/chainsaw/namespaced-mutating-policies/existing/background-scan/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-nmpol-background-scan-cm
+  namespace: test-nmpol-background-scan-ns
+data:
+  key: value

--- a/test/conformance/chainsaw/namespaced-mutating-policies/existing/background-scan/namespace.yaml
+++ b/test/conformance/chainsaw/namespaced-mutating-policies/existing/background-scan/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-nmpol-background-scan-ns

--- a/test/conformance/chainsaw/namespaced-mutating-policies/existing/background-scan/policy.yaml
+++ b/test/conformance/chainsaw/namespaced-mutating-policies/existing/background-scan/policy.yaml
@@ -1,0 +1,35 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: NamespacedMutatingPolicy
+metadata:
+  name: test-nmpol-background-scan
+  namespace: test-nmpol-background-scan-ns
+spec:
+  failurePolicy: Fail
+  evaluation:
+    admission:
+      enabled: false
+    background:
+      enabled: true
+    mutateExisting:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [ "" ]
+      apiVersions: [ "v1" ]
+      operations: [ "CREATE", "UPDATE" ]
+      resources: [ "configmaps" ]
+      resourceNames: [ "test-nmpol-background-scan-cm" ]
+  matchConditions:
+  - name: target-namespace
+    expression: object.metadata.namespace == 'test-nmpol-background-scan-ns'
+  mutations:
+  - patchType: ApplyConfiguration
+    applyConfiguration:
+      expression: >
+        Object{
+          metadata: Object.metadata{
+            labels: Object.metadata.labels{
+              background: "scan"
+            }
+          }
+        }


### PR DESCRIPTION
First: My main goal is that #16254 gets fixed :) this is just a attempt; but I don't have experience with coding. So, no hard feelings if this PR gets closed if the quality isn't on the level where it should be.

## Explanation

The background controller did not create `CELMutate` UpdateRequests for `MutatingPolicy` or `NamespacedMutatingPolicy` resources with `mutateExisting.enabled: true`, so background-only mutations never ran.

Changes:

- `pkg/policy/mpol.go`: add `createURForMutatingPolicy` and `createURForNamespacedMutatingPolicy` helpers that create `CELMutate` UpdateRequests for background scans
- `pkg/policy/policy_controller.go`: register `MutatingPolicy` and `NamespacedMutatingPolicy` informers/listers, handle `mpol`/`nmpol` keys in `syncPolicy`, add event handlers, spec-change guards in `updatePolicy`, `deletePolicy` cases, and list both types in the periodic `requeuePolicies` scan loop
- `pkg/policy/utils.go`: handle `*policiesv1beta1.MutatingPolicy` and `*policiesv1beta1.NamespacedMutatingPolicy` in `castPolicy`
- `pkg/background/mpol/processor.go`: build a synthetic `AdmissionRequest` per target for background-only scans (setting `Operation: Update`, `Object.Raw`, `Kind`, `Resource`, `Namespace`, `Name`); fix `GetPolicy` to route `namespace/name` keys directly to the `NamespacedMutatingPolicy` API; extract bare policy name before passing to `MatchNames`; derive `scopePredicate` from the UR's policy key (not the target namespace) to prevent cross-matching same-named cluster/namespaced policies
- `pkg/cel/policies/mpol/engine/reconciler.go`: branch on `req.NamespacedName.Namespace` to fix same-name collision — controller-runtime ignores namespace for cluster-scoped `Get` calls, so the reconciler could return the wrong policy type when a `MutatingPolicy` and a `NamespacedMutatingPolicy` share a name
- `cmd/background-controller/main.go`: pass `MutatingPolicy` and `NamespacedMutatingPolicy` informers to `NewPolicyController`
- `test/conformance/chainsaw/mutating-policies/existing/background-scan`: chainsaw e2e test verifying the background scan mutates an existing ConfigMap without any admission trigger
- `test/conformance/chainsaw/namespaced-mutating-policies/existing/background-scan`: same test for `NamespacedMutatingPolicy`
- `test/conformance/chainsaw/mutating-policies/existing/same-name-as-nmpol`: chainsaw e2e test verifying that a `MutatingPolicy` and a `NamespacedMutatingPolicy` with the same name are each applied to their respective targets independently

## Related issue

Closes #16254

## Milestone of this PR

/milestone TBD

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.

I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

Kyverno's `MutatingPolicy` and `NamespacedMutatingPolicy` (CEL-based, `policies.kyverno.io/v1beta1`) support mutating existing resources via background scan (`mutateExisting.enabled: true`), but the background controller never actually triggered those scans. The `policyController`'s periodic requeue loop and event handlers only handled `ClusterPolicy`/`Policy` (kpol) and `GeneratingPolicy`/`NamespacedGeneratingPolicy` (gpol/ngpol) — both mutating policy types were silently ignored, so no `CELMutate` UpdateRequests were ever created and existing resources were never mutated.

This PR wires both `MutatingPolicy` and `NamespacedMutatingPolicy` into the full background scan lifecycle. It also fixes three bugs discovered during implementation:

1. **Nil `AdmissionRequest`** — background-scan URs carry no admission request; fixed by building a full per-target synthetic request
2. **`NamespacedMutatingPolicy` lookup failure** — the cluster-scoped API rejects `/` in resource names; fixed by routing `namespace/name` keys directly to the namespaced API
3. **CEL engine reconciler same-name collision** — controller-runtime ignores namespace for cluster-scoped `Get` calls, so the reconciler was returning the wrong policy type when both types share a name; fixed by branching on `req.NamespacedName.Namespace`

### Proof Manifests

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is 1.18.
- [ ] My PR contains new or altered behavior to Kyverno and CLI support should be added and my PR doesn't contain that functionality.