### PR TITLE
fix(cli): honor request.operation=CONNECT in policy context

### DIFF
--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -857,7 +857,7 @@ func (p *PolicyProcessor) makePolicyContext(
 	}
 	// we need to get the resources back from the context to account for injected variables
 	switch operation {
-	case kyvernov1.Create:
+	case kyvernov1.Create, kyvernov1.Connect:
 		ret, err := policyContext.JSONContext().Query("request.object")
 		if err != nil {
 			return nil, err

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -793,6 +793,8 @@ func (p *PolicyProcessor) makePolicyContext(
 		operation = kyvernov1.Delete
 	case "UPDATE":
 		operation = kyvernov1.Update
+	case "CONNECT":
+		operation = kyvernov1.Connect
 	}
 	// an explicitly configured operation (e.g. from the test result entry) takes
 	// precedence over the values file

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor_test.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor_test.go
@@ -331,6 +331,7 @@ func Test_makePolicyContext_operation(t *testing.T) {
 		p := &PolicyProcessor{
 			Store:     &store.Store{},
 			Variables: vars,
+			Out:       os.Stdout,
 		}
 		pc, err := p.makePolicyContext(jp, cfg, res, policyArray[0], nil, schema.GroupVersionKind{Version: "v1", Kind: "Pod"}, "")
 		assert.NilError(t, err)

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor_test.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor_test.go
@@ -5,11 +5,17 @@ import (
 	"testing"
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/resource"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/store"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/variables"
+	"github.com/kyverno/kyverno/pkg/config"
+	"github.com/kyverno/kyverno/pkg/engine/jmespath"
 	yamlutils "github.com/kyverno/kyverno/pkg/utils/yaml"
 	"gotest.tools/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var policyNamespaceSelector = []byte(`{
@@ -295,4 +301,39 @@ func Test_resolveResource_generatingPolicyFallsThrough(t *testing.T) {
 	got, err := p.resolveResource("Deployment")
 	assert.NilError(t, err)
 	assert.Equal(t, "deployments", got)
+}
+
+func Test_makePolicyContext_operation(t *testing.T) {
+	// makePolicyContext derives the admission operation from the
+	// `request.operation` variable. CONNECT must be honored like the other
+	// operations; before the fix it fell through to the CREATE default.
+	testcases := []struct {
+		operation string
+		expected  kyvernov1.AdmissionOperation
+	}{
+		{operation: "CREATE", expected: kyvernov1.Create},
+		{operation: "UPDATE", expected: kyvernov1.Update},
+		{operation: "DELETE", expected: kyvernov1.Delete},
+		{operation: "CONNECT", expected: kyvernov1.Connect},
+	}
+	res := unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": "test"},
+	}}
+	policyArray, _, _, _, _, _, _, _ := yamlutils.GetPolicy(policyNamespaceSelector)
+	assert.Assert(t, len(policyArray) > 0)
+	cfg := config.NewDefaultConfiguration(false)
+	jp := jmespath.New(cfg)
+	for _, tc := range testcases {
+		vars, err := variables.New(os.Stdout, nil, "", "", nil, "request.operation="+tc.operation)
+		assert.NilError(t, err)
+		p := &PolicyProcessor{
+			Store:     &store.Store{},
+			Variables: vars,
+		}
+		pc, err := p.makePolicyContext(jp, cfg, res, policyArray[0], nil, schema.GroupVersionKind{Version: "v1", Kind: "Pod"}, "")
+		assert.NilError(t, err)
+		assert.Equal(t, tc.expected, pc.Operation(), "operation %s", tc.operation)
+	}
 }

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor_test.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor_test.go
@@ -6,6 +6,7 @@ import (
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/apis/v1alpha1"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/resource"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/store"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/variables"
@@ -337,4 +338,42 @@ func Test_makePolicyContext_operation(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, tc.expected, pc.Operation(), "operation %s", tc.operation)
 	}
+}
+
+func Test_makePolicyContext_connectRefreshesResourceFromContext(t *testing.T) {
+	// Under CONNECT, an injected request.object must be reflected in
+	// NewResource(), matching CREATE. This guards the behavior so it holds even
+	// if the resource/context aliasing in makePolicyContext changes.
+	injected := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": "injected"},
+	}
+	res := unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": "original"},
+	}}
+	policyArray, _, _, _, _, _, _, _ := yamlutils.GetPolicy(policyNamespaceSelector)
+	assert.Assert(t, len(policyArray) > 0)
+	cfg := config.NewDefaultConfiguration(false)
+	jp := jmespath.New(cfg)
+	vals := &v1alpha1.ValuesSpec{
+		GlobalValues: map[string]interface{}{
+			"request.operation": "CONNECT",
+			"request.object":    injected,
+		},
+	}
+	vars, err := variables.New(os.Stdout, nil, "", "", vals)
+	assert.NilError(t, err)
+	p := &PolicyProcessor{
+		Store:     &store.Store{},
+		Variables: vars,
+		Out:       os.Stdout,
+	}
+	pc, err := p.makePolicyContext(jp, cfg, res, policyArray[0], nil, schema.GroupVersionKind{Version: "v1", Kind: "Pod"}, "")
+	assert.NilError(t, err)
+	assert.Equal(t, kyvernov1.Connect, pc.Operation())
+	newResource := pc.NewResource()
+	assert.Equal(t, "injected", newResource.GetName(), "CONNECT should reflect injected request.object")
 }


### PR DESCRIPTION
## Explanation

The Kyverno CLI builds a policy context from the simulated `request.operation` variable, but only mapped `DELETE` and `UPDATE`. `CONNECT` fell through to the `CREATE` default, so `kyverno apply` evaluated `CONNECT`-only rules as if they were `CREATE`. This is a fix of existing behavior.

## Related issue

Closes #16406

## What type of PR is this

/kind bug

## Proposed Changes

`makePolicyContext` now also maps `request.operation=CONNECT` to `kyvernov1.Connect`, matching the operation set already accepted in `request.operation` condition validation and webhook rule operations. Since the operation drives rule matching, the CLI now evaluates `CONNECT` requests the same way the admission webhook does.

Added `Test_makePolicyContext_operation`, which asserts the resolved operation for `CREATE`/`UPDATE`/`DELETE`/`CONNECT`. The `CONNECT` case fails before this change (resolves to `CREATE`) and passes after.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective.
- [x] My PR has the [DCO sign-off](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco).
