### PR TITLE
fix(webhook): bound admission report creation goroutines with a timeout

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -372,6 +372,7 @@ func main() {
 		maxAuditWorkers                 int
 		maxAuditCapacity                int
 		maxAdmissionReports             int
+		maxReportsInFlight              int
 		controllerRuntimeMetricsAddress string
 		tlsKeyAlgorithm                 string
 	)
@@ -405,6 +406,7 @@ func main() {
 	flagset.IntVar(&maxAuditWorkers, "maxAuditWorkers", 8, "Maximum number of workers for audit policy processing")
 	flagset.IntVar(&maxAuditCapacity, "maxAuditCapacity", 1000, "Maximum capacity of the audit policy task queue")
 	flagset.IntVar(&maxAdmissionReports, "maxAdmissionReports", 10000, "Maximum number of admission reports before we stop creating new ones")
+	flagset.IntVar(&maxReportsInFlight, "maxReportsInFlight", 1000, "Maximum number of concurrent admission report creations before new ones are dropped")
 	flagset.StringVar(&controllerRuntimeMetricsAddress, "controllerRuntimeMetricsAddress", "", `Bind address for controller-runtime metrics server. It will be defaulted to ":8080" if unspecified. Set this to "0" to disable the metrics server.`)
 	flagset.StringVar(&tlsKeyAlgorithm, "tlsKeyAlgorithm", "RSA", "Key algorithm for self-signed TLS certificates (RSA, ECDSA, Ed25519)")
 	// config
@@ -816,7 +818,7 @@ func main() {
 							time.Sleep(2 * time.Second)
 							continue
 						}
-						breaker.SetReportsBreaker(breaker.NewBreaker("admission reports", ephrCounterFunc(ephrs)))
+						breaker.SetReportsBreaker(breaker.WithConcurrencyLimit("admission reports in-flight", maxReportsInFlight, breaker.NewBreaker("admission reports", ephrCounterFunc(ephrs))))
 						return
 					}
 				}()
@@ -826,7 +828,7 @@ func main() {
 				}))
 				// no error has occurred, create a normal breaker
 			} else {
-				breaker.SetReportsBreaker(breaker.NewBreaker("admission reports", ephrCounterFunc(ephrs)))
+				breaker.SetReportsBreaker(breaker.WithConcurrencyLimit("admission reports in-flight", maxReportsInFlight, breaker.NewBreaker("admission reports", ephrCounterFunc(ephrs))))
 			}
 			// admission reports are disabled, create a fake breaker by default
 		} else {

--- a/pkg/breaker/concurrency.go
+++ b/pkg/breaker/concurrency.go
@@ -1,0 +1,53 @@
+package breaker
+
+import (
+	"context"
+
+	"github.com/kyverno/kyverno/pkg/metrics"
+)
+
+// concurrencyLimiter decorates a Breaker with a bound on concurrent in-flight
+// Do calls. When the bound is reached additional calls are dropped (returning
+// nil, like an open breaker) and recorded through the breaker drop metrics
+// under the limiter's own name. This bounds the damage when the inner call
+// hangs (e.g. a reports API that accepts connections but never responds):
+// report creations are fired at admission request rate, and without a bound
+// the callers pile up until the pod is OOM killed.
+type concurrencyLimiter struct {
+	name  string
+	inner Breaker
+	slots chan struct{}
+}
+
+// WithConcurrencyLimit bounds the number of concurrent in-flight Do calls on
+// the given breaker. A limit of zero or less returns the breaker unchanged.
+func WithConcurrencyLimit(name string, limit int, inner Breaker) Breaker {
+	if limit <= 0 {
+		return inner
+	}
+	return &concurrencyLimiter{
+		name:  name,
+		inner: inner,
+		slots: make(chan struct{}, limit),
+	}
+}
+
+func (l *concurrencyLimiter) Do(ctx context.Context, inner func(context.Context) error) error {
+	metrics := metrics.GetBreakerMetrics()
+
+	if metrics != nil {
+		metrics.RecordTotalIncrease(ctx, l.name)
+	}
+	select {
+	case l.slots <- struct{}{}:
+	default:
+		if metrics != nil {
+			metrics.RecordDrop(ctx, l.name)
+		}
+		return nil
+	}
+	defer func() {
+		<-l.slots
+	}()
+	return l.inner.Do(ctx, inner)
+}

--- a/pkg/breaker/concurrency_test.go
+++ b/pkg/breaker/concurrency_test.go
@@ -1,0 +1,68 @@
+package breaker
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_concurrencyLimiter_Do(t *testing.T) {
+	t.Run("zero limit returns inner unchanged", func(t *testing.T) {
+		inner := NewBreaker("", nil)
+		subject := WithConcurrencyLimit("", 0, inner)
+		assert.Equal(t, Breaker(inner), subject)
+	})
+	t.Run("passes calls through under the limit", func(t *testing.T) {
+		subject := WithConcurrencyLimit("", 2, NewBreaker("", nil))
+		called := false
+		err := subject.Do(context.TODO(), func(context.Context) error {
+			called = true
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.True(t, called)
+	})
+	t.Run("propagates inner errors", func(t *testing.T) {
+		subject := WithConcurrencyLimit("", 1, NewBreaker("", nil))
+		err := subject.Do(context.TODO(), func(context.Context) error {
+			return errors.New("foo")
+		})
+		assert.Error(t, err)
+	})
+	t.Run("drops calls when saturated and releases slots", func(t *testing.T) {
+		subject := WithConcurrencyLimit("", 1, NewBreaker("", nil))
+		started := make(chan struct{})
+		release := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = subject.Do(context.TODO(), func(context.Context) error {
+				close(started)
+				<-release
+				return nil
+			})
+		}()
+		<-started
+		// saturated: the call must be dropped without invoking inner
+		called := false
+		err := subject.Do(context.TODO(), func(context.Context) error {
+			called = true
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.False(t, called)
+		// once the slot is released, calls pass through again
+		close(release)
+		wg.Wait()
+		err = subject.Do(context.TODO(), func(context.Context) error {
+			called = true
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.True(t, called)
+	})
+}

--- a/pkg/utils/report/create_ephemeral.go
+++ b/pkg/utils/report/create_ephemeral.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/kyverno/kyverno/api/kyverno"
 	reportsv1 "github.com/kyverno/kyverno/api/reports/v1"
@@ -11,6 +12,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// CreationTimeout bounds the fire-and-forget admission report creation goroutines
+// in the webhook handlers. Without it, a reports API that accepts connections but
+// never responds keeps every goroutine (and its report payload) alive indefinitely.
+const CreationTimeout = 10 * time.Second
 
 func IsPolicyReportable(pol metav1.Object) bool {
 	if pol == nil { // invalid behavior

--- a/pkg/webhooks/resource/mutation/mutation.go
+++ b/pkg/webhooks/resource/mutation/mutation.go
@@ -30,11 +30,6 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
-// reportCreationTimeout bounds the fire-and-forget admission report creation goroutines.
-// Without it, a reports API that accepts connections but never responds keeps every
-// goroutine (and its report payload) alive indefinitely.
-const reportCreationTimeout = 30 * time.Second
-
 type MutationHandler interface {
 	// HandleMutation handles validating webhook admission request
 	// If there are no errors in validating rule we apply generation rules
@@ -166,7 +161,7 @@ func (v *mutationHandler) applyMutations(
 			// The timeout bounds how long this goroutine can live: if the reports API
 			// hangs (e.g. an unhealthy reports-server behind an aggregated APIService),
 			// unbounded goroutines accumulate at the admission request rate and OOM the pod.
-			ctx, cancel := context.WithTimeout(context.Background(), reportCreationTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), reportutils.CreationTimeout)
 			defer cancel()
 			if err := v.createReports(ctx, policyContext.NewResource(), request, engineResponses...); err != nil {
 				v.log.Error(err, "failed to create report")

--- a/pkg/webhooks/resource/mutation/mutation.go
+++ b/pkg/webhooks/resource/mutation/mutation.go
@@ -30,6 +30,11 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
+// reportCreationTimeout bounds the fire-and-forget admission report creation goroutines.
+// Without it, a reports API that accepts connections but never responds keeps every
+// goroutine (and its report payload) alive indefinitely.
+const reportCreationTimeout = 30 * time.Second
+
 type MutationHandler interface {
 	// HandleMutation handles validating webhook admission request
 	// If there are no errors in validating rule we apply generation rules
@@ -158,7 +163,12 @@ func (v *mutationHandler) applyMutations(
 
 	if v.needsReports(request, v.admissionReports) && reportutils.IsPolicyReportable(policyContext.Policy()) {
 		go func() { //nolint:gosec // background context is intentional: the goroutine outlives the request
-			if err := v.createReports(context.TODO(), policyContext.NewResource(), request, engineResponses...); err != nil {
+			// The timeout bounds how long this goroutine can live: if the reports API
+			// hangs (e.g. an unhealthy reports-server behind an aggregated APIService),
+			// unbounded goroutines accumulate at the admission request rate and OOM the pod.
+			ctx, cancel := context.WithTimeout(context.Background(), reportCreationTimeout)
+			defer cancel()
+			if err := v.createReports(ctx, policyContext.NewResource(), request, engineResponses...); err != nil {
 				v.log.Error(err, "failed to create report")
 			}
 		}()

--- a/pkg/webhooks/resource/validation/validation.go
+++ b/pkg/webhooks/resource/validation/validation.go
@@ -27,6 +27,11 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
+// reportCreationTimeout bounds the fire-and-forget admission report creation goroutines.
+// Without it, a reports API that accepts connections but never responds keeps every
+// goroutine (and its report payload) alive indefinitely.
+const reportCreationTimeout = 30 * time.Second
+
 type ValidationHandler interface {
 	// HandleValidation handles validating webhook admission request
 	// If there are no errors in validating rule we apply generation rules
@@ -155,7 +160,12 @@ func (v *validationHandler) HandleValidationEnforce(
 	// create the admission report if any of the policies involved doesn't have the report exclusion label
 	if NeedsReports(request, policyContext.NewResource(), v.admissionReports) && hasReportablePolicy(policies) {
 		go func() { //nolint:gosec // background context is intentional: the goroutine outlives the request
-			if err := v.createReports(context.TODO(), policyContext.NewResource(), request, engineResponses...); err != nil {
+			// The timeout bounds how long this goroutine can live: if the reports API
+			// hangs (e.g. an unhealthy reports-server behind an aggregated APIService),
+			// unbounded goroutines accumulate at the admission request rate and OOM the pod.
+			ctx, cancel := context.WithTimeout(context.Background(), reportCreationTimeout)
+			defer cancel()
+			if err := v.createReports(ctx, policyContext.NewResource(), request, engineResponses...); err != nil {
 				if reportutils.IsNamespaceTerminationError(err) {
 					// Log namespace termination errors at debug level as they are expected
 					v.log.V(2).Info("skipping report creation due to namespace termination", "error", err.Error())

--- a/pkg/webhooks/resource/validation/validation.go
+++ b/pkg/webhooks/resource/validation/validation.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -26,11 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
-
-// reportCreationTimeout bounds the fire-and-forget admission report creation goroutines.
-// Without it, a reports API that accepts connections but never responds keeps every
-// goroutine (and its report payload) alive indefinitely.
-const reportCreationTimeout = 30 * time.Second
 
 type ValidationHandler interface {
 	// HandleValidation handles validating webhook admission request
@@ -159,13 +155,16 @@ func (v *validationHandler) HandleValidationEnforce(
 
 	// create the admission report if any of the policies involved doesn't have the report exclusion label
 	if NeedsReports(request, policyContext.NewResource(), v.admissionReports) && hasReportablePolicy(policies) {
+		// snapshot the responses before starting the goroutine: engineResponses is
+		// appended to below, and the report must not depend on that ordering
+		responses := slices.Clone(engineResponses)
 		go func() { //nolint:gosec // background context is intentional: the goroutine outlives the request
 			// The timeout bounds how long this goroutine can live: if the reports API
 			// hangs (e.g. an unhealthy reports-server behind an aggregated APIService),
 			// unbounded goroutines accumulate at the admission request rate and OOM the pod.
-			ctx, cancel := context.WithTimeout(context.Background(), reportCreationTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), reportutils.CreationTimeout)
 			defer cancel()
-			if err := v.createReports(ctx, policyContext.NewResource(), request, engineResponses...); err != nil {
+			if err := v.createReports(ctx, policyContext.NewResource(), request, responses...); err != nil {
 				if reportutils.IsNamespaceTerminationError(err) {
 					// Log namespace termination errors at debug level as they are expected
 					v.log.V(2).Info("skipping report creation due to namespace termination", "error", err.Error())


### PR DESCRIPTION
# fix(webhook): bound admission report creation goroutines with a timeout

## Explanation

The classic-policy validate and mutate admission handlers create admission reports in fire-and-forget goroutines using `context.TODO()`:

- `pkg/webhooks/resource/validation/validation.go` (`HandleValidationEnforce`)
- `pkg/webhooks/resource/mutation/mutation.go` (`HandleMutation`)

The Kyverno client is built without a REST timeout (`pkg/config/client.go` only sets QPS/burst), so these goroutines have **no upper bound on their lifetime**. If the reports API *hangs* instead of failing fast — e.g. an overloaded reports-server behind an aggregated APIService that is still routable but no longer answering — each goroutine blocks until the kube-apiserver eventually times out the proxied call (~60s), holding the serialized report payload the whole time.

The reports circuit breaker does not protect against this failure mode: its health signal is a watch on `ephemeralreports`, which detects a *disconnected* reports API (watch errors, `IsRunning() == false` → breaker opens, reports dropped — works well), but not a *hanging* one — an established watch that silently stops delivering events keeps `IsRunning() == true` and the breaker closed while report creations pile up.

## Real-world incident

We hit this in a production-scale cluster (Kyverno v1.15.2, kind-`*` policy, ~250 admission req/s, reports-server-backed APIService):

1. reports-server became overloaded and started hanging (requests queued past their deadlines) while its APIService was still marked `Available` for a few more minutes.
2. During that window, every admission request leaked one hung report-creation goroutine. Goroutine counts went from a ~300 baseline to **50k–244k per pod within 1–3 minutes**.
3. Every admission-controller replica blew through its memory limit and was OOMKilled, nearly simultaneously — and kept OOM-crash-looping on restart for ~70 minutes.
4. With all webhook backends dead and `failurePolicy: Fail`, the kube-apiserver's in-flight mutating requests saturated waiting on webhook timeouts, and all writes cluster-wide failed until the reports API recovered.

## Fix

Two complementary bounds:

1. **Time bound** — the report-creation goroutines get a 10s `context.WithTimeout` (shared `reportutils.CreationTimeout`), mirroring the existing `backgroundTimeout` pattern in `handleBackgroundApplies` (`pkg/webhooks/resource/updaterequest.go`) and the audit worker context in `handlers.go`.

2. **Count bound** — a concurrency-limiting decorator (`breaker.WithConcurrencyLimit`) wraps the shared reports breaker, capping concurrent in-flight report creations (default 1000, configurable via `--maxReportsInFlight`). When saturated, additional creations are dropped like an open breaker and recorded through the existing breaker metrics under `circuit_name="admission reports in-flight"` — so `kyverno_breaker_drops` can be alerted on for saturation, with no new metric needed. Because it wraps the shared breaker, it covers every admission report write path: the async classic-policy goroutines and the synchronous ValidatingPolicy / MutatingPolicy / ImageValidatingPolicy handlers.

With both bounds, the incident scenario tops out at `min(admission_rate × 10s, 1000)` in-flight creations per pod instead of growing without bound, the pods survive, and the APIService availability controller flips the group to 503-fast-fail (at which point the existing count-based breaker takes over as designed).

## Related information

- Slack discussion or issue link (optional)

## Milestone of this PR

/milestone TBD

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further comments

Proof of behavior: existing unit tests pass (`go test ./pkg/webhooks/resource/...`, 86 tests). The change only narrows the context passed to `createReports`; the error path (log-and-continue) is unchanged.
