### PR TITLE
fix: CustomNamespaceLister.List honors the label selector

### DIFF
--- a/pkg/admissionpolicy/api.go
+++ b/pkg/admissionpolicy/api.go
@@ -15,7 +15,11 @@ type CustomNamespaceLister struct {
 }
 
 func (c *CustomNamespaceLister) List(selector labels.Selector) (ret []*corev1.Namespace, err error) {
-	namespace, err := c.dClient.GetKubeClient().CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+	listOptions := metav1.ListOptions{}
+	if selector != nil && !selector.Empty() {
+		listOptions.LabelSelector = selector.String()
+	}
+	namespace, err := c.dClient.GetKubeClient().CoreV1().Namespaces().List(context.Background(), listOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/admissionpolicy/api_test.go
+++ b/pkg/admissionpolicy/api_test.go
@@ -101,6 +101,35 @@ func TestCustomNamespaceListerList(t *testing.T) {
 		assert.Len(t, list, 2)
 	})
 
+	t.Run("list namespaces filtered by selector", func(t *testing.T) {
+		k8sClient := fake.NewClientset(
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns1, Labels: map[string]string{"team": "a"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns2, Labels: map[string]string{"team": "b"}}},
+		)
+
+		mockDC := &mockDClient{kubeClient: k8sClient}
+		lister := NewCustomNamespaceLister(mockDC)
+
+		list, err := lister.List(labels.SelectorFromSet(map[string]string{"team": "a"}))
+		assert.NoError(t, err)
+		assert.Len(t, list, 1)
+		assert.Equal(t, ns1, list[0].Name)
+	})
+
+	t.Run("nil selector lists all namespaces", func(t *testing.T) {
+		k8sClient := fake.NewClientset(
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns1}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns2}},
+		)
+
+		mockDC := &mockDClient{kubeClient: k8sClient}
+		lister := NewCustomNamespaceLister(mockDC)
+
+		list, err := lister.List(nil)
+		assert.NoError(t, err)
+		assert.Len(t, list, 2)
+	})
+
 	t.Run("list namespaces failure", func(t *testing.T) {
 		k8sClient := fake.NewClientset()
 


### PR DESCRIPTION
## Explanation

`CustomNamespaceLister.List()` is used by Kyverno's admission-policy matcher (for ValidatingAdmissionPolicy bindings) to resolve `namespaceSelector` matches. The implementation ignored the `selector` argument entirely and always listed every namespace in the cluster, so any policy scoped to a subset of namespaces via a label selector was silently evaluated against all namespaces instead. This is a fix of existing behavior.

## Related issue

Closes #16545

## What type of PR is this

/kind bug

## Proposed Changes

- `pkg/admissionpolicy/api.go`: `List()` now populates `metav1.ListOptions.LabelSelector` from the given `labels.Selector` (skipping it when the selector is `nil` or `labels.Everything()`, preserving current unfiltered behavior for that case).
- `pkg/admissionpolicy/api_test.go`: added regression tests — a restrictive selector returns only the matching namespace, and a `nil` selector still returns all namespaces. Verified the new selector test fails against the pre-fix code and passes after the fix.

### Proof Manifests

This is an internal Go-level fix to a `client-go` `NamespaceLister` implementation with no user-facing manifest surface; verification is via the added unit tests in `pkg/admissionpolicy/api_test.go`.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the AI Usage Policy. AI assistance (Claude) was used to identify, implement, and verify this fix; disclosed here per policy.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

Verified locally with Go 1.26.5: `go test ./pkg/admissionpolicy/...`, `go vet ./pkg/admissionpolicy/...`, `go build ./pkg/admissionpolicy/...`, and `gofmt -l` all clean. Confirmed the new selector-filtering test fails on the pre-fix code (returns all namespaces) and passes after the fix.
