### PR TITLE
Attribute time_add argument errors to time_add, not time_to_cron

### DIFF
--- a/pkg/engine/jmespath/time.go
+++ b/pkg/engine/jmespath/time.go
@@ -100,9 +100,9 @@ func jpTimeToCron(arguments []interface{}) (interface{}, error) {
 }
 
 func jpTimeAdd(arguments []interface{}) (interface{}, error) {
-	if t, err := getTimeArg(timeToCron, arguments, 0); err != nil {
+	if t, err := getTimeArg(timeAdd, arguments, 0); err != nil {
 		return nil, err
-	} else if d, err := getDurationArg(timeToCron, arguments, 1); err != nil {
+	} else if d, err := getDurationArg(timeAdd, arguments, 1); err != nil {
 		return nil, err
 	} else {
 		return t.Add(d).Format(time.RFC3339), nil

--- a/pkg/engine/jmespath/time_test.go
+++ b/pkg/engine/jmespath/time_test.go
@@ -3,6 +3,7 @@ package jmespath
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -97,6 +98,14 @@ func Test_TimeAdd(t *testing.T) {
 			assert.Equal(t, result, tc.expectedResult)
 		})
 	}
+}
+
+// A bad time_add argument should name time_add in the error, not another function.
+func Test_jpTimeAdd_ErrorAttributesToTimeAdd(t *testing.T) {
+	_, err := jpTimeAdd([]interface{}{123, "1h"})
+	assert.Assert(t, err != nil)
+	assert.Assert(t, strings.Contains(err.Error(), "time_add"))
+	assert.Assert(t, !strings.Contains(err.Error(), "time_to_cron"))
 }
 
 func Test_TimeParse(t *testing.T) {


### PR DESCRIPTION
## Explanation

This is a small fix. `jpTimeAdd` passed the `timeToCron` function-name constant to `getTimeArg`/`getDurationArg`, so an invalid argument to the `time_add` JMESPath function produced an error naming `time_to_cron` instead of `time_add` — misleading for anyone debugging a policy. It now uses the `timeAdd` constant. Added a regression test.

## Related issue

Spotted while looking at the `jp`/jmespath code around #16488. This is an independent fix and does not by itself resolve that issue.

## Milestone of this PR

<!-- n/a -->

## Documentation

No user-facing behavior change beyond the corrected error text.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective.
- [x] My commit is signed off (DCO).
