### PR TITLE
fix(reports): honor background.enabled in resource report controller watches

### DIFF
--- a/pkg/controllers/report/resource/controller.go
+++ b/pkg/controllers/report/resource/controller.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/kyverno/kyverno/pkg/admissionpolicy"
+	celpolicies "github.com/kyverno/kyverno/pkg/cel/policies"
 	kyvernov1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/kyverno/v1"
 	policiesv1beta1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/policies.kyverno.io/v1beta1"
 	kyvernov1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1"
@@ -381,181 +382,14 @@ func (c *controller) startWatcher(ctx context.Context, logger logr.Logger, gvr s
 func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	clusterPolicies, err := utils.FetchClusterPolicies(c.cpolLister)
+	kinds, err := c.collectPolicyKinds()
 	if err != nil {
 		return err
 	}
-	policies, err := utils.FetchPolicies(c.polLister, metav1.NamespaceAll)
-	if err != nil {
-		return err
-	}
-	kinds := utils.BuildKindSet(logger, utils.RemoveNonValidationPolicies(append(clusterPolicies, policies...)...)...)
 	gvkToGvr := map[schema.GroupVersionKind]schema.GroupVersionResource{}
 	for _, policyKind := range sets.List(kinds) {
 		group, version, kind, subresource := kubeutils.ParseKindSelector(policyKind)
 		c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)
-	}
-	restMapper, err := restmapper.GetRESTMapper(c.client)
-	if err != nil {
-		return err
-	}
-	if c.vapLister != nil {
-		vapPolicies, err := utils.FetchValidatingAdmissionPolicies(c.vapLister)
-		if err != nil {
-			return err
-		}
-		// fetch kinds from validating admission policies
-		for _, policy := range vapPolicies {
-			kinds := admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)
-			for _, kind := range kinds {
-				group, version, kind, subresource := kubeutils.ParseKindSelector(kind)
-				c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)
-			}
-		}
-	}
-	if c.mapLister != nil {
-		mapPolicies, err := utils.FetchMutatingAdmissionPolicies(c.mapLister)
-		if err != nil {
-			return err
-		}
-		for _, policy := range mapPolicies {
-			converted := admissionpolicy.ConvertMatchResources(policy.Spec.MatchConstraints)
-			kinds := admissionpolicy.GetKinds(converted, restMapper)
-			for _, kind := range kinds {
-				group, version, kind, subresource := kubeutils.ParseKindSelector(kind)
-				c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)
-			}
-		}
-	}
-	if c.mapAlphaLister != nil {
-		mapAlphaPolicies, err := utils.FetchMutatingAdmissionPoliciesAlpha(c.mapAlphaLister)
-		if err != nil {
-			return err
-		}
-		for _, policy := range mapAlphaPolicies {
-			var matchConstraints *admissionregistrationv1beta1.MatchResources
-			if policy.Spec.MatchConstraints != nil {
-				matchConstraints = &admissionregistrationv1beta1.MatchResources{
-					ResourceRules:        convertResourceRulesForResourceController(policy.Spec.MatchConstraints.ResourceRules),
-					ExcludeResourceRules: convertResourceRulesForResourceController(policy.Spec.MatchConstraints.ExcludeResourceRules),
-					MatchPolicy:          (*admissionregistrationv1beta1.MatchPolicyType)(policy.Spec.MatchConstraints.MatchPolicy),
-				}
-			}
-			converted := admissionpolicy.ConvertMatchResources(matchConstraints)
-			kinds := admissionpolicy.GetKinds(converted, restMapper)
-			for _, kind := range kinds {
-				group, version, kind, subresource := kubeutils.ParseKindSelector(kind)
-				c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)
-			}
-		}
-	}
-	if c.vpolLister != nil {
-		vpols, err := utils.FetchValidatingPolicies(c.vpolLister)
-		if err != nil {
-			return err
-		}
-		// fetch kinds from validating admission policies
-		for _, policy := range vpols {
-			kinds := admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)
-			for _, autogen := range policy.Status.Autogen.Configs {
-				genKinds := admissionpolicy.GetKinds(autogen.Spec.MatchConstraints, restMapper)
-				kinds = append(kinds, genKinds...)
-			}
-
-			for _, kind := range kinds {
-				group, version, kind, subresource := kubeutils.ParseKindSelector(kind)
-				c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)
-			}
-		}
-	}
-	if c.nvpolLister != nil {
-		vpols, err := utils.FetchNamespacedValidatingPolicies(c.nvpolLister, "")
-		if err != nil {
-			return err
-		}
-		// fetch kinds from validating admission policies
-		for _, policy := range vpols {
-			kinds := admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)
-			for _, autogen := range policy.Status.Autogen.Configs {
-				genKinds := admissionpolicy.GetKinds(autogen.Spec.MatchConstraints, restMapper)
-				kinds = append(kinds, genKinds...)
-			}
-
-			for _, kind := range kinds {
-				group, version, kind, subresource := kubeutils.ParseKindSelector(kind)
-				c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)
-			}
-		}
-	}
-	if c.mpolLister != nil {
-		mpols, err := utils.FetchMutatingPolicies(c.mpolLister)
-		if err != nil {
-			return err
-		}
-		for _, policy := range mpols {
-			matchConstraints := policy.Spec.MatchConstraints
-			kinds := admissionpolicy.GetKinds(matchConstraints, restMapper)
-			for _, policy := range policy.Status.Autogen.Configs {
-				matchConstraints := policy.Spec.MatchConstraints
-				genKinds := admissionpolicy.GetKinds(matchConstraints, restMapper)
-
-				kinds = append(kinds, genKinds...)
-			}
-
-			for _, kind := range kinds {
-				group, version, kind, subresource := kubeutils.ParseKindSelector(kind)
-				c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)
-			}
-		}
-	}
-	if c.nmpolLister != nil {
-		mpols, err := utils.FetchNamespacedMutatingPolicies(c.nmpolLister, "")
-		if err != nil {
-			return err
-		}
-		for _, policy := range mpols {
-			matchConstraints := policy.Spec.MatchConstraints
-			kinds := admissionpolicy.GetKinds(matchConstraints, restMapper)
-			for _, policy := range policy.Status.Autogen.Configs {
-				matchConstraints := policy.Spec.MatchConstraints
-				genKinds := admissionpolicy.GetKinds(matchConstraints, restMapper)
-
-				kinds = append(kinds, genKinds...)
-			}
-
-			for _, kind := range kinds {
-				group, version, kind, subresource := kubeutils.ParseKindSelector(kind)
-				c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)
-			}
-		}
-	}
-	if c.ivpolLister != nil {
-		ivpols, err := utils.FetchImageVerificationPolicies(c.ivpolLister)
-		if err != nil {
-			return err
-		}
-		// fetch kinds from image verification admission policies
-		for _, policy := range ivpols {
-			kinds := admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)
-			for _, kind := range kinds {
-				group, version, kind, subresource := kubeutils.ParseKindSelector(kind)
-				c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)
-			}
-		}
-	}
-	if c.nivpolLister != nil {
-		ivpols, err := utils.FetchNamespacedImageVerificationPolicies(c.nivpolLister, "")
-		if err != nil {
-			return err
-		}
-		// fetch kinds from image verification admission policies
-		for _, policy := range ivpols {
-			kinds := admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)
-			for _, kind := range kinds {
-				group, version, kind, subresource := kubeutils.ParseKindSelector(kind)
-				c.addGVKToGVRMapping(group, version, kind, subresource, gvkToGvr)
-			}
-		}
 	}
 	dynamicWatchers := map[schema.GroupVersionResource]*watcher{}
 	for gvk, gvr := range gvkToGvr {
@@ -583,6 +417,139 @@ func (c *controller) updateDynamicWatchers(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// collectPolicyKinds returns the set of resource kinds that the report
+// controllers need to watch, gathered from every policy source. It is split out
+// of updateDynamicWatchers so the policy-to-kinds mapping can be unit-tested
+// without starting any dynamic watchers.
+func (c *controller) collectPolicyKinds() (sets.Set[string], error) {
+	kinds := sets.New[string]()
+	clusterPolicies, err := utils.FetchClusterPolicies(c.cpolLister)
+	if err != nil {
+		return nil, err
+	}
+	policies, err := utils.FetchPolicies(c.polLister, metav1.NamespaceAll)
+	if err != nil {
+		return nil, err
+	}
+	// only watch kinds for policies that participate in background scanning; this
+	// mirrors the background scan controller, which filters the same way before
+	// evaluating. watching kinds for background-disabled policies is wasted work.
+	kinds.Insert(utils.BuildKindSet(logger, utils.RemoveNonBackgroundPolicies(append(clusterPolicies, policies...)...)...).UnsortedList()...)
+	restMapper, err := restmapper.GetRESTMapper(c.client)
+	if err != nil {
+		return nil, err
+	}
+	if c.vapLister != nil {
+		vapPolicies, err := utils.FetchValidatingAdmissionPolicies(c.vapLister)
+		if err != nil {
+			return nil, err
+		}
+		// fetch kinds from validating admission policies
+		for _, policy := range vapPolicies {
+			kinds.Insert(admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)...)
+		}
+	}
+	if c.mapLister != nil {
+		mapPolicies, err := utils.FetchMutatingAdmissionPolicies(c.mapLister)
+		if err != nil {
+			return nil, err
+		}
+		for _, policy := range mapPolicies {
+			converted := admissionpolicy.ConvertMatchResources(policy.Spec.MatchConstraints)
+			kinds.Insert(admissionpolicy.GetKinds(converted, restMapper)...)
+		}
+	}
+	if c.mapAlphaLister != nil {
+		mapAlphaPolicies, err := utils.FetchMutatingAdmissionPoliciesAlpha(c.mapAlphaLister)
+		if err != nil {
+			return nil, err
+		}
+		for _, policy := range mapAlphaPolicies {
+			var matchConstraints *admissionregistrationv1beta1.MatchResources
+			if policy.Spec.MatchConstraints != nil {
+				matchConstraints = &admissionregistrationv1beta1.MatchResources{
+					ResourceRules:        convertResourceRulesForResourceController(policy.Spec.MatchConstraints.ResourceRules),
+					ExcludeResourceRules: convertResourceRulesForResourceController(policy.Spec.MatchConstraints.ExcludeResourceRules),
+					MatchPolicy:          (*admissionregistrationv1beta1.MatchPolicyType)(policy.Spec.MatchConstraints.MatchPolicy),
+				}
+			}
+			converted := admissionpolicy.ConvertMatchResources(matchConstraints)
+			kinds.Insert(admissionpolicy.GetKinds(converted, restMapper)...)
+		}
+	}
+	if c.vpolLister != nil {
+		vpols, err := utils.FetchValidatingPolicies(c.vpolLister)
+		if err != nil {
+			return nil, err
+		}
+		// fetch kinds from validating admission policies
+		for _, policy := range celpolicies.RemoveNoneBackgroundPolicies(vpols) {
+			kinds.Insert(admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)...)
+			for _, autogen := range policy.Status.Autogen.Configs {
+				kinds.Insert(admissionpolicy.GetKinds(autogen.Spec.MatchConstraints, restMapper)...)
+			}
+		}
+	}
+	if c.nvpolLister != nil {
+		nvpols, err := utils.FetchNamespacedValidatingPolicies(c.nvpolLister, "")
+		if err != nil {
+			return nil, err
+		}
+		// fetch kinds from validating admission policies
+		for _, policy := range celpolicies.RemoveNoneBackgroundPolicies(nvpols) {
+			kinds.Insert(admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)...)
+			for _, autogen := range policy.Status.Autogen.Configs {
+				kinds.Insert(admissionpolicy.GetKinds(autogen.Spec.MatchConstraints, restMapper)...)
+			}
+		}
+	}
+	if c.mpolLister != nil {
+		mpols, err := utils.FetchMutatingPolicies(c.mpolLister)
+		if err != nil {
+			return nil, err
+		}
+		for _, policy := range celpolicies.RemoveNoneBackgroundPolicies(mpols) {
+			kinds.Insert(admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)...)
+			for _, autogen := range policy.Status.Autogen.Configs {
+				kinds.Insert(admissionpolicy.GetKinds(autogen.Spec.MatchConstraints, restMapper)...)
+			}
+		}
+	}
+	if c.nmpolLister != nil {
+		nmpols, err := utils.FetchNamespacedMutatingPolicies(c.nmpolLister, "")
+		if err != nil {
+			return nil, err
+		}
+		for _, policy := range celpolicies.RemoveNoneBackgroundPolicies(nmpols) {
+			kinds.Insert(admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)...)
+			for _, autogen := range policy.Status.Autogen.Configs {
+				kinds.Insert(admissionpolicy.GetKinds(autogen.Spec.MatchConstraints, restMapper)...)
+			}
+		}
+	}
+	if c.ivpolLister != nil {
+		ivpols, err := utils.FetchImageVerificationPolicies(c.ivpolLister)
+		if err != nil {
+			return nil, err
+		}
+		// fetch kinds from image verification admission policies
+		for _, policy := range celpolicies.RemoveNoneBackgroundPolicies(ivpols) {
+			kinds.Insert(admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)...)
+		}
+	}
+	if c.nivpolLister != nil {
+		nivpols, err := utils.FetchNamespacedImageVerificationPolicies(c.nivpolLister, "")
+		if err != nil {
+			return nil, err
+		}
+		// fetch kinds from image verification admission policies
+		for _, policy := range celpolicies.RemoveNoneBackgroundPolicies(nivpols) {
+			kinds.Insert(admissionpolicy.GetKinds(policy.Spec.MatchConstraints, restMapper)...)
+		}
+	}
+	return kinds, nil
 }
 
 func (c *controller) addGVKToGVRMapping(group, version, kind, subresource string, gvrMap map[schema.GroupVersionKind]schema.GroupVersionResource) {

--- a/pkg/controllers/report/resource/controller_test.go
+++ b/pkg/controllers/report/resource/controller_test.go
@@ -1,0 +1,118 @@
+package resource
+
+import (
+	"testing"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	versionedfake "github.com/kyverno/kyverno/pkg/client/clientset/versioned/fake"
+	kyvernoinformer "github.com/kyverno/kyverno/pkg/client/informers/externalversions"
+	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
+)
+
+// matchResourcesFor selects the given core/v1 resource (e.g. "pods") on CREATE.
+func matchResourcesFor(resource string) *admissionregistrationv1.MatchResources {
+	return &admissionregistrationv1.MatchResources{
+		ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+			RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Resources:   []string{resource},
+				},
+			},
+		}},
+	}
+}
+
+// newTestController builds a resource-report controller backed by fake listers
+// (seeded with the given policies) and a fake dclient, enough to exercise
+// collectPolicyKinds without an API server.
+func newTestController(t *testing.T, objects ...runtime.Object) *controller {
+	t.Helper()
+	kClient := versionedfake.NewSimpleClientset(objects...)
+	factory := kyvernoinformer.NewSharedInformerFactory(kClient, 0)
+	cpolInformer := factory.Kyverno().V1().ClusterPolicies()
+	polInformer := factory.Kyverno().V1().Policies()
+	vpolInformer := factory.Policies().V1beta1().ValidatingPolicies()
+	// touch the informers so the factory actually starts them
+	_ = cpolInformer.Informer()
+	_ = polInformer.Informer()
+	_ = vpolInformer.Informer()
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	factory.Start(stop)
+	factory.WaitForCacheSync(stop)
+	return &controller{
+		client:          dclient.NewEmptyFakeClient(),
+		cpolLister:      cpolInformer.Lister(),
+		polLister:       polInformer.Lister(),
+		vpolLister:      vpolInformer.Lister(),
+		dynamicWatchers: map[schema.GroupVersionResource]*watcher{},
+	}
+}
+
+// A background-disabled ValidatingPolicy is never evaluated by the background
+// scan controller, so the resource controller must not watch its resource kinds
+// (watching + hashing them is the wasted work this guards against).
+func TestCollectPolicyKinds_SkipsBackgroundDisabledValidatingPolicies(t *testing.T) {
+	enabled := &policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "enabled-on-pods"},
+		Spec:       policiesv1beta1.ValidatingPolicySpec{MatchConstraints: matchResourcesFor("pods")},
+	}
+	disabled := &policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "disabled-on-configmaps"},
+		Spec: policiesv1beta1.ValidatingPolicySpec{
+			MatchConstraints: matchResourcesFor("configmaps"),
+			EvaluationConfiguration: &policiesv1beta1.EvaluationConfiguration{
+				Background: &policiesv1beta1.BackgroundConfiguration{Enabled: ptr.To(false)},
+			},
+		},
+	}
+	c := newTestController(t, enabled, disabled)
+
+	kinds, err := c.collectPolicyKinds()
+	require.NoError(t, err)
+	assert.True(t, kinds.Has("v1/Pod"), "kinds from a background-enabled policy must be collected, got %v", sets.List(kinds))
+	assert.False(t, kinds.Has("v1/ConfigMap"), "kinds from a background-disabled policy must be skipped, got %v", sets.List(kinds))
+}
+
+// Same asymmetry on the traditional ClusterPolicy path: a policy with
+// background:false should not contribute resource kinds to the watch set.
+func TestCollectPolicyKinds_SkipsBackgroundDisabledClusterPolicies(t *testing.T) {
+	validate := &kyvernov1.Validation{Message: "must comply"}
+	enabled := &kyvernov1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "enabled-on-pods"},
+		Spec: kyvernov1.Spec{Rules: []kyvernov1.Rule{{
+			Name:           "check",
+			MatchResources: kyvernov1.MatchResources{ResourceDescription: kyvernov1.ResourceDescription{Kinds: []string{"Pod"}}},
+			Validation:     validate,
+		}}},
+	}
+	disabled := &kyvernov1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "disabled-on-configmaps"},
+		Spec: kyvernov1.Spec{
+			Background: ptr.To(false),
+			Rules: []kyvernov1.Rule{{
+				Name:           "check",
+				MatchResources: kyvernov1.MatchResources{ResourceDescription: kyvernov1.ResourceDescription{Kinds: []string{"ConfigMap"}}},
+				Validation:     validate,
+			}},
+		},
+	}
+	c := newTestController(t, enabled, disabled)
+
+	kinds, err := c.collectPolicyKinds()
+	require.NoError(t, err)
+	assert.True(t, kinds.Has("Pod"), "kinds from a background-enabled ClusterPolicy must be collected, got %v", sets.List(kinds))
+	assert.False(t, kinds.Has("ConfigMap"), "kinds from a background-disabled ClusterPolicy must be skipped, got %v", sets.List(kinds))
+}

--- a/test/integration/resourcereport/resource_test.go
+++ b/test/integration/resourcereport/resource_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+
+package resourcereport_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	kyvernoinformer "github.com/kyverno/kyverno/pkg/client/informers/externalversions"
+	"github.com/kyverno/kyverno/pkg/controllers/report/resource"
+	"github.com/kyverno/kyverno/test/integration/framework"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/metadata"
+	"k8s.io/utils/ptr"
+)
+
+// matchResourcesFor selects the given core/v1 resource (e.g. "pods") on CREATE.
+func matchResourcesFor(resource string) *admissionregistrationv1.MatchResources {
+	return &admissionregistrationv1.MatchResources{
+		ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+			RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Resources:   []string{resource},
+				},
+			},
+		}},
+	}
+}
+
+// TestResourceController_DoesNotWatchBackgroundDisabledPolicyKinds drives the
+// real resource-report controller against a real (envtest) API server. It
+// creates a background-enabled ValidatingPolicy on Pods and a background-disabled
+// one on ConfigMaps, then asserts (via the controller's own metadata cache) that
+// a created Pod is tracked (its kind is watched + hashed) while a created
+// ConfigMap is not (the disabled policy's kind is never watched). This is the
+// end-to-end proof that the fix actually stops the wasted watch/list/hash work
+// for background-disabled policies, not just at the kind-set level.
+func TestResourceController_DoesNotWatchBackgroundDisabledPolicyKinds(t *testing.T) {
+	testEnv, err := framework.NewTestEnv(
+		"../../../config/crds/policies.kyverno.io", // ValidatingPolicy etc.
+		"../../../config/crds/kyverno",             // ClusterPolicy/Policy (the controller always watches these)
+	)
+	require.NoError(t, err)
+	defer testEnv.Stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	enabled := &policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "enabled-on-pods"},
+		Spec:       policiesv1beta1.ValidatingPolicySpec{MatchConstraints: matchResourcesFor("pods")},
+	}
+	disabled := &policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "disabled-on-configmaps"},
+		Spec: policiesv1beta1.ValidatingPolicySpec{
+			MatchConstraints: matchResourcesFor("configmaps"),
+			EvaluationConfiguration: &policiesv1beta1.EvaluationConfiguration{
+				Background: &policiesv1beta1.BackgroundConfiguration{Enabled: ptr.To(false)},
+			},
+		},
+	}
+	require.NoError(t, testEnv.Client.Create(ctx, enabled))
+	require.NoError(t, testEnv.Client.Create(ctx, disabled))
+
+	// Wire the real controller exactly like cmd/reports-controller/main.go, only
+	// the vpol/cpol/pol sources are populated (the rest are not needed here).
+	metaClient, err := metadata.NewForConfig(testEnv.Env.Config)
+	require.NoError(t, err)
+	factory := kyvernoinformer.NewSharedInformerFactory(testEnv.KyvernoClient, 0)
+	ctrl := resource.NewController(
+		testEnv.DClient,
+		factory.Kyverno().V1().Policies(),
+		factory.Kyverno().V1().ClusterPolicies(),
+		factory.Policies().V1beta1().ValidatingPolicies(),
+		nil, nil, nil, nil, nil, // nvpol, mpol, nmpol, ivpol, nivpol
+		nil, nil, nil, // vap, map, mapAlpha
+		metaClient,
+	)
+	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
+
+	// Warmup opens the dynamic watchers for the current policy set; Run keeps it
+	// reconciling and stops the watchers cleanly when ctx is cancelled.
+	require.NoError(t, ctrl.Warmup(ctx))
+	go ctrl.Run(ctx, 1)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "probe-pod", Namespace: "default"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "nginx"}}},
+	}
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "probe-cm", Namespace: "default"}}
+	require.NoError(t, testEnv.Client.Create(ctx, pod))
+	require.NoError(t, testEnv.Client.Create(ctx, cm))
+
+	// The enabled policy's kind (Pod) is watched, so the created Pod lands in the
+	// controller's metadata cache.
+	require.Eventually(t, func() bool {
+		_, _, _, ok := ctrl.GetResourceHash(pod.GetUID())
+		return ok
+	}, 15*time.Second, 200*time.Millisecond, "the background-enabled policy's kind (Pod) must be watched and tracked")
+
+	// The background-disabled policy's kind (ConfigMap) must never be watched, so
+	// the created ConfigMap is not in the cache. Give the watch path the same
+	// window the Pod got, to make a false-negative meaningful.
+	require.Never(t, func() bool {
+		_, _, _, ok := ctrl.GetResourceHash(cm.GetUID())
+		return ok
+	}, 3*time.Second, 200*time.Millisecond, "the background-disabled policy's kind (ConfigMap) must not be watched")
+
+	// Belt and suspenders: assert the final state explicitly.
+	_, _, _, ok := ctrl.GetResourceHash(cm.GetUID())
+	assert.False(t, ok, "ConfigMap must not be tracked by the resource controller")
+}


### PR DESCRIPTION
## Problem

The resource report controller builds its set of dynamically watched resource kinds from every policy, ignoring whether the policy is actually used for background scanning (`spec.evaluation.background.enabled` on CEL policies, `spec.background` on ClusterPolicy/Policy).

The only consumer of this controller's metadata cache is the background scan controller, and that one already skips background-disabled policies. So for every `background: false` policy we still open a dynamic watch and list + hash all of its matching resources, producing nothing.

On a cluster with one background-enabled policy and several disabled ones this surfaced as elevated reports-controller CPU (reported on Slack).

## Fix

Gate the watch set the same way the background scan controller gates its scan set, so the two stay in sync:

- the six CEL policy types use `celpolicies.RemoveNoneBackgroundPolicies` (the same filter the background controller already applies)
- the traditional path uses `utils.RemoveNonBackgroundPolicies` instead of `RemoveNonValidationPolicies` (`BuildKindSet` already restricts to validate/verifyImages rules, so the only behavioral change is adding the background gate)

VAP/MAP are left alone (they have no Kyverno background toggle, and the background controller doesn't gate them either).

The kind collection logic is pulled into a `collectPolicyKinds` helper so it can be tested without standing up watchers. That refactor is behavior-preserving: collect the kind strings first, then resolve them to GVRs in one pass, same result as before.

## Testing

- unit tests:
  - a `background: false` policy's kinds are excluded from the watch set
  - a background-enabled policy's kinds are included
  - covers both CEL policies and ClusterPolicy/Policy paths
- integration test (envtest):
  - runs the real controller
  - confirms a Pod from a background-enabled policy is watched/tracked
  - confirms a ConfigMap from a `background: false` policy is never watched/tracked
  - verified the test fails without the fix, so it catches the regression

- `gofmt` clean
- `go vet` clean
- `go build` clean

`golangci-lint` did not run locally. The repository now targets Go 1.26.2, while the pinned `golangci-lint` v2.11.4 currently only builds with Go 1.25.

## Out of scope

- VAP/MAP background handling (no background toggle on those)

## Release note

Fixed the resource report controller watching and hashing resources for policies with background scanning disabled, reducing reports-controller CPU usage on clusters that mix background-enabled and background-disabled policies.

Slack discussion : [https://app.slack.com/client/T09NY5SBT/CLGR9BJU9](https://app.slack.com/client/T09NY5SBT/CLGR9BJU9)
