### PR TITLE
fix(ci): force conflicts when server-side applying conformance CRDs

### DIFF
--- a/.github/actions/tests/conformance/run/action.yaml
+++ b/.github/actions/tests/conformance/run/action.yaml
@@ -95,7 +95,7 @@ runs:
       shell: bash
       run: |
         set -e
-        kubectl apply --server-side -R -f ./config/crds
+        kubectl apply --server-side --force-conflicts -R -f ./config/crds
     - name: Install kubectl-evict
       if: inputs.install-kubectl-evict == 'true'
       shell: bash


### PR DESCRIPTION
## Summary
This PR fixes conformance CI failures caused by server-side apply conflicts when refreshing CRDs after Kyverno is installed by Helm.

## Problem
Conformance jobs fail in step "Run ./.github/actions/tests/conformance/run" with errors like:

- Apply failed with 1 conflict: conflict with "helm": .spec.versions

Example failing job:
- https://github.com/kyverno/kyverno/actions/runs/28579490311/job/84741352532\#step:3:951

## Root Cause
The conformance action installs Kyverno via Helm, then refreshes CRDs from the repository using server-side apply.

Helm owns managed fields on CRDs (including .spec.versions). A plain server-side apply command fails on field ownership conflicts.

## Fix
Update the CRD refresh command to force conflict resolution in this ephemeral CI environment:

- from: kubectl apply --server-side -R -f ./config/crds
- to: kubectl apply --server-side --force-conflicts -R -f ./config/crds

Changed file:
- [.github/actions/tests/conformance/run/action.yaml](.github/actions/tests/conformance/run/action.yaml#L98)

## Why This Is Safe
Conformance runs use throwaway kind clusters. For these jobs, repository CRDs are intended to be authoritative for test coverage, so taking ownership from Helm-managed fields is expected and scoped to CI.

## Scope
- One-line change in conformance composite action.
- No runtime/controller behavior changes outside CI workflow.

## Validation
- Reproduced failure pattern from main run logs (Helm ownership conflict on .spec.versions).
- Triggered new CI on this branch after applying the fix.
