### PR TITLE
fix(cli): derive OCI apiVersion annotation from policy object

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/oci/internal/annotations.go
+++ b/cmd/cli/kubectl-kyverno/commands/oci/internal/annotations.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -10,6 +11,8 @@ const (
 	AnnotationKind        = "io.kyverno.image.kind"
 	AnnotationName        = "io.kyverno.image.name"
 	AnnotationApiVersion  = "io.kyverno.image.apiVersion"
+
+	defaultApiVersion = "kyverno.io/v1"
 )
 
 func Annotations(policy kyvernov1.PolicyInterface) map[string]string {
@@ -20,10 +23,15 @@ func Annotations(policy kyvernov1.PolicyInterface) map[string]string {
 	if policy.IsNamespaced() {
 		kind = "Policy"
 	}
+	apiVersion := defaultApiVersion
+	if obj, ok := policy.(runtime.Object); ok {
+		if gvk := obj.GetObjectKind().GroupVersionKind(); gvk.Version != "" {
+			apiVersion = gvk.GroupVersion().String()
+		}
+	}
 	return map[string]string{
-		AnnotationKind: kind,
-		AnnotationName: policy.GetName(),
-		// TODO: we need a way to get apiVersion
-		AnnotationApiVersion: "kyverno.io/v1",
+		AnnotationKind:       kind,
+		AnnotationName:       policy.GetName(),
+		AnnotationApiVersion: apiVersion,
 	}
 }

--- a/cmd/cli/kubectl-kyverno/commands/oci/internal/annotations_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/oci/internal/annotations_test.go
@@ -21,8 +21,8 @@ func TestAnnotations(t *testing.T) {
 		name: "cluster policy",
 		policy: &kyvernov1.ClusterPolicy{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "kyverno.io/v1",
-				APIVersion: "ClusterPolicy",
+				Kind:       "ClusterPolicy",
+				APIVersion: "kyverno.io/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
@@ -37,9 +37,37 @@ func TestAnnotations(t *testing.T) {
 		name: "policy",
 		policy: &kyvernov1.Policy{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "kyverno.io/v1",
-				APIVersion: "Policy",
+				Kind:       "Policy",
+				APIVersion: "kyverno.io/v1",
 			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+		},
+		want: map[string]string{
+			AnnotationKind:       "Policy",
+			AnnotationName:       "test",
+			AnnotationApiVersion: "kyverno.io/v1",
+		},
+	}, {
+		name: "cluster policy with non-default api version",
+		policy: &kyvernov1.ClusterPolicy{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ClusterPolicy",
+				APIVersion: "kyverno.io/v2beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+		},
+		want: map[string]string{
+			AnnotationKind:       "ClusterPolicy",
+			AnnotationName:       "test",
+			AnnotationApiVersion: "kyverno.io/v2beta1",
+		},
+	}, {
+		name: "policy with missing api version falls back to default",
+		policy: &kyvernov1.Policy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
 			},


### PR DESCRIPTION
## Explanation

When packaging a Kyverno policy into an OCI image, the CLI generates an `io.kyverno.image.apiVersion` annotation describing the policy. This annotation was always hardcoded to `kyverno.io/v1`, regardless of the actual `apiVersion` of the policy object being packaged (e.g. `kyverno.io/v2beta1`). This fix derives the annotation from the policy object's own API version instead of hardcoding it.

## Related issue

Closes #16569

## Milestone of this PR

## What type of PR is this

/kind bug

## Proposed Changes

`internal.Annotations()` now type-asserts the policy to `runtime.Object` and reads `GetObjectKind().GroupVersionKind()` to derive the `apiVersion` annotation, falling back to `kyverno.io/v1` only if the object's `TypeMeta` has no version set (e.g. constructed programmatically without it). Both `*kyvernov1.Policy` and `*kyvernov1.ClusterPolicy` — the only concrete types behind `kyvernov1.PolicyInterface` produced by the CLI's policy loader — implement `runtime.Object` and carry their original `apiVersion` in `TypeMeta` after being parsed from YAML (verified locally, see below).

### Proof Manifests

Policy YAML used to reproduce the bug:

```yaml
apiVersion: kyverno.io/v2beta1
kind: ClusterPolicy
metadata:
  name: test-policy
spec:
  rules:
  - name: check
    match:
      any:
      - resources:
          kinds:
          - Pod
    validate:
      message: "test"
      pattern:
        metadata:
          labels:
            app: "?*"
```

Loaded this policy through the CLI's actual loader (`policy.Load`) and called `internal.Annotations()` on the result:

**Before the fix:**
```
annotations: map[string]string{"io.kyverno.image.apiVersion":"kyverno.io/v1", "io.kyverno.image.kind":"ClusterPolicy", "io.kyverno.image.name":"test-policy"}
```

**After the fix:**
```
annotations: map[string]string{"io.kyverno.image.apiVersion":"kyverno.io/v2beta1", "io.kyverno.image.kind":"ClusterPolicy", "io.kyverno.image.name":"test-policy"}
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
- [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

Considered adding an `GetAPIVersion()`-style method directly to `PolicyInterface`, but that would touch every implementer of the interface across the codebase for a fix scoped to OCI annotation generation. Type-asserting to `runtime.Object` inside `Annotations()` keeps the change local to the one call site that needs it.
