### PR TITLE
fix: truncate EphemeralReport GenerateName base to 57 chars to prevent 63-char limit violation

### DIFF
--- a/pkg/utils/report/new.go
+++ b/pkg/utils/report/new.go
@@ -38,12 +38,25 @@ func BuildAdmissionReport(resource unstructured.Unstructured, request admissionv
 	return report
 }
 
+func isAlphaNumeric(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
 func NewBackgroundScanReport(namespace, name string, gvk schema.GroupVersionKind, owner string, uid types.UID) reportsv1.ReportInterface {
 	var report reportsv1.ReportInterface
 	if namespace == "" {
 		report = &reportsv1.ClusterEphemeralReport{}
 	} else {
 		report = &reportsv1.EphemeralReport{}
+	}
+	// Kubernetes GenerateName appends a 5-char random suffix plus a hyphen separator.
+	// The total name must not exceed 63 characters (DNS-1035 label limit).
+	// So the base name must not exceed 57 characters before the trailing hyphen is added.
+	if len(name) > 57 {
+		name = name[:57]
+		for len(name) > 0 && !isAlphaNumeric(name[len(name)-1]) {
+			name = name[:len(name)-1]
+		}
 	}
 	report.SetGenerateName(name + "-")
 	report.SetNamespace(namespace)

--- a/pkg/utils/report/new_test.go
+++ b/pkg/utils/report/new_test.go
@@ -1,0 +1,83 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestNewBackgroundScanReport_NameTruncation(t *testing.T) {
+	t.Parallel()
+
+	gvk := schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "Deployment",
+	}
+	uid := types.UID("test-uid-1234")
+
+	// exactly 57 'a' characters
+	exactly57 := strings.Repeat("a", 57)
+
+	// 80-character name; first 57 chars are "this-is-a-very-long-validating-adm"... let's be explicit
+	longName := "this-is-a-very-long-validating-admission-policy-binding-name-that-exceeds-limit"
+
+	tests := []struct {
+		name       string
+		inputName  string
+		wantLen    int    // expected len of GenerateName (includes trailing hyphen)
+		wantPrefix string // first N chars before the hyphen
+	}{
+		{
+			name:       "short name passes through unchanged",
+			inputName:  "short-binding",
+			wantLen:    len("short-binding") + 1, // +1 for trailing "-"
+			wantPrefix: "short-binding",
+		},
+		{
+			name:       "name exactly 57 chars passes through unchanged",
+			inputName:  exactly57,
+			wantLen:    58, // 57 + trailing "-"
+			wantPrefix: exactly57,
+		},
+		{
+			name:       "name over 57 chars is truncated to 57",
+			inputName:  longName,
+			wantLen:    58, // 57 + trailing "-"
+			wantPrefix: longName[:57],
+		},
+		{
+			name:       "57th character is a period gets stripped",
+			inputName:  strings.Repeat("a", 56) + "." + "bbbbbbbbbbbbbbbbbbbbbbb",
+			wantLen:    57, // 56 chars + "-"
+			wantPrefix: strings.Repeat("a", 56),
+		},
+		{
+			name:       "57th character is underscore gets stripped",
+			inputName:  strings.Repeat("a", 56) + "_" + "ccccccccccccccccccccccc",
+			wantLen:    57, // 56 chars + "-"
+			wantPrefix: strings.Repeat("a", 56),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			report := NewBackgroundScanReport("test-namespace", tt.inputName, gvk, "test-owner", uid)
+			got := report.GetGenerateName()
+
+			if len(got) != tt.wantLen {
+				t.Errorf("GetGenerateName() length = %d, want %d (value: %q)", len(got), tt.wantLen, got)
+			}
+			if !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Errorf("GetGenerateName() = %q, want prefix %q", got, tt.wantPrefix)
+			}
+			if !strings.HasSuffix(got, "-") {
+				t.Errorf("GetGenerateName() = %q, must end with '-'", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Fixes #16436 (complementary to #16437).

`NewBackgroundScanReport` in `pkg/utils/report/new.go` passes the raw
binding name directly to `report.SetGenerateName(name + "-")`.

Kubernetes `GenerateName` appends a hyphen-separated 5-character random
suffix to produce the final resource name:
[base name] + "-" + [5 random chars] = total name

The total must satisfy the DNS-1035 label limit of **63 characters**:
63 (max) - 5 (random suffix) - 1 (hyphen separator) = 57 (max base length)

Any binding name longer than 57 characters causes the API server to reject
the generated `EphemeralReport` name with a validation error.

## Fix

Add a length guard in `NewBackgroundScanReport` before `SetGenerateName`:

```go
if len(name) > 57 {
    name = name[:57]
    for len(name) > 0 && !isAlphaNumeric(name[len(name)-1]) {
        name = name[:len(name)-1]
    }
}
```

`GenerateName` already guarantees uniqueness via its random suffix — no
hash needed.

## Relationship to #16437

PR #16437 fixes the label key truncation in `metadata.go`. This PR fixes
the complementary `GenerateName` crash path in `new.go`. Both are needed
to fully resolve #16436.

## Proof Manifest

A `ValidatingAdmissionPolicyBinding` with a name exceeding 57 characters
triggers the bug:

```yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingAdmissionPolicyBinding
metadata:
  name: "validate-deployment-resource-limits-and-requests-binding-for-production"
spec:
  policyName: "validate-deployment-resource-limits-and-requests"
  validationActions: [Warn]
  matchResources:
    namespaceSelector:
      matchLabels:
        environment: production
```

Without this fix, `background-scan-controller` fails to create the
`EphemeralReport` for any resource matched by this binding.

## Tests

Added `pkg/utils/report/new_test.go` covering:

| Case | Input | Expected |
|---|---|---|
| Short name | < 57 chars | Unchanged |
| Exact boundary | = 57 chars | Unchanged |
| Over limit | > 57 chars | Truncated to 57 |
| Trailing `.` at position 57 | 56 chars + `.` | Stripped to 56 chars |
| Trailing `_` at position 57 | 56 chars + `_` | Stripped to 56 chars |

## Checklist

- [x] I have read the contributing guidelines
- [x] I have read the AI Usage Policy and disclosed AI assistance via `Assisted-by` trailers in my commits
- [x] This is a bug fix and I have added unit tests that prove my fix is effective
- [ ] I have read the PR documentation guide and followed the process including adding proof manifests to this PR
- [ ] My PR needs to be cherry picked to a specific release branch