### PR TITLE
fix(autogen): preserve workload metadata fields in VPol/IVPol autogen

### DIFF
--- a/pkg/cel/autogen/replacement.go
+++ b/pkg/cel/autogen/replacement.go
@@ -4,14 +4,38 @@ import (
 	"bytes"
 )
 
-// protectedSuffixes lists field paths that must remain anchored to the
-// workload object's own metadata and must never be rewritten into a pod
-// template path. For example, `object.metadata.namespace` must stay as-is
-// because pod templates (e.g. on Deployments) usually do not carry a
-// `metadata.namespace` field, which would otherwise break match conditions.
-var protectedSuffixes = [][]byte{
-	[]byte(".namespace"),
+// protectedMetadataFields lists ObjectMeta fields that identify the workload
+// resource itself. These must stay anchored to the controller object during
+// autogen and must never be rewritten into a pod template path. Pod-relevant
+// metadata (labels, annotations) is intentionally omitted so it continues to
+// rewrite to the pod template.
+var protectedMetadataFields = []string{
+	"namespace",
+	"name",
+	"generateName",
+	"uid",
+	"resourceVersion",
+	"generation",
+	"creationTimestamp",
+	"deletionTimestamp",
+	"deletionGracePeriodSeconds",
+	"finalizers",
+	"ownerReferences",
+	"managedFields",
 }
+
+func buildProtectedMetadataSuffixes(fields []string) (dotSuffixes, bracketSuffixes [][]byte) {
+	for _, field := range fields {
+		dotSuffixes = append(dotSuffixes, []byte("."+field))
+		bracketSuffixes = append(bracketSuffixes,
+			[]byte(`["`+field+`"]`),
+			[]byte(`['`+field+`']`),
+		)
+	}
+	return dotSuffixes, bracketSuffixes
+}
+
+var protectedSuffixes, protectedBracketSuffixes = buildProtectedMetadataSuffixes(protectedMetadataFields)
 
 type Replacement struct {
 	From string
@@ -67,21 +91,31 @@ func replace(data, from, to []byte) []byte {
 }
 
 // isProtected reports whether rest (the bytes immediately following a match)
-// begins with any of the protected suffixes as a complete path segment. The
-// suffix must either end the expression or be followed by a non-identifier
-// character so that fields like `metadata.namespace` are protected while
-// hypothetical fields like `metadata.namespaceFoo` are not.
+// begins with any of the protected suffixes as a complete path segment.
 func isProtected(rest []byte) bool {
 	for _, suffix := range protectedSuffixes {
-		if !bytes.HasPrefix(rest, suffix) {
-			continue
+		if isCompleteSuffix(rest, suffix) {
+			return true
 		}
-		next := rest[len(suffix):]
-		if len(next) == 0 || !isIdentifierByte(next[0]) {
+	}
+	for _, suffix := range protectedBracketSuffixes {
+		if bytes.HasPrefix(rest, suffix) {
 			return true
 		}
 	}
 	return false
+}
+
+// isCompleteSuffix reports whether rest begins with suffix as a full path
+// segment. The suffix must either end the expression or be followed by a
+// non-identifier character so that fields like `metadata.name` are protected
+// while hypothetical fields like `metadata.nameFoo` are not.
+func isCompleteSuffix(rest, suffix []byte) bool {
+	if !bytes.HasPrefix(rest, suffix) {
+		return false
+	}
+	next := rest[len(suffix):]
+	return len(next) == 0 || !isIdentifierByte(next[0])
 }
 
 // isIdentifierByte reports whether b can be part of a CEL identifier segment.

--- a/pkg/cel/autogen/replacement_test.go
+++ b/pkg/cel/autogen/replacement_test.go
@@ -115,6 +115,78 @@ func TestApplyRewritesExpressions(t *testing.T) {
 			config: "deployments",
 			want:   "object.spec.template.spec.containers.all(container, has(container.securityContext) && has(container.securityContext.allowPrivilegeEscalation) && container.securityContext.allowPrivilegeEscalation == false)",
 		},
+		{
+			name:   "deployments object metadata.name is preserved",
+			expr:   "object.metadata.name",
+			config: "deployments",
+			want:   "object.metadata.name",
+		},
+		{
+			name:   "cronjobs object metadata.name is preserved",
+			expr:   "object.metadata.name",
+			config: "cronjobs",
+			want:   "object.metadata.name",
+		},
+		{
+			name:   "deployments object metadata.uid is preserved",
+			expr:   "object.metadata.uid",
+			config: "deployments",
+			want:   "object.metadata.uid",
+		},
+		{
+			name:   "deployments object metadata.generateName is preserved",
+			expr:   "object.metadata.generateName",
+			config: "deployments",
+			want:   "object.metadata.generateName",
+		},
+		{
+			name:   "deployments resource.Get preserves namespace and name",
+			expr:   "resource.Get('v1', 'secrets', object.metadata.namespace, object.metadata.name)",
+			config: "deployments",
+			want:   "resource.Get('v1', 'secrets', object.metadata.namespace, object.metadata.name)",
+		},
+		{
+			name:   "cronjobs resource.Get preserves namespace and name",
+			expr:   "resource.Get('v1', 'secrets', object.metadata.namespace, object.metadata.name)",
+			config: "cronjobs",
+			want:   "resource.Get('v1', 'secrets', object.metadata.namespace, object.metadata.name)",
+		},
+		{
+			name:   "deployments name preserved while labels are rewritten",
+			expr:   "object.metadata.name == 'x' && object.metadata.labels['team'] == 'y'",
+			config: "deployments",
+			want:   "object.metadata.name == 'x' && object.spec.template.metadata.labels['team'] == 'y'",
+		},
+		{
+			name:   "deployments bracket notation metadata name is preserved",
+			expr:   `object.metadata["name"]`,
+			config: "deployments",
+			want:   `object.metadata["name"]`,
+		},
+		{
+			name:   "deployments single-quote bracket notation metadata name is preserved",
+			expr:   "object.metadata['name']",
+			config: "deployments",
+			want:   "object.metadata['name']",
+		},
+		{
+			name:   "deployments bracket notation metadata labels is rewritten",
+			expr:   `object.metadata["labels"]`,
+			config: "deployments",
+			want:   `object.spec.template.metadata["labels"]`,
+		},
+		{
+			name:   "only the name segment is protected, not longer identifiers",
+			expr:   "object.metadata.nameFoo",
+			config: "deployments",
+			want:   "object.spec.template.metadata.nameFoo",
+		},
+		{
+			name:   "statefulsets object metadata.name is preserved",
+			expr:   "object.metadata.name",
+			config: "statefulsets",
+			want:   "object.metadata.name",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cel/policies/vpol/autogen/autogen_test.go
+++ b/pkg/cel/policies/vpol/autogen/autogen_test.go
@@ -218,6 +218,58 @@ func TestGenerateRuleForControllers(t *testing.T) {
 			},
 		},
 		{
+			name:        "autogen preserves object.metadata.name in validations",
+			controllers: sets.New("deployments"),
+			policySpec: []byte(`{
+				"matchConstraints": {
+					"resourceRules": [{
+						"apiGroups": [""],
+						"apiVersions": ["v1"],
+						"operations": ["CREATE", "UPDATE"],
+						"resources": ["pods"]
+					}]
+				},
+				"matchConditions": [{
+					"name": "in allowed namespace",
+					"expression": "resource.List('v1', 'configmaps', object.metadata.namespace).size() > 0"
+				}],
+				"validations": [{
+					"expression": "object.metadata.name != ''"
+				}]
+			}`),
+			generatedRule: map[string]policiesv1beta1.ValidatingPolicyAutogen{
+				autogen.AutogenDefaults: {
+					Targets: []policiesv1beta1.Target{
+						{Group: "apps", Version: "v1", Resource: "deployments", Kind: "Deployment"},
+					},
+					Spec: &policiesv1beta1.ValidatingPolicySpec{
+						MatchConstraints: &admissionregistrationv1.MatchResources{
+							ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+								RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+									Operations: []admissionregistrationv1.OperationType{
+										admissionregistrationv1.Create,
+										admissionregistrationv1.Update,
+									},
+									Rule: admissionregistrationv1.Rule{
+										APIGroups:   []string{"apps"},
+										APIVersions: []string{"v1"},
+										Resources:   []string{"deployments"},
+									},
+								},
+							}},
+						},
+						MatchConditions: []admissionregistrationv1.MatchCondition{{
+							Name:       "in allowed namespace",
+							Expression: "resource.List('v1', 'configmaps', object.metadata.namespace).size() > 0",
+						}},
+						Validations: []admissionregistrationv1.Validation{{
+							Expression: "object.metadata.name != ''",
+						}},
+					},
+				},
+			},
+		},
+		{
 			name:        "autogen preserves object.metadata.namespace in match conditions",
 			controllers: sets.New("deployments"),
 			policySpec: []byte(`{


### PR DESCRIPTION
## Explanation

When a Pod-targeted `ValidatingPolicy` or `ImageValidatingPolicy` is autogenerated for pod controllers (Deployments, CronJobs, etc.), Kyverno rewrites CEL paths so pod-level expressions apply to the controller's pod template. That works correctly for `object.spec` and pod-relevant metadata (`labels`, `annotations`), but workload identity fields such as `object.metadata.name`, `uid`, and `resource.Get(..., object.metadata.name)` were incorrectly rewritten into `object.spec.template.metadata.*`. Those fields identify the controller resource itself, not the pod template, so rewritten expressions could silently fail or fetch the wrong resources.

This PR extends the existing protected-suffix mechanism in `pkg/cel/autogen` so workload `ObjectMeta` identity fields stay anchored at the controller level during autogen, while pod-template fields continue to rewrite as before. This is a **bug fix** for new CEL policy types (`ValidatingPolicy`, `ImageValidatingPolicy`).

**Note:** This does **not** implement OR-labels across controller and pod-template metadata levels (discussed in #12484 and rejected as too broad). Labels and annotations still rewrite to the pod template only, which is the intended behavior for Pod-targeted policies.

## Related issue

Closes #12484
Closes #12435

## Milestone of this PR

/milestone 1.19.0

Targets **Kyverno Release 1.19.0** (release-critical per #12484).

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  - Follow-up: document `namespaceObject.metadata.name` for namespace checks in CEL policies (suggested by @MariamFahmy98 in #12484). No user-facing behavior change for labels/spec autogen.

## What type of PR is this

/kind bug

## Proposed Changes

- Extend `protectedMetadataFields` in [`pkg/cel/autogen/replacement.go`](pkg/cel/autogen/replacement.go) to cover workload identity fields: `name`, `generateName`, `uid`, `resourceVersion`, `generation`, `creationTimestamp`, `deletionTimestamp`, `deletionGracePeriodSeconds`, `finalizers`, `ownerReferences`, `managedFields` (in addition to existing `namespace` protection).
- Generate dot-notation (`.name`) and bracket-notation (`["name"]`, `['name']`) protected suffixes via `buildProtectedMetadataSuffixes()`.
- Add `isCompleteSuffix()` so `.name` does not match `.nameFoo`.
- Pod-relevant fields (`labels`, `annotations`, `spec`) continue rewriting to `spec.template` (or CronJob equivalent).
- Add unit tests in `replacement_test.go` and integration test in `vpol/autogen/autogen_test.go`.

**Out of scope (intentional):**
- Legacy `pkg/autogen/v1` ClusterPolicy autogen (separate follow-up).
- OR-labels across controller + pod-template metadata (#12484 discussion).
- Auto-injected `podSpec` variables (maintainer suggestion; path rewrite already covers `object.spec`).

### Proof Manifests

**Before fix** — Pod policy with `object.metadata.name` autogened for Deployments:

```cel
# Input (Pod policy)
object.metadata.name != ''

# Broken autogen output
object.spec.template.metadata.name != ''   # pod template name is typically empty
```

**After fix** — same expression preserved:

```cel
object.metadata.name != ''
```

**Example Pod-targeted ValidatingPolicy** (autogens to Deployments):

```yaml
apiVersion: policies.kyverno.io/v1beta1
kind: ValidatingPolicy
metadata:
  name: workload-name-check
spec:
  matchConstraints:
    resourceRules:
      - apiGroups: [""]
        apiVersions: ["v1"]
        operations: [CREATE, UPDATE]
        resources: ["pods"]
  matchConditions:
    - name: in-allowed-namespace
      expression: "resource.List('v1', 'configmaps', object.metadata.namespace).size() > 0"
  variables:
    - name: secretRef
      expression: "resource.Get('v1', 'secrets', object.metadata.namespace, object.metadata.name)"
  validations:
    - expression: "object.metadata.name != ''"
      message: "workload name must be set"
```

**Expected autogen output** (`status.autogen.configs.defaults`):

```yaml
matchConditions:
  - name: in-allowed-namespace
    expression: "resource.List('v1', 'configmaps', object.metadata.namespace).size() > 0"
variables:
  - name: secretRef
    expression: "resource.Get('v1', 'secrets', object.metadata.namespace, object.metadata.name)"
validations:
  - expression: "object.metadata.name != ''"
```

Labels in match conditions still rewrite to template (unchanged behavior):

```cel
# Pod policy
has(object.metadata.labels) && object.metadata.labels.prod == 'true'

# Autogen for Deployment (unchanged, correct)
has(object.spec.template.metadata.labels) && object.spec.template.metadata.labels.prod == 'true'
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.


## Test plan

- [x] `go test ./pkg/cel/autogen/... ./pkg/cel/policies/vpol/autogen/... ./pkg/cel/policies/ivpol/autogen/... -v`
- [x] `go test -race ./pkg/cel/autogen/... ./pkg/cel/policies/vpol/autogen/... ./pkg/cel/policies/ivpol/autogen/...`
- [x] `golangci-lint run ./pkg/cel/autogen/... ./pkg/cel/policies/vpol/autogen/... ./pkg/cel/policies/ivpol/autogen/...` (0 issues)
- [x] `make imports fmt`
- [x] Chainsaw conformance: `chainsaw test test/conformance/chainsaw/validating-policies/autogen/` — **5/5 passed** on KinD with locally built Kyverno

## Further Comments

Alternative considered: injecting a `podSpec` CEL variable during autogen (per @realshuting in #12484). Rejected as over-scoped — path rewriting already normalizes `object.spec` and pod labels/annotations; the actual bug was over-aggressive `object.metadata` rewriting for identity fields only.

Alternative considered: OR-labels across controller and pod-template metadata (issue opener's initial proposal). Rejected per discussion in #12484 — can produce overly broad policies when users intentionally use different labels at different levels.

For namespace checks across controllers, maintainers recommend `namespaceObject.metadata.name` (never rewritten by autogen). Website docs follow-up welcome.
```

---