### PR TITLE
fix: truncate ValidatingAdmissionPolicyBinding names that exceed the 63-char label limit

### DIFF
--- a/pkg/utils/report/metadata.go
+++ b/pkg/utils/report/metadata.go
@@ -105,17 +105,17 @@ func PolicyExceptionLabel(exception kyvernov2.PolicyException) string {
 }
 
 func ValidatingAdmissionPolicyBindingLabel(binding admissionregistrationv1.ValidatingAdmissionPolicyBinding) string {
-	return LabelPrefixValidatingAdmissionPolicyBinding + truncateLabelName(binding.GetName())
+	return LabelPrefixValidatingAdmissionPolicyBinding + normalizeLabelName(binding.GetName())
 }
 
 func MutatingAdmissionPolicyBindingLabel(binding metav1.Object) string {
-	return LabelPrefixMutatingAdmissionPolicyBinding + truncateLabelName(binding.GetName())
+	return LabelPrefixMutatingAdmissionPolicyBinding + normalizeLabelName(binding.GetName())
 }
 
-// truncateLabelName ensures the name portion of a Kubernetes label key stays within the
+// normalizeLabelName ensures the name portion of a Kubernetes label key stays within the
 // 63-character limit. Names exceeding this limit are replaced by their MD5 hash (32 hex
 // chars), which is deterministic and always within bounds.
-func truncateLabelName(name string) string {
+func normalizeLabelName(name string) string {
 	if len(name) <= 63 {
 		return name
 	}

--- a/pkg/utils/report/metadata.go
+++ b/pkg/utils/report/metadata.go
@@ -105,11 +105,22 @@ func PolicyExceptionLabel(exception kyvernov2.PolicyException) string {
 }
 
 func ValidatingAdmissionPolicyBindingLabel(binding admissionregistrationv1.ValidatingAdmissionPolicyBinding) string {
-	return LabelPrefixValidatingAdmissionPolicyBinding + binding.GetName()
+	return LabelPrefixValidatingAdmissionPolicyBinding + truncateLabelName(binding.GetName())
 }
 
 func MutatingAdmissionPolicyBindingLabel(binding metav1.Object) string {
-	return LabelPrefixMutatingAdmissionPolicyBinding + binding.GetName()
+	return LabelPrefixMutatingAdmissionPolicyBinding + truncateLabelName(binding.GetName())
+}
+
+// truncateLabelName ensures the name portion of a Kubernetes label key stays within the
+// 63-character limit. Names exceeding this limit are replaced by their MD5 hash (32 hex
+// chars), which is deterministic and always within bounds.
+func truncateLabelName(name string) string {
+	if len(name) <= 63 {
+		return name
+	}
+	hash := md5.Sum([]byte(name))
+	return hex.EncodeToString(hash[:])
 }
 
 func CleanupKyvernoLabels(obj metav1.Object) {

--- a/pkg/utils/report/metadata_test.go
+++ b/pkg/utils/report/metadata_test.go
@@ -1,10 +1,12 @@
 package report
 
 import (
+	"strings"
 	"testing"
 
 	reportsv1 "github.com/kyverno/kyverno/api/reports/v1"
 	"github.com/stretchr/testify/assert"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -314,4 +316,56 @@ func TestCleanupKyvernoLabels_NilLabels(t *testing.T) {
 	// Should not panic
 	CleanupKyvernoLabels(obj)
 	assert.Nil(t, obj.Labels)
+}
+
+func TestValidatingAdmissionPolicyBindingLabel_ShortName(t *testing.T) {
+	binding := admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-binding"},
+	}
+	label := ValidatingAdmissionPolicyBindingLabel(binding)
+	assert.Equal(t, LabelPrefixValidatingAdmissionPolicyBinding+"my-binding", label)
+	namePart := strings.TrimPrefix(label, LabelPrefixValidatingAdmissionPolicyBinding)
+	assert.LessOrEqual(t, len(namePart), 63, "label name portion must be ≤ 63 chars")
+}
+
+func TestValidatingAdmissionPolicyBindingLabel_LongName(t *testing.T) {
+	// Some operators generate ValidatingAdmissionPolicyBinding names derived from CRD group names,
+	// which can exceed the 63-char Kubernetes label name limit.
+	longName := "biding-autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
+	assert.Greater(t, len(longName), 63, "test precondition: name must be > 63 chars")
+
+	binding := admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: longName},
+	}
+	label := ValidatingAdmissionPolicyBindingLabel(binding)
+
+	namePart := strings.TrimPrefix(label, LabelPrefixValidatingAdmissionPolicyBinding)
+	assert.LessOrEqual(t, len(namePart), 63, "label name portion must be ≤ 63 chars")
+	assert.NotEqual(t, longName, namePart, "long name should be hashed, not used as-is")
+}
+
+func TestValidatingAdmissionPolicyBindingLabel_LongName_Deterministic(t *testing.T) {
+	longName := "biding-autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
+	binding := admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: longName},
+	}
+	assert.Equal(t, ValidatingAdmissionPolicyBindingLabel(binding), ValidatingAdmissionPolicyBindingLabel(binding),
+		"same binding name must always produce the same label")
+}
+
+func TestTruncateLabelName_ShortName(t *testing.T) {
+	assert.Equal(t, "short-name", truncateLabelName("short-name"))
+}
+
+func TestTruncateLabelName_ExactlyAtLimit(t *testing.T) {
+	name := strings.Repeat("a", 63)
+	assert.Equal(t, name, truncateLabelName(name))
+}
+
+func TestTruncateLabelName_OneOverLimit(t *testing.T) {
+	name := strings.Repeat("a", 64)
+	result := truncateLabelName(name)
+	assert.LessOrEqual(t, len(result), 63)
+	// MD5 hex is always 32 chars
+	assert.Equal(t, 32, len(result))
 }

--- a/pkg/utils/report/metadata_test.go
+++ b/pkg/utils/report/metadata_test.go
@@ -381,17 +381,17 @@ func TestValidatingAdmissionPolicyBindingLabel_LongName_Deterministic(t *testing
 }
 
 func TestTruncateLabelName_ShortName(t *testing.T) {
-	assert.Equal(t, "short-name", truncateLabelName("short-name"))
+	assert.Equal(t, "short-name", normalizeLabelName("short-name"))
 }
 
 func TestTruncateLabelName_ExactlyAtLimit(t *testing.T) {
 	name := strings.Repeat("a", 63)
-	assert.Equal(t, name, truncateLabelName(name))
+	assert.Equal(t, name, normalizeLabelName(name))
 }
 
 func TestTruncateLabelName_OneOverLimit(t *testing.T) {
 	name := strings.Repeat("a", 64)
-	result := truncateLabelName(name)
+	result := normalizeLabelName(name)
 	assert.LessOrEqual(t, len(result), 63)
 	// MD5 hex is always 32 chars
 	assert.Equal(t, 32, len(result))

--- a/pkg/utils/report/metadata_test.go
+++ b/pkg/utils/report/metadata_test.go
@@ -7,6 +7,7 @@ import (
 	reportsv1 "github.com/kyverno/kyverno/api/reports/v1"
 	"github.com/stretchr/testify/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -339,7 +340,33 @@ func TestValidatingAdmissionPolicyBindingLabel_LongName(t *testing.T) {
 	}
 	label := ValidatingAdmissionPolicyBindingLabel(binding)
 
+	assert.True(t, strings.HasPrefix(label, LabelPrefixValidatingAdmissionPolicyBinding), "label must start with the validating binding prefix")
 	namePart := strings.TrimPrefix(label, LabelPrefixValidatingAdmissionPolicyBinding)
+	assert.LessOrEqual(t, len(namePart), 63, "label name portion must be ≤ 63 chars")
+	assert.NotEqual(t, longName, namePart, "long name should be hashed, not used as-is")
+}
+
+func TestMutatingAdmissionPolicyBindingLabel_ShortName(t *testing.T) {
+	binding := admissionregistrationv1beta1.MutatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-mutating-binding"},
+	}
+	label := MutatingAdmissionPolicyBindingLabel(&binding)
+	assert.Equal(t, LabelPrefixMutatingAdmissionPolicyBinding+"my-mutating-binding", label)
+	namePart := strings.TrimPrefix(label, LabelPrefixMutatingAdmissionPolicyBinding)
+	assert.LessOrEqual(t, len(namePart), 63, "label name portion must be ≤ 63 chars")
+}
+
+func TestMutatingAdmissionPolicyBindingLabel_LongName(t *testing.T) {
+	longName := "biding-autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com"
+	assert.Greater(t, len(longName), 63, "test precondition: name must be > 63 chars")
+
+	binding := admissionregistrationv1beta1.MutatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: longName},
+	}
+	label := MutatingAdmissionPolicyBindingLabel(&binding)
+
+	assert.True(t, strings.HasPrefix(label, LabelPrefixMutatingAdmissionPolicyBinding), "label must start with the mutating binding prefix")
+	namePart := strings.TrimPrefix(label, LabelPrefixMutatingAdmissionPolicyBinding)
 	assert.LessOrEqual(t, len(namePart), 63, "label name portion must be ≤ 63 chars")
 	assert.NotEqual(t, longName, namePart, "long name should be hashed, not used as-is")
 }


### PR DESCRIPTION
## Explanation

When a `ValidatingAdmissionPolicyBinding` name exceeds 63 characters (which happens with operators that derive binding names from CRD group names), Kyverno's `background-scan-controller` fails to persist `EphemeralReport` objects. Kubernetes rejects the label key because its name portion (after the `/`) exceeds the 63-character limit. Policy Reporter loses visibility of those resources, though policy evaluation itself is unaffected.

`ValidatingAdmissionPolicyBindingLabel` and `MutatingAdmissionPolicyBindingLabel` in `pkg/utils/report/metadata.go` were passing `binding.GetName()` directly as the label key name portion without length validation.

The fix adds a `truncateLabelName` helper that replaces names longer than 63 chars with their MD5 hex hash (32 chars). MD5 is used instead of simple truncation (as done in `autogen` for rule names) because label keys require uniqueness. Two bindings with different names but a shared 63-char prefix would otherwise collide to the same key. Both the SET and GET paths go through the same function, so the lookup remains consistent.

## Related issue

Closes #16436

Similar issue was fixed for GVR names in #11547 / #11620.

## Milestone of this PR

<!--
Add the milestone label by commenting `/milestone 1.2.3`.
-->

## Documentation (required for features)

Not applicable. This is a bug fix with no behavior change visible to end users beyond the fix itself.

## What type of PR is this

/kind bug

## Proposed Changes

- Add `truncateLabelName(name string) string` helper in `pkg/utils/report/metadata.go`
- Apply it in `ValidatingAdmissionPolicyBindingLabel` and `MutatingAdmissionPolicyBindingLabel`
- Add unit tests covering short names, exact-limit names, over-limit names, and determinism

### Proof Manifests

The fix is validated by unit tests. To reproduce the issue manually, apply a `ValidatingAdmissionPolicyBinding` with a name longer than 63 characters alongside a Kyverno `ClusterPolicy` with background scanning enabled, and observe that the `background-scan-controller` logs label validation errors and no `EphemeralReport` is created.

Example binding name that triggers the issue (84 chars):

```
biding-autoscale.dataplanegroups.konnectclouddataplanegroupconfig.konnect.konghq.com
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). I used AI assistance to help draft this fix; disclosed via `Assisted-by` trailer in the commit.
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The `truncateLabelName` helper is intentionally placed in `metadata.go` alongside the existing `CalculateResourceHash` function, which already uses `crypto/md5` and `encoding/hex` from the same file's imports. No new dependencies are introduced.