### PR TITLE
fix(reports): correct label prefix for mpol/dpol policies

### DIFF
--- a/pkg/utils/report/metadata.go
+++ b/pkg/utils/report/metadata.go
@@ -38,11 +38,15 @@ const (
 	LabelDomainValidatingPolicy                 = "vpol.kyverno.io"
 	LabelDomainImageValidatingPolicy            = "ivpol.kyverno.io"
 	LabelDomainGeneratingPolicy                 = "gpol.kyverno.io"
+	LabelDomainMutatingPolicy                   = "mpol.kyverno.io"
+	LabelDomainDeletingPolicy                   = "dpol.kyverno.io"
 	LabelPrefixClusterPolicy                    = LabelDomainClusterPolicy + "/"
 	LabelPrefixPolicy                           = LabelDomainPolicy + "/"
 	LabelPrefixValidatingPolicy                 = LabelDomainValidatingPolicy + "/"
 	LabelPrefixImageValidatingPolicy            = LabelDomainImageValidatingPolicy + "/"
 	LabelPrefixGeneratingPolicy                 = LabelDomainGeneratingPolicy + "/"
+	LabelPrefixMutatingPolicy                   = LabelDomainMutatingPolicy + "/"
+	LabelPrefixDeletingPolicy                   = LabelDomainDeletingPolicy + "/"
 	LabelPrefixPolicyException                  = "polex.kyverno.io/"
 	LabelPrefixValidatingAdmissionPolicy        = "validatingadmissionpolicy.apiserver.io/"
 	LabelPrefixValidatingAdmissionPolicyBinding = "validatingadmissionpolicybinding.apiserver.io/"
@@ -59,6 +63,8 @@ func IsPolicyLabel(label string) bool {
 		strings.HasPrefix(label, LabelPrefixValidatingPolicy) ||
 		strings.HasPrefix(label, LabelPrefixImageValidatingPolicy) ||
 		strings.HasPrefix(label, LabelPrefixGeneratingPolicy) ||
+		strings.HasPrefix(label, LabelPrefixMutatingPolicy) ||
+		strings.HasPrefix(label, LabelPrefixDeletingPolicy) ||
 		strings.HasPrefix(label, LabelPrefixPolicyException) ||
 		strings.HasPrefix(label, LabelPrefixValidatingAdmissionPolicy) ||
 		strings.HasPrefix(label, LabelPrefixValidatingAdmissionPolicyBinding) ||
@@ -81,6 +87,12 @@ func PolicyLabelPrefix(policy engineapi.GenericPolicy) string {
 	}
 	if policy.AsGeneratingPolicy() != nil {
 		return LabelPrefixGeneratingPolicy
+	}
+	if policy.AsMutatingPolicyLike() != nil {
+		return LabelPrefixMutatingPolicy
+	}
+	if policy.AsDeletingPolicy() != nil || policy.AsCleanupPolicy() != nil {
+		return LabelPrefixDeletingPolicy
 	}
 	if policy.AsMutatingAdmissionPolicy() != nil {
 		return LabelPrefixMutatingAdmissionPolicy

--- a/pkg/utils/report/metadata_test.go
+++ b/pkg/utils/report/metadata_test.go
@@ -288,7 +288,13 @@ func TestPolicyLabelPrefix_MutatingAndDeletingPolicies(t *testing.T) {
 	dpol := &policiesv1beta1.DeletingPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-dpol"},
 	}
+	nsDpol := &policiesv1beta1.NamespacedDeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-dpol", Namespace: "default"},
+	}
 	cleanup := &kyvernov2.CleanupPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cleanuppol"},
+	}
+	clusterCleanup := &kyvernov2.ClusterCleanupPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-cleanuppol"},
 	}
 
@@ -300,7 +306,9 @@ func TestPolicyLabelPrefix_MutatingAndDeletingPolicies(t *testing.T) {
 		{"mutating policy", engineapi.NewMutatingPolicy(mpol), LabelPrefixMutatingPolicy},
 		{"namespaced mutating policy", engineapi.NewNamespacedMutatingPolicy(nsMpol), LabelPrefixMutatingPolicy},
 		{"deleting policy", engineapi.NewDeletingPolicyFromLike(dpol), LabelPrefixDeletingPolicy},
+		{"namespaced deleting policy", engineapi.NewDeletingPolicyFromLike(nsDpol), LabelPrefixDeletingPolicy},
 		{"cleanup policy", engineapi.NewCleanupPolicyFromInterface(cleanup), LabelPrefixDeletingPolicy},
+		{"cluster cleanup policy", engineapi.NewCleanupPolicyFromInterface(clusterCleanup), LabelPrefixDeletingPolicy},
 	}
 
 	for _, tt := range tests {

--- a/pkg/utils/report/metadata_test.go
+++ b/pkg/utils/report/metadata_test.go
@@ -3,7 +3,10 @@ package report
 import (
 	"testing"
 
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
 	reportsv1 "github.com/kyverno/kyverno/api/reports/v1"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -253,6 +256,8 @@ func TestIsPolicyLabel_AllPrefixes(t *testing.T) {
 		{LabelPrefixValidatingPolicy + "my-vpol", true},
 		{LabelPrefixImageValidatingPolicy + "my-ivpol", true},
 		{LabelPrefixGeneratingPolicy + "my-gpol", true},
+		{LabelPrefixMutatingPolicy + "my-mpol", true},
+		{LabelPrefixDeletingPolicy + "my-dpol", true},
 		{LabelPrefixPolicyException + "my-polex", true},
 		{LabelPrefixValidatingAdmissionPolicy + "my-vap", true},
 		{LabelPrefixValidatingAdmissionPolicyBinding + "my-vapb", true},
@@ -269,6 +274,39 @@ func TestIsPolicyLabel_AllPrefixes(t *testing.T) {
 		t.Run(tt.label, func(t *testing.T) {
 			result := IsPolicyLabel(tt.label)
 			assert.Equal(t, tt.expected, result, "IsPolicyLabel(%q) should be %v", tt.label, tt.expected)
+		})
+	}
+}
+
+func TestPolicyLabelPrefix_MutatingAndDeletingPolicies(t *testing.T) {
+	mpol := &policiesv1beta1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-mpol"},
+	}
+	nsMpol := &policiesv1beta1.NamespacedMutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-mpol", Namespace: "default"},
+	}
+	dpol := &policiesv1beta1.DeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-dpol"},
+	}
+	cleanup := &kyvernov2.CleanupPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cleanuppol"},
+	}
+
+	tests := []struct {
+		name   string
+		policy engineapi.GenericPolicy
+		prefix string
+	}{
+		{"mutating policy", engineapi.NewMutatingPolicy(mpol), LabelPrefixMutatingPolicy},
+		{"namespaced mutating policy", engineapi.NewNamespacedMutatingPolicy(nsMpol), LabelPrefixMutatingPolicy},
+		{"deleting policy", engineapi.NewDeletingPolicyFromLike(dpol), LabelPrefixDeletingPolicy},
+		{"cleanup policy", engineapi.NewCleanupPolicyFromInterface(cleanup), LabelPrefixDeletingPolicy},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.prefix, PolicyLabelPrefix(tt.policy))
+			assert.True(t, IsPolicyLabel(PolicyLabel(tt.policy)))
 		})
 	}
 }

--- a/test/integration/mpol/handler_test.go
+++ b/test/integration/mpol/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-logr/logr"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	mpolengine "github.com/kyverno/kyverno/pkg/cel/policies/mpol/engine"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
 	mpol "github.com/kyverno/kyverno/pkg/webhooks/resource/mpol"
 	"github.com/kyverno/kyverno/test/integration/framework"
@@ -162,6 +163,66 @@ func TestMutate_JSONPatch_AddsLabel(t *testing.T) {
 	require.NotNil(t, p, "patch for /metadata/labels/env should exist")
 	assert.Equal(t, "add", p.Operation)
 	assert.Equal(t, "production", p.Value)
+}
+
+// allReportsEnabled is a ReportingConfiguration stub that enables every report
+// kind, used to exercise the real report-writing path in tests since the
+// package-level reportutils.ReportingCfg is initialized with reporting disabled.
+type allReportsEnabled struct{}
+
+func (allReportsEnabled) ValidateReportsEnabled() bool              { return true }
+func (allReportsEnabled) MutateReportsEnabled() bool                { return true }
+func (allReportsEnabled) MutateExistingReportsEnabled() bool        { return true }
+func (allReportsEnabled) ImageVerificationReportsEnabled() bool     { return true }
+func (allReportsEnabled) GenerateReportsEnabled() bool              { return true }
+func (allReportsEnabled) IsStatusAllowed(engineapi.RuleStatus) bool { return true }
+
+// Regression test for the report label prefix bug where MutatingPolicy reports
+// were mislabeled under the ValidatingAdmissionPolicy prefix. Verifies the
+// actual EphemeralReport created by the admission handler carries the
+// mpol.kyverno.io label for the triggering policy.
+func TestMutate_JSONPatch_ReportHasMutatingPolicyLabel(t *testing.T) {
+	policy := &policiesv1beta1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "report-label-mpol"},
+		Spec: policiesv1beta1.MutatingPolicySpec{
+			MatchConstraints: framework.PodMatchRules(),
+			Mutations: []admissionregistrationv1alpha1.Mutation{{
+				PatchType: admissionregistrationv1alpha1.PatchTypeJSONPatch,
+				JSONPatch: &admissionregistrationv1alpha1.JSONPatch{
+					Expression: `[JSONPatch{op: "add", path: "/metadata/labels/env", value: "production"}]`,
+				},
+			}},
+		},
+	}
+
+	createPolicyWithCleanup(t, policy)
+	waitForPolicyReady(t, 1)
+
+	eventGen := &framework.MockEventGen{}
+	h := mpol.New(testEnv.ContextProvider, engine, testEnv.KyvernoClient, allReportsEnabled{}, nil, "", eventGen)
+
+	ctx := framework.ContextWithPolicies(context.Background(), "report-label-mpol")
+	resp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("report-label-pod", "default", []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {"name": "report-label-pod", "namespace": "default", "labels": {}},
+		"spec": {"containers": [{"name": "app", "image": "nginx"}]}
+	}`)), "", time.Now())
+
+	assert.True(t, resp.Allowed, "mutation should allow the resource")
+
+	wantLabel := reportutils.LabelPrefixMutatingPolicy + "report-label-mpol"
+	require.Eventually(t, func() bool {
+		reports, err := testEnv.KyvernoClient.ReportsV1().EphemeralReports("default").List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			return false
+		}
+		for _, r := range reports.Items {
+			if _, ok := r.Labels[wantLabel]; ok {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 100*time.Millisecond, "expected an EphemeralReport labeled %q", wantLabel)
 }
 
 func TestMutate_JSONPatch_AllowsWithoutChange(t *testing.T) {

--- a/test/integration/mpol/handler_test.go
+++ b/test/integration/mpol/handler_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-logr/logr"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/kyverno/kyverno/pkg/breaker"
 	mpolengine "github.com/kyverno/kyverno/pkg/cel/policies/mpol/engine"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
@@ -36,6 +37,7 @@ func TestMain(m *testing.M) {
 	var err error
 	testEnv, err = framework.NewTestEnv(
 		"../../../config/crds/policies.kyverno.io",
+		"../../../config/crds/reports",
 	)
 	if err != nil {
 		panic(err)
@@ -53,6 +55,11 @@ func TestMain(m *testing.M) {
 		testEnv.Stop()
 		panic(err)
 	}
+
+	// The report-writing path in the mpol handler goes through breaker.GetReportsBreaker(),
+	// which is nil unless a real controller process (main.go) has set it. Install a
+	// pass-through breaker so tests exercising report creation don't panic.
+	breaker.SetReportsBreaker(breaker.NewBreaker("reports", func(context.Context) bool { return false }))
 
 	code := m.Run()
 	testEnv.Stop()
@@ -198,6 +205,15 @@ func TestMutate_JSONPatch_ReportHasMutatingPolicyLabel(t *testing.T) {
 	createPolicyWithCleanup(t, policy)
 	waitForPolicyReady(t, 1)
 
+	// The report-result filtering in reportutils.EngineResponseToReportResults reads the
+	// package-level reportutils.ReportingCfg, not the ReportingConfiguration passed to
+	// mpol.New. The framework's TestMain initializes it with no allowed rule statuses, so
+	// "pass" results are dropped before a report is ever written. Override it here so the
+	// mutation result actually makes it into the report, and restore it afterwards.
+	prevCfg := reportutils.ReportingCfg
+	reportutils.ReportingCfg = allReportsEnabled{}
+	t.Cleanup(func() { reportutils.ReportingCfg = prevCfg })
+
 	eventGen := &framework.MockEventGen{}
 	h := mpol.New(testEnv.ContextProvider, engine, testEnv.KyvernoClient, allReportsEnabled{}, nil, "", eventGen)
 
@@ -211,17 +227,14 @@ func TestMutate_JSONPatch_ReportHasMutatingPolicyLabel(t *testing.T) {
 	assert.True(t, resp.Allowed, "mutation should allow the resource")
 
 	wantLabel := reportutils.LabelPrefixMutatingPolicy + "report-label-mpol"
+	listOpts := metav1.ListOptions{LabelSelector: wantLabel}
+	t.Cleanup(func() {
+		testEnv.KyvernoClient.ReportsV1().EphemeralReports("default").DeleteCollection(context.Background(), metav1.DeleteOptions{}, listOpts)
+	})
+
 	require.Eventually(t, func() bool {
-		reports, err := testEnv.KyvernoClient.ReportsV1().EphemeralReports("default").List(context.Background(), metav1.ListOptions{})
-		if err != nil {
-			return false
-		}
-		for _, r := range reports.Items {
-			if _, ok := r.Labels[wantLabel]; ok {
-				return true
-			}
-		}
-		return false
+		reports, err := testEnv.KyvernoClient.ReportsV1().EphemeralReports("default").List(context.Background(), listOpts)
+		return err == nil && len(reports.Items) > 0
 	}, 5*time.Second, 100*time.Millisecond, "expected an EphemeralReport labeled %q", wantLabel)
 }
 


### PR DESCRIPTION
I noticed that PolicyLabelPrefix doesn't currently handle MutatingPolicy/NamespacedMutatingPolicy or DeletingPolicy/CleanupPolicy. Instead, both fall back to the ValidatingAdmissionPolicy default. As a result, reports for these policy types end up with incorrect labels, which can also lead to label collisions when a ValidatingAdmissionPolicy shares the same name.

This change adds dedicated mpol.kyverno.io and dpol.kyverno.io label prefixes and wires them into both PolicyLabelPrefix and IsPolicyLabel, following the existing pattern used for vpol, ivpol, and gpol. It also includes unit tests covering all four policy variants.