### PR TITLE
Add status conditions to DeletingPolicy

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -280,6 +280,8 @@ func createrLeaderControllers(
 		kyvernoInformer.Policies().V1beta1().NamespacedMutatingPolicies(),
 		kyvernoInformer.Policies().V1beta1().GeneratingPolicies(),
 		kyvernoInformer.Policies().V1beta1().NamespacedGeneratingPolicies(),
+		kyvernoInformer.Policies().V1beta1().DeletingPolicies(),
+		kyvernoInformer.Policies().V1beta1().NamespacedDeletingPolicies(),
 		reportsServiceAccountName,
 		stateRecorder,
 	)

--- a/pkg/controllers/deleting/controller.go
+++ b/pkg/controllers/deleting/controller.go
@@ -328,9 +328,10 @@ func (c *controller) updateDeletingPolicyStatus(ctx context.Context, policy v1be
 	switch p := policy.(type) {
 	case *v1beta1.DeletingPolicy:
 		err := controllerutils.UpdateStatus(ctx, p, c.kyvernoClient.PoliciesV1beta1().DeletingPolicies(), func(p *v1beta1.DeletingPolicy) error {
-			p.Status = v1beta1.DeletingPolicyStatus{
-				LastExecutionTime: metav1.NewTime(time),
-			}
+			// Only update LastExecutionTime; ConditionStatus is owned by the
+			// policy status controller and must be preserved to avoid the two
+			// writers clobbering each other's field.
+			p.Status.LastExecutionTime = metav1.NewTime(time)
 			return nil
 		}, func(current, expect *v1beta1.DeletingPolicy) bool {
 			return datautils.DeepEqual(current.Status, expect.Status)
@@ -341,9 +342,10 @@ func (c *controller) updateDeletingPolicyStatus(ctx context.Context, policy v1be
 		logging.Info("updated deleting policy status", "name", p.GetName(), "namespace", p.GetNamespace(), "status", p.Status)
 	case *v1beta1.NamespacedDeletingPolicy:
 		err := controllerutils.UpdateStatus(ctx, p, c.kyvernoClient.PoliciesV1beta1().NamespacedDeletingPolicies(p.GetNamespace()), func(p *v1beta1.NamespacedDeletingPolicy) error {
-			p.Status = v1beta1.DeletingPolicyStatus{
-				LastExecutionTime: metav1.NewTime(time),
-			}
+			// Only update LastExecutionTime; ConditionStatus is owned by the
+			// policy status controller and must be preserved to avoid the two
+			// writers clobbering each other's field.
+			p.Status.LastExecutionTime = metav1.NewTime(time)
 			return nil
 		}, func(current, expect *v1beta1.NamespacedDeletingPolicy) bool {
 			return datautils.DeepEqual(current.Status, expect.Status)

--- a/pkg/controllers/policystatus/controller.go
+++ b/pkg/controllers/policystatus/controller.go
@@ -54,6 +54,8 @@ func NewController(
 	nmpolInformer policiesv1beta1informers.NamespacedMutatingPolicyInformer,
 	gpolInformer policiesv1beta1informers.GeneratingPolicyInformer,
 	ngpolInformer policiesv1beta1informers.NamespacedGeneratingPolicyInformer,
+	dpolInformer policiesv1beta1informers.DeletingPolicyInformer,
+	ndpolInformer policiesv1beta1informers.NamespacedDeletingPolicyInformer,
 	reportsSA string,
 	polStateRecorder webhook.StateRecorder,
 ) Controller {
@@ -205,6 +207,38 @@ func NewController(
 	if err != nil {
 		logger.Error(err, "failed to register event handlers for NamespacedGeneratingPolicy")
 	}
+
+	_, _, err = controllerutils.AddExplicitEventHandlers(
+		logger,
+		dpolInformer.Informer(),
+		c.queue,
+		func(obj interface{}) cache.ExplicitKey {
+			dpol, ok := obj.(*policiesv1beta1.DeletingPolicy)
+			if !ok {
+				return ""
+			}
+			return cache.ExplicitKey(webhook.BuildRecorderKey(webhook.DeletingPolicyType, dpol.Name, ""))
+		},
+	)
+	if err != nil {
+		logger.Error(err, "failed to register event handlers for DeletingPolicy")
+	}
+
+	_, _, err = controllerutils.AddExplicitEventHandlers(
+		logger,
+		ndpolInformer.Informer(),
+		c.queue,
+		func(obj interface{}) cache.ExplicitKey {
+			ndpol, ok := obj.(*policiesv1beta1.NamespacedDeletingPolicy)
+			if !ok {
+				return ""
+			}
+			return cache.ExplicitKey(webhook.BuildRecorderKey(webhook.NamespacedDeletingPolicyType, ndpol.Name, ndpol.Namespace))
+		},
+	)
+	if err != nil {
+		logger.Error(err, "failed to register event handlers for NamespacedDeletingPolicy")
+	}
 	return c
 }
 
@@ -302,6 +336,22 @@ func (c controller) reconcile(ctx context.Context, logger logr.Logger, key strin
 				return err
 			}
 			return c.updateNGpolStatus(ctx, ngpol)
+		})
+	case webhook.DeletingPolicyType:
+		return retryStatusUpdate(l, func() error {
+			dpol, err := c.client.PoliciesV1beta1().DeletingPolicies().Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			return c.updateDpolStatus(ctx, dpol)
+		})
+	case webhook.NamespacedDeletingPolicyType:
+		return retryStatusUpdate(l, func() error {
+			ndpol, err := c.client.PoliciesV1beta1().NamespacedDeletingPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			return c.updateNDpolStatus(ctx, ndpol)
 		})
 	}
 	return nil

--- a/pkg/controllers/policystatus/controller_test.go
+++ b/pkg/controllers/policystatus/controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
@@ -98,6 +99,38 @@ func TestReconcile_ValidatingPolicy_retriesOnUpdateStatusConflict(t *testing.T) 
 	updated, err := client.PoliciesV1beta1().ValidatingPolicies().Get(ctx, vpol.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.NotNil(t, updated.Status.ConditionStatus.Conditions)
+}
+
+// TestReconcile_DeletingPolicy_preservesLastExecutionTime verifies that the
+// status controller (which owns ConditionStatus) does not clobber the
+// LastExecutionTime field owned by the deleting controller.
+func TestReconcile_DeletingPolicy_preservesLastExecutionTime(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	lastExec := metav1.NewTime(metav1.Now().Add(-time.Hour).Truncate(time.Second))
+	dpol := &policiesv1beta1.DeletingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dpol"},
+		Spec:       policiesv1beta1.DeletingPolicySpec{MatchConstraints: emptyMatchResources},
+		Status:     policiesv1beta1.DeletingPolicyStatus{LastExecutionTime: lastExec},
+	}
+
+	client := versionedfake.NewSimpleClientset(dpol)
+	dc := dclient.NewEmptyFakeClient()
+	c := controller{
+		dclient:          dc,
+		client:           client,
+		authChecker:      auth.NewSubjectChecker(dc.GetKubeClient().AuthorizationV1().SubjectAccessReviews(), "", nil),
+		polStateRecorder: webhook.NewStateRecorder(nil),
+	}
+
+	key := webhook.BuildRecorderKey(webhook.DeletingPolicyType, dpol.Name, "")
+	require.NoError(t, c.reconcile(ctx, logr.Discard(), key, "", ""))
+
+	updated, err := client.PoliciesV1beta1().DeletingPolicies().Get(ctx, dpol.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, updated.Status.ConditionStatus.Conditions, "ConditionStatus should be populated")
+	assert.True(t, updated.Status.LastExecutionTime.Equal(&lastExec), "LastExecutionTime must be preserved, got %v want %v", updated.Status.LastExecutionTime, lastExec)
 }
 
 // TestReconcile_AllPolicyTypes verifies that reconcile() correctly routes each
@@ -237,6 +270,43 @@ func TestReconcile_AllPolicyTypes(t *testing.T) {
 				pol, err := client.PoliciesV1beta1().GeneratingPolicies().Get(context.Background(), "test-gpol", metav1.GetOptions{})
 				require.NoError(t, err)
 				assert.NotEmpty(t, pol.Status.ConditionStatus.Conditions, "GeneratingPolicy status should have conditions")
+			},
+		},
+		{
+			name: "DeletingPolicy",
+			key:  webhook.BuildRecorderKey(webhook.DeletingPolicyType, "test-dpol", ""),
+			objects: []runtime.Object{
+				&policiesv1beta1.DeletingPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-dpol"},
+					Spec:       policiesv1beta1.DeletingPolicySpec{MatchConstraints: emptyMatchResources},
+				},
+			},
+			checkFunc: func(t *testing.T, client *versionedfake.Clientset) {
+				t.Helper()
+				pol, err := client.PoliciesV1beta1().DeletingPolicies().Get(context.Background(), "test-dpol", metav1.GetOptions{})
+				require.NoError(t, err)
+				assert.NotEmpty(t, pol.Status.ConditionStatus.Conditions, "DeletingPolicy status should have conditions")
+				// Deleting policies have no webhook, so only the RBAC condition is expected.
+				for i := range pol.Status.ConditionStatus.Conditions {
+					assert.NotEqual(t, string(policiesv1beta1.PolicyConditionTypeWebhookConfigured), pol.Status.ConditionStatus.Conditions[i].Type,
+						"DeletingPolicy should not report a WebhookConfigured condition")
+				}
+			},
+		},
+		{
+			name: "NamespacedDeletingPolicy",
+			key:  webhook.BuildRecorderKey(webhook.NamespacedDeletingPolicyType, "test-ndpol", "test-ns"),
+			objects: []runtime.Object{
+				&policiesv1beta1.NamespacedDeletingPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-ndpol", Namespace: "test-ns"},
+					Spec:       policiesv1beta1.DeletingPolicySpec{MatchConstraints: emptyMatchResources},
+				},
+			},
+			checkFunc: func(t *testing.T, client *versionedfake.Clientset) {
+				t.Helper()
+				pol, err := client.PoliciesV1beta1().NamespacedDeletingPolicies("test-ns").Get(context.Background(), "test-ndpol", metav1.GetOptions{})
+				require.NoError(t, err)
+				assert.NotEmpty(t, pol.Status.ConditionStatus.Conditions, "NamespacedDeletingPolicy status should have conditions")
 			},
 		},
 	}

--- a/pkg/controllers/policystatus/dpol.go
+++ b/pkg/controllers/policystatus/dpol.go
@@ -1,0 +1,91 @@
+package policystatus
+
+import (
+	"context"
+
+	"github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
+	datautils "github.com/kyverno/kyverno/pkg/utils/data"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// reconcileDeletingConditions builds the ConditionStatus for a deleting policy.
+//
+// Unlike admission-based policies, DeletingPolicy/NamespacedDeletingPolicy are
+// driven by a schedule rather than a webhook, so there is no WebhookConfigured
+// condition to report. The relevant signal is whether Kyverno can observe the
+// resources targeted by the policy's match constraints. The existing status is
+// passed in so conditions are merged (and their transition times preserved)
+// instead of being reset on every reconcile.
+//
+// Limitation: permissionsCheck evaluates get/list/watch as the reports service
+// account (the subject this controller's authChecker is bound to), which is the
+// same signal used for the other CEL policy types. It does NOT verify that the
+// cleanup controller's service account holds the "delete" verb on the target
+// resources — deletion runs in a separate binary under a different SA. So this
+// condition reflects resource observability, not deletion capability; the
+// messages below are intentionally worded to that effect. Reporting true
+// deletion-readiness would require checking the "delete" verb as the cleanup
+// controller SA and is tracked as a follow-up.
+func (c controller) reconcileDeletingConditions(ctx context.Context, matchConstraints *admissionregistrationv1.MatchResources, current v1beta1.ConditionStatus) v1beta1.ConditionStatus {
+	status := *current.DeepCopy()
+
+	var rules []admissionregistrationv1.NamedRuleWithOperations
+	if matchConstraints != nil {
+		rules = matchConstraints.ResourceRules
+	}
+	gvrs := c.resolveGVRs(rules)
+	if errs := c.permissionsCheck(ctx, gvrs); len(errs) != 0 {
+		status.SetReadyByCondition(v1beta1.PolicyConditionTypeRBACPermissionsGranted, metav1.ConditionFalse, "Kyverno cannot access the resources targeted by this policy, missing permissions.")
+	} else {
+		status.SetReadyByCondition(v1beta1.PolicyConditionTypeRBACPermissionsGranted, metav1.ConditionTrue, "Kyverno can access the resources targeted by this policy.")
+	}
+
+	ready := true
+	for _, condition := range status.Conditions {
+		if condition.Status != metav1.ConditionTrue {
+			ready = false
+			break
+		}
+	}
+	if status.Ready == nil || status.IsReady() != ready {
+		status.Ready = &ready
+	}
+	return status
+}
+
+func (c controller) updateDpolStatus(ctx context.Context, dpol *v1beta1.DeletingPolicy) error {
+	updateFunc := func(dpol *v1beta1.DeletingPolicy) error {
+		// Only touch ConditionStatus; LastExecutionTime is owned by the deleting
+		// controller and must be preserved to avoid the two writers clobbering
+		// each other's field.
+		dpol.Status.ConditionStatus = c.reconcileDeletingConditions(ctx, dpol.Spec.MatchConstraints, dpol.Status.ConditionStatus)
+		return nil
+	}
+	return controllerutils.UpdateStatus(
+		ctx,
+		dpol,
+		c.client.PoliciesV1beta1().DeletingPolicies(),
+		updateFunc,
+		func(current, expect *v1beta1.DeletingPolicy) bool {
+			return datautils.DeepEqual(current.Status, expect.Status)
+		},
+	)
+}
+
+func (c controller) updateNDpolStatus(ctx context.Context, ndpol *v1beta1.NamespacedDeletingPolicy) error {
+	updateFunc := func(ndpol *v1beta1.NamespacedDeletingPolicy) error {
+		ndpol.Status.ConditionStatus = c.reconcileDeletingConditions(ctx, ndpol.Spec.MatchConstraints, ndpol.Status.ConditionStatus)
+		return nil
+	}
+	return controllerutils.UpdateStatus(
+		ctx,
+		ndpol,
+		c.client.PoliciesV1beta1().NamespacedDeletingPolicies(ndpol.GetNamespace()),
+		updateFunc,
+		func(current, expect *v1beta1.NamespacedDeletingPolicy) bool {
+			return datautils.DeepEqual(current.Status, expect.Status)
+		},
+	)
+}

--- a/pkg/controllers/webhook/recorder.go
+++ b/pkg/controllers/webhook/recorder.go
@@ -73,6 +73,10 @@ func BuildRecorderKey(policyType, name, namespace string) string {
 		return GeneratingPolicyType + "/" + name
 	case NamespacedGeneratingPolicyType:
 		return NamespacedGeneratingPolicyType + "/" + name + "+" + namespace
+	case DeletingPolicyType:
+		return DeletingPolicyType + "/" + name
+	case NamespacedDeletingPolicyType:
+		return NamespacedDeletingPolicyType + "/" + name + "+" + namespace
 	}
 	return ""
 }

--- a/pkg/controllers/webhook/utils.go
+++ b/pkg/controllers/webhook/utils.go
@@ -291,4 +291,6 @@ const (
 	NamespacedMutatingPolicyType        = "NamespacedMutatingPolicy"
 	GeneratingPolicyType                = "GeneratingPolicy"
 	NamespacedGeneratingPolicyType      = "NamespacedGeneratingPolicy"
+	DeletingPolicyType                  = "DeletingPolicy"
+	NamespacedDeletingPolicyType        = "NamespacedDeletingPolicy"
 )

--- a/test/conformance/chainsaw/_step-templates/deleting-policy-ready.yaml
+++ b/test/conformance/chainsaw/_step-templates/deleting-policy-ready.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/steptemplate-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: deleting-policy-ready
+spec:
+  try:
+  - assert:
+      template: true
+      resource:
+        apiVersion: policies.kyverno.io/v1beta1
+        kind: DeletingPolicy
+        metadata:
+          name: ($name)
+        status:
+          conditionStatus:
+            # DeletingPolicy is schedule-driven and has no webhook, so only the
+            # RBAC condition is reported.
+            (conditions[?type == 'RBACPermissionsGranted']):
+            - message: Kyverno can access the resources targeted by this policy.
+              reason: Succeeded
+              status: "True"
+              type: RBACPermissionsGranted
+            ready: true

--- a/test/conformance/chainsaw/_step-templates/namespaced-deleting-policy-ready.yaml
+++ b/test/conformance/chainsaw/_step-templates/namespaced-deleting-policy-ready.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/steptemplate-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: namespaced-deleting-policy-ready
+spec:
+  try:
+  - assert:
+      template: true
+      resource:
+        apiVersion: policies.kyverno.io/v1beta1
+        kind: NamespacedDeletingPolicy
+        metadata:
+          name: ($name)
+          namespace: ($namespace)
+        status:
+          conditionStatus:
+            # NamespacedDeletingPolicy is schedule-driven and has no webhook, so
+            # only the RBAC condition is reported.
+            (conditions[?type == 'RBACPermissionsGranted']):
+            - message: Kyverno can access the resources targeted by this policy.
+              reason: Succeeded
+              status: "True"
+              type: RBACPermissionsGranted
+            ready: true

--- a/test/conformance/chainsaw/deleting-policies/policy-status-ready/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/deleting-policies/policy-status-ready/chainsaw-test.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: policy-status-ready
+spec:
+  concurrent: false
+  steps:
+  - name: create deleting policy
+    try:
+    - apply:
+        file: policy.yaml
+  - name: wait-deleting-policy-ready
+    use:
+      template: ../../_step-templates/deleting-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: deleting-status-ready

--- a/test/conformance/chainsaw/deleting-policies/policy-status-ready/policy.yaml
+++ b/test/conformance/chainsaw/deleting-policies/policy-status-ready/policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: DeletingPolicy
+metadata:
+  name: deleting-status-ready
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      resources:
+      - pods
+  schedule: '*/1 * * * *'

--- a/test/conformance/chainsaw/namespaced-deleting-policies/policy-status-ready/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/namespaced-deleting-policies/policy-status-ready/chainsaw-test.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: namespaced-policy-status-ready
+spec:
+  concurrent: false
+  steps:
+  - name: create namespace
+    try:
+    - apply:
+        file: ns.yaml
+  - name: create namespaced deleting policy
+    try:
+    - apply:
+        file: policy.yaml
+  - name: wait-namespaced-deleting-policy-ready
+    use:
+      template: ../../_step-templates/namespaced-deleting-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: deleting-status-ready
+        - name: namespace
+          value: ndpol-status-test

--- a/test/conformance/chainsaw/namespaced-deleting-policies/policy-status-ready/ns.yaml
+++ b/test/conformance/chainsaw/namespaced-deleting-policies/policy-status-ready/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ndpol-status-test

--- a/test/conformance/chainsaw/namespaced-deleting-policies/policy-status-ready/policy.yaml
+++ b/test/conformance/chainsaw/namespaced-deleting-policies/policy-status-ready/policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: NamespacedDeletingPolicy
+metadata:
+  name: deleting-status-ready
+  namespace: ndpol-status-test
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      resources:
+      - pods
+  schedule: '*/1 * * * *'


### PR DESCRIPTION
DeletingPolicy and NamespacedDeletingPolicy were the only CEL policy types without status reporting. Every other policy type exposes a `conditionStatus` with a `Ready` condition, but these only updated `lastExecutionTime`, leaving the CRD's `READY` column empty and giving no visibility into whether a policy was healthy before it executed.

This PR adds status reporting for both policy types. Since they run on a schedule and don't have a webhook, I added a small dedicated status helper that reuses the existing `resolveGVRs` and `permissionsCheck` logic to report an RBAC condition along with an overall `Ready` summary. No other policy types are affected.

The RBAC check runs using the reports ServiceAccount and currently verifies only `get`, `list`, and `watch` permissions. The status messages reflect that accurately, they indicate Kyverno can discover the target resources, not that it can delete them.

I also switched both status updates to field-scoped patches so the deleting controller (`lastExecutionTime`) and the status controller (`conditionStatus`) no longer overwrite each other's changes.

**Tests:** Added unit tests for both cluster- and namespace-scoped policies, plus Chainsaw tests verifying `Ready=True`.

**Follow-ups:**

* Validate the `delete` permission using the cleanup controller's ServiceAccount.
* Re-evaluate status when RBAC changes, since it currently only refreshes on informer resync.
