### PR TITLE
Test(conformance): pin Sigstore scaffolding version and remove redundant UR cleanup

### DIFF
--- a/.github/workflows/tests-conformance.yaml
+++ b/.github/workflows/tests-conformance.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: Create kind cluster and setup Sigstore Scaffolding
         uses: sigstore/scaffolding/actions/setup@8bd68672d418e5bd1b0ee1f2e2981874c3a30967 # v0.7.33
         with:
-          version: main
+          version: v0.7.33
           k8s-version: ${{ matrix.k8s-version }}
           knative-version: "1.10.0"
       - name: Create TUF values config map

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-policy/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-policy/chainsaw-test.yaml
@@ -53,12 +53,3 @@ spec:
     try:
     - assert:
         file: chainsaw-step-06-assert-1-1.yaml
-  - name: step-99
-    try:
-    - command:
-        args:
-        - delete
-        - ur
-        - -A
-        - --all
-        entrypoint: kubectl


### PR DESCRIPTION
## Explanation

This PR improves the stability and maintainability of the conformance test suite by making two targeted updates:

- Pins the Sigstore scaffolding version to `v0.7.33` instead of tracking `main`, ensuring deterministic and reproducible workflow execution.
- Removes an unnecessary UpdateRequest cleanup step from the `cpol-clone-sync-delete-policy` Chainsaw test, simplifying the test while preserving its intended behavior.

## Related issue
[Discussed with](https://kubernetes.slack.com/archives/C032MM2CH7X/p1783933402709679) @realshuting 

## Milestone of this PR


## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
 /kind cleanup


## Proposed Changes

- Pin the Sigstore scaffolding setup action to `v0.7.33` in the conformance workflow to avoid unexpected failures caused by upstream changes.
- Remove the redundant UpdateRequest cleanup step from the `cpol-clone-sync-delete-policy` Chainsaw test.


### Proof Manifests
### Validation

- Verified that the conformance workflow now uses the pinned Sigstore scaffolding version (`v0.7.33`).
- Executed the `cpol-clone-sync-delete-policy` Chainsaw test locally after removing the UpdateRequest cleanup step.
- Confirmed the test passes successfully without explicitly deleting UpdateRequests.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments
These changes follow the discussion during the investigation of recent conformance test failures. Pinning the Sigstore scaffolding version improves workflow reproducibility, while removing the redundant cleanup step simplifies the test without affecting the expected behavior.