### PR TITLE
fix: honor namespace selectors in custom lister

### DIFF
--- a/pkg/admissionpolicy/api.go
+++ b/pkg/admissionpolicy/api.go
@@ -15,7 +15,11 @@ type CustomNamespaceLister struct {
 }
 
 func (c *CustomNamespaceLister) List(selector labels.Selector) (ret []*corev1.Namespace, err error) {
-	namespace, err := c.dClient.GetKubeClient().CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+	listOptions := metav1.ListOptions{}
+	if selector != nil {
+		listOptions.LabelSelector = selector.String()
+	}
+	namespace, err := c.dClient.GetKubeClient().CoreV1().Namespaces().List(context.Background(), listOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/admissionpolicy/api_test.go
+++ b/pkg/admissionpolicy/api_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -99,6 +100,21 @@ func TestCustomNamespaceListerList(t *testing.T) {
 		list, err := lister.List(labels.Everything())
 		assert.NoError(t, err)
 		assert.Len(t, list, 2)
+	})
+
+	t.Run("list namespaces honors selector", func(t *testing.T) {
+		k8sClient := fake.NewClientset(
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns1, Labels: map[string]string{"team": "a"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns2, Labels: map[string]string{"team": "b"}}},
+		)
+
+		mockDC := &mockDClient{kubeClient: k8sClient}
+		lister := NewCustomNamespaceLister(mockDC)
+
+		list, err := lister.List(labels.SelectorFromSet(map[string]string{"team": "a"}))
+		require.NoError(t, err)
+		require.Len(t, list, 1)
+		assert.Equal(t, ns1, list[0].Name)
 	})
 
 	t.Run("list namespaces failure", func(t *testing.T) {


### PR DESCRIPTION
## Explanation

This PR fixes a namespace-listing bug in the admission policy path. `CustomNamespaceLister.List()` implemented the `NamespaceLister` interface but ignored the incoming label selector, which caused selector-scoped lookups to return every namespace instead of just the matches.

## Related issue

Closes #16545

## Milestone of this PR

Not set by contributor.

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update the documentation and the link is:

## What type of PR is this

/kind bug

## Summary
- Honor the selector passed to `CustomNamespaceLister.List()` by forwarding it as a namespace label selector.
- Add a regression test covering a restrictive namespace selector.

## Linked Issue
Fixes #16545

## What Changed
- Set `metav1.ListOptions.LabelSelector` from the provided `labels.Selector` before listing namespaces.
- Added a test that seeds matching and non-matching namespaces and asserts only the matching namespace is returned.

## Verification
- `go test ./pkg/admissionpolicy` — passed
- `make imports fmt` — passed
- `make imports-check` — passed
- `make fmt-check` — passed
- `make codegen-all-code` — not run to completion: requires Docker for `codegen-cli-api-group-resources`, and Docker is not available in this environment
- `make verify-codegen` — passed
- `./.tools/golangci-lint run` — passed
- `make test-unit` — passed

## Proposed Changes
- Keep the fix scoped to `pkg/admissionpolicy` and preserve existing `labels.Everything()` behavior.
- Cover the selector contract with a focused unit test.

### Proof Manifests

Not applicable for this internal lister fix; the added unit test in `pkg/admissionpolicy/api_test.go` is the proof for the behavior change.

## Scope
- Only `pkg/admissionpolicy/api.go` and `pkg/admissionpolicy/api_test.go` were changed.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the AI Usage Policy. If I used AI assistance, I have disclosed it in my commit(s).
- [ ] I have read the PR documentation guide and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

`make codegen-all-code` could not complete in this environment because the `codegen-cli-api-group-resources` target requires Docker, which is not installed here.
