### PR TITLE
fix(perf-testing): eliminate data race on shared err variable in pod creation goroutines

### DIFF
--- a/docs/perf-testing/main.go
+++ b/docs/perf-testing/main.go
@@ -76,10 +76,9 @@ func main() {
 				wg.Add(1)
 				go func(num string, wg *sync.WaitGroup) {
 					pod := newPod(num)
-					_, err = client.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+					_, err := client.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 					if err != nil {
 						fmt.Println("failed to create the pod: ", err)
-						// os.Exit(1)
 					}
 					wg.Done()
 				}(num, &wg)


### PR DESCRIPTION
## Explanation

The pod creation goroutines in `docs/perf-testing/main.go` were writing to the outer `err` variable declared in `main()` via closure. Under Go's race detector this is a data race: multiple goroutines write to the same memory location without synchronisation, which can scramble or lose failure information.

The fix is a one-line change: use `:=` (short variable declaration) inside the goroutine so each goroutine gets its own local `err` variable. No shared state, no race.

The redundant `// os.Exit(1)` comment alongside the race-prone code is also removed as it no longer makes sense.

## Related issue

Closes #16549

## What type of PR is this

/kind cleanup

## Proposed Changes

- `docs/perf-testing/main.go`: change `_, err =` to `_, err :=` inside the pod creation goroutine