### PR TITLE
fix(cli): require --resource flag in migrate command

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/migrate/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/migrate/command.go
@@ -31,6 +31,9 @@ func Command() *cobra.Command {
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if len(options.Resources) == 0 {
+				return errors.New("at least one resource must be specified with --resource")
+			}
 			clientConfig, err := config.CreateClientConfigWithContext(options.KubeConfig, options.Context)
 			if err != nil {
 				return err

--- a/cmd/cli/kubectl-kyverno/commands/migrate/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/migrate/command_test.go
@@ -1,0 +1,25 @@
+package migrate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandNoResourceFlag(t *testing.T) {
+	cmd := Command()
+	assert.NotNil(t, cmd)
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "at least one resource must be specified"))
+}
+
+func TestCommandHelp(t *testing.T) {
+	cmd := Command()
+	assert.NotNil(t, cmd)
+	cmd.SetArgs([]string{"--help"})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Explanation

The `kyverno migrate` command exits successfully when `--resource` is not provided, performing no migration. Since no useful work can happen without specifying a resource, the command should fail early with a clear error.

## Related issue

Closes #16470

## What type of PR is this

/kind bug

## Proposed Changes

Added early validation in the `RunE` function to check `len(options.Resources) == 0` before initializing any Kubernetes clients. Returns a clear error: "at least one resource must be specified with --resource".

### Proof

```bash
$ kyverno migrate
Error: at least one resource must be specified with --resource

$ kyverno migrate --resource policies.kyverno.io
# proceeds normally (requires kubeconfig)
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). AI assistance disclosed via Co-authored-by trailer.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>