### PR TITLE
fix(webhooks): add success log to MutatingPolicy admission handler

### DIFF
--- a/pkg/webhooks/resource/mpol/handler.go
+++ b/pkg/webhooks/resource/mpol/handler.go
@@ -126,6 +126,17 @@ func (h *handler) mutate(ctx context.Context, logger logr.Logger, admissionReque
 		logger.Error(err, "mutation failures")
 		return admissionutils.Response(admissionRequest.UID, err)
 	}
+	for _, policy := range response.Policies {
+		var successRules []string
+		for _, rule := range policy.Rules {
+			if rule.Status() == engineapi.RuleStatusPass {
+				successRules = append(successRules, rule.Name())
+			}
+		}
+		if len(successRules) > 0 {
+			logger.V(2).Info("mutation rules from MutatingPolicy applied successfully", "policy", policy.Policy.GetName(), "rules", successRules)
+		}
+	}
 	return resp
 }
 


### PR DESCRIPTION
﻿## What does this PR do?

The MutatingPolicy (CEL-based) webhook handler in pkg/webhooks/resource/mpol/handler.go was missing the V(2) success log that the classic Policy mutation handler emits after rules are applied successfully.

The existing handler in pkg/webhooks/resource/mutation/mutation.go (line 131) emits a structured log when rules pass. Without an equivalent log in the mpol handler, operators have no signal that CEL mutation rules fired, making webhook debugging harder.

## Changes

After a successful admissionResponse() call in mutate(), iterate response.Policies and emit a V(2) log for each policy that had at least one passing rule, mirroring the pattern from the classic mutation handler.

## How to test

1. Deploy a MutatingPolicy that matches a resource type.
2. Create or update a matching resource.
3. Set log verbosity to V(2) or higher.
4. Observe "mutation rules from MutatingPolicy applied successfully" in the webhook logs.

Fixes #13958

Signed-off-by: B R GOVIND <brgovind2005@gmail.com>
