### PR TITLE
fix: prevent panic in lookupImageExtractor for empty imageExtractor path

### DIFF
--- a/pkg/utils/api/image.go
+++ b/pkg/utils/api/image.go
@@ -175,6 +175,12 @@ func lookupImageExtractor(kind string, configs kyvernov1.ImageExtractorConfigs) 
 				}
 				value := c.Value
 				if value == "" {
+					if len(fields) == 0 {
+						// No usable path components and no explicit value: this
+						// extractor cannot resolve an image, so skip it instead of
+						// indexing fields[-1] and panicking.
+						continue
+					}
 					value = fields[len(fields)-1]
 					fields = fields[:len(fields)-1]
 				}

--- a/pkg/utils/api/image_test.go
+++ b/pkg/utils/api/image_test.go
@@ -341,3 +341,21 @@ func Test_extractImageInfo(t *testing.T) {
 		assert.DeepEqual(t, test.images, images)
 	}
 }
+
+// Test_extractImageInfo_NoPathComponents is a regression test for a panic in
+// lookupImageExtractor: a custom imageExtractor whose path resolves to zero
+// components (e.g. "", "/", "//", or whitespace) with no explicit value caused
+// an "index out of range [-1]" panic. Such an extractor is now skipped, so
+// extraction fails gracefully with an error instead of crashing.
+func Test_extractImageInfo_NoPathComponents(t *testing.T) {
+	raw := []byte(`{"apiVersion":"tekton.dev/v1beta1","kind":"Task","metadata":{"name":"x"},"spec":{}}`)
+	resource, err := kubeutils.BytesToUnstructured(raw)
+	assert.NilError(t, err)
+	for _, path := range []string{"", "/", "//", "   "} {
+		configs := kyvernov1.ImageExtractorConfigs{
+			"Task": []kyvernov1.ImageExtractorConfig{{Path: path}},
+		}
+		_, err := ExtractImagesFromResource(*resource, configs, cfg)
+		assert.ErrorContains(t, err, "no extractors found")
+	}
+}


### PR DESCRIPTION
### Problem

A `verifyImages` rule can define custom `imageExtractors`. When an extractor entry has an **empty** (or slash-only / whitespace) `path` and **no** explicit `value`, the path splits into zero components and `lookupImageExtractor` runs `fields[len(fields)-1]` with `len(fields) == 0`, panicking:

```
panic: runtime error: index out of range [-1]
    pkg/utils/api/image.go:178 lookupImageExtractor
```

Both are user-controllable through the policy spec: the CRD marks `path` required but sets no `minLength` (so `""` is accepted), and `value` is optional. The panic occurs while building extractors, before the resource is inspected.

### Fix

Skip an extractor that has neither usable path components nor an explicit value, instead of indexing `fields[-1]`. Adds a regression test covering `path` = `""`, `/`, `//`, and whitespace.

### Testing

`go test ./pkg/utils/api/` passes; the new test panics on `main` without the fix and passes with it.