### PR TITLE
ci: bump codecov-action to v6.0.2 to fix uploader GPG key verification

### DIFF
--- a/.github/workflows/check-unit-tests.yaml
+++ b/.github/workflows/check-unit-tests.yaml
@@ -72,7 +72,7 @@ jobs:
       with:
         name: coverage.out
     - name: Upload Report to Codecov
-      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
       with:
         files: ./coverage.out
         fail_ci_if_error: true


### PR DESCRIPTION
                                                                               



## Description

The Codecov upload step has failed on every PR since ~June 6, blocking merges.

### Cause

Codecov migrated their Keybase/GPG signing key and disabled the old account (codecov/codecov-action#1956).

Our pinned `codecov-action` v6.0.0 (March) still fetches the deleted key, so the uploader fails with:

```text
Can't check signature: No public key
```

Because `fail_ci_if_error: true` is enabled, the upload failure fails the entire job.

### Fix

Bump the action pin from `v6.0.0` to `v6.0.2`, the release that updates the key location (same fix included in v7.0.0).

Only the unit-tests workflow uses Codecov, so the change is limited in scope.

### References

- codecov/codecov-action#1956 (Keybase migration / key import failure)
- https://github.com/codecov/codecov-action/releases/tag/v6.0.2
- Slack discussion:[https://kubernetes.slack.com/archives/C032MM2CH7X/p1781096791046079](https://kubernetes.slack.com/archives/C032MM2CH7X/p1781096791046079)