### PR TITLE
fix(verification): use sigstore-go TUF client and fallback to trusted_root.json

### DIFF
--- a/pkg/image/verifiers/ivpol/cosign/certs_test.go
+++ b/pkg/image/verifiers/ivpol/cosign/certs_test.go
@@ -78,7 +78,7 @@ func certToPEM(cert *x509.Certificate) []byte {
 	})
 }
 
-func publicKeyToPEM(key interface{}) []byte {
+func testPublicKeyToPEM(key interface{}) []byte {
 	pubBytes, err := x509.MarshalPKIXPublicKey(key)
 	if err != nil {
 		return nil
@@ -494,33 +494,33 @@ func TestDecodePEM(t *testing.T) {
 	}{
 		{
 			name:     "RSA public key",
-			input:    publicKeyToPEM(&rsaKey.PublicKey),
+			input:    testPublicKeyToPEM(&rsaKey.PublicKey),
 			hashAlgo: crypto.SHA256,
 			wantErr:  false,
 			keyType:  "RSA",
 		},
 		{
 			name:     "ECDSA public key",
-			input:    publicKeyToPEM(&ecdsaKey.PublicKey),
+			input:    testPublicKeyToPEM(&ecdsaKey.PublicKey),
 			hashAlgo: crypto.SHA256,
 			wantErr:  false,
 			keyType:  "ECDSA",
 		},
 		{
 			name:     "SHA-256 hash algorithm",
-			input:    publicKeyToPEM(&rsaKey.PublicKey),
+			input:    testPublicKeyToPEM(&rsaKey.PublicKey),
 			hashAlgo: crypto.SHA256,
 			wantErr:  false,
 		},
 		{
 			name:     "SHA-384 hash algorithm",
-			input:    publicKeyToPEM(&rsaKey.PublicKey),
+			input:    testPublicKeyToPEM(&rsaKey.PublicKey),
 			hashAlgo: crypto.SHA384,
 			wantErr:  false,
 		},
 		{
 			name:     "SHA-512 hash algorithm",
-			input:    publicKeyToPEM(&rsaKey.PublicKey),
+			input:    testPublicKeyToPEM(&rsaKey.PublicKey),
 			hashAlgo: crypto.SHA512,
 			wantErr:  false,
 		},

--- a/pkg/image/verifiers/ivpol/cosign/opts.go
+++ b/pkg/image/verifiers/ivpol/cosign/opts.go
@@ -39,8 +39,8 @@ var (
 	getCTLogPubsFn = func(ctx context.Context) (*cosign.TrustedTransparencyLogPubKeys, error) {
 		return cosign.GetCTLogPubs(ctx)
 	}
-	getFulcioRootsFn    = func() (*x509.CertPool, error) { return fulcioroots.Get() }
-	getFulcioIntermedFn = func() (*x509.CertPool, error) { return fulcioroots.GetIntermediates() }
+	getFulcioRootsFn        = func() (*x509.CertPool, error) { return fulcioroots.Get() }
+	getFulcioIntermedFn     = func() (*x509.CertPool, error) { return fulcioroots.GetIntermediates() }
 	getTrustedRootFromTUFFn = func(ctx context.Context, t *v1beta1.TUF) (*root.TrustedRoot, error) {
 		return getTrustedRootFromTUF(ctx, t)
 	}
@@ -332,8 +332,7 @@ func initTUFAndFetch(ctx context.Context, t *v1beta1.TUF) (*sigstoreTrustMateria
 		}
 
 		// Fetch Fulcio material — individual targets may be absent.
-		rootsErr := error(nil)
-		intermedErr := error(nil)
+		var rootsErr, intermedErr error
 		m.fulcioRoots, rootsErr = getFulcioRootsFn()
 		m.fulcioIntermediates, intermedErr = getFulcioIntermedFn()
 		if rootsErr != nil || intermedErr != nil {

--- a/pkg/image/verifiers/ivpol/cosign/opts.go
+++ b/pkg/image/verifiers/ivpol/cosign/opts.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -20,10 +22,28 @@ import (
 	rekor "github.com/sigstore/rekor/pkg/client"
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/sigstore-go/pkg/root"
+	sigstoreTuf "github.com/sigstore/sigstore-go/pkg/tuf"
 	"github.com/sigstore/sigstore/pkg/fulcioroots"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/tuf"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+var (
+	tufInitializeFn = func(ctx context.Context, mirror string, rootBytes []byte) error {
+		return tuf.Initialize(ctx, mirror, rootBytes)
+	}
+	getRekorPubsFn = func(ctx context.Context) (*cosign.TrustedTransparencyLogPubKeys, error) {
+		return cosign.GetRekorPubs(ctx)
+	}
+	getCTLogPubsFn = func(ctx context.Context) (*cosign.TrustedTransparencyLogPubKeys, error) {
+		return cosign.GetCTLogPubs(ctx)
+	}
+	getFulcioRootsFn    = func() (*x509.CertPool, error) { return fulcioroots.Get() }
+	getFulcioIntermedFn = func() (*x509.CertPool, error) { return fulcioroots.GetIntermediates() }
+	getTrustedRootFromTUFFn = func(ctx context.Context, t *v1beta1.TUF) (*root.TrustedRoot, error) {
+		return getTrustedRootFromTUF(ctx, t)
+	}
 )
 
 // maxIntermediateCerts limits the number of intermediate certificates accepted
@@ -246,6 +266,10 @@ type sigstoreTrustMaterial struct {
 // trust material within a single sigstoretuf.WithLock acquisition.
 // This prevents a concurrent goroutine from reinitializing the singleton
 // with a different mirror between the initialization and the reads.
+//
+// Uses the sigstore-go TUF client (go-tuf/v2) for trusted_root.json to
+// support TAP-15 succinct_roles (hash-bin delegations), and falls back
+// to trusted_root.json when individual TUF targets are missing.
 func initTUFAndFetch(ctx context.Context, t *v1beta1.TUF) (*sigstoreTrustMaterial, error) {
 	// Step 1: read optional root bytes — pure I/O, no TUF lock needed.
 	var rootBytes []byte
@@ -274,38 +298,57 @@ func initTUFAndFetch(ctx context.Context, t *v1beta1.TUF) (*sigstoreTrustMateria
 	// sigstoretuf wrappers) to avoid deadlocking on the same mutex.
 	var m sigstoreTrustMaterial
 	err := sigstoretuf.WithLock(func() error {
-		if err := tuf.Initialize(ctx, mirror, rootBytes); err != nil {
+		if err := tufInitializeFn(ctx, mirror, rootBytes); err != nil {
 			return fmt.Errorf("failed to initialize TUF client (mirror=%q): %w", mirror, err)
 		}
+
+		// Fetch trusted_root.json via sigstore-go TUF client (go-tuf/v2)
+		// instead of tuf.NewFromEnv (go-tuf v0.7.0) to support TAP-15
+		// succinct_roles (hash-bin delegations).
+		tr, trustedRootErr := getTrustedRootFromTUFFn(ctx, t)
+		if trustedRootErr != nil {
+			return fmt.Errorf("getting trusted root: %w", trustedRootErr)
+		}
+		m.trustedRoot = tr
+
+		// Fetch Rekor public keys — may fail for private TUF mirrors
+		// that don't serve individual targets; fall back to trusted root.
 		var err error
-		m.rekorPubKeys, err = cosign.GetRekorPubs(ctx)
+		m.rekorPubKeys, err = getRekorPubsFn(ctx)
 		if err != nil {
-			return fmt.Errorf("getting Rekor public keys: %w", err)
+			m.rekorPubKeys, err = rekorPubsFromTrustedRoot(m.trustedRoot)
+			if err != nil {
+				return fmt.Errorf("getting Rekor public keys: %w", err)
+			}
 		}
-		m.ctlogPubKeys, err = cosign.GetCTLogPubs(ctx)
+
+		// Fetch CTLog public keys — same caveat as Rekor.
+		m.ctlogPubKeys, err = getCTLogPubsFn(ctx)
 		if err != nil {
-			return fmt.Errorf("getting CTLog public keys: %w", err)
+			m.ctlogPubKeys, err = ctLogPubsFromTrustedRoot(m.trustedRoot)
+			if err != nil {
+				return fmt.Errorf("getting CTLog public keys: %w", err)
+			}
 		}
-		tufClient, err := tuf.NewFromEnv(ctx)
-		if err != nil {
-			return fmt.Errorf("initializing tuf client: %w", err)
+
+		// Fetch Fulcio material — individual targets may be absent.
+		rootsErr := error(nil)
+		intermedErr := error(nil)
+		m.fulcioRoots, rootsErr = getFulcioRootsFn()
+		m.fulcioIntermediates, intermedErr = getFulcioIntermedFn()
+		if rootsErr != nil || intermedErr != nil {
+			fRoots, fIntermediates, fErr := fulcioRootsFromTrustedRoot(m.trustedRoot)
+			if fErr != nil {
+				return fmt.Errorf("failed to fetch Fulcio material and trusted root fallback also failed: %w", fErr)
+			}
+			if rootsErr != nil {
+				m.fulcioRoots = fRoots
+			}
+			if intermedErr != nil {
+				m.fulcioIntermediates = fIntermediates
+			}
 		}
-		targetBytes, err := tufClient.GetTarget("trusted_root.json")
-		if err != nil {
-			return fmt.Errorf("error getting target trusted_root.json: %w", err)
-		}
-		m.trustedRoot, err = root.NewTrustedRootFromJSON(targetBytes)
-		if err != nil {
-			return fmt.Errorf("error creating trusted root: %w", err)
-		}
-		m.fulcioRoots, err = fulcioroots.Get()
-		if err != nil {
-			return fmt.Errorf("failed to fetch Fulcio roots: %w", err)
-		}
-		m.fulcioIntermediates, err = fulcioroots.GetIntermediates()
-		if err != nil {
-			return fmt.Errorf("failed to fetch Fulcio intermediates: %w", err)
-		}
+
 		return nil
 	})
 	if err != nil {
@@ -374,7 +417,6 @@ func getRekor(_ context.Context, ctlog *v1beta1.CTLog, defaultRekorPubKeys, defa
 			rekorPubKey = &key
 		}
 	}
-
 	if !ctlog.InsecureIgnoreSCT {
 		if ctlog.CTLogPubKey == "" {
 			// Reuse pre-fetched defaults to avoid an extra TUF lock acquisition.
@@ -389,6 +431,170 @@ func getRekor(_ context.Context, ctlog *v1beta1.CTLog, defaultRekorPubKeys, defa
 	}
 
 	return rekorClient, rekorPubKey, ctlogPubKey, nil
+}
+
+// getTrustedRootFromTUF fetches trusted_root.json from the TUF repository
+// using the sigstore-go TUF client (go-tuf/v2) which supports TAP-15
+// succinct_roles (hash-bin delegations). This is the core fix for private
+// Sigstore TUF mirrors (e.g. RSTUF) that serve targets via hash-bin
+// delegations.
+func getTrustedRootFromTUF(ctx context.Context, t *v1beta1.TUF) (*root.TrustedRoot, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	opts := sigstoreTuf.DefaultOptions().WithContext(ctx)
+	if t != nil {
+		if t.Mirror != "" {
+			opts.RepositoryBaseURL = t.Mirror
+		}
+		if t.Root.Path != "" {
+			rootBytes, err := blob.LoadFileOrURL(t.Root.Path)
+			if err != nil {
+				return nil, fmt.Errorf("loading TUF root: %w", err)
+			}
+			opts.Root = rootBytes
+		} else if t.Root.Data != "" {
+			rootBytes, err := base64.StdEncoding.DecodeString(t.Root.Data)
+			if err != nil {
+				return nil, fmt.Errorf("decoding TUF root: %w", err)
+			}
+			opts.Root = rootBytes
+		}
+	}
+	client, err := sigstoreTuf.New(opts)
+	if err != nil {
+		return nil, fmt.Errorf("creating sigstore-go TUF client: %w", err)
+	}
+	targetBytes, err := client.GetTarget("trusted_root.json")
+	if err != nil {
+		return nil, fmt.Errorf("getting trusted_root.json from TUF: %w", err)
+	}
+	trustedRoot, err := root.NewTrustedRootFromJSON(targetBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing trusted root: %w", err)
+	}
+	return trustedRoot, nil
+}
+
+// rekorPubsFromTrustedRoot extracts Rekor transparency log public keys from
+// a TrustedRoot, used as a fallback when individual TUF targets (rekor.pub)
+// are unavailable.
+func rekorPubsFromTrustedRoot(tr *root.TrustedRoot) (*cosign.TrustedTransparencyLogPubKeys, error) {
+	if tr == nil {
+		return nil, fmt.Errorf("trusted root not available")
+	}
+	keys := cosign.NewTrustedTransparencyLogPubKeys()
+	added := 0
+	var lastErr error
+	for _, tlog := range tr.RekorLogs() {
+		pemBytes, err := publicKeyToPEM(tlog.PublicKey)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to encode Rekor public key: %w", err)
+			continue
+		}
+		if err := keys.AddTransparencyLogPubKey(pemBytes, logKeyStatus(tlog.ValidityPeriodStart, tlog.ValidityPeriodEnd)); err != nil {
+			lastErr = fmt.Errorf("failed to add Rekor public key: %w", err)
+			continue
+		}
+		added++
+	}
+	if added == 0 {
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, fmt.Errorf("no Rekor public keys found in trusted root")
+	}
+	return &keys, nil
+}
+
+// ctLogPubsFromTrustedRoot extracts CT log public keys from a TrustedRoot,
+// used as a fallback when individual TUF targets (ctfe.pub) are unavailable.
+func ctLogPubsFromTrustedRoot(tr *root.TrustedRoot) (*cosign.TrustedTransparencyLogPubKeys, error) {
+	if tr == nil {
+		return nil, fmt.Errorf("trusted root not available")
+	}
+	keys := cosign.NewTrustedTransparencyLogPubKeys()
+	added := 0
+	var lastErr error
+	for _, tlog := range tr.CTLogs() {
+		pemBytes, err := publicKeyToPEM(tlog.PublicKey)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to encode CTLog public key: %w", err)
+			continue
+		}
+		if err := keys.AddTransparencyLogPubKey(pemBytes, logKeyStatus(tlog.ValidityPeriodStart, tlog.ValidityPeriodEnd)); err != nil {
+			lastErr = fmt.Errorf("failed to add CTLog public key: %w", err)
+			continue
+		}
+		added++
+	}
+	if added == 0 {
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, fmt.Errorf("no CTLog public keys found in trusted root")
+	}
+	return &keys, nil
+}
+
+// fulcioRootsFromTrustedRoot extracts Fulcio root and intermediate
+// certificates from a TrustedRoot, used as a fallback when individual
+// TUF targets (fulcio_v1.crt.pem) are unavailable.
+func fulcioRootsFromTrustedRoot(tr *root.TrustedRoot) (*x509.CertPool, *x509.CertPool, error) {
+	if tr == nil {
+		return nil, nil, fmt.Errorf("trusted root not available")
+	}
+	cas := tr.FulcioCertificateAuthorities()
+	if len(cas) == 0 {
+		return nil, nil, fmt.Errorf("no certificate authority in trusted root")
+	}
+	roots := x509.NewCertPool()
+	intermediates := x509.NewCertPool()
+	rootsAdded := 0
+	for _, ca := range cas {
+		fca, ok := ca.(*root.FulcioCertificateAuthority)
+		if !ok {
+			continue
+		}
+		if logKeyStatus(fca.ValidityPeriodStart, fca.ValidityPeriodEnd) == tuf.Expired {
+			continue
+		}
+		if fca.Root != nil {
+			roots.AddCert(fca.Root)
+			rootsAdded++
+		}
+		for _, inter := range fca.Intermediates {
+			if inter != nil {
+				intermediates.AddCert(inter)
+			}
+		}
+	}
+	if rootsAdded == 0 {
+		return nil, nil, fmt.Errorf("no Fulcio root certificates found in trusted root")
+	}
+	return roots, intermediates, nil
+}
+
+func publicKeyToPEM(pubKey interface{}) ([]byte, error) {
+	derBytes, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: derBytes,
+	}), nil
+}
+
+func logKeyStatus(start, end time.Time) tuf.StatusKind {
+	now := time.Now()
+	if !start.IsZero() && now.Before(start) {
+		return tuf.Expired
+	}
+	if !end.IsZero() && now.After(end) {
+		return tuf.Expired
+	}
+	return tuf.Active
 }
 
 // resolveTrustedMaterial returns the sigstore-go TrustedMaterial used to

--- a/pkg/image/verifiers/ivpol/cosign/opts_integration_test.go
+++ b/pkg/image/verifiers/ivpol/cosign/opts_integration_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+package cosign
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func TestInitializeTuf_Default(t *testing.T) {
+	ctx := testContext(t)
+	err := initializeTuf(ctx, nil)
+	require.NoError(t, err)
+}
+
+func TestInitializeTuf_WithCustomMirror(t *testing.T) {
+	ctx := testContext(t)
+	tufCfg := &v1beta1.TUF{
+		Mirror: "https://custom-tuf.example.com",
+	}
+	err := initializeTuf(ctx, tufCfg)
+	assert.Error(t, err)
+}
+
+func TestGetRekor_WithURL(t *testing.T) {
+	ctx := testContext(t)
+	err := initializeTuf(ctx, nil)
+	require.NoError(t, err)
+	tr, err := getTrustedRootFromTUF(ctx, nil)
+	require.NoError(t, err)
+	ctlog := &v1beta1.CTLog{
+		URL: "https://rekor.sigstore.dev",
+	}
+	rekorClient, rekorPubKeys, ctlogPubKeys, err := getRekor(ctx, ctlog, tr)
+	require.NoError(t, err)
+	assert.NotNil(t, rekorClient)
+	assert.NotNil(t, rekorPubKeys)
+	assert.NotNil(t, ctlogPubKeys)
+}
+
+func TestGetRekor_NilCTLog(t *testing.T) {
+	ctx := testContext(t)
+	err := initializeTuf(ctx, nil)
+	require.NoError(t, err)
+	tr, err := getTrustedRootFromTUF(ctx, nil)
+	require.NoError(t, err)
+	rekorClient, rekorPubKeys, ctlogPubKeys, err := getRekor(ctx, nil, tr)
+	require.NoError(t, err)
+	assert.Nil(t, rekorClient)
+	assert.NotNil(t, rekorPubKeys)
+	assert.NotNil(t, ctlogPubKeys)
+}
+
+func TestGetFulcio(t *testing.T) {
+	ctx := testContext(t)
+	err := initializeTuf(ctx, nil)
+	require.NoError(t, err)
+	tr, err := getTrustedRootFromTUF(ctx, nil)
+	require.NoError(t, err)
+	roots, intermediates, err := getFulcio(ctx, tr)
+	require.NoError(t, err)
+	assert.NotNil(t, roots)
+	assert.NotNil(t, intermediates)
+}
+
+func TestGetTrustedRootFromTUF(t *testing.T) {
+	ctx := testContext(t)
+	err := initializeTuf(ctx, nil)
+	require.NoError(t, err)
+	trustedRoot, err := getTrustedRootFromTUF(ctx, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, trustedRoot)
+}

--- a/pkg/image/verifiers/ivpol/cosign/opts_test.go
+++ b/pkg/image/verifiers/ivpol/cosign/opts_test.go
@@ -2,14 +2,25 @@ package cosign
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/sigstore/sigstore-go/pkg/root"
+	"github.com/sigstore/sigstore/pkg/tuf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -79,7 +90,86 @@ func baseOpts() ([]remote.Option, []name.Option) {
 	return []remote.Option{}, []name.Option{}
 }
 
+func stubTufWithFixture(t *testing.T) {
+	t.Helper()
+	origTufInit := tufInitializeFn
+	origRoot := getTrustedRootFromTUFFn
+	origRekor := getRekorPubsFn
+	origCTLog := getCTLogPubsFn
+	origFulcioRoots := getFulcioRootsFn
+	origFulcioIntermed := getFulcioIntermedFn
+	tufInitializeFn = func(_ context.Context, _ string, _ []byte) error { return nil }
+	getTrustedRootFromTUFFn = func(_ context.Context, _ *v1beta1.TUF) (*root.TrustedRoot, error) {
+		return newTestTrustedRoot(t), nil
+	}
+	getRekorPubsFn = func(_ context.Context) (*cosign.TrustedTransparencyLogPubKeys, error) {
+		return nil, fmt.Errorf("stubbed Rekor TUF lookup")
+	}
+	getCTLogPubsFn = func(_ context.Context) (*cosign.TrustedTransparencyLogPubKeys, error) {
+		return nil, fmt.Errorf("stubbed CTLog TUF lookup")
+	}
+	getFulcioRootsFn = func() (*x509.CertPool, error) {
+		return nil, fmt.Errorf("stubbed Fulcio roots TUF lookup")
+	}
+	getFulcioIntermedFn = func() (*x509.CertPool, error) {
+		return nil, fmt.Errorf("stubbed Fulcio intermediates TUF lookup")
+	}
+	t.Cleanup(func() {
+		tufInitializeFn = origTufInit
+		getTrustedRootFromTUFFn = origRoot
+		getRekorPubsFn = origRekor
+		getCTLogPubsFn = origCTLog
+		getFulcioRootsFn = origFulcioRoots
+		getFulcioIntermedFn = origFulcioIntermed
+	})
+}
+
+func newTestTrustedRoot(t *testing.T) *root.TrustedRoot {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-root"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+
+	ca := &root.FulcioCertificateAuthority{
+		Root:                cert,
+		ValidityPeriodStart: now.Add(-time.Hour),
+		ValidityPeriodEnd:   now.Add(24 * time.Hour),
+	}
+	logID := []byte("test-log-id")
+	tlog := &root.TransparencyLog{
+		BaseURL:             "https://rekor.sigstore.dev",
+		ID:                  logID,
+		ValidityPeriodStart: now.Add(-time.Hour),
+		ValidityPeriodEnd:   now.Add(24 * time.Hour),
+		HashFunc:            crypto.SHA256,
+		PublicKey:           &key.PublicKey,
+		SignatureHashFunc:   crypto.SHA256,
+	}
+	tr, err := root.NewTrustedRoot(root.TrustedRootMediaType01,
+		[]root.CertificateAuthority{ca},
+		map[string]*root.TransparencyLog{"ctlog": tlog},
+		nil,
+		map[string]*root.TransparencyLog{"rekor": tlog},
+	)
+	require.NoError(t, err)
+	return tr
+}
+
 func TestCheckOptions_KeyBased(t *testing.T) {
+	stubTufWithFixture(t)
 	ctx := context.TODO()
 	baseROpts, baseNOpts := baseOpts()
 
@@ -105,6 +195,7 @@ func TestCheckOptions_KeyBased(t *testing.T) {
 }
 
 func TestCheckOptions_Keyless(t *testing.T) {
+	stubTufWithFixture(t)
 	ctx := context.TODO()
 	baseROpts, baseNOpts := baseOpts()
 
@@ -134,6 +225,7 @@ func TestCheckOptions_Keyless(t *testing.T) {
 }
 
 func TestCheckOptions_KeylessWithRegex(t *testing.T) {
+	stubTufWithFixture(t)
 	ctx := context.TODO()
 	baseROpts, baseNOpts := baseOpts()
 
@@ -162,6 +254,7 @@ func TestCheckOptions_KeylessWithRegex(t *testing.T) {
 }
 
 func TestCheckOptions_MultipleIdentities(t *testing.T) {
+	stubTufWithFixture(t)
 	ctx := context.TODO()
 	baseROpts, baseNOpts := baseOpts()
 
@@ -335,6 +428,33 @@ func TestGetRekor_MissingURL(t *testing.T) {
 	assert.Contains(t, err.Error(), "rekor URL must be provided")
 }
 
+func TestRekorPubsFromTrustedRoot(t *testing.T) {
+	tr := newTestTrustedRoot(t)
+
+	keys, err := rekorPubsFromTrustedRoot(tr)
+	require.NoError(t, err)
+	assert.NotNil(t, keys)
+	assert.NotEmpty(t, keys.Keys)
+}
+
+func TestCTLogPubsFromTrustedRoot(t *testing.T) {
+	tr := newTestTrustedRoot(t)
+
+	keys, err := ctLogPubsFromTrustedRoot(tr)
+	require.NoError(t, err)
+	assert.NotNil(t, keys)
+	assert.NotEmpty(t, keys.Keys)
+}
+
+func TestFulcioRootsFromTrustedRoot(t *testing.T) {
+	tr := newTestTrustedRoot(t)
+
+	roots, intermediates, err := fulcioRootsFromTrustedRoot(tr)
+	require.NoError(t, err)
+	assert.NotNil(t, roots)
+	assert.NotNil(t, intermediates)
+}
+
 // TestGetRekor_InsecureIgnoreTlog_NoURL covers the fix for private Sigstore
 // deployments (e.g. GitHub Actions' fulcio.githubapp.com) that set
 // insecureIgnoreTlog: true without providing a Rekor URL: getRekor must not
@@ -353,6 +473,21 @@ func TestGetRekor_InsecureIgnoreTlog_NoURL(t *testing.T) {
 	assert.Nil(t, rekorClient)
 	assert.Nil(t, rekorPubKeys)
 	assert.NotNil(t, ctlogPubKeys)
+}
+
+func TestRekorPubsFromTrustedRoot_Nil(t *testing.T) {
+	_, err := rekorPubsFromTrustedRoot(nil)
+	assert.Error(t, err)
+}
+
+func TestCTLogPubsFromTrustedRoot_Nil(t *testing.T) {
+	_, err := ctLogPubsFromTrustedRoot(nil)
+	assert.Error(t, err)
+}
+
+func TestFulcioRootsFromTrustedRoot_Nil(t *testing.T) {
+	_, _, err := fulcioRootsFromTrustedRoot(nil)
+	assert.Error(t, err)
 }
 
 // TestGetRekor_InsecureIgnoreSCT_SkipsCTLogPubKeys ensures CT log public keys
@@ -390,6 +525,132 @@ func TestInitTUFAndFetch_TrustedRoot(t *testing.T) {
 	trust, err := initTUFAndFetch(ctx, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, trust.trustedRoot)
+}
+
+// TestInitTUFAndFetch_FallbackToTrustedRoot verifies that when individual
+// TUF targets are missing, initTUFAndFetch falls back to trusted_root.json
+// for Rekor/CTLog/Fulcio material.
+func TestInitTUFAndFetch_FallbackToTrustedRoot(t *testing.T) {
+	origTufInit := tufInitializeFn
+	origRoot := getTrustedRootFromTUFFn
+	origRekor := getRekorPubsFn
+	origCTLog := getCTLogPubsFn
+	origFulcioRoots := getFulcioRootsFn
+	origFulcioIntermed := getFulcioIntermedFn
+	t.Cleanup(func() {
+		tufInitializeFn = origTufInit
+		getTrustedRootFromTUFFn = origRoot
+		getRekorPubsFn = origRekor
+		getCTLogPubsFn = origCTLog
+		getFulcioRootsFn = origFulcioRoots
+		getFulcioIntermedFn = origFulcioIntermed
+	})
+
+	tufInitializeFn = func(_ context.Context, _ string, _ []byte) error { return nil }
+	getTrustedRootFromTUFFn = func(_ context.Context, _ *v1beta1.TUF) (*root.TrustedRoot, error) {
+		return newTestTrustedRoot(t), nil
+	}
+	getRekorPubsFn = func(_ context.Context) (*cosign.TrustedTransparencyLogPubKeys, error) {
+		return nil, fmt.Errorf("simulated TUF target missing: rekor.pub")
+	}
+	getCTLogPubsFn = func(_ context.Context) (*cosign.TrustedTransparencyLogPubKeys, error) {
+		return nil, fmt.Errorf("simulated TUF target missing: ctfe.pub")
+	}
+	getFulcioRootsFn = func() (*x509.CertPool, error) {
+		return nil, fmt.Errorf("simulated TUF target missing: fulcio_v1.crt.pem")
+	}
+	getFulcioIntermedFn = func() (*x509.CertPool, error) {
+		return nil, fmt.Errorf("simulated TUF target missing: fulcio_v1.crt.pem")
+	}
+
+	trust, err := initTUFAndFetch(context.TODO(), nil)
+	require.NoError(t, err)
+	assert.NotNil(t, trust.rekorPubKeys)
+	assert.NotEmpty(t, trust.rekorPubKeys.Keys)
+	assert.NotNil(t, trust.ctlogPubKeys)
+	assert.NotEmpty(t, trust.ctlogPubKeys.Keys)
+	assert.NotNil(t, trust.fulcioRoots)
+	assert.NotNil(t, trust.fulcioIntermediates)
+	assert.NotNil(t, trust.trustedRoot)
+}
+
+// TestInitTUFAndFetch_PartialFulcioFallback verifies that when only Fulcio
+// roots or intermediates fail individually, the fallback still succeeds.
+func TestInitTUFAndFetch_PartialFulcioFallback(t *testing.T) {
+	origTufInit := tufInitializeFn
+	origRoot := getTrustedRootFromTUFFn
+	origRekor := getRekorPubsFn
+	origCTLog := getCTLogPubsFn
+	origFulcioRoots := getFulcioRootsFn
+	origFulcioIntermed := getFulcioIntermedFn
+	t.Cleanup(func() {
+		tufInitializeFn = origTufInit
+		getTrustedRootFromTUFFn = origRoot
+		getRekorPubsFn = origRekor
+		getCTLogPubsFn = origCTLog
+		getFulcioRootsFn = origFulcioRoots
+		getFulcioIntermedFn = origFulcioIntermed
+	})
+
+	tufInitializeFn = func(_ context.Context, _ string, _ []byte) error { return nil }
+	getTrustedRootFromTUFFn = func(_ context.Context, _ *v1beta1.TUF) (*root.TrustedRoot, error) {
+		return newTestTrustedRoot(t), nil
+	}
+	getRekorPubsFn = func(ctx context.Context) (*cosign.TrustedTransparencyLogPubKeys, error) {
+		return cosign.GetRekorPubs(ctx)
+	}
+	getCTLogPubsFn = func(ctx context.Context) (*cosign.TrustedTransparencyLogPubKeys, error) {
+		return cosign.GetCTLogPubs(ctx)
+	}
+	// Only intermediates fail; roots succeed
+	getFulcioRootsFn = func() (*x509.CertPool, error) {
+		return x509.NewCertPool(), nil
+	}
+	getFulcioIntermedFn = func() (*x509.CertPool, error) {
+		return nil, fmt.Errorf("simulated error fetching intermediates")
+	}
+
+	trust, err := initTUFAndFetch(context.TODO(), nil)
+	require.NoError(t, err)
+	assert.NotNil(t, trust.fulcioRoots)
+	assert.NotNil(t, trust.fulcioIntermediates)
+}
+
+func TestPublicKeyToPEM(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	pemBytes, err := publicKeyToPEM(&key.PublicKey)
+	require.NoError(t, err)
+	assert.Contains(t, string(pemBytes), "-----BEGIN PUBLIC KEY-----")
+	assert.Contains(t, string(pemBytes), "-----END PUBLIC KEY-----")
+}
+
+func TestPublicKeyToPEM_UnsupportedType(t *testing.T) {
+	_, err := publicKeyToPEM("not-a-key")
+	assert.Error(t, err)
+}
+
+func TestLogKeyStatus(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name  string
+		start time.Time
+		end   time.Time
+		want  tuf.StatusKind
+	}{
+		{"both zero", time.Time{}, time.Time{}, tuf.Active},
+		{"valid window", now.Add(-time.Hour), now.Add(time.Hour), tuf.Active},
+		{"start in future", now.Add(time.Hour), now.Add(2 * time.Hour), tuf.Expired},
+		{"end in past", now.Add(-2 * time.Hour), now.Add(-time.Hour), tuf.Expired},
+		{"zero start, valid end", time.Time{}, now.Add(time.Hour), tuf.Active},
+		{"valid start, zero end", now.Add(-time.Hour), time.Time{}, tuf.Active},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, logKeyStatus(tt.start, tt.end))
+		})
+	}
 }
 
 // TestResolveTrustedMaterial covers loading the trusted material from an
@@ -454,6 +715,7 @@ func TestResolveTrustedMaterial(t *testing.T) {
 }
 
 func TestCheckOptions_CTLogConfiguration(t *testing.T) {
+	stubTufWithFixture(t)
 	tests := []struct {
 		name     string
 		ctlog    *v1beta1.CTLog
@@ -523,6 +785,7 @@ func TestCheckOptions_CTLogConfiguration(t *testing.T) {
 }
 
 func TestCheckOptions_VerifierTypes(t *testing.T) {
+	stubTufWithFixture(t)
 	tests := []struct {
 		name      string
 		cosignCfg *v1beta1.Cosign
@@ -673,6 +936,7 @@ func TestCheckOptions_KeyBased_AirGapped(t *testing.T) {
 // without a Rekor URL must not fail policy evaluation before verification
 // can proceed.
 func TestCheckOptions_Keyless_InsecureIgnoreTlog_NoURL(t *testing.T) {
+	stubTufWithFixture(t)
 	ctx := context.TODO()
 	baseROpts, baseNOpts := baseOpts()
 
@@ -699,4 +963,35 @@ func TestCheckOptions_Keyless_InsecureIgnoreTlog_NoURL(t *testing.T) {
 	assert.Nil(t, opts.RekorClient)
 	assert.Nil(t, opts.RekorPubKeys)
 	assert.Nil(t, opts.CTLogPubKeys)
+}
+
+// TestCheckOptions_FallbackViaInitTUFAndFetch verifies that checkOptions
+// works end-to-end when individual TUF targets are missing, with fallback
+// to trusted_root.json through initTUFAndFetch.
+func TestCheckOptions_FallbackViaInitTUFAndFetch(t *testing.T) {
+	stubTufWithFixture(t)
+	ctx := context.TODO()
+	baseROpts, baseNOpts := baseOpts()
+
+	cosignCfg := &v1beta1.Cosign{
+		Keyless: &v1beta1.Keyless{
+			Identities: []v1beta1.Identity{
+				{
+					Issuer:  testIssuer,
+					Subject: testSubject,
+				},
+			},
+		},
+		CTLog: &v1beta1.CTLog{
+			URL:               "https://rekor.sigstore.dev",
+			InsecureIgnoreSCT: true,
+		},
+	}
+
+	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, opts)
+	assert.NotNil(t, opts.RootCerts)
+	assert.NotNil(t, opts.RekorPubKeys)
+	assert.NotNil(t, opts.TrustedMaterial)
 }


### PR DESCRIPTION
Kyverno image verification fails with private Sigstore TUF mirrors
(e.g. RSTUF) that serve targets via hash-bin delegations (TAP-15
succinct_roles) instead of listing them at the top level of
targets.json.

Root cause: getTrustedRootFromTUF() used sigstore/pkg/tuf (go-tuf v0.7.0)
which does not support succinct_roles. sigstore-go/pkg/tuf (go-tuf/v2)
does and is already used by standalone cosign.

Additionally, individual TUF targets (rekor.pub, fulcio_v1.crt.pem,
ctfe.pub) may be absent even when trusted_root.json is available.
Standard Sigstore TUF (tuf-repo-cdn.sigstore.dev) provides both formats
and is not affected.

Changes in pkg/image/verifiers/ivpol/cosign/opts.go:

New injectable function variables (for testability):
  - tufInitializeFn, getRekorPubsFn, getCTLogPubsFn,
    getFulcioRootsFn, getFulcioIntermedFn, getTrustedRootFromTUFFn

initTUFAndFetch (modified):
  - Load trusted_root.json before getRekor/getFulcio (was loaded after)
  - Use sigstore-go TUF client (go-tuf/v2) for trusted_root.json to
    support TAP-15 succinct_roles
  - getRekorPubsFn: fallback to TrustedRoot.RekorLogs() on TUF failure
  - getCTLogPubsFn: fallback to TrustedRoot.CTLogs() on TUF failure
  - getFulcioRootsFn/getFulcioIntermedFn: fallback to
    TrustedRoot.FulcioCertificateAuthorities() on TUF failure

New helpers:
  - rekorPubsFromTrustedRoot: extract Rekor pub keys from TrustedRoot
  - ctLogPubsFromTrustedRoot: extract CT log pub keys from TrustedRoot
  - fulcioRootsFromTrustedRoot: extract Fulcio root/intermediate certs
  - publicKeyToPEM: marshal crypto.PublicKey to PEM
  - logKeyStatus: derive tuf.Active/Expired from validity period
    (zero time treated as unbounded)
  - getTrustedRootFromTUF: fetch trusted_root.json via sigstore-go TUF

Changes in pkg/image/verifiers/ivpol/cosign/opts_test.go:

  - stubTufWithFixture: updated for initTUFAndFetch + injectable vars
  - newTestTrustedRoot: builds a TrustedRoot with test Fulcio CA,
    Rekor and CTLog transparency log entries
  - TestInitTUFAndFetch_FallbackToTrustedRoot: Rekor/CTLog/Fulcio
    targets fail individually -> fallback to trusted_root.json succeeds
  - TestInitTUFAndFetch_PartialFulcioFallback: only intermediates fail
    -> partial fallback succeeds
  - TestRekorPubsFromTrustedRoot, TestCTLogPubsFromTrustedRoot,
    TestFulcioRootsFromTrustedRoot: helper extraction tests
  - TestRekorPubsFromTrustedRoot_Nil, TestCTLogPubsFromTrustedRoot_Nil,
    TestFulcioRootsFromTrustedRoot_Nil: nil-safe tests
  - TestPublicKeyToPEM, TestPublicKeyToPEM_UnsupportedType,
    TestLogKeyStatus: helper unit tests
  - TestCheckOptions_FallbackViaInitTUFAndFetch: end-to-end checkOptions
    test with all TUF targets failing -> succeeds via trusted root
