### PR TITLE
fix(ext/wildcard): fix typo and add t.Run() subtests in match_test.go

### DIFF
--- a/ext/wildcard/match_test.go
+++ b/ext/wildcard/match_test.go
@@ -1,6 +1,7 @@
 package wildcard
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -348,9 +349,12 @@ func TestMatch(t *testing.T) {
 			matched: false,
 		},
 	}
-	// Iterating over the test cases, call the function under test and asert the output.
-	for _, testCase := range testCases {
-		actualResult := Match(testCase.pattern, testCase.text)
-		assert.Equal(t, testCase.matched, actualResult)
+	// Iterating over the test cases, call the function under test and assert the output.
+	for i, testCase := range testCases {
+		tc := testCase
+		t.Run(fmt.Sprintf("case-%d", i+1), func(t *testing.T) {
+			actualResult := Match(tc.pattern, tc.text)
+			assert.Equal(t, tc.matched, actualResult)
+		})
 	}
 }


### PR DESCRIPTION
Closes #16624.

Two small improvements to `ext/wildcard/match_test.go` with no behaviour change:

### 1. Fix typo in comment
```diff
-// Iterating over the test cases, call the function under test and asert the output.
+// Iterating over the test cases, call the function under test and assert the output.
```

### 2. Add `t.Run()` subtests
Wraps each table-driven iteration in a named `t.Run("case-N", ...)` subtest so individual failures are clearly identified in test output (e.g. `--- FAIL: TestMatch/case-7`) without changing test logic.