### PR TITLE
fix(readiness-checker): guard nil EndpointConditions.Ready to prevent panic

### DIFF
--- a/cmd/readiness-checker/main.go
+++ b/cmd/readiness-checker/main.go
@@ -270,7 +270,7 @@ func runCheckHTTP() {
 	}
 }
 
-func attemptCheckEndpoints(ctx context.Context, clientset *kubernetes.Clientset, svcName, namespace string, existingEndpointSliceNames []string) error {
+func attemptCheckEndpoints(ctx context.Context, clientset kubernetes.Interface, svcName, namespace string, existingEndpointSliceNames []string) error {
 	if existingEndpointSliceNames == nil {
 		endpointSlices, err := clientset.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
@@ -281,7 +281,7 @@ func attemptCheckEndpoints(ctx context.Context, clientset *kubernetes.Clientset,
 				if owner.Kind == "Service" && owner.Name == svcName {
 					// we are ready, no need to do further processing
 					for _, endpoint := range e.Endpoints {
-						if *endpoint.Conditions.Ready {
+						if endpoint.Conditions.Ready != nil && *endpoint.Conditions.Ready {
 							return nil
 						}
 					}
@@ -309,7 +309,7 @@ func attemptCheckEndpoints(ctx context.Context, clientset *kubernetes.Clientset,
 			continue
 		}
 		for _, endpoint := range eps.Endpoints {
-			if *endpoint.Conditions.Ready {
+			if endpoint.Conditions.Ready != nil && *endpoint.Conditions.Ready {
 				return nil
 			}
 		}

--- a/cmd/readiness-checker/main_test.go
+++ b/cmd/readiness-checker/main_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func newEndpointSlice(name, namespace, svcName string, ready *bool) *discoveryv1.EndpointSlice {
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind: "Service",
+					Name: svcName,
+				},
+			},
+		},
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: ready,
+				},
+			},
+		},
+	}
+}
+
+func TestAttemptCheckEndpoints_ListPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		ready   *bool
+		wantErr error
+	}{
+		{name: "ready", ready: boolPtr(true), wantErr: nil},
+		{name: "not-ready", ready: boolPtr(false), wantErr: errNoReadyEndpoints},
+		{name: "nil-ready", ready: nil, wantErr: errNoReadyEndpoints},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			slice := newEndpointSlice("svc-abc123", "default", "svc", tt.ready)
+			clientset := fake.NewClientset(slice)
+
+			err := attemptCheckEndpoints(context.Background(), clientset, "svc", "default", nil)
+			if err != tt.wantErr {
+				t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestAttemptCheckEndpoints_GetPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		ready   *bool
+		wantErr error
+	}{
+		{name: "ready", ready: boolPtr(true), wantErr: nil},
+		{name: "not-ready", ready: boolPtr(false), wantErr: errNoReadyEndpoints},
+		{name: "nil-ready", ready: nil, wantErr: errNoReadyEndpoints},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			slice := newEndpointSlice("svc-abc123", "default", "svc", tt.ready)
+			clientset := fake.NewClientset(slice)
+
+			err := attemptCheckEndpoints(context.Background(), clientset, "svc", "default", []string{"svc-abc123"})
+			if err != tt.wantErr {
+				t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Explanation

`attemptCheckEndpoints()` in `cmd/readiness-checker` dereferences `endpoint.Conditions.Ready` (a `*bool`) without a nil check. Per the `discovery.k8s.io/v1` API, that field is optional, so any `EndpointSlice` returned by the API server with an endpoint that omits it causes a panic during Kyverno's rollout readiness checks. This fix treats a `nil` `Ready` pointer as not-ready instead of panicking.

## Related issue

Closes #16543

## Documentation (required for features)

Not applicable — this is a bug fix with no user-facing behavior change beyond removing the panic.

## What type of PR is this

/kind bug

## Proposed Changes

- Guard both dereferences of `endpoint.Conditions.Ready` (initial `List()` path and the `Get()`-by-name recheck path) in `attemptCheckEndpoints()` with a nil check, treating `nil` as not-ready so the caller continues polling instead of crashing.
- Change the `attemptCheckEndpoints` parameter type from `*kubernetes.Clientset` to `kubernetes.Interface` so it can be exercised with a fake clientset in unit tests.
- Add `cmd/readiness-checker/main_test.go` with table-driven tests covering ready, not-ready, and nil-ready endpoints for both the `List()` and `Get()` code paths. These tests panic against the pre-fix code and pass after the fix.

### Proof Manifests

Not applicable — this is an internal Go helper (`cmd/readiness-checker`) with no Kyverno policy or CRD surface; the added unit tests are the verification artifact for this fix.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

Verified locally that reverting just the nil-guard lines against the new tests reproduces the original panic (`nil pointer dereference` in `attemptCheckEndpoints`), confirming the tests catch the regression.
