### PR TITLE
fix(cli): improve JMESPath syntax error messages in jp query

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/jp/query/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/jp/query/command.go
@@ -152,7 +152,10 @@ func evaluate(input interface{}, query string) (interface{}, error) {
 	jp := jmespath.New(config.NewDefaultConfiguration(false))
 	q, err := jp.Query(query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compile JMESPath: %s, error: %v", query, err)
+		if syntaxError, ok := err.(gojmespath.SyntaxError); ok {
+			return nil, fmt.Errorf("invalid JMESPath syntax: %s\n%s", syntaxError.Error(), syntaxError.HighlightLocation())
+		}
+		return nil, fmt.Errorf("failed to compile JMESPath expression: %s, error: %v", query, err)
 	}
 	result, err := q.Search(input)
 	if err != nil {

--- a/cmd/cli/kubectl-kyverno/commands/jp/query/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/jp/query/command_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCommand(t *testing.T) {
@@ -55,4 +56,19 @@ func TestCommandHelp(t *testing.T) {
 	out, err := io.ReadAll(b)
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(string(out), cmd.Long))
+}
+
+func TestEvaluateInvalidSyntax(t *testing.T) {
+	// An invalid JMESPath expression should return an error containing "syntax"
+	_, err := evaluate(map[string]interface{}{"foo": "bar"}, "invalid[expression")
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "syntax")
+}
+
+func TestEvaluateValidExpression(t *testing.T) {
+	// A valid JMESPath expression with valid input should succeed
+	input := map[string]interface{}{"foo": "bar"}
+	result, err := evaluate(input, "foo")
+	require.NoError(t, err)
+	assert.Equal(t, "bar", result)
 }


### PR DESCRIPTION
## Explanation

The `kyverno jp query` command returns cryptic "failed to compile JMESPath" errors when given invalid expressions. Users cannot tell what is wrong or where the error is. This adds syntax-aware error handling that shows the exact position of the error with a caret marker.

## Related issue

Closes #16488

## What type of PR is this

/kind bug

## Proposed Changes

In the `evaluate()` function, added a type assertion to detect `gojmespath.SyntaxError` during compilation and display the highlighted error location:

```
$ kyverno jp query "invalid[" -i resource.yaml
invalid JMESPath syntax: SyntaxError: Expected tStar, received: tEOF
invalid[
       ^
```

### Proof

```bash
# Before: cryptic error
$ kyverno jp query "invalid{{" -i resource.yaml
Error: failed to compile JMESPath: invalid{{, error: SyntaxError: ...

# After: clear position marker
$ kyverno jp query "invalid{{" -i resource.yaml
Error: invalid JMESPath syntax: SyntaxError: Unexpected "{"
invalid{{
       ^
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). AI assistance disclosed via Co-authored-by trailer.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>