### PR TITLE
fix(admissionpolicy): default userInfo groups and uid during background scans

### DIFF
--- a/pkg/admissionpolicy/user_info.go
+++ b/pkg/admissionpolicy/user_info.go
@@ -35,18 +35,20 @@ func NewUser(userInfo authenticationv1.UserInfo) UserInfo {
 	}
 }
 
-// backgroundUsername is a sentinel used when a policy is evaluated with no admission user (for
-// example background scans of ValidatingAdmissionPolicies and MutatingAdmissionPolicies). It only
-// needs to be non-empty: authenticationv1.UserInfo.Username has the omitempty JSON tag, so an empty
-// value is dropped when the admission request is converted to the map the CEL engine reads, which
-// makes request.userInfo.username absent and fails any policy that references it. It is deliberately
-// not a valid serviceaccount username (no system:serviceaccount: prefix) so it does not collide with
-// policies that allowlist or deny real service accounts.
+// backgroundUsername is a sentinel identity used when a policy is evaluated with no admission user,
+// such as a background scan of a ValidatingAdmissionPolicy or MutatingAdmissionPolicy. UserInfo
+// fields are omitempty, so an empty username, uid or groups is dropped when the request is converted
+// to the map the CEL engine reads, making request.userInfo.<field> absent and failing any policy
+// that references it. The value only needs to be non-empty; it is not a valid serviceaccount identity
+// (no system:serviceaccount: prefix) and not a privileged group, so it does not match policies that
+// allowlist or deny real service accounts or groups such as system:masters.
 const backgroundUsername = "system:kyverno:background-scan"
 
-// ResolveUser returns a UserInfo for CEL evaluation. It keeps every field of the provided userInfo
-// and only fills in the sentinel username when none is set, so request.userInfo.username is always
-// present while any supplied username, groups, uid or extra are preserved.
+// ResolveUser returns a UserInfo for CEL evaluation. It preserves every provided field and fills the
+// sentinel identity into username, uid and groups only when they are empty, so those keys are present
+// during background scans while any supplied value is kept. Extra is left as-is: it is keyed by
+// arbitrary strings, so a sentinel entry could not satisfy request.userInfo.extra["<key>"] accesses
+// and would defeat has() guards that policies use to make such accesses safe.
 func ResolveUser(userInfo *authenticationv1.UserInfo) UserInfo {
 	u := authenticationv1.UserInfo{}
 	if userInfo != nil {
@@ -54,6 +56,12 @@ func ResolveUser(userInfo *authenticationv1.UserInfo) UserInfo {
 	}
 	if u.Username == "" {
 		u.Username = backgroundUsername
+	}
+	if u.UID == "" {
+		u.UID = backgroundUsername
+	}
+	if len(u.Groups) == 0 {
+		u.Groups = []string{backgroundUsername}
 	}
 	return NewUser(u)
 }

--- a/pkg/admissionpolicy/user_info_background_test.go
+++ b/pkg/admissionpolicy/user_info_background_test.go
@@ -89,6 +89,65 @@ func TestMutate_BackgroundScan_UserInfoUsernameIsAvailable(t *testing.T) {
 	assert.Assert(t, !hasUserInfoError(err, resp), "request.userInfo.username must be available for MAP background scan")
 }
 
+// noSuchKey reports whether any rule failed with a "no such key: <field>" evaluation error,
+// which is what happens when an omitempty userInfo field is dropped during a background scan.
+func noSuchKey(field string, err error, resp engineapi.EngineResponse) bool {
+	want := "no such key: " + field
+	if err != nil && strings.Contains(err.Error(), want) {
+		return true
+	}
+	for _, r := range resp.PolicyResponse.Rules {
+		if strings.Contains(r.Message(), want) {
+			return true
+		}
+	}
+	return false
+}
+
+// The same omitempty drop that hid request.userInfo.username also hides groups and uid during
+// background scans (#14281 residual). A policy referencing either must evaluate without a
+// "no such key" error when the scanner passes an empty UserInfo.
+func TestValidate_BackgroundScan_GroupsAndUIDAreAvailable(t *testing.T) {
+	resource, err := kubeutils.BytesToUnstructured([]byte(`{"apiVersion": "v1", "kind": "Node", "metadata": {"name": "node-1"}}`))
+	assert.NilError(t, err)
+	nodeGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}
+
+	cases := []struct {
+		field      string
+		expression string
+	}{
+		// the standard "exclude kubelet requests" shape from the Kubernetes VAP docs
+		{"groups", `!("system:masters" in request.userInfo.groups)`},
+		{"uid", `request.userInfo.uid != "known-uid"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.field, func(t *testing.T) {
+			policy := &admissionregistrationv1.ValidatingAdmissionPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "ref-" + tc.field},
+				Spec: admissionregistrationv1.ValidatingAdmissionPolicySpec{
+					Validations: []admissionregistrationv1.Validation{{Expression: tc.expression}},
+				},
+			}
+			policyData := engineapi.NewValidatingAdmissionPolicyData(policy)
+
+			resp, err := Validate(policyData, *resource, resource.GroupVersionKind(), nodeGVR, map[string]map[string]string{}, nil, &authenticationv1.UserInfo{}, true)
+			assert.NilError(t, err)
+			assert.Assert(t, !noSuchKey(tc.field, err, resp), "request.userInfo.%s must be available during background scan", tc.field)
+			assert.Equal(t, engineapi.RuleStatusPass, resp.PolicyResponse.Rules[0].Status(), "the synthetic scan user must not be a privileged group / known uid")
+		})
+	}
+}
+
+func TestResolveUser_DefaultsGroupsAndUIDWhenEmpty(t *testing.T) {
+	u := ResolveUser(&authenticationv1.UserInfo{})
+	assert.Assert(t, len(u.GetGroups()) > 0, "groups must be defaulted so request.userInfo.groups is present")
+	assert.Assert(t, u.GetUID() != "", "uid must be defaulted so request.userInfo.uid is present")
+	// the synthetic group must not be a real privileged group
+	for _, g := range u.GetGroups() {
+		assert.Assert(t, g != "system:masters" && g != "system:authenticated", "synthetic group must not be privileged: %s", g)
+	}
+}
+
 func TestResolveUser_PreservesProvidedFieldsWhenUsernameEmpty(t *testing.T) {
 	// A caller may supply groups/uid/extra without a username (the CLI accepts a userInfo with
 	// only groups). Those fields must be kept; only the username is defaulted.


### PR DESCRIPTION

## Explanation

Follow-up to #16561 (which fixed `request.userInfo.username`). As @realshuting flagged on that PR ([r3577101715](https://github.com/kyverno/kyverno/pull/16561#discussion_r3577101715)), the same `omitempty` behavior applies to the other `UserInfo` fields.

During a background scan of a native `ValidatingAdmissionPolicy` / `MutatingAdmissionPolicy` there is no admission user, so the scanner passes an empty `UserInfo`. `authenticationv1.UserInfo` has `omitempty` on every field, so an empty `groups`/`uid` is dropped when the request is serialized into the map the CEL engine reads. A policy referencing `request.userInfo.groups` or `.uid` then fails with `no such key: groups` (etc). The common case is the standard "exclude kubelet requests" match (`"system:nodes" in request.userInfo.groups`).

This extends `ResolveUser` to also fill the sentinel identity into `uid` and `groups` when they're empty (`username` was already handled in #16561). Any provided value is preserved.

`extra` is intentionally left untouched: it's a map keyed by arbitrary strings, so a sentinel entry can't satisfy `request.userInfo.extra["<key>"]` (it still errors on the specific key) and would defeat a `has(request.userInfo.extra) && ...` guard by flipping `has()` to `true` and then erroring on the real key. Leaving it absent keeps those guards working.

 fixes #16590   (the `extra` decision above is the remaining part).

## Verification

- New tests in `pkg/admissionpolicy/user_info_background_test.go`:
  - A `ValidatingAdmissionPolicy` referencing `request.userInfo.groups` / `.uid` evaluates during a background scan without a `no such key` error.
  - `ResolveUser` defaults `groups`/`uid` when empty and the synthetic group is non-privileged.
  - Provided fields and real usernames are still preserved.
  - Reverting the fix makes the `groups`/`uid` cases fail with the original error.
- Full `pkg/admissionpolicy` suite passes with `-race`.
- CLI conformance passes:
  - VAP + MAP `check-user-info`
  - `admission_user_info` (+ deprecated)
  - `deny-modify-platform-label`
- `gofmt` and `go vet` clean.