### PR TITLE
fix: suppress PolicyReport skip entries for ValidatingPolicy matchConditions non-matches

### DIFF
--- a/pkg/cel/policies/vpol/engine/engine.go
+++ b/pkg/cel/policies/vpol/engine/engine.go
@@ -136,7 +136,7 @@ func (e *engineImpl) handlePolicy(ctx context.Context, policy Policy, jsonPayloa
 	if err != nil {
 		response.Rules = handlers.WithResponses(engineapi.RuleError("evaluation", engineapi.Validation, "failed to load context", err, nil))
 	} else if result == nil {
-		response.Rules = append(response.Rules, *engineapi.RuleSkip("", engineapi.Validation, "skip", nil))
+		response.Rules = append(response.Rules, *engineapi.RuleSkip("", engineapi.Validation, "skip", nil).WithSkipReason(engineapi.SkipReasonMatchConditions))
 	} else if len(result.Exceptions) > 0 {
 		exceptions := make([]engineapi.GenericException, 0, len(result.Exceptions))
 		keys := make([]string, 0, len(result.Exceptions))

--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -204,7 +204,12 @@ func (s *scanner) ScanResource(
 			engineResponse, err := engine.Handle(ctx, request, nil)
 			rules := make([]engineapi.RuleResponse, 0)
 			for _, policy := range engineResponse.Policies {
-				rules = append(rules, policy.Rules...)
+				for _, rule := range policy.Rules {
+					if rule.Status() == engineapi.RuleStatusSkip && rule.SkipReason() == engineapi.SkipReasonMatchConditions {
+						continue
+					}
+					rules = append(rules, rule)
+				}
 			}
 
 			response := engineapi.EngineResponse{

--- a/pkg/engine/api/ruleresponse.go
+++ b/pkg/engine/api/ruleresponse.go
@@ -21,6 +21,17 @@ type PodSecurityChecks struct {
 	Checks []pssutils.PSSCheckResult
 }
 
+// SkipReason is the reason a rule was skipped. It is internal routing metadata
+// and is not persisted to PolicyReport results.
+type SkipReason string
+
+const (
+	// SkipReasonMatchConditions indicates the rule was skipped because
+	// matchConditions evaluated to false. This mirrors admission-time behavior
+	// where the webhook is never called when matchConditions don't match.
+	SkipReasonMatchConditions SkipReason = "matchConditions"
+)
+
 // RuleResponse details for each rule application
 type RuleResponse struct {
 	// name is the rule name specified in policy
@@ -51,6 +62,8 @@ type RuleResponse struct {
 	mapBinding *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding
 	// emitWarning enable passing rule message as warning to api server warning header
 	emitWarning bool
+	// skipReason is the internal reason a rule was skipped, not persisted to reports
+	skipReason SkipReason
 	// properties are the additional properties from the rule that will be added to the policy report result
 	properties map[string]string
 }
@@ -204,6 +217,15 @@ func (r *RuleResponse) HasStatus(status ...RuleStatus) bool {
 		}
 	}
 	return false
+}
+
+func (r RuleResponse) WithSkipReason(reason SkipReason) *RuleResponse {
+	r.skipReason = reason
+	return &r
+}
+
+func (r *RuleResponse) SkipReason() SkipReason {
+	return r.skipReason
 }
 
 // String implements Stringer interface

--- a/pkg/engine/api/ruleresponse_test.go
+++ b/pkg/engine/api/ruleresponse_test.go
@@ -162,3 +162,46 @@ func TestRuleResponse_HasStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestRuleResponse_WithSkipReason(t *testing.T) {
+	tests := []struct {
+		name           string
+		skipReason     SkipReason
+		expectedReason SkipReason
+	}{
+		{
+			name:           "no skip reason set returns empty",
+			skipReason:     "",
+			expectedReason: "",
+		},
+		{
+			name:           "SkipReasonMatchConditions is set and returned",
+			skipReason:     SkipReasonMatchConditions,
+			expectedReason: SkipReasonMatchConditions,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := RuleSkip("test-rule", Validation, "skip", nil)
+			if tt.skipReason != "" {
+				r = r.WithSkipReason(tt.skipReason)
+			}
+			if got := r.SkipReason(); got != tt.expectedReason {
+				t.Errorf("RuleResponse.SkipReason() = %v, want %v", got, tt.expectedReason)
+			}
+		})
+	}
+}
+
+func TestRuleResponse_SkipReasonNotPersistedToProperties(t *testing.T) {
+	// SkipReason is internal routing metadata and must not appear in Properties
+	// which are written to PolicyReport results.
+	r := RuleSkip("test-rule", Validation, "skip", nil).WithSkipReason(SkipReasonMatchConditions)
+	if r.Properties() != nil {
+		for k := range r.Properties() {
+			if k == "skipReason" || k == string(SkipReasonMatchConditions) {
+				t.Errorf("SkipReason must not be persisted to Properties, found key: %v", k)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Explanation
When a `ValidatingPolicy` includes `matchConditions` (e.g. filtering by namespace labels), Kyverno's background scanner records a `Skip` result in the `PolicyReport` for every resource in namespaces that don't match the condition. This produces noisy `SKIP=1` reports across unrelated namespaces and diverges from admission-time behavior where `matchConditions` not matching means the webhook is never called and no report is generated. This PR fixes the inconsistency by suppressing skip entries that result specifically from `matchConditions` evaluating to false.

## Related issue

Closes #14702

@realshuting as discussed in the issue thread.

## Milestone of this PR

/milestone 1.19.0

## What type of PR is this

/kind bug

## Proposed Changes

Introduces an internal `SkipReason` type on `RuleResponse` (`pkg/engine/api/ruleresponse.go`) with a `SkipReasonMatchConditions` constant and `WithSkipReason`/`SkipReason()` methods. The vpol engine marks the `result == nil` path (where `matchConditions` evaluated to false) with this reason. The background scanner in `pkg/controllers/report/utils/scanner.go` filters out rules carrying this reason before writing `PolicyReport` entries. All other skip reasons (`PolicyException`, explicit rule skips) are unaffected.

`SkipReason` is internal routing metadata and is not persisted to `PolicyReport` result properties.

## Verification

Unit tests added in `pkg/engine/api/ruleresponse_test.go` covering `WithSkipReason`/`SkipReason()` and verifying `SkipReason` is not persisted to `Properties`. Full package test suite passes:

```
go test ./pkg/engine/api/... ./pkg/cel/policies/vpol/... ./pkg/controllers/report/... -- PASS
go build ./pkg/engine/api/... ./pkg/cel/policies/vpol/... ./pkg/controllers/report/... -- clean
```

## Checklist

- [x] I have read the [[contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md)](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [[AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md)](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md).
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.