### PR TITLE
fix(background): honor resourceFilters for MutatingPolicy mutateExisting targets

### DIFF
--- a/pkg/background/common/filter.go
+++ b/pkg/background/common/filter.go
@@ -1,0 +1,16 @@
+package common
+
+import (
+	"github.com/kyverno/kyverno/pkg/config"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// IsFilteredByConfig reports whether obj should be skipped per ConfigMap resourceFilters.
+// Semantics match admission webhook filtering (pkg/webhooks/handlers/filter.go).
+func IsFilteredByConfig(configuration config.Configuration, obj *unstructured.Unstructured) bool {
+	if obj == nil || obj.Object == nil {
+		return false
+	}
+	gvk := obj.GroupVersionKind()
+	return configuration.ToFilter(gvk, "", obj.GetNamespace(), obj.GetName())
+}

--- a/pkg/background/common/filter_test.go
+++ b/pkg/background/common/filter_test.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/kyverno/kyverno/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestIsFilteredByConfig_KubeSystemNamespace(t *testing.T) {
+	cfg := config.NewDefaultConfiguration(false)
+	cfg.Load(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "kyverno", Namespace: "kyverno"},
+		Data:       map[string]string{"resourceFilters": "[*/*,kube-system,*]"},
+	})
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"})
+	obj.SetName("kube-system")
+
+	if !IsFilteredByConfig(cfg, obj) {
+		t.Fatal("expected kube-system Namespace to be filtered")
+	}
+}
+
+func TestIsFilteredByConfig_UnfilteredNamespace(t *testing.T) {
+	cfg := config.NewDefaultConfiguration(false)
+	cfg.Load(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "kyverno", Namespace: "kyverno"},
+		Data:       map[string]string{"resourceFilters": "[*/*,kube-system,*]"},
+	})
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"})
+	obj.SetName("default")
+
+	if IsFilteredByConfig(cfg, obj) {
+		t.Fatal("expected default Namespace not to be filtered")
+	}
+}
+
+func TestIsFilteredByConfig_NilObject(t *testing.T) {
+	cfg := config.NewDefaultConfiguration(false)
+	if IsFilteredByConfig(cfg, nil) {
+		t.Fatal("expected nil object not to be filtered")
+	}
+}

--- a/pkg/background/mpol/processor.go
+++ b/pkg/background/mpol/processor.go
@@ -20,6 +20,7 @@ import (
 	mpolengine "github.com/kyverno/kyverno/pkg/cel/policies/mpol/engine"
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	event "github.com/kyverno/kyverno/pkg/event"
 	"github.com/kyverno/kyverno/pkg/policy"
@@ -51,6 +52,8 @@ type processor struct {
 	statusControl common.StatusControlInterface
 
 	eventGen event.Interface
+
+	configuration config.Configuration
 }
 
 type gvkItem struct {
@@ -65,6 +68,7 @@ func NewProcessor(client dclient.Interface,
 	context libs.Context,
 	statusControl common.StatusControlInterface,
 	eventGen event.Interface,
+	configuration config.Configuration,
 ) *processor {
 	return &processor{
 		client:        client,
@@ -74,6 +78,7 @@ func NewProcessor(client dclient.Interface,
 		context:       context,
 		statusControl: statusControl,
 		eventGen:      eventGen,
+		configuration: configuration,
 	}
 }
 
@@ -147,6 +152,11 @@ func (p *processor) Process(ur *kyvernov2.UpdateRequest) error {
 	}
 	for _, target := range targets.Items {
 		object := &target
+		if common.IsFilteredByConfig(p.configuration, object) {
+			logger.V(4).Info("skipping mutateExisting target due to resourceFilters",
+				"kind", object.GetKind(), "namespace", object.GetNamespace(), "name", object.GetName())
+			continue
+		}
 		mapping, err := p.mapper.RESTMapping(target.GroupVersionKind().GroupKind(), target.GroupVersionKind().Version)
 		if err != nil {
 			failures = append(failures, fmt.Errorf("failed to get resource version for mpol %s: %v", ur.Spec.GetPolicyKey(), err))

--- a/pkg/background/mpol/processor_test.go
+++ b/pkg/background/mpol/processor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
@@ -15,10 +16,13 @@ import (
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/fake"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	"github.com/kyverno/kyverno/pkg/config"
+	configmocks "github.com/kyverno/kyverno/pkg/config/mocks"
 	"github.com/kyverno/kyverno/pkg/event"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
@@ -29,6 +33,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
 )
+
+func defaultTestConfig() config.Configuration {
+	return config.NewDefaultConfiguration(false)
+}
 
 type fakeContext struct{}
 
@@ -121,7 +129,7 @@ func TestProcess_NoPolicyFound(t *testing.T) {
 		meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "kyverno.io", Version: "v1"}}),
 		&libs.FakeContextProvider{},
 		&fakeStatusControl{},
-		event.NewFake())
+		event.NewFake(), defaultTestConfig())
 
 	ur := &kyvernov2.UpdateRequest{
 		ObjectMeta: metav1.ObjectMeta{
@@ -172,6 +180,7 @@ func TestProcess_EngineEvaluateError(t *testing.T) {
 		&libs.FakeContextProvider{},
 		&fakeStatusControl{},
 		event.NewFake(),
+		defaultTestConfig(),
 	)
 
 	ur := &kyvernov2.UpdateRequest{
@@ -240,6 +249,7 @@ func TestProcess_NilAdmissionRequest_DoesNotPanic(t *testing.T) {
 		&libs.FakeContextProvider{},
 		&fakeStatusControl{},
 		event.NewFake(),
+		defaultTestConfig(),
 	)
 
 	// UR has no AdmissionRequest — this is the background-scan case.
@@ -304,6 +314,7 @@ func TestGetPolicy_NamespacedMutatingPolicy(t *testing.T) {
 		&libs.FakeContextProvider{},
 		sc,
 		event.NewFake(),
+		defaultTestConfig(),
 	)
 
 	ur := &kyvernov2.UpdateRequest{
@@ -332,6 +343,7 @@ func TestProcess_EmptyPolicyKey(t *testing.T) {
 		&libs.FakeContextProvider{},
 		sc,
 		event.NewFake(),
+		defaultTestConfig(),
 	)
 
 	ur := &kyvernov2.UpdateRequest{
@@ -368,6 +380,7 @@ func TestGetPolicy_BareNameFallback_NamespacedMutatingPolicy(t *testing.T) {
 		&libs.FakeContextProvider{},
 		sc,
 		event.NewFake(),
+		defaultTestConfig(),
 	)
 
 	// UR uses bare name (as created by webhook handler), with AdmissionRequest carrying the namespace.
@@ -391,4 +404,168 @@ func TestGetPolicy_BareNameFallback_NamespacedMutatingPolicy(t *testing.T) {
 	assert.Equal(t, "mypol", result.GetName())
 	assert.Equal(t, "test-ns", result.GetNamespace())
 	assert.False(t, sc.failedCalled, "UR should not be marked failed when policy is found via fallback")
+}
+
+func TestProcess_SkipsFilteredTargets(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConfig := configmocks.NewMockConfiguration(ctrl)
+	kubeSystemGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
+	defaultGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
+
+	mockConfig.EXPECT().
+		ToFilter(kubeSystemGVK, "", "", "kube-system").
+		Return(true).
+		Times(1)
+	mockConfig.EXPECT().
+		ToFilter(defaultGVK, "", "", "default").
+		Return(false).
+		Times(1)
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(kubeSystemGVK, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "NamespaceList"}, &unstructured.UnstructuredList{})
+
+	kubeSystem := &unstructured.Unstructured{}
+	kubeSystem.SetGroupVersionKind(kubeSystemGVK)
+	kubeSystem.SetName("kube-system")
+
+	defaultNS := &unstructured.Unstructured{}
+	defaultNS.SetGroupVersionKind(defaultGVK)
+	defaultNS.SetName("default")
+
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "namespaces"}: "NamespaceList",
+	}
+	fakeClient, err := dclient.NewFakeClient(scheme, gvrToListKind, kubeSystem, defaultNS)
+	require.NoError(t, err)
+	fakeClient.SetDiscovery(dclient.NewFakeDiscoveryClient(nil))
+
+	kyvernoClient := fake.NewSimpleClientset(&policiesv1beta1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "filter-pol"},
+		Spec: policiesv1beta1.MutatingPolicySpec{
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+					RuleWithOperations: admissionregistrationv1alpha1.RuleWithOperations{
+						Rule: admissionregistrationv1alpha1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"namespaces"},
+						},
+					},
+				}},
+			},
+		},
+	})
+
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "", Version: "v1"}})
+	restMapper.Add(kubeSystemGVK, meta.RESTScopeRoot)
+
+	engine := &fakeEngine{}
+	engine.On("Evaluate").Return(mpolengine.EngineResponse{}, nil).Once()
+
+	p := NewProcessor(
+		fakeClient,
+		kyvernoClient,
+		engine,
+		restMapper,
+		&libs.FakeContextProvider{},
+		&fakeStatusControl{},
+		event.NewFake(),
+		mockConfig,
+	)
+
+	ur := &kyvernov2.UpdateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "ur-filter", Namespace: "kyverno"},
+		Spec: kyvernov2.UpdateRequestSpec{
+			Policy: "filter-pol",
+			Context: kyvernov2.UpdateRequestSpecContext{
+				AdmissionRequestInfo: kyvernov2.AdmissionRequestInfoObject{},
+			},
+		},
+	}
+
+	err = p.Process(ur)
+	assert.NoError(t, err)
+	engine.AssertNumberOfCalls(t, "Evaluate", 1)
+}
+
+func TestProcess_MutatesUnfilteredTargets(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConfig := configmocks.NewMockConfiguration(ctrl)
+	cmGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	mockConfig.EXPECT().
+		ToFilter(cmGVK, "", "default", "target-cm").
+		Return(false).
+		Times(1)
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(cmGVK, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMapList"}, &unstructured.UnstructuredList{})
+	cm := &unstructured.Unstructured{}
+	cm.SetAPIVersion("v1")
+	cm.SetKind("ConfigMap")
+	cm.SetNamespace("default")
+	cm.SetName("target-cm")
+	cm.SetUID("uid-1")
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "configmaps"}: "ConfigMapList",
+	}
+	fakeClient, err := dclient.NewFakeClient(scheme, gvrToListKind, cm)
+	require.NoError(t, err)
+	fakeClient.SetDiscovery(dclient.NewFakeDiscoveryClient(nil))
+
+	kyvernoClient := fake.NewSimpleClientset(&policiesv1beta1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "mutate-pol"},
+		Spec: policiesv1beta1.MutatingPolicySpec{
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+					RuleWithOperations: admissionregistrationv1alpha1.RuleWithOperations{
+						Rule: admissionregistrationv1alpha1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"configmaps"},
+						},
+					},
+				}},
+			},
+		},
+	})
+
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "", Version: "v1"}})
+	restMapper.Add(cmGVK, meta.RESTScopeNamespace)
+
+	patched := cm.DeepCopy()
+	patched.SetLabels(map[string]string{"foo": "bar"})
+
+	engine := &fakeEngine{}
+	engine.On("Evaluate").Return(mpolengine.EngineResponse{PatchedResource: patched}, nil).Once()
+
+	p := NewProcessor(
+		fakeClient,
+		kyvernoClient,
+		engine,
+		restMapper,
+		&libs.FakeContextProvider{},
+		&fakeStatusControl{},
+		event.NewFake(),
+		mockConfig,
+	)
+
+	ur := &kyvernov2.UpdateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "ur-mutate", Namespace: "kyverno"},
+		Spec: kyvernov2.UpdateRequestSpec{
+			Policy: "mutate-pol",
+			Context: kyvernov2.UpdateRequestSpecContext{
+				AdmissionRequestInfo: kyvernov2.AdmissionRequestInfoObject{},
+			},
+		},
+	}
+
+	err = p.Process(ur)
+	assert.NoError(t, err)
+	engine.AssertNumberOfCalls(t, "Evaluate", 1)
 }

--- a/pkg/background/update_request_controller.go
+++ b/pkg/background/update_request_controller.go
@@ -259,7 +259,7 @@ func (c *controller) processUR(ur *kyvernov2.UpdateRequest) error {
 		ctrl := gpol.NewCELGenerateController(c.client, c.kyvernoClient, c.context, c.gpolEngine, c.gpolProvider, c.watchManager, statusControl, c.eventGen, logger)
 		return ctrl.ProcessUR(ur)
 	case kyvernov2.CELMutate:
-		processor := mpol.NewProcessor(c.client, c.kyvernoClient, c.mpolEngine, c.restMapper, c.context, statusControl, c.eventGen)
+		processor := mpol.NewProcessor(c.client, c.kyvernoClient, c.mpolEngine, c.restMapper, c.context, statusControl, c.eventGen, c.configuration)
 		return processor.Process(ur)
 	}
 	return nil

--- a/test/conformance/chainsaw/mutating-policies/existing/same-trigger-target-resource-filters/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/same-trigger-target-resource-filters/chainsaw-test.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: same-trigger-target-resource-filters
+spec:
+  concurrent: false
+  steps:
+  - name: create namespaces
+    try:
+    - create:
+        file: ns.yaml
+    - assert:
+        file: ns.yaml
+  - name: create policy
+    use:
+      template: ..//../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait-mutating-policy-ready
+    use:
+      template: ..//../../_step-templates/mutating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: test-mpol-same-trigger-target
+  - name: sleep
+    try:
+    - sleep:
+        duration: 3s
+  - name: update resources
+    try:
+    - script:
+        content: kubectl label ns test-mpol-same-trigger-target-1 color=green
+  - name: check test namespaces patched
+    try:
+    - assert:
+        file: ns-assert.yaml
+  - name: check kube-system not patched
+    try:
+    - script:
+        content: |
+          value=$(kubectl get ns kube-system -o jsonpath='{.metadata.labels.foo}')
+          if [ "$value" = "bar" ]; then
+            echo "kube-system was unexpectedly labeled foo=bar"
+            exit 1
+          fi

--- a/test/conformance/chainsaw/mutating-policies/existing/same-trigger-target-resource-filters/ns-assert.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/same-trigger-target-resource-filters/ns-assert.yaml
@@ -1,0 +1,14 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: test-mpol-same-trigger-target-1
+  labels:
+    foo: bar
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: test-mpol-same-trigger-target-2
+  labels:
+    foo: bar

--- a/test/conformance/chainsaw/mutating-policies/existing/same-trigger-target-resource-filters/ns.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/same-trigger-target-resource-filters/ns.yaml
@@ -1,0 +1,10 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: test-mpol-same-trigger-target-1
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: test-mpol-same-trigger-target-2

--- a/test/conformance/chainsaw/mutating-policies/existing/same-trigger-target-resource-filters/policy.yaml
+++ b/test/conformance/chainsaw/mutating-policies/existing/same-trigger-target-resource-filters/policy.yaml
@@ -1,0 +1,26 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: MutatingPolicy
+metadata:
+  name: test-mpol-same-trigger-target
+spec:
+  failurePolicy: Fail
+  evaluation:
+    mutateExisting:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [ "" ]
+      apiVersions: [ "v1" ]
+      operations: [ "CREATE", "UPDATE"]
+      resources: [ "namespaces" ]
+  mutations:
+  - patchType: ApplyConfiguration
+    applyConfiguration:
+      expression: >
+        Object{
+          metadata: Object.metadata{
+            labels: Object.metadata.labels{
+              foo: "bar"
+            }
+          }
+        }


### PR DESCRIPTION
## Explanation

When a `MutatingPolicy` has `mutateExisting` enabled, Kyverno mutates **existing** resources in the background (for example, labeling all namespaces when a namespace trigger event occurs). Users expect resources listed in the Kyverno ConfigMap `resourceFilters` (such as `kube-system`) to be excluded cluster-wide—the same way admission webhooks already skip filtered resources.

**Before this PR:** `resourceFilters` were applied to the **trigger** at admission time (`WithFilter` in `pkg/webhooks/handlers/filter.go`), but the background `mpol` processor listed and mutated **targets** without calling `ToFilter`. As a result, `kube-system` could still receive `mutateExisting` mutations even though it appears in default `resourceFilters` (e.g. `[*/*,kube-system,*]`).

**After this PR:** Background `mutateExisting` processing for `MutatingPolicy` honors ConfigMap `resourceFilters` for **targets**, consistent with admission webhook behavior.

This is a **bug fix** scoped to `MutatingPolicy` `mutateExisting` targets only.

## Related issue

Closes #16285

Related to #16240 (broader CEL policy `resourceFilters` support for `GeneratingPolicy` / `ValidatingPolicy`). This PR does not change those paths.

## Milestone of this PR

/milestone 1.19.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.

- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

**N/A** — bug fix restoring expected `resourceFilters` behavior; no new user-facing configuration.

## What type of PR is this

/kind bug

## Proposed Changes

1. **Before:** Admission webhooks filtered incoming **triggers** via `resourceFilters`, but `pkg/background/mpol/processor.go` enumerated all `mutateExisting` targets and mutated them without filtering. Filtered namespaces like `kube-system` could still be patched.

2. **This PR:**
   - Adds `common.IsFilteredByConfig()` in `pkg/background/common/filter.go` (same semantics as webhooks: `ToFilter(gvk, "", namespace, name)`).
   - Wires `config.Configuration` into `mpol.NewProcessor` (same pattern as legacy `mutateExisting`).
   - Skips filtered targets once in the unified target loop in `Process()` (covers both list-based `collectGVK` and expression-based `getTargetsFromExpression` paths).
   - Adds unit tests and a chainsaw conformance test.

3. **After:** `mutateExisting` background mutations for `MutatingPolicy` skip resources matched by ConfigMap `resourceFilters`. With default filters, `kube-system` is not labeled when a same-trigger-target namespace policy runs.

### Proof Manifests

**MutatingPolicy** (`test/conformance/chainsaw/mutating-policies/existing/same-trigger-target-resource-filters/policy.yaml`):

```yaml
apiVersion: policies.kyverno.io/v1beta1
kind: MutatingPolicy
metadata:
  name: test-mpol-same-trigger-target
spec:
  failurePolicy: Fail
  evaluation:
    mutateExisting:
      enabled: true
  matchConstraints:
    resourceRules:
    - apiGroups: [ "" ]
      apiVersions: [ "v1" ]
      operations: [ "CREATE", "UPDATE" ]
      resources: [ "namespaces" ]
  mutations:
  - patchType: ApplyConfiguration
    applyConfiguration:
      expression: >
        Object{
          metadata: Object.metadata{
            labels: Object.metadata.labels{
              foo: "bar"
            }
          }
        }
```

**Test namespaces** (`ns.yaml`):

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: test-mpol-same-trigger-target-1
---
apiVersion: v1
kind: Namespace
metadata:
  name: test-mpol-same-trigger-target-2
```

**Expected behavior:**

1. Deploy Kyverno with default `resourceFilters` (includes `[*/*,kube-system,*]`).
2. Apply the policy and test namespaces above.
3. Trigger mutateExisting: `kubectl label ns test-mpol-same-trigger-target-1 color=green`
4. **Expected:**
   - `test-mpol-same-trigger-target-1` and `test-mpol-same-trigger-target-2` receive `foo: bar`
   - `kube-system` does **not** receive `foo: bar`

**Reproducing the bug (pre-fix):** On `main` without this change, the chainsaw test fails at `check kube-system not patched` with `kube-system was unexpectedly labeled foo=bar`.

**Unit tests:**

```bash
go test -race ./pkg/background/common/... ./pkg/background/mpol/... -count=1
```

**Automated e2e (chainsaw):**

```bash
cd test/conformance/chainsaw/mutating-policies
chainsaw test existing/same-trigger-target-resource-filters --config .chainsaw.yaml
```

**Local end-to-end (KinD):**

Requires Docker, `kind`, `kubectl`, `helm`, and `chainsaw`. Only the **background-controller** image must be rebuilt; admission behavior is unchanged.

```bash
set -euo pipefail
go test -race ./pkg/background/common/... ./pkg/background/mpol/... -count=1
make imports-check fmt-check

make kind-create-cluster kind-deploy-kyverno   # skip if cluster already exists
make kind-load-background-controller
kubectl rollout restart deployment/kyverno-background-controller -n kyverno
kubectl rollout status deployment/kyverno-background-controller -n kyverno --timeout=180s

kubectl label ns kube-system foo- 2>/dev/null || true
cd test/conformance/chainsaw/mutating-policies
chainsaw test existing/same-trigger-target-resource-filters --config .chainsaw.yaml
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.


## Further Comments

- **Triggers vs targets:** Admission already filters **triggers**; this PR filters **targets** during background `mutateExisting` processing—the gap reported in #16285.
- Filtering is applied at a **single convergence point** in `mpol.processor.Process()`: both list-based and expression-based target enumeration feed the same loop.
- **Out of scope (#16240):** `GeneratingPolicy`, `ValidatingPolicy` background paths, and legacy `ClusterPolicy` target enumeration are unchanged.
- `IsFilteredByConfig` lives in `pkg/background/common` for potential reuse in follow-up work for #16240.