### PR TITLE
fix(cli): require --resource flag on kyverno migrate

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/migrate/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/migrate/command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/command"
 	"github.com/kyverno/kyverno/pkg/config"
@@ -60,6 +61,9 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&options.KubeConfig, "kubeconfig", "", "path to kubeconfig file with authorization and master location information")
 	cmd.Flags().StringVar(&options.Context, "context", "", "The name of the kubeconfig context to use")
 	cmd.Flags().StringSliceVar(&options.Resources, "resource", nil, "The resource to migrate")
+	if err := cmd.MarkFlagRequired("resource"); err != nil {
+		log.Println("WARNING", err)
+	}
 	return cmd
 }
 

--- a/cmd/cli/kubectl-kyverno/commands/migrate/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/migrate/command_test.go
@@ -1,9 +1,6 @@
 package migrate
 
 import (
-	"bytes"
-	"io"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,15 +9,9 @@ import (
 func TestCommandWithoutResourceFlag(t *testing.T) {
 	cmd := Command()
 	assert.NotNil(t, cmd)
-	b := bytes.NewBufferString("")
-	cmd.SetErr(b)
 	cmd.SetArgs([]string{})
 	err := cmd.Execute()
-	assert.Error(t, err)
-	out, err := io.ReadAll(b)
-	assert.NoError(t, err)
-	expected := `Error: required flag(s) "resource" not set`
-	assert.True(t, strings.Contains(string(out), expected))
+	assert.ErrorContains(t, err, `required flag(s) "resource" not set`)
 }
 
 func TestCommandWithResourceFlagRunsToConfigLookup(t *testing.T) {

--- a/cmd/cli/kubectl-kyverno/commands/migrate/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/migrate/command_test.go
@@ -1,0 +1,32 @@
+package migrate
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandWithoutResourceFlag(t *testing.T) {
+	cmd := Command()
+	assert.NotNil(t, cmd)
+	b := bytes.NewBufferString("")
+	cmd.SetErr(b)
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	out, err := io.ReadAll(b)
+	assert.NoError(t, err)
+	expected := `Error: required flag(s) "resource" not set`
+	assert.True(t, strings.Contains(string(out), expected))
+}
+
+func TestCommandWithResourceFlagRunsToConfigLookup(t *testing.T) {
+	cmd := Command()
+	assert.NotNil(t, cmd)
+	cmd.SetArgs([]string{"--resource", "foo", "--kubeconfig", "/nonexistent/kubeconfig"})
+	err := cmd.Execute()
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Explanation

The kyverno migrate CLI command is meant to migrate one or more resources whose `--resource` flag identifies what to migrate. When run without `--resource`, the command exits successfully (code 0) without performing any migration or printing any error, which can mislead users into believing the migration succeeded. This PR fixes that by making kyverno migrate fail with a clear error message when `--resource` is not provided.

## Related issue

Closes #16470

## Milestone of this PR

/milestone 1.19.0

## What type of PR is this

/kind bug

## Proposed Changes

`--resource` is now marked as a required flag on kyverno migrate via `cmd.MarkFlagRequired("resource")`, the same pattern already used by other CLI commands in this codebase (`oci push --image`, `docs --output`, `create role --api-groups`, etc). Cobra now rejects the command up front with `Error: required flag(s) "resource" not set` and a non-zero exit code instead of silently doing nothing.

### Proof Manifests

This fix is CLI flag validation, not policy/admission behavior  there's no Kubernetes resource or Kyverno policy YAML involved. Proof is the CLI transcript before/after the fix:

Before:
```
$ kyverno migrate
$ echo $?
0
```

After:
```
$ kyverno migrate
Error: required flag(s) "resource" not set
$ echo $?
1
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
- [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
