### PR TITLE
fix: key clone source resources by policy and rule

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -371,15 +371,9 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 						if len(rule.Generation.CloneList.Kinds) != 0 { // cloneList
 							// We cannot cast this to an unstructured object because it doesn't have a kind.
 							if isGit {
-								if ruleToCloneSourceResource[policy.GetName()] == nil {
-									ruleToCloneSourceResource[policy.GetName()] = map[string]string{}
-								}
-								ruleToCloneSourceResource[policy.GetName()][rule.Name] = res.CloneSourceResource
+								policyCloneSources[rule.Name] = res.CloneSourceResource
 							} else {
-								if ruleToCloneSourceResource[policy.GetName()] == nil {
-									ruleToCloneSourceResource[policy.GetName()] = map[string]string{}
-								}
-								ruleToCloneSourceResource[policy.GetName()][rule.Name] = path.GetFullPath(res.CloneSourceResource, testDir)
+								policyCloneSources[rule.Name] = path.GetFullPath(res.CloneSourceResource, testDir)
 							}
 						} else { // clone or data
 							ruleUnstr, err := generate.GetUnstrRule(rule.Generation.DeepCopy())
@@ -394,15 +388,9 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 							}
 							if len(genClone) != 0 {
 								if isGit {
-									if ruleToCloneSourceResource[policy.GetName()] == nil {
-										ruleToCloneSourceResource[policy.GetName()] = map[string]string{}
-									}
-									ruleToCloneSourceResource[policy.GetName()][rule.Name] = res.CloneSourceResource
+									policyCloneSources[rule.Name] = res.CloneSourceResource
 								} else {
-									if ruleToCloneSourceResource[policy.GetName()] == nil {
-										ruleToCloneSourceResource[policy.GetName()] = map[string]string{}
-									}
-									ruleToCloneSourceResource[policy.GetName()][rule.Name] = path.GetFullPath(res.CloneSourceResource, testDir)
+									policyCloneSources[rule.Name] = path.GetFullPath(res.CloneSourceResource, testDir)
 								}
 							}
 						}

--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -353,22 +353,33 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 	}
 
 	// TODO document the code below
-	ruleToCloneSourceResource := map[string]string{}
+	ruleToCloneSourceResource := map[string]map[string]string{}
 	for _, policy := range results.Policies {
 		for _, rule := range autogen.Default.ComputeRules(policy, "") {
 			for _, res := range testCase.Test.Results {
 				if isRulelessPolicyKind(policy.GetKind()) {
 					continue
 				}
-				// TODO: what if two policies have a rule with the same name ?
-				if rule.Name == res.Rule {
+
+				if policy.GetName() == res.Policy && rule.Name == res.Rule {
+					policyCloneSources := ruleToCloneSourceResource[policy.GetName()]
+					if policyCloneSources == nil {
+						policyCloneSources = map[string]string{}
+						ruleToCloneSourceResource[policy.GetName()] = policyCloneSources
+					}
 					if rule.HasGenerate() {
 						if len(rule.Generation.CloneList.Kinds) != 0 { // cloneList
 							// We cannot cast this to an unstructured object because it doesn't have a kind.
 							if isGit {
-								ruleToCloneSourceResource[rule.Name] = res.CloneSourceResource
+								if ruleToCloneSourceResource[policy.GetName()] == nil {
+									ruleToCloneSourceResource[policy.GetName()] = map[string]string{}
+								}
+								ruleToCloneSourceResource[policy.GetName()][rule.Name] = res.CloneSourceResource
 							} else {
-								ruleToCloneSourceResource[rule.Name] = path.GetFullPath(res.CloneSourceResource, testDir)
+								if ruleToCloneSourceResource[policy.GetName()] == nil {
+									ruleToCloneSourceResource[policy.GetName()] = map[string]string{}
+								}
+								ruleToCloneSourceResource[policy.GetName()][rule.Name] = path.GetFullPath(res.CloneSourceResource, testDir)
 							}
 						} else { // clone or data
 							ruleUnstr, err := generate.GetUnstrRule(rule.Generation.DeepCopy())
@@ -383,9 +394,15 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 							}
 							if len(genClone) != 0 {
 								if isGit {
-									ruleToCloneSourceResource[rule.Name] = res.CloneSourceResource
+									if ruleToCloneSourceResource[policy.GetName()] == nil {
+										ruleToCloneSourceResource[policy.GetName()] = map[string]string{}
+									}
+									ruleToCloneSourceResource[policy.GetName()][rule.Name] = res.CloneSourceResource
 								} else {
-									ruleToCloneSourceResource[rule.Name] = path.GetFullPath(res.CloneSourceResource, testDir)
+									if ruleToCloneSourceResource[policy.GetName()] == nil {
+										ruleToCloneSourceResource[policy.GetName()] = map[string]string{}
+									}
+									ruleToCloneSourceResource[policy.GetName()][rule.Name] = path.GetFullPath(res.CloneSourceResource, testDir)
 								}
 							}
 						}

--- a/cmd/cli/kubectl-kyverno/processor/generate.go
+++ b/cmd/cli/kubectl-kyverno/processor/generate.go
@@ -24,21 +24,24 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func handleGeneratePolicy(out io.Writer, store *store.Store, generateResponse *engineapi.EngineResponse, policyContext engine.PolicyContext, ruleToCloneSourceResource map[string]string) ([]engineapi.RuleResponse, error) {
+func handleGeneratePolicy(out io.Writer, store *store.Store, generateResponse *engineapi.EngineResponse, policyContext engine.PolicyContext, ruleToCloneSourceResource map[string]map[string]string) ([]engineapi.RuleResponse, error) {
 	newResource := policyContext.NewResource()
 	objects := []runtime.Object{&newResource}
+	policyName := policyContext.Policy().GetName()
 	for _, rule := range generateResponse.PolicyResponse.Rules {
-		if path, ok := ruleToCloneSourceResource[rule.Name()]; ok {
-			resourceBytes, err := resource.GetFileBytes(path)
-			if err != nil {
-				fmt.Fprintf(out, "failed to get resource bytes\n")
-			} else {
-				r, err := resource.GetUnstructuredResources(resourceBytes)
+		if paths, ok := ruleToCloneSourceResource[policyName]; ok {
+			if path, ok := paths[rule.Name()]; ok {
+				resourceBytes, err := resource.GetFileBytes(path)
 				if err != nil {
-					fmt.Fprintf(out, "failed to convert resource bytes to unstructured format\n")
-				}
-				for _, res := range r {
-					objects = append(objects, res)
+					fmt.Fprintf(out, "failed to get resource bytes\n")
+				} else {
+					r, err := resource.GetUnstructuredResources(resourceBytes)
+					if err != nil {
+						fmt.Fprintf(out, "failed to convert resource bytes to unstructured format\n")
+					}
+					for _, res := range r {
+						objects = append(objects, res)
+					}
 				}
 			}
 		}

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -98,7 +98,7 @@ type PolicyProcessor struct {
 	Stdin                     bool
 	Rc                        *ResultCounts
 	PrintPatchResource        bool
-	RuleToCloneSourceResource map[string]string
+	RuleToCloneSourceResource map[string]map[string]string
 	Client                    dclient.Interface
 	AuditWarn                 bool
 	Subresources              []v1alpha1.Subresource

--- a/test/cli/test-generate/duplicate-rule-clone-source/cloneSourceResources-a.yaml
+++ b/test/cli/test-generate/duplicate-rule-clone-source/cloneSourceResources-a.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: regcred
+  namespace: default
+  labels:
+    allowedToBeCloned: "true"
+type: Opaque
+data:
+  password: MWYyZDFlMmU2N2Rm
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: missing-label
+  namespace: default
+type: Opaque
+data:
+  password: MWYyZDFlMmU2N2Rm

--- a/test/cli/test-generate/duplicate-rule-clone-source/cloneSourceResources-b.yaml
+++ b/test/cli/test-generate/duplicate-rule-clone-source/cloneSourceResources-b.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: regcred-b
+  namespace: default
+  labels:
+    allowedToBeCloned: "true"
+type: Opaque
+data:
+  password: MWYyZDFlMmU2N2Rm
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: missing-label
+  namespace: default
+type: Opaque
+data:
+  password: MWYyZDFlMmU2N2Rm

--- a/test/cli/test-generate/duplicate-rule-clone-source/generatedResource-a.yaml
+++ b/test/cli/test-generate/duplicate-rule-clone-source/generatedResource-a.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: regcred
+  namespace: hello-world-namespace
+  labels:
+    allowedToBeCloned: "true"
+type: Opaque
+data:
+  password: MWYyZDFlMmU2N2Rm

--- a/test/cli/test-generate/duplicate-rule-clone-source/generatedResource-b.yaml
+++ b/test/cli/test-generate/duplicate-rule-clone-source/generatedResource-b.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: regcred-b
+  namespace: hello-world-namespace
+  labels:
+    allowedToBeCloned: "true"
+type: Opaque
+data:
+  password: MWYyZDFlMmU2N2Rm

--- a/test/cli/test-generate/duplicate-rule-clone-source/kyverno-test.yaml
+++ b/test/cli/test-generate/duplicate-rule-clone-source/kyverno-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kyverno-test.yaml
+policies:
+- policy-a.yaml
+- policy-b.yaml
+resources:
+- resource.yaml
+results:
+- cloneSourceResource: cloneSourceResources-a.yaml
+  generatedResource: generatedResource-a.yaml
+  kind: Namespace
+  policy: clone-list-secrets-a
+  resources:
+  - hello-world-namespace
+  result: pass
+  rule: clone-list-labelled-secrets
+- cloneSourceResource: cloneSourceResources-b.yaml
+  generatedResource: generatedResource-b.yaml
+  kind: Namespace
+  policy: clone-list-secrets-b
+  resources:
+  - hello-world-namespace
+  result: pass
+  rule: clone-list-labelled-secrets

--- a/test/cli/test-generate/duplicate-rule-clone-source/policy-a.yaml
+++ b/test/cli/test-generate/duplicate-rule-clone-source/policy-a.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/description: 'Secrets like registry credentials often need
+      to exist in multiple Namespaces so Pods there have access. Manually duplicating
+      those Secrets is time consuming and error prone. This policy will copy all Secrets
+      with the appropriate label which exists in the `default` Namespace to new Namespaces
+      when they are created. It will also push updates to the copied Secrets should the
+      source Secret be changed.'
+    policies.kyverno.io/subject: Secret
+    policies.kyverno.io/title: Clone List Secrets
+  name: clone-list-secrets-a
+spec:
+  admission: true
+  background: true
+  rules:
+  - generate:
+      cloneList:
+        namespace: default
+        kinds:
+          - v1/Secret
+          - v1/ConfigMap
+        selector:
+          matchLabels:
+            allowedToBeCloned: "true"
+      namespace: '{{request.object.metadata.name}}'
+      synchronize: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+    name: clone-list-labelled-secrets

--- a/test/cli/test-generate/duplicate-rule-clone-source/policy-b.yaml
+++ b/test/cli/test-generate/duplicate-rule-clone-source/policy-b.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/description: 'Secrets like registry credentials often need
+      to exist in multiple Namespaces so Pods there have access. Manually duplicating
+      those Secrets is time consuming and error prone. This policy will copy all Secrets
+      with the appropriate label which exists in the `default` Namespace to new Namespaces
+      when they are created. It will also push updates to the copied Secrets should the
+      source Secret be changed.'
+    policies.kyverno.io/subject: Secret
+    policies.kyverno.io/title: Clone List Secrets
+  name: clone-list-secrets-b
+spec:
+  admission: true
+  background: true
+  rules:
+  - generate:
+      cloneList:
+        namespace: default
+        kinds:
+          - v1/Secret
+          - v1/ConfigMap
+        selector:
+          matchLabels:
+            allowedToBeCloned: "true"
+      namespace: '{{request.object.metadata.name}}'
+      synchronize: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+    name: clone-list-labelled-secrets

--- a/test/cli/test-generate/duplicate-rule-clone-source/resource.yaml
+++ b/test/cli/test-generate/duplicate-rule-clone-source/resource.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hello-world-namespace
+  namespace: hello-world-namespace


### PR DESCRIPTION
## Explanation
This PR fixes a `kyverno test` bug where generate clone source resources were associated using only the rule name.

Rule names are only unique within a policy, not globally. When multiple policies in the same test use the same generate rule name, the CLI could associate a `cloneSourceResource` with the wrong policy/rule pair and produce incorrect test results.

The fix tracks clone source resources by both policy name and rule name, and updates generate processing to resolve clone sources using the same policy/rule identity.

## Related issue
Closes #16366

## Milestone of this PR


## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind bug


## Proposed Changes

- Key CLI generate test clone source resources by policy name and rule name instead of rule name only.
- Match test results using both policy name and rule name while collecting clone source resources.
- Update the generate processor to look up clone source resources using policy/rule identity.
- Add a regression CLI test with two policies sharing the same generate rule name but using different clone source resources.

### Proof Manifests

Added a new CLI regression test under:

```text
test/cli/test-generate/duplicate-rule-clone-source/
```

The test contains two generate policies with the **same rule name** but **different policy names** and **different clone source resources**.

Before this fix, the CLI associated clone source resources using only the rule name, causing one policy to use the other policy's clone source and fail.

After this fix, clone source resources are resolved using both the policy name and rule name, so each policy receives the correct clone source resource.

Validation performed:

```bash
go run ./cmd/cli/kubectl-kyverno test test/cli/test-generate/duplicate-rule-clone-source
go run ./cmd/cli/kubectl-kyverno test test/cli/test-generate/clone-list
go test ./cmd/cli/kubectl-kyverno/commands/test ./cmd/cli/kubectl-kyverno/processor
```

Expected result:

```
Test Summary: 2 tests passed and 0 tests failed
```



## Checklist



- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments
This change keeps the existing CLI test behavior but fixes clone source lookup identity for multi-policy test cases. The regression test covers two policies with the same rule name to ensure clone source resources remain policy-scoped.
