### PR TITLE
fix(ivpol): add debug logging for CEL image verification functions

### DIFF
--- a/pkg/cel/libs/imageverify/impl.go
+++ b/pkg/cel/libs/imageverify/impl.go
@@ -85,9 +85,7 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 
 			if attestor.IsCosign() {
 				f.logger.V(4).Info("verifying image signature", "image", image, "attestor", attestor.Name, "type", "cosign")
-				if err := f.cosignVerifier.VerifyImageSignature(ctx, img, &attestor); err != nil {
-					f.logger.V(2).Info("failed to verify image cosign", "image", image, "attestor", attestor.Name, "error", err)
-				} else {
+				if err := f.cosignVerifier.VerifyImageSignature(ctx, img, &attestor); err == nil {
 					f.logger.V(4).Info("image signature verified", "image", image, "attestor", attestor.Name, "type", "cosign")
 					count += 1
 				}
@@ -99,9 +97,7 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 				if attestor.Notary.TSACerts != nil {
 					tsaCerts = attestor.Notary.TSACerts.Value
 				}
-				if err := f.notaryVerifier.VerifyImageSignature(ctx, img, certs, tsaCerts); err != nil {
-					f.logger.V(2).Info("failed to verify image notary", "image", image, "attestor", attestor.Name, "error", err)
-				} else {
+				if err := f.notaryVerifier.VerifyImageSignature(ctx, img, certs, tsaCerts); err == nil {
 					f.logger.V(4).Info("image signature verified", "image", image, "attestor", attestor.Name, "type", "notary")
 					count += 1
 				}
@@ -144,9 +140,7 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 			}
 			if attestor.IsCosign() {
 				f.logger.V(4).Info("verifying attestation signature", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "cosign")
-				if err := f.cosignVerifier.VerifyAttestationSignature(ctx, img, &attest, &attestor); err != nil {
-					f.logger.V(2).Info("failed to verify attestation cosign", "image", image, "attestation", attestation, "attestor", attestor.Name, "error", err)
-				} else {
+				if err := f.cosignVerifier.VerifyAttestationSignature(ctx, img, &attest, &attestor); err == nil {
 					f.logger.V(4).Info("attestation signature verified", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "cosign")
 					count += 1
 				}
@@ -161,9 +155,7 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 				if attestor.Notary.TSACerts != nil {
 					tsaCerts = attestor.Notary.TSACerts.Value
 				}
-				if err := f.notaryVerifier.VerifyAttestationSignature(ctx, img, attest.Referrer.Type, certs, tsaCerts); err != nil {
-					f.logger.V(2).Info("failed to verify attestation notary", "image", image, "attestation", attestation, "attestor", attestor.Name, "error", err)
-				} else {
+				if err := f.notaryVerifier.VerifyAttestationSignature(ctx, img, attest.Referrer.Type, certs, tsaCerts); err == nil {
 					f.logger.V(4).Info("attestation signature verified", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "notary")
 					count += 1
 				}

--- a/pkg/cel/libs/imageverify/impl.go
+++ b/pkg/cel/libs/imageverify/impl.go
@@ -51,6 +51,7 @@ func ImageVerifyCELFuncs(
 	}
 	return &ivfuncs{
 		Adapter:         adapter,
+		logger:          logger,
 		imgCtx:          imgCtx,
 		creds:           spec.Credentials,
 		imgRules:        imgRules,
@@ -71,8 +72,10 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 		if match, err := matching.MatchImage(image, f.imgRules...); err != nil {
 			return types.WrapErr(err)
 		} else if !match {
+			f.logger.V(4).Info("skipping image, no matchImageReferences match", "image", image)
 			return f.NativeToValue(count)
 		}
+		f.logger.V(4).Info("verifyImageSignatures called", "image", image, "attestorCount", len(attestors))
 		for _, attestor := range attestors {
 			opts := GetRemoteOptsFromPolicy(f.creds)
 			img, err := f.imgCtx.Get(ctx, image, opts...)
@@ -81,9 +84,11 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 			}
 
 			if attestor.IsCosign() {
+				f.logger.V(4).Info("verifying image signature", "image", image, "attestor", attestor.Name, "type", "cosign")
 				if err := f.cosignVerifier.VerifyImageSignature(ctx, img, &attestor); err != nil {
-					f.logger.Info("failed to verify image cosign", "error", err)
+					f.logger.V(2).Info("failed to verify image cosign", "image", image, "attestor", attestor.Name, "error", err)
 				} else {
+					f.logger.V(4).Info("image signature verified", "image", image, "attestor", attestor.Name, "type", "cosign")
 					count += 1
 				}
 			} else if attestor.IsNotary() {
@@ -95,12 +100,14 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 					tsaCerts = attestor.Notary.TSACerts.Value
 				}
 				if err := f.notaryVerifier.VerifyImageSignature(ctx, img, certs, tsaCerts); err != nil {
-					f.logger.Info("failed to verify image notary", "error", err)
+					f.logger.V(2).Info("failed to verify image notary", "image", image, "attestor", attestor.Name, "error", err)
 				} else {
+					f.logger.V(4).Info("image signature verified", "image", image, "attestor", attestor.Name, "type", "notary")
 					count += 1
 				}
 			}
 		}
+		f.logger.V(6).Info("verifyImageSignatures returning", "image", image, "verifiedCount", count)
 		return f.NativeToValue(count)
 	}
 }
@@ -121,8 +128,10 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 		if match, err := matching.MatchImage(image, f.imgRules...); err != nil {
 			return types.WrapErr(err)
 		} else if !match {
+			f.logger.V(4).Info("skipping image, no matchImageReferences match", "image", image)
 			return f.NativeToValue(count)
 		}
+		f.logger.V(4).Info("verifyAttestationSignatures called", "image", image, "attestation", attestation, "attestorCount", len(attestors))
 		for _, attestor := range attestors {
 			attest, ok := f.attestationList[attestation]
 			if !ok {
@@ -134,9 +143,11 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 				return types.NewErr("failed to get imagedata: %v", err)
 			}
 			if attestor.IsCosign() {
+				f.logger.V(4).Info("verifying attestation signature", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "cosign")
 				if err := f.cosignVerifier.VerifyAttestationSignature(ctx, img, &attest, &attestor); err != nil {
-					f.logger.Info("failed to verify attestation cosign", "error", err)
+					f.logger.V(2).Info("failed to verify attestation cosign", "image", image, "attestation", attestation, "attestor", attestor.Name, "error", err)
 				} else {
+					f.logger.V(4).Info("attestation signature verified", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "cosign")
 					count += 1
 				}
 			} else if attestor.IsNotary() {
@@ -151,12 +162,14 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 					tsaCerts = attestor.Notary.TSACerts.Value
 				}
 				if err := f.notaryVerifier.VerifyAttestationSignature(ctx, img, attest.Referrer.Type, certs, tsaCerts); err != nil {
-					f.logger.Info("failed to verify attestation notary", "error", err)
+					f.logger.V(2).Info("failed to verify attestation notary", "image", image, "attestation", attestation, "attestor", attestor.Name, "error", err)
 				} else {
+					f.logger.V(4).Info("attestation signature verified", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "notary")
 					count += 1
 				}
 			}
 		}
+		f.logger.V(6).Info("verifyAttestationSignatures returning", "image", image, "attestation", attestation, "verifiedCount", count)
 		return f.NativeToValue(count)
 	}
 }

--- a/pkg/cel/libs/imageverify/impl.go
+++ b/pkg/cel/libs/imageverify/impl.go
@@ -85,7 +85,9 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 
 			if attestor.IsCosign() {
 				f.logger.V(4).Info("verifying image signature", "image", image, "attestor", attestor.Name, "type", "cosign")
-				if err := f.cosignVerifier.VerifyImageSignature(ctx, img, &attestor); err == nil {
+				if err := f.cosignVerifier.VerifyImageSignature(ctx, img, &attestor); err != nil {
+					f.logger.V(6).Info("image signature verification failed", "image", image, "attestor", attestor.Name, "type", "cosign", "error", err)
+				} else {
 					f.logger.V(4).Info("image signature verified", "image", image, "attestor", attestor.Name, "type", "cosign")
 					count += 1
 				}
@@ -97,7 +99,10 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 				if attestor.Notary.TSACerts != nil {
 					tsaCerts = attestor.Notary.TSACerts.Value
 				}
-				if err := f.notaryVerifier.VerifyImageSignature(ctx, img, certs, tsaCerts); err == nil {
+				f.logger.V(4).Info("verifying image signature", "image", image, "attestor", attestor.Name, "type", "notary")
+				if err := f.notaryVerifier.VerifyImageSignature(ctx, img, certs, tsaCerts); err != nil {
+					f.logger.V(6).Info("image signature verification failed", "image", image, "attestor", attestor.Name, "type", "notary", "error", err)
+				} else {
 					f.logger.V(4).Info("image signature verified", "image", image, "attestor", attestor.Name, "type", "notary")
 					count += 1
 				}
@@ -140,7 +145,9 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 			}
 			if attestor.IsCosign() {
 				f.logger.V(4).Info("verifying attestation signature", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "cosign")
-				if err := f.cosignVerifier.VerifyAttestationSignature(ctx, img, &attest, &attestor); err == nil {
+				if err := f.cosignVerifier.VerifyAttestationSignature(ctx, img, &attest, &attestor); err != nil {
+					f.logger.V(6).Info("attestation signature verification failed", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "cosign", "error", err)
+				} else {
 					f.logger.V(4).Info("attestation signature verified", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "cosign")
 					count += 1
 				}
@@ -155,7 +162,10 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 				if attestor.Notary.TSACerts != nil {
 					tsaCerts = attestor.Notary.TSACerts.Value
 				}
-				if err := f.notaryVerifier.VerifyAttestationSignature(ctx, img, attest.Referrer.Type, certs, tsaCerts); err == nil {
+				f.logger.V(4).Info("verifying attestation signature", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "notary")
+				if err := f.notaryVerifier.VerifyAttestationSignature(ctx, img, attest.Referrer.Type, certs, tsaCerts); err != nil {
+					f.logger.V(6).Info("attestation signature verification failed", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "notary", "error", err)
+				} else {
 					f.logger.V(4).Info("attestation signature verified", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "notary")
 					count += 1
 				}

--- a/pkg/cel/libs/imageverify/impl_test.go
+++ b/pkg/cel/libs/imageverify/impl_test.go
@@ -3,6 +3,7 @@ package imageverify
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/cel-go/cel"
 	"github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/sdk/extensions/imagedataloader"
@@ -61,7 +62,7 @@ func Test_impl_verify_image_signature_string_stringarray(t *testing.T) {
 
 	options := []cel.EnvOption{
 		cel.Variable("attestors", cel.MapType(cel.StringType, cel.DynType)),
-		Lib(nil, imgCtx, ivpol, nil),
+		Lib(nil, imgCtx, ivpol, nil, logr.Discard()),
 	}
 	env, err := cel.NewEnv(options...)
 	assert.NoError(t, err)
@@ -99,7 +100,7 @@ func Test_impl_verify_image_attestations_string_string_stringarray(t *testing.T)
 
 	options := []cel.EnvOption{
 		cel.Variable("attestors", cel.MapType(cel.StringType, cel.DynType)),
-		Lib(nil, imgCtx, ivpol, nil),
+		Lib(nil, imgCtx, ivpol, nil, logr.Discard()),
 	}
 	env, err := cel.NewEnv(options...)
 	assert.NoError(t, err)

--- a/pkg/cel/libs/imageverify/lib.go
+++ b/pkg/cel/libs/imageverify/lib.go
@@ -26,9 +26,10 @@ func Latest() *version.Version {
 	return versions.KyvernoLatest
 }
 
-func Lib(v *version.Version, imgCtx imagedataloader.ImageContext, ivpol policiesv1beta1.ImageValidatingPolicyLike, lister k8scorev1.SecretInterface) cel.EnvOption {
+func Lib(v *version.Version, imgCtx imagedataloader.ImageContext, ivpol policiesv1beta1.ImageValidatingPolicyLike, lister k8scorev1.SecretInterface, logger logr.Logger) cel.EnvOption {
 	// create the cel lib env option
 	return cel.Lib(&lib{
+		logger:  logger,
 		version: v,
 		imgCtx:  imgCtx,
 		ivpol:   ivpol,

--- a/pkg/image/verification/evaluator/compiler.go
+++ b/pkg/image/verification/evaluator/compiler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/cel/libs"
 	"github.com/kyverno/kyverno/pkg/cel/libs/imageverify"
 	ivpolvar "github.com/kyverno/kyverno/pkg/image/verification/variables"
+	"github.com/kyverno/kyverno/pkg/logging"
 	"github.com/kyverno/kyverno/pkg/toggle"
 	"github.com/kyverno/sdk/extensions/cel/libs/globalcontext"
 	"github.com/kyverno/sdk/extensions/cel/libs/gzip"
@@ -211,7 +212,7 @@ func (c *compilerImpl) createBaseIvpolEnv(libsctx libs.Context, ivpol policiesv1
 			imagedata.Latest(),
 		),
 		imageverify.Lib(
-			imageverify.Latest(), c.ictx, ivpol, c.lister,
+			imageverify.Latest(), c.ictx, ivpol, c.lister, logging.WithName("ivpol/imageverify"),
 		),
 		resource.Lib(
 			resource.Context{ContextInterface: libsctx},

--- a/pkg/image/verification/evaluator/compiler.go
+++ b/pkg/image/verification/evaluator/compiler.go
@@ -212,7 +212,8 @@ func (c *compilerImpl) createBaseIvpolEnv(libsctx libs.Context, ivpol policiesv1
 			imagedata.Latest(),
 		),
 		imageverify.Lib(
-			imageverify.Latest(), c.ictx, ivpol, c.lister, logging.WithName("ivpol/imageverify"),
+			imageverify.Latest(), c.ictx, ivpol, c.lister,
+			logging.WithName("ivpol/imageverify").WithValues("policy", ivpol.GetName(), "namespace", namespace),
 		),
 		resource.Lib(
 			resource.Context{ContextInterface: libsctx},


### PR DESCRIPTION
## Summary

Fixes #16023.

Wires the imageverify CEL library logger through to `verifyImageSignatures` and `verifyAttestationSignatures`, adding V(4)/V(6) diagnostics for function entry, match skips, verification attempts, and return values.

## Testing

- `go test ./pkg/cel/libs/imageverify/...`