### PR TITLE
chore: cut v1.18.2-rc.2

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: kyverno-policies
-version: 3.8.1  # VERSION
-appVersion: v1.18.1
+version: 3.8.2-rc.2  # VERSION
+appVersion: v1.18.2-rc.2
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policies/README.md
+++ b/charts/kyverno-policies/README.md
@@ -2,7 +2,7 @@
 
 Kubernetes Pod Security Standards implemented as Kyverno policies
 
-![Version: 3.8.1](https://img.shields.io/badge/Version-3.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.18.1](https://img.shields.io/badge/AppVersion-v1.18.1-informational?style=flat-square)
+![Version: 3.8.2-rc.2](https://img.shields.io/badge/Version-3.8.2--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.18.2-rc.2](https://img.shields.io/badge/AppVersion-v1.18.2--rc.2-informational?style=flat-square)
 
 ## About
 

--- a/charts/kyverno/Chart.lock
+++ b/charts/kyverno/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: grafana
   repository: ""
-  version: 3.8.1
+  version: 3.8.2-rc.2
 - name: crds
   repository: ""
-  version: 3.8.1
+  version: 3.8.2-rc.2
 - name: kyverno-api
   repository: https://kyverno.github.io/api
   version: 0.0.1-alpha.2
@@ -14,5 +14,5 @@ dependencies:
 - name: reports-server
   repository: https://kyverno.github.io/reports-server/
   version: 0.1.6
-digest: sha256:f09c63f775fb3728813f5301ba3469e931623ab6f924e54066e8d665d2d68e5a
-generated: "2026-05-18T17:16:15.487764+08:00"
+digest: sha256:a423b622572444c5d66a3ce311963a13570b750fbcab36e18282e79a5b3921e7
+generated: "2026-07-09T15:17:42.477478+08:00"

--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: kyverno
-version: 3.8.1  # VERSION
-appVersion: v1.18.1
+version: 3.8.2-rc.2  # VERSION
+appVersion: v1.18.2-rc.2
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
 keywords:
@@ -39,10 +39,10 @@ annotations:
       description: Enable the flag `--validatingAdmissionPolicyReports` by default in the reports controller.
 dependencies:
   - name: grafana
-    version: 3.8.1  # VERSION
+    version: 3.8.2-rc.2  # VERSION
     condition: grafana.enabled
   - name: crds
-    version: 3.8.1  # VERSION
+    version: 3.8.2-rc.2  # VERSION
     condition: crds.install
   - name: kyverno-api
     version: 0.0.1-alpha.2

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -2,7 +2,7 @@
 
 Kubernetes Native Policy Management
 
-![Version: 3.8.1](https://img.shields.io/badge/Version-3.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.18.1](https://img.shields.io/badge/AppVersion-v1.18.1-informational?style=flat-square)
+![Version: 3.8.2-rc.2](https://img.shields.io/badge/Version-3.8.2--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.18.2-rc.2](https://img.shields.io/badge/AppVersion-v1.18.2--rc.2-informational?style=flat-square)
 
 ## About
 
@@ -974,8 +974,8 @@ Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | crds | 3.8.1 |
-|  | grafana | 3.8.1 |
+|  | crds | 3.8.2-rc.2 |
+|  | grafana | 3.8.2-rc.2 |
 | https://kyverno.github.io/api | kyverno-api | 0.0.1-alpha.2 |
 | https://kyverno.github.io/reports-server/ | reports-server | 0.1.6 |
 | https://openreports.github.io/reports-api | openreports | 0.1.0 |

--- a/charts/kyverno/charts/crds/Chart.yaml
+++ b/charts/kyverno/charts/crds/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: crds
-version: 3.8.1  # VERSION
+version: 3.8.2-rc.2  # VERSION

--- a/charts/kyverno/charts/crds/README.md
+++ b/charts/kyverno/charts/crds/README.md
@@ -1,6 +1,6 @@
 # crds
 
-![Version: 3.8.1](https://img.shields.io/badge/Version-3.8.1-informational?style=flat-square)
+![Version: 3.8.2-rc.2](https://img.shields.io/badge/Version-3.8.2--rc.2-informational?style=flat-square)
 
 ## Values
 

--- a/charts/kyverno/charts/grafana/Chart.yaml
+++ b/charts/kyverno/charts/grafana/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: grafana
-version: 3.8.1  # VERSION
+version: 3.8.2-rc.2  # VERSION

--- a/charts/kyverno/charts/grafana/README.md
+++ b/charts/kyverno/charts/grafana/README.md
@@ -1,6 +1,6 @@
 # grafana
 
-![Version: 3.8.1](https://img.shields.io/badge/Version-3.8.1-informational?style=flat-square)
+![Version: 3.8.2-rc.2](https://img.shields.io/badge/Version-3.8.2--rc.2-informational?style=flat-square)
 
 ## Values
 


### PR DESCRIPTION
## Summary
- Cut release candidate `v1.18.2-rc.2` from `release-1.18`
- Bump chart versions:
  - `kyverno`: `3.8.2-rc.2`
  - `kyverno-policies`: `3.8.2-rc.2`
  - `kyverno/charts/crds`: `3.8.2-rc.2`
  - `kyverno/charts/grafana`: `3.8.2-rc.2`
- Bump `appVersion` to `v1.18.2-rc.2`
- Regenerate Helm docs/CRDs and sync dependency lock

## Commands Run
```bash
APP_CHART_VERSION=v1.18.2-rc.2 KYVERNO_CHART_VERSION=3.8.2-rc.2 POLICIES_CHART_VERSION=3.8.2-rc.2 make codegen-helm-update-versions
make codegen-helm-all
make helm-setup-dependency-charts
```

## Validation
```bash
go test ./...
```