### PR TITLE
fix(cel): set rule name from policy in vpol engine

### DIFF
--- a/pkg/cel/policies/vpol/engine/engine.go
+++ b/pkg/cel/policies/vpol/engine/engine.go
@@ -192,8 +192,7 @@ func (e *engineImpl) handlePolicy(ctx context.Context, policy Policy, jsonPayloa
 			)
 		}
 	} else {
-		// TODO: do we want to set a rule name?
-		ruleName := ""
+		ruleName := policy.Policy.GetName()
 		if result.Error != nil {
 			response.Rules = append(response.Rules, *engineapi.RuleError(ruleName, engineapi.Validation, "error", result.Error, withValidationIndex(nil, result.Index)))
 		} else if result.Result {

--- a/pkg/cel/policies/vpol/engine/engine_test.go
+++ b/pkg/cel/policies/vpol/engine/engine_test.go
@@ -108,3 +108,25 @@ func TestWithValidationIndex(t *testing.T) {
 			"user-defined cel.validationIndex must not be clobbered by the engine")
 	})
 }
+func TestHandle_RuleNameIsSetFromPolicy(t *testing.T) {
+	// rule name in the response must match the policy name, consistent with
+	// ivpol and gpol engines.
+	policy := buildJSONPolicy("my-policy", []admissionregistrationv1.Validation{
+		{Expression: "object.name == 'forbidden'", Message: "name not allowed"},
+	})
+
+	provider, err := NewProvider(compiler.NewCompiler(), []policiesv1beta1.ValidatingPolicyLike{policy}, nil)
+	require.NoError(t, err)
+
+	eng := NewEngine(provider, nil, nil)
+	payload := &unstructured.Unstructured{Object: map[string]any{"name": "allowed"}}
+
+	resp, err := eng.Handle(context.Background(), celengine.RequestFromJSON(nil, payload), nil)
+	require.NoError(t, err)
+	require.Len(t, resp.Policies, 1)
+	require.Len(t, resp.Policies[0].Rules, 1)
+
+	rule := resp.Policies[0].Rules[0]
+	assert.Equal(t, "my-policy", rule.Name(), "rule name must match the policy name")
+}
+

--- a/pkg/cel/policies/vpol/engine/engine_test.go
+++ b/pkg/cel/policies/vpol/engine/engine_test.go
@@ -109,24 +109,41 @@ func TestWithValidationIndex(t *testing.T) {
 	})
 }
 func TestHandle_RuleNameIsSetFromPolicy(t *testing.T) {
-	// rule name in the response must match the policy name, consistent with
-	// ivpol and gpol engines.
-	policy := buildJSONPolicy("my-policy", []admissionregistrationv1.Validation{
-		{Expression: "object.name == 'forbidden'", Message: "name not allowed"},
-	})
-
-	provider, err := NewProvider(compiler.NewCompiler(), []policiesv1beta1.ValidatingPolicyLike{policy}, nil)
-	require.NoError(t, err)
-
-	eng := NewEngine(provider, nil, nil)
-	payload := &unstructured.Unstructured{Object: map[string]any{"name": "allowed"}}
-
-	resp, err := eng.Handle(context.Background(), celengine.RequestFromJSON(nil, payload), nil)
-	require.NoError(t, err)
-	require.Len(t, resp.Policies, 1)
-	require.Len(t, resp.Policies[0].Rules, 1)
-
-	rule := resp.Policies[0].Rules[0]
-	assert.Equal(t, "my-policy", rule.Name(), "rule name must match the policy name")
+	tests := []struct {
+		name        string
+		expression  string
+		payloadName string
+		wantStatus  engineapi.RuleStatus
+	}{
+		{
+			name:        "rule name set on fail",
+			expression:  "object.name == 'forbidden'",
+			payloadName: "allowed",
+			wantStatus:  engineapi.RuleStatusFail,
+		},
+		{
+			name:        "rule name set on pass",
+			expression:  "object.name == 'allowed'",
+			payloadName: "allowed",
+			wantStatus:  engineapi.RuleStatusPass,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := buildJSONPolicy("my-policy", []admissionregistrationv1.Validation{
+				{Expression: tt.expression, Message: "test"},
+			})
+			provider, err := NewProvider(compiler.NewCompiler(), []policiesv1beta1.ValidatingPolicyLike{policy}, nil)
+			require.NoError(t, err)
+			eng := NewEngine(provider, nil, nil)
+			payload := &unstructured.Unstructured{Object: map[string]any{"name": tt.payloadName}}
+			resp, err := eng.Handle(context.Background(), celengine.RequestFromJSON(nil, payload), nil)
+			require.NoError(t, err)
+			require.Len(t, resp.Policies, 1)
+			require.Len(t, resp.Policies[0].Rules, 1)
+			rule := resp.Policies[0].Rules[0]
+			assert.Equal(t, tt.wantStatus, rule.Status())
+			assert.Equal(t, "my-policy", rule.Name(), "rule name must match the policy name")
+		})
+	}
 }
-


### PR DESCRIPTION
## Problem

The `vpol` engine emits rule responses with an empty rule name across all outcomes — pass, fail, and error:

```go
// TODO: do we want to set a rule name?
ruleName := ""
```

When a `ValidatingPolicy` fires, the rule name in the engine response is always `""`. Users inspecting policy reports or admission responses have no way to identify which policy produced the result.

## Root Cause

The other two CEL policy engines already handle this correctly:

**`ivpol/engine`**
```go
ruleName := ivpol.Policy.GetName()
```

**`gpol/engine`**
```go
engineapi.RuleError(policy.Policy.GetName(), ...)
```

`vpol` was the only engine leaving this unresolved — the TODO indicated the decision was deferred and never followed up on.

## Fix

```go
ruleName := policy.Policy.GetName()
```

Consistent with `ivpol` and `gpol`. Also removes the resolved TODO comment.

## Tests

Added `TestHandle_RuleNameIsSetFromPolicy` in `engine_test.go` to assert that the rule name in the response matches the policy name.