### PR TITLE
fix: remove perf-testing pod creation race

### DIFF
--- a/docs/perf-testing/main.go
+++ b/docs/perf-testing/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -70,23 +71,9 @@ func main() {
 				}
 				os.Exit(0)
 			}
-			var wg sync.WaitGroup
-			for i := 0; i < count; i++ {
-				num := strconv.Itoa(i)
-				wg.Add(1)
-				go func(num string, wg *sync.WaitGroup) {
-					pod := newPod(num)
-					_, err = client.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-					if err != nil {
-						fmt.Println("failed to create the pod: ", err)
-						// os.Exit(1)
-					}
-					wg.Done()
-				}(num, &wg)
-
-				fmt.Printf("created pod perf-testing-pod-%v\n", num)
+			for _, err := range createPods(context.TODO(), client, namespace, count) {
+				fmt.Println("failed to create the pod: ", err)
 			}
-			wg.Wait()
 		case "replicasets":
 			if delete {
 				if err := client.AppsV1().ReplicaSets(namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil {
@@ -125,6 +112,37 @@ func main() {
 			}
 		}
 	}
+}
+
+func createPods(ctx context.Context, client kubernetes.Interface, namespace string, count int) []error {
+	var wg sync.WaitGroup
+	errCh := make(chan error, count)
+
+	for i := 0; i < count; i++ {
+		num := strconv.Itoa(i)
+		wg.Add(1)
+		go func(num string) {
+			defer wg.Done()
+			pod := newPod(num)
+			if _, err := client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+				errCh <- fmt.Errorf("%s: %w", pod.Name, err)
+			}
+		}(num)
+
+		fmt.Printf("created pod perf-testing-pod-%v\n", num)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	errs := make([]error, 0, len(errCh))
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+	sort.Slice(errs, func(i, j int) bool {
+		return errs[i].Error() < errs[j].Error()
+	})
+	return errs
 }
 
 func newPod(i string) *corev1.Pod {

--- a/docs/perf-testing/main.go
+++ b/docs/perf-testing/main.go
@@ -5,11 +5,11 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
 
+	"go.uber.org/multierr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,8 +71,10 @@ func main() {
 				}
 				os.Exit(0)
 			}
-			for _, err := range createPods(context.TODO(), client, namespace, count) {
-				fmt.Println("failed to create the pod: ", err)
+			if err := createPods(context.TODO(), client, namespace, count); err != nil {
+				for _, podErr := range multierr.Errors(err) {
+					fmt.Println("failed to create the pod: ", podErr)
+				}
 			}
 		case "replicasets":
 			if delete {
@@ -114,7 +116,7 @@ func main() {
 	}
 }
 
-func createPods(ctx context.Context, client kubernetes.Interface, namespace string, count int) []error {
+func createPods(ctx context.Context, client kubernetes.Interface, namespace string, count int) error {
 	var wg sync.WaitGroup
 	errCh := make(chan error, count)
 
@@ -139,10 +141,7 @@ func createPods(ctx context.Context, client kubernetes.Interface, namespace stri
 	for err := range errCh {
 		errs = append(errs, err)
 	}
-	sort.Slice(errs, func(i, j int) bool {
-		return errs[i].Error() < errs[j].Error()
-	})
-	return errs
+	return multierr.Combine(errs...)
 }
 
 func newPod(i string) *corev1.Pod {

--- a/docs/perf-testing/main_test.go
+++ b/docs/perf-testing/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestCreatePodsSuccess(t *testing.T) {
+	client := kubefake.NewSimpleClientset()
+	namespace = "test"
+
+	errs := createPods(context.Background(), client, namespace, 3)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %d: %v", len(errs), errs)
+	}
+
+	pods, err := client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("failed to list pods: %v", err)
+	}
+	if len(pods.Items) != 3 {
+		t.Fatalf("expected 3 pods, got %d", len(pods.Items))
+	}
+}
+
+func TestCreatePodsCollectsPerPodErrors(t *testing.T) {
+	client := kubefake.NewSimpleClientset()
+	namespace = "test"
+
+	failedPods := map[string]error{
+		"perf-testing-pod-1": errors.New("boom-1"),
+		"perf-testing-pod-3": errors.New("boom-3"),
+	}
+	client.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction := action.(k8stesting.CreateAction)
+		pod := createAction.GetObject().(*corev1.Pod)
+		if err, ok := failedPods[pod.Name]; ok {
+			return true, nil, err
+		}
+		return false, nil, nil
+	})
+
+	errs := createPods(context.Background(), client, namespace, 4)
+	if len(errs) != len(failedPods) {
+		t.Fatalf("expected %d errors, got %d: %v", len(failedPods), len(errs), errs)
+	}
+
+	got := make([]string, 0, len(errs))
+	for _, err := range errs {
+		got = append(got, err.Error())
+	}
+	sort.Strings(got)
+
+	want := []string{
+		"perf-testing-pod-1: boom-1",
+		"perf-testing-pod-3: boom-3",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected errors:\nwant:\n%s\n\ngot:\n%s", strings.Join(want, "\n"), strings.Join(got, "\n"))
+	}
+}

--- a/docs/perf-testing/main_test.go
+++ b/docs/perf-testing/main_test.go
@@ -3,10 +3,9 @@ package main
 import (
 	"context"
 	"errors"
-	"sort"
-	"strings"
 	"testing"
 
+	"go.uber.org/multierr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,9 +17,9 @@ func TestCreatePodsSuccess(t *testing.T) {
 	client := kubefake.NewSimpleClientset()
 	namespace = "test"
 
-	errs := createPods(context.Background(), client, namespace, 3)
-	if len(errs) != 0 {
-		t.Fatalf("expected no errors, got %d: %v", len(errs), errs)
+	err := createPods(context.Background(), client, namespace, 3)
+	if err != nil {
+		t.Fatalf("expected no errors, got %v", err)
 	}
 
 	pods, err := client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
@@ -49,22 +48,25 @@ func TestCreatePodsCollectsPerPodErrors(t *testing.T) {
 		return false, nil, nil
 	})
 
-	errs := createPods(context.Background(), client, namespace, 4)
+	err := createPods(context.Background(), client, namespace, 4)
+	if err == nil {
+		t.Fatal("expected aggregated error, got nil")
+	}
+
+	errs := multierr.Errors(err)
 	if len(errs) != len(failedPods) {
 		t.Fatalf("expected %d errors, got %d: %v", len(failedPods), len(errs), errs)
 	}
-
-	got := make([]string, 0, len(errs))
+	got := map[string]struct{}{}
 	for _, err := range errs {
-		got = append(got, err.Error())
+		got[err.Error()] = struct{}{}
 	}
-	sort.Strings(got)
-
-	want := []string{
+	for _, want := range []string{
 		"perf-testing-pod-1: boom-1",
 		"perf-testing-pod-3: boom-3",
-	}
-	if strings.Join(got, "\n") != strings.Join(want, "\n") {
-		t.Fatalf("unexpected errors:\nwant:\n%s\n\ngot:\n%s", strings.Join(want, "\n"), strings.Join(got, "\n"))
+	} {
+		if _, ok := got[want]; !ok {
+			t.Fatalf("missing expected error %q in %v", want, got)
+		}
 	}
 }


### PR DESCRIPTION
## Explanation
This fixes a race in the `docs/perf-testing` pod creation path. The perf helper was writing pod creation errors into a shared outer variable from multiple goroutines, which could trigger race detector failures and lose per-pod error details during benchmark runs.

## Related issue
Closes #16549

## Milestone of this PR

## Documentation (required for features)
My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update the documentation and the link is:

## What type of PR is this
/kind bug

## Proposed Changes
## Summary
- move concurrent pod creation into a helper that keeps errors goroutine-local
- collect and return per-pod creation errors instead of mutating shared state
- add focused unit tests covering successful creation and per-pod failures

## Linked Issue
Fixes #16549

## What Changed
- replaced the shared outer `err` write in the pod goroutines with local error handling and channel-based collection
- added `docs/perf-testing/main_test.go` with fake-client coverage for the concurrent helper

## Verification
- `go test ./docs/perf-testing` — passed
- `go test -race ./docs/perf-testing` — passed
- `make imports fmt` — passed on retry; first attempt failed while downloading `goimports` from `proxy.golang.org` with a TLS handshake timeout
- `make imports-check fmt-check` — passed
- `make codegen-all-code` — failed: generator bootstrap invoked `go 1.23.12` for `informer-gen`, which requires `>= 1.25.0`
- `make verify-codegen` — passed
- `./.tools/golangci-lint run ./docs/perf-testing/...` — failed: bundled binary was built with Go 1.25 while the repo targets Go 1.26.5
- `GOTOOLCHAIN=go1.26.5 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run ./docs/perf-testing/...` — passed

## Scope
- only `docs/perf-testing/main.go` and `docs/perf-testing/main_test.go` were changed

### Proof Manifests
Not applicable. This change only affects the internal perf-testing helper and is covered by Go tests.

## Checklist
- [x] I have read the contributing guidelines.
- [x] I have read the AI Usage Policy. AI assistance was disclosed in the commit trailer.
- [ ] I have read the PR documentation guide and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments
`make codegen-all-code` appears blocked by the local generator bootstrap path using `go 1.23.12` for some tools even when the repo otherwise auto-switches to newer toolchains. No generated files were affected by this change, and `make verify-codegen` remained clean.
