### PR TITLE
fix: prevent panic in `kyverno test` on a git URL without a path

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/load.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/load.go
@@ -34,6 +34,9 @@ func loadTest(path string, fileName string, gitBranch string) (test.TestCases, e
 		if err != nil {
 			return nil, err
 		} else {
+			if gitURL.Path == "" {
+				return nil, fmt.Errorf("invalid URL path %s - expected https://github.com/:owner/:repository/:branch (without --git-branch flag) OR https://github.com/:owner/:repository/:directory (with --git-branch flag)", gitURL.Path)
+			}
 			pathElems := strings.Split(gitURL.Path[1:], "/")
 			if len(pathElems) <= 1 {
 				return nil, fmt.Errorf("invalid URL path %s - expected https://github.com/:owner/:repository/:branch (without --git-branch flag) OR https://github.com/:owner/:repository/:directory (with --git-branch flag)", gitURL.Path)

--- a/cmd/cli/kubectl-kyverno/commands/test/load_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/load_test.go
@@ -1,0 +1,16 @@
+package test
+
+import (
+	"strings"
+	"testing"
+)
+
+// A git URL with a host but no path (e.g. "http://github.com") must not panic
+// loadTest with a slice-bounds error on gitURL.Path[1:]; it should return the
+// invalid-URL-path error instead.
+func Test_loadTest_URLWithoutPath(t *testing.T) {
+	_, err := loadTest("http://github.com", "kyverno-test.yaml", "")
+	if err == nil || !strings.Contains(err.Error(), "invalid URL path") {
+		t.Fatalf("expected an invalid URL path error, got: %v", err)
+	}
+}


### PR DESCRIPTION
### Problem

`loadTest` slices `gitURL.Path[1:]` for any path detected as a git source (`IsGit` = any `http(s)` URL). When the URL has a host but **no path**, e.g.

```
kyverno test http://github.com
```

`url.Parse` sets `Path` to `""` and the slice panics:

```
panic: runtime error: slice bounds out of range [1:0]
```

### Fix

Return the existing `invalid URL path ...` error when the path is empty, instead of slicing it. Adds a regression test.

### Testing

`go test ./cmd/cli/kubectl-kyverno/commands/test/` passes; the new test panics on `main` without the fix and passes with it.