### PR TITLE
fix(jmespath): treat link-local IPs as internal in is_external_url

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -1273,6 +1273,14 @@ func jpImageNormalize(configuration config.Configuration) gojmespath.JpFunction 
 	}
 }
 
+// isInternalIP reports whether ip belongs to a non-public range that must not
+// be treated as external. Besides loopback and private ranges this covers
+// link-local unicast (169.254.0.0/16 and fe80::/10, which includes the
+// 169.254.169.254 cloud metadata endpoint) and the unspecified address.
+func isInternalIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()
+}
+
 func jpIsExternalURL(arguments []any) (any, error) {
 	var err error
 	str, err := validateArg(pathCanonicalize, arguments, 0, reflect.String)
@@ -1285,7 +1293,7 @@ func jpIsExternalURL(arguments []any) (any, error) {
 	}
 	ip := net.ParseIP(parsedURL.Hostname())
 	if ip != nil {
-		return !(ip.IsLoopback() || ip.IsPrivate()), nil
+		return !isInternalIP(ip), nil
 	}
 	// If it can't be parsed as an IP, then resolve the domain name
 	addrs, err := net.DefaultResolver.LookupIPAddr(context.Background(), parsedURL.Hostname())
@@ -1293,7 +1301,7 @@ func jpIsExternalURL(arguments []any) (any, error) {
 		return nil, err
 	}
 	for _, addr := range addrs {
-		if addr.IP.IsLoopback() || addr.IP.IsPrivate() {
+		if isInternalIP(addr.IP) {
 			return false, nil
 		}
 	}

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -1740,6 +1740,15 @@ func Test_IsExternalURL(t *testing.T) {
 		}, {
 			jmesPath:       "is_external_url('http://www.google.com@192.168.1.3')", //url with basic auth
 			expectedResult: false,
+		}, {
+			jmesPath:       "is_external_url('http://169.254.169.254/latest/meta-data')", //link-local cloud metadata endpoint
+			expectedResult: false,
+		}, {
+			jmesPath:       "is_external_url('http://[fe80::1]')", //ipv6 link-local
+			expectedResult: false,
+		}, {
+			jmesPath:       "is_external_url('http://0.0.0.0')", //unspecified address
+			expectedResult: false,
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
## Explanation

`is_external_url` is meant to tell a policy whether a URL points at an external host or an internal/non-routable one, so it can be used to reject requests aimed at internal infrastructure. Today it only treats loopback and RFC 1918 private ranges as internal, so link-local addresses and the unspecified address are reported as external. That includes `169.254.169.254`, the cloud metadata endpoint (AWS/GCP/Azure IMDS), which a policy relying on this helper would wrongly accept as a safe external target. This is a fix.

## Related issue

None.

## What type of PR is this

/kind bug

## Proposed Changes

`is_external_url` returned true for addresses that are not routable off-host:
- link-local unicast (`169.254.0.0/16` and `fe80::/10`), which covers the `169.254.169.254` cloud metadata endpoint
- the unspecified address (`0.0.0.0` / `::`)

Both the literal-IP branch and the resolved-DNS branch had the same gap, so the check is now shared in one `isInternalIP` helper and both branches use it. Added regression cases for the metadata IP, an IPv6 link-local address, and `0.0.0.0`.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
