### PR TITLE
chore(workflow): dynamically discover active branches for Trivy issue sync

### DIFF
--- a/.github/workflows/sync-trivy-issues.yaml
+++ b/.github/workflows/sync-trivy-issues.yaml
@@ -25,7 +25,31 @@ jobs:
         script: |
           const { owner, repo } = context.repo;
 
-          const branches = ["main", "release-1.17", "release-1.16"];
+          const repoBranches = await github.paginate(
+            github.rest.repos.listBranches,
+            { owner, repo, per_page: 100 }
+          );
+
+          const latestReleaseBranch = repoBranches
+            .map(b => b.name)
+            .map(name => {
+              const match = name.match(/^release-(\d+)\.(\d+)$/);
+              if (!match) return null;
+              return {
+                name,
+                major: Number(match[1]),
+                minor: Number(match[2]),
+              };
+            })
+            .filter(Boolean)
+            .sort((a, b) => (b.major - a.major) || (b.minor - a.minor))[0]?.name;
+
+          const branches = ["main"];
+          if (latestReleaseBranch) {
+            branches.push(latestReleaseBranch);
+          }
+          core.info(`Syncing alerts for branches: ${branches.join(", ")}`);
+
           const allAlerts = [];
           for (const branch of branches) {
             const ref = `refs/heads/${branch}`;


### PR DESCRIPTION
## Summary

Replace hardcoded branch list in `sync-trivy-issues.yaml` with dynamic discovery that automatically targets `main` and the highest numbered release branch (e.g., `release-1.18`).

## Problem

Previously, the sync workflow used a hardcoded list of branches. This approach:
- Requires manual updates when a new release branch is created
- Leaves stale security alerts open for inactive branches (e.g., release-1.16, release-1.17)
- Clutters the issue list with vulnerabilities that won't be fixed on unmaintained versions

## Solution

The updated workflow now:
- **Queries the GitHub API** to fetch all repository branches dynamically
- **Filters for release branches** using semantic versioning pattern (`release-X.Y`)
- **Selects the highest version** for the active release branch (e.g., release-1.18 over release-1.17)
- **Always targets main + active release** — ensuring only maintained branches are monitored
- **Auto-closes stale issues** if alerts are no longer present in the targeted branch set

## Result

- ✅ Trivy alerts are synced only for actively maintained branches
- ✅ Stale alerts from inactive branches are automatically closed
- ✅ No manual branch list updates required when new releases are created
- ✅ Issue list reflects actual security exposure of maintained code

## Testing

The workflow was triggered on both `main` and `release-1.18`:
- Trivy scans completed successfully
- Sync workflow auto-discovered and targeted both branches
- Non-active-branch issues were successfully auto-closed
- Active alerts remain synced for main/release-1.18