### PR TITLE
fix(engine): make Equals/NotEquals symmetric for string vs numeric operands

### DIFF
--- a/pkg/engine/variables/operator/equal.go
+++ b/pkg/engine/variables/operator/equal.go
@@ -92,7 +92,7 @@ func (eh EqualHandler) validateValueWithStringPattern(key string, value interfac
 	// operand). This keeps the comparison symmetric with the int/float key paths,
 	// e.g. Equals("5", 5). Non-numeric keys (e.g. "abc" or quantity-like "100Mi")
 	// are skipped here and fall through to the string handling below, avoiding
-	// noisy parse-error logs for what is simply a not-equal comparison.
+	// noisy parse-error logs for what is simply an unequal comparison.
 	switch typedValue := value.(type) {
 	case int:
 		if _, err := strconv.ParseInt(key, 10, 64); err == nil {

--- a/pkg/engine/variables/operator/equal.go
+++ b/pkg/engine/variables/operator/equal.go
@@ -87,6 +87,18 @@ func (eh EqualHandler) validateValueWithStringPattern(key string, value interfac
 		}
 	}
 
+	// When the value is numeric, compare it against the string key by reusing
+	// the numeric handlers (which parse the string operand). This keeps the
+	// comparison symmetric with the int/float key paths, e.g. Equals("5", 5).
+	switch typedValue := value.(type) {
+	case int:
+		return eh.validateValueWithIntPattern(int64(typedValue), key)
+	case int64:
+		return eh.validateValueWithIntPattern(typedValue, key)
+	case float64:
+		return eh.validateValueWithFloatPattern(typedValue, key)
+	}
+
 	if val, ok := value.(string); ok {
 		return wildcard.Match(val, key)
 	}

--- a/pkg/engine/variables/operator/equal.go
+++ b/pkg/engine/variables/operator/equal.go
@@ -87,16 +87,25 @@ func (eh EqualHandler) validateValueWithStringPattern(key string, value interfac
 		}
 	}
 
-	// When the value is numeric, compare it against the string key by reusing
-	// the numeric handlers (which parse the string operand). This keeps the
-	// comparison symmetric with the int/float key paths, e.g. Equals("5", 5).
+	// When the value is numeric and the string key parses as the same numeric
+	// type, compare them by reusing the numeric handlers (which parse the string
+	// operand). This keeps the comparison symmetric with the int/float key paths,
+	// e.g. Equals("5", 5). Non-numeric keys (e.g. "abc" or quantity-like "100Mi")
+	// are skipped here and fall through to the string handling below, avoiding
+	// noisy parse-error logs for what is simply a not-equal comparison.
 	switch typedValue := value.(type) {
 	case int:
-		return eh.validateValueWithIntPattern(int64(typedValue), key)
+		if _, err := strconv.ParseInt(key, 10, 64); err == nil {
+			return eh.validateValueWithIntPattern(int64(typedValue), key)
+		}
 	case int64:
-		return eh.validateValueWithIntPattern(typedValue, key)
+		if _, err := strconv.ParseInt(key, 10, 64); err == nil {
+			return eh.validateValueWithIntPattern(typedValue, key)
+		}
 	case float64:
-		return eh.validateValueWithFloatPattern(typedValue, key)
+		if _, err := strconv.ParseFloat(key, 64); err == nil {
+			return eh.validateValueWithFloatPattern(typedValue, key)
+		}
 	}
 
 	if val, ok := value.(string); ok {

--- a/pkg/engine/variables/operator/equal_test.go
+++ b/pkg/engine/variables/operator/equal_test.go
@@ -159,6 +159,43 @@ func TestEqualHandler_Evaluate(t *testing.T) {
 			value:    123,
 			expected: false,
 		},
+		// String key vs numeric value (issue #16358 - symmetry)
+		{
+			name:     "string key equal int value",
+			key:      "5",
+			value:    5,
+			expected: true,
+		},
+		{
+			name:     "string key equal int64 value",
+			key:      "5",
+			value:    int64(5),
+			expected: true,
+		},
+		{
+			name:     "string key equal float64 value",
+			key:      "5",
+			value:    float64(5),
+			expected: true,
+		},
+		{
+			name:     "string key equal fractional float64 value",
+			key:      "5.5",
+			value:    5.5,
+			expected: true,
+		},
+		{
+			name:     "string key not equal int value",
+			key:      "5",
+			value:    6,
+			expected: false,
+		},
+		{
+			name:     "non-numeric string key vs int value",
+			key:      "abc",
+			value:    5,
+			expected: false,
+		},
 		// Resource quantity comparisons
 		{
 			name:     "resource quantity equal",
@@ -258,6 +295,43 @@ func TestEqualHandler_Evaluate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := handler.Evaluate(tt.key, tt.value)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestEqualNotEqual_TypeSymmetry verifies that comparing logically equivalent
+// values produces the same result regardless of operand order, and that
+// NotEquals is always the negation of Equals (issue #16358).
+func TestEqualNotEqual_TypeSymmetry(t *testing.T) {
+	log := logr.Discard()
+	eq := NewEqualHandler(log, nil)
+	neq := NewNotEqualHandler(log, nil)
+
+	pairs := []struct {
+		name string
+		a, b interface{}
+	}{
+		{"string and int", "5", 5},
+		{"string and int64", "5", int64(5)},
+		{"string and float64", "5", float64(5)},
+		{"fractional string and float64", "5.5", 5.5},
+		{"non-equal string and int", "5", 6},
+		{"non-numeric string and int", "abc", 5},
+	}
+
+	for _, p := range pairs {
+		t.Run(p.name, func(t *testing.T) {
+			// Equals is order-independent.
+			assert.Equal(t, eq.Evaluate(p.a, p.b), eq.Evaluate(p.b, p.a),
+				"Equals should be symmetric for %v and %v", p.a, p.b)
+			// NotEquals is order-independent.
+			assert.Equal(t, neq.Evaluate(p.a, p.b), neq.Evaluate(p.b, p.a),
+				"NotEquals should be symmetric for %v and %v", p.a, p.b)
+			// NotEquals is the negation of Equals in both orders.
+			assert.Equal(t, eq.Evaluate(p.a, p.b), !neq.Evaluate(p.a, p.b),
+				"NotEquals should be the negation of Equals for %v and %v", p.a, p.b)
+			assert.Equal(t, eq.Evaluate(p.b, p.a), !neq.Evaluate(p.b, p.a),
+				"NotEquals should be the negation of Equals for %v and %v", p.b, p.a)
 		})
 	}
 }

--- a/pkg/engine/variables/operator/notequal.go
+++ b/pkg/engine/variables/operator/notequal.go
@@ -92,16 +92,25 @@ func (neh NotEqualHandler) validateValueWithStringPattern(key string, value inte
 		}
 	}
 
-	// When the value is numeric, compare it against the string key by reusing
-	// the numeric handlers (which parse the string operand). This keeps the
-	// comparison symmetric with the int/float key paths, e.g. NotEquals("5", 5).
+	// When the value is numeric and the string key parses as the same numeric
+	// type, compare them by reusing the numeric handlers (which parse the string
+	// operand). This keeps the comparison symmetric with the int/float key paths,
+	// e.g. NotEquals("5", 5). Non-numeric keys (e.g. "abc" or quantity-like
+	// "100Mi") are skipped here and fall through to the string handling below,
+	// avoiding noisy parse-error logs for what is simply a not-equal comparison.
 	switch typedValue := value.(type) {
 	case int:
-		return neh.validateValueWithIntPattern(int64(typedValue), key)
+		if _, err := strconv.ParseInt(key, 10, 64); err == nil {
+			return neh.validateValueWithIntPattern(int64(typedValue), key)
+		}
 	case int64:
-		return neh.validateValueWithIntPattern(typedValue, key)
+		if _, err := strconv.ParseInt(key, 10, 64); err == nil {
+			return neh.validateValueWithIntPattern(typedValue, key)
+		}
 	case float64:
-		return neh.validateValueWithFloatPattern(typedValue, key)
+		if _, err := strconv.ParseFloat(key, 64); err == nil {
+			return neh.validateValueWithFloatPattern(typedValue, key)
+		}
 	}
 
 	if val, ok := value.(string); ok {

--- a/pkg/engine/variables/operator/notequal.go
+++ b/pkg/engine/variables/operator/notequal.go
@@ -92,6 +92,18 @@ func (neh NotEqualHandler) validateValueWithStringPattern(key string, value inte
 		}
 	}
 
+	// When the value is numeric, compare it against the string key by reusing
+	// the numeric handlers (which parse the string operand). This keeps the
+	// comparison symmetric with the int/float key paths, e.g. NotEquals("5", 5).
+	switch typedValue := value.(type) {
+	case int:
+		return neh.validateValueWithIntPattern(int64(typedValue), key)
+	case int64:
+		return neh.validateValueWithIntPattern(typedValue, key)
+	case float64:
+		return neh.validateValueWithFloatPattern(typedValue, key)
+	}
+
 	if val, ok := value.(string); ok {
 		return !wildcard.Match(val, key)
 	}

--- a/pkg/engine/variables/operator/notequal_test.go
+++ b/pkg/engine/variables/operator/notequal_test.go
@@ -47,6 +47,37 @@ func TestNotEqualHandler_Evaluate(t *testing.T) {
 			value:    "world",
 			expected: true,
 		},
+		// String key vs numeric value (issue #16358 - symmetry)
+		{
+			name:     "string key not equal int value (equal values)",
+			key:      "5",
+			value:    5,
+			expected: false,
+		},
+		{
+			name:     "string key not equal int64 value (equal values)",
+			key:      "5",
+			value:    int64(5),
+			expected: false,
+		},
+		{
+			name:     "string key not equal float64 value (equal values)",
+			key:      "5",
+			value:    float64(5),
+			expected: false,
+		},
+		{
+			name:     "string key not equal int value (different values)",
+			key:      "5",
+			value:    6,
+			expected: true,
+		},
+		{
+			name:     "non-numeric string key vs int value",
+			key:      "abc",
+			value:    5,
+			expected: true,
+		},
 		{
 			name:     "resource quantity vs non-quantity",
 			key:      "100Mi",

--- a/test/cli/test/test-string-numeric-equals/kyverno-test.yaml
+++ b/test/cli/test/test-string-numeric-equals/kyverno-test.yaml
@@ -1,0 +1,23 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: test-string-numeric-equals
+policies:
+- policy.yaml
+resources:
+- resources.yaml
+results:
+# replicas == 5 -> Equals("5", 5) is true -> deny fires -> fail
+- kind: Deployment
+  policy: deny-five-replicas
+  rule: deny-when-replicas-equals-five
+  resources:
+  - deployment-five-replicas
+  result: fail
+# replicas == 3 -> Equals("5", 3) is false -> deny does not fire -> pass
+- kind: Deployment
+  policy: deny-five-replicas
+  rule: deny-when-replicas-equals-five
+  resources:
+  - deployment-three-replicas
+  result: pass

--- a/test/cli/test/test-string-numeric-equals/policy.yaml
+++ b/test/cli/test/test-string-numeric-equals/policy.yaml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-five-replicas
+spec:
+  admission: true
+  background: false
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Deployment
+    name: deny-when-replicas-equals-five
+    # The deny condition compares a string literal key ("5") against a numeric
+    # value resolved from the resource (spec.replicas is an integer). This is the
+    # operand order that previously evaluated incorrectly (issue #16358): the
+    # string key vs numeric value path returned false, so the deny never fired
+    # and a Deployment with 5 replicas was wrongly allowed.
+    validate:
+      failureAction: Enforce
+      message: Deployments with exactly 5 replicas are not allowed.
+      deny:
+        conditions:
+          all:
+          - key: "5"
+            operator: Equals
+            value: "{{ request.object.spec.replicas }}"

--- a/test/cli/test/test-string-numeric-equals/resources.yaml
+++ b/test/cli/test/test-string-numeric-equals/resources.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-five-replicas
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.27
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-three-replicas
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.27


### PR DESCRIPTION
## Explanation

The `Equals` / `NotEquals` condition operators evaluated logically-equivalent values inconsistently depending on operand order. Comparing a numeric key against a string value (e.g. `Equals(5, "5")`) returned `true`, but the reverse — a string key against a numeric value (e.g. `Equals("5", 5)`) — returned `false` (and `NotEquals("5", 5)` returned `true`). This is a **bug fix** for incorrect policy evaluation: a policy comparing a string literal against a numeric variable could have a precondition or deny rule evaluated incorrectly.

## Related issue

Closes #16358

## What type of PR is this

/kind bug

## Proposed Changes

The operator handlers dispatch on the **key's** type. The numeric handlers (`validateValueWithIntPattern` / `validateValueWithFloatPattern`) already contain a `case string:` that parses a string value, so `Equals(5, "5")` works. However, `validateValueWithStringPattern` only handled duration, resource-quantity, and string (wildcard) values — when the value was numeric it fell through to `return false` (`Equals`) / `return true` (`NotEquals`).

This change makes `validateValueWithStringPattern` (in both `equal.go` and `notequal.go`) handle a numeric value by delegating to the existing numeric handlers with the operands flipped. This reuses already-tested parsing logic and makes the comparison **symmetric by construction** — the previously-broken direction now runs the exact same code path as the working direction.

The numeric check is placed **after** the existing duration and resource-quantity checks, so those behaviors are unchanged (e.g. `Equals("100Mi", 100)` correctly remains `false`; `Equals("100", 100)` is `true`).

Behavior before/after:

| Comparison | Before | After |
|---|---|---|
| `Equals("5", 5)` | `false` ❌ | `true` ✅ |
| `Equals(5, "5")` | `true` | `true` |
| `NotEquals("5", 5)` | `true` ❌ | `false` ✅ |
| `Equals("5.5", 5.5)` | `false` ❌ | `true` ✅ |
| `Equals("100Mi", 100)` | `false` | `false` (unchanged) |

### Proof Manifests

A Kyverno CLI test is included at `test/cli/test/test-string-numeric-equals/` that exercises the previously-broken operand order (string literal key vs numeric value) end-to-end. It is auto-discovered by `make test-cli-local-validate`.

I verified the test **fails against the pre-fix binary** (`Want fail, got pass` — the 5-replica Deployment was wrongly allowed because `Equals("5", 5)` returned `false`) and **passes after the fix**.

# Kyverno policy

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: deny-five-replicas
spec:
  admission: true
  background: false
  rules:
  - match:
      any:
      - resources:
          kinds:
          - Deployment
    name: deny-when-replicas-equals-five
    validate:
      failureAction: Enforce
      message: Deployments with exactly 5 replicas are not allowed.
      deny:
        conditions:
          all:
          - key: "5"
            operator: Equals
            value: "{{ request.object.spec.replicas }}"
```

# Kyverno CLI test manifest

```yaml
apiVersion: cli.kyverno.io/v1alpha1
kind: Test
metadata:
  name: test-string-numeric-equals
policies:
- policy.yaml
resources:
- resources.yaml
results:
# replicas == 5 -> Equals("5", 5) is true -> deny fires -> fail
- kind: Deployment
  policy: deny-five-replicas
  rule: deny-when-replicas-equals-five
  resources:
  - deployment-five-replicas
  result: fail
# replicas == 3 -> Equals("5", 3) is false -> deny does not fire -> pass
- kind: Deployment
  policy: deny-five-replicas
  rule: deny-when-replicas-equals-five
  resources:
  - deployment-three-replicas
  result: pass
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

The fix delegates to the existing numeric handlers rather than duplicating parse logic, so `Equals`/`NotEquals` remain mutual negations across both operand orders. Coverage:
- Unit tests in `equal_test.go` / `notequal_test.go` cover the string-vs-numeric direction, plus a dedicated `TestEqualNotEqual_TypeSymmetry` asserting order-independence and `NotEquals == !Equals`.
- A Kyverno CLI test (`test/cli/test/test-string-numeric-equals/`) proves the fix end-to-end and was confirmed to fail before the fix and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
