### PR TITLE
fix(cli): require --resource flag for migrate command

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/migrate/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/migrate/command.go
@@ -60,6 +60,9 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&options.KubeConfig, "kubeconfig", "", "path to kubeconfig file with authorization and master location information")
 	cmd.Flags().StringVar(&options.Context, "context", "", "The name of the kubeconfig context to use")
 	cmd.Flags().StringSliceVar(&options.Resources, "resource", nil, "The resource to migrate")
+	if err := cmd.MarkFlagRequired("resource"); err != nil {
+		panic(err)
+	}
 	return cmd
 }
 

--- a/cmd/cli/kubectl-kyverno/commands/migrate/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/migrate/command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/command"
 	"github.com/kyverno/kyverno/pkg/config"
@@ -61,7 +62,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&options.Context, "context", "", "The name of the kubeconfig context to use")
 	cmd.Flags().StringSliceVar(&options.Resources, "resource", nil, "The resource to migrate")
 	if err := cmd.MarkFlagRequired("resource"); err != nil {
-		panic(err)
+		log.Println("WARNING", err)
 	}
 	return cmd
 }

--- a/cmd/cli/kubectl-kyverno/commands/migrate/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/migrate/command_test.go
@@ -1,0 +1,51 @@
+package migrate
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandWithoutResource(t *testing.T) {
+	cmd := Command()
+	assert.NotNil(t, cmd)
+	b := bytes.NewBufferString("")
+	cmd.SetErr(b)
+	err := cmd.Execute()
+	assert.Error(t, err)
+	out, err := io.ReadAll(b)
+	assert.NoError(t, err)
+	expected := `Error: required flag(s) "resource" not set`
+	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(out)))
+}
+
+func TestCommandWithInvalidArg(t *testing.T) {
+	cmd := Command()
+	assert.NotNil(t, cmd)
+	b := bytes.NewBufferString("")
+	cmd.SetErr(b)
+	cmd.SetArgs([]string{"foo"})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	out, err := io.ReadAll(b)
+	assert.NoError(t, err)
+	expected := `Error: unknown command "foo" for "migrate"`
+	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(out)))
+}
+
+func TestCommandWithInvalidFlag(t *testing.T) {
+	cmd := Command()
+	assert.NotNil(t, cmd)
+	b := bytes.NewBufferString("")
+	cmd.SetErr(b)
+	cmd.SetArgs([]string{"--xxx"})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	out, err := io.ReadAll(b)
+	assert.NoError(t, err)
+	expected := `Error: unknown flag: --xxx`
+	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(out)))
+}


### PR DESCRIPTION
## Explanation

This PR fixes a bug in the Kyverno CLI. Running `kyverno migrate` without the `--resource` flag previously exited successfully (exit code 0) without performing any migration, which is misleading. Since no migration can occur without a resource, the command now fails early with a clear error, consistent with its documented usage where all examples require `--resource`.

## Related issue

Closes #16470

## What type of PR is this

/kind bug

## Proposed Changes

- Mark the `--resource` flag as required in the `migrate` command (same pattern already used by `docs`, `oci pull/push`, and `create` commands).
- Add unit tests for the `migrate` command covering the bare invocation (now errors with `required flag(s) "resource" not set`), unknown args, and unknown flags.

Before:
```
$ kyverno migrate
$ echo $?
0
```

After:
```
$ kyverno migrate
Error: required flag(s) "resource" not set
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective.
- [x] My PR needs to be cherry picked to a release branch? No.

## Further Comments

Test run: `go test ./cmd/cli/kubectl-kyverno/commands/migrate/...` → ok