### PR TITLE
fix(engine): honor per-rule failureAction in admission block decision

### DIFF
--- a/pkg/engine/api/engineresponse.go
+++ b/pkg/engine/api/engineresponse.go
@@ -212,6 +212,88 @@ func (er EngineResponse) getRulesWithErrors(predicate func(RuleResponse) bool) [
 	return rules
 }
 
+// matchesFailureActionOverride reports whether a validationFailureAction override applies
+// to the given resource namespace and namespace labels.
+func matchesFailureActionOverride(v kyvernov1.ValidationFailureActionOverride, namespaceLabels map[string]string, resourceNamespace string) bool {
+	if !v.Action.IsValid() {
+		return false
+	}
+	if v.Namespaces == nil {
+		// If both Namespaces and NamespaceSelector are nil, the override applies to all namespaces
+		if v.NamespaceSelector == nil {
+			return true
+		}
+		hasPass, err := utils.CheckSelector(v.NamespaceSelector, namespaceLabels)
+		return err == nil && hasPass
+	}
+	for _, ns := range v.Namespaces {
+		if wildcard.Match(ns, resourceNamespace) {
+			if v.NamespaceSelector == nil {
+				return true
+			}
+			hasPass, err := utils.CheckSelector(v.NamespaceSelector, namespaceLabels)
+			if err == nil && hasPass {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ResolveValidationFailureAction resolves the effective failureAction for a single
+// validate rule. It honors the rule's own failureActionOverrides and failureAction
+// first, then falls back to the deprecated policy-level overrides and
+// spec.validationFailureAction. Scoping the decision to a single rule ensures that a
+// policy mixing Audit and Enforce validate rules honors each rule's action
+// independently of its position in the policy (see issue #16557).
+func ResolveValidationFailureAction(validation *kyvernov1.Validation, spec *kyvernov1.Spec, namespaceLabels map[string]string, resourceNamespace string) kyvernov1.ValidationFailureAction {
+	if validation != nil {
+		for _, v := range validation.FailureActionOverrides {
+			if matchesFailureActionOverride(v, namespaceLabels, resourceNamespace) {
+				return v.Action
+			}
+		}
+		if validation.FailureAction != nil {
+			return *validation.FailureAction
+		}
+	}
+	for _, v := range spec.ValidationFailureActionOverrides {
+		if matchesFailureActionOverride(v, namespaceLabels, resourceNamespace) {
+			return v.Action
+		}
+	}
+	return spec.ValidationFailureAction
+}
+
+// EnforcesFailedRules reports whether any failed rule should block the admission request,
+// i.e. its effective failureAction resolves to Enforce. Validate rules stamped by the
+// engine carry their own per-rule action, so an Enforce rule blocks regardless of its
+// position relative to Audit rules in the same policy. Failed rules without a per-rule
+// action (mutate rules, image verification, or responses built outside the engine) fall
+// back to the policy-level action, preserving existing behavior (see issue #16557).
+func (er EngineResponse) EnforcesFailedRules() bool {
+	var policyAction *kyvernov1.ValidationFailureAction
+	for _, rule := range er.PolicyResponse.Rules {
+		if !rule.HasStatus(RuleStatusFail) {
+			continue
+		}
+		if action := rule.ValidationFailureAction(); action != nil {
+			if action.Enforce() {
+				return true
+			}
+			continue
+		}
+		if policyAction == nil {
+			a := er.GetValidationFailureAction()
+			policyAction = &a
+		}
+		if policyAction.Enforce() {
+			return true
+		}
+	}
+	return false
+}
+
 // If the policy is of type ValidatingAdmissionPolicy, an empty string is returned.
 func (er EngineResponse) GetValidationFailureAction() kyvernov1.ValidationFailureAction {
 	pol := er.Policy()
@@ -222,32 +304,10 @@ func (er EngineResponse) GetValidationFailureAction() kyvernov1.ValidationFailur
 	for _, r := range spec.Rules {
 		if r.HasValidate() {
 			for _, v := range r.Validation.FailureActionOverrides {
-				if !v.Action.IsValid() {
-					continue
-				}
-				if v.Namespaces == nil {
-					// If both Namespaces and NamespaceSelector are nil, the override applies to all namespaces
-					if v.NamespaceSelector == nil {
-						return v.Action
-					}
-					hasPass, err := utils.CheckSelector(v.NamespaceSelector, er.namespaceLabels)
-					if err == nil && hasPass {
-						return v.Action
-					}
-				}
-				for _, ns := range v.Namespaces {
-					if wildcard.Match(ns, er.PatchedResource.GetNamespace()) {
-						if v.NamespaceSelector == nil {
-							return v.Action
-						}
-						hasPass, err := utils.CheckSelector(v.NamespaceSelector, er.namespaceLabels)
-						if err == nil && hasPass {
-							return v.Action
-						}
-					}
+				if matchesFailureActionOverride(v, er.namespaceLabels, er.PatchedResource.GetNamespace()) {
+					return v.Action
 				}
 			}
-
 			if r.Validation.FailureAction != nil {
 				return *r.Validation.FailureAction
 			}
@@ -272,29 +332,8 @@ func (er EngineResponse) GetValidationFailureAction() kyvernov1.ValidationFailur
 		}
 	}
 	for _, v := range spec.ValidationFailureActionOverrides {
-		if !v.Action.IsValid() {
-			continue
-		}
-		if v.Namespaces == nil {
-			// If both Namespaces and NamespaceSelector are nil, the override applies to all namespaces
-			if v.NamespaceSelector == nil {
-				return v.Action
-			}
-			hasPass, err := utils.CheckSelector(v.NamespaceSelector, er.namespaceLabels)
-			if err == nil && hasPass {
-				return v.Action
-			}
-		}
-		for _, ns := range v.Namespaces {
-			if wildcard.Match(ns, er.PatchedResource.GetNamespace()) {
-				if v.NamespaceSelector == nil {
-					return v.Action
-				}
-				hasPass, err := utils.CheckSelector(v.NamespaceSelector, er.namespaceLabels)
-				if err == nil && hasPass {
-					return v.Action
-				}
-			}
+		if matchesFailureActionOverride(v, er.namespaceLabels, er.PatchedResource.GetNamespace()) {
+			return v.Action
 		}
 	}
 	return spec.ValidationFailureAction

--- a/pkg/engine/api/engineresponse_test.go
+++ b/pkg/engine/api/engineresponse_test.go
@@ -1480,3 +1480,128 @@ func TestGetValidationFailureAction_RuleLevelOverride(t *testing.T) {
 		t.Errorf("expected rule-level %v, got %v", ruleAudit, action)
 	}
 }
+
+func TestResolveValidationFailureAction(t *testing.T) {
+	audit := kyvernov1.Audit
+	enforce := kyvernov1.Enforce
+	spec := &kyvernov1.Spec{
+		ValidationFailureAction: enforce,
+		ValidationFailureActionOverrides: []kyvernov1.ValidationFailureActionOverride{{
+			Action:     audit,
+			Namespaces: []string{"audited-*"},
+		}},
+	}
+
+	tests := []struct {
+		name              string
+		validation        *kyvernov1.Validation
+		spec              *kyvernov1.Spec
+		namespaceLabels   map[string]string
+		resourceNamespace string
+		want              kyvernov1.ValidationFailureAction
+	}{{
+		name:       "rule-level action wins over spec-level",
+		validation: &kyvernov1.Validation{FailureAction: &audit},
+		spec:       spec,
+		want:       audit,
+	}, {
+		name:       "falls back to spec-level action when rule has none",
+		validation: &kyvernov1.Validation{},
+		spec:       spec,
+		want:       enforce,
+	}, {
+		name: "rule-level override matches namespace",
+		validation: &kyvernov1.Validation{
+			FailureAction: &enforce,
+			FailureActionOverrides: []kyvernov1.ValidationFailureActionOverride{{
+				Action:     audit,
+				Namespaces: []string{"team-*"},
+			}},
+		},
+		spec:              spec,
+		resourceNamespace: "team-a",
+		want:              audit,
+	}, {
+		name:              "spec-level override matches namespace when rule has none",
+		validation:        &kyvernov1.Validation{},
+		spec:              spec,
+		resourceNamespace: "audited-ns",
+		want:              audit,
+	}, {
+		name:       "nil validation falls back to spec-level action",
+		validation: nil,
+		spec:       spec,
+		want:       enforce,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveValidationFailureAction(tt.validation, tt.spec, tt.namespaceLabels, tt.resourceNamespace)
+			if got != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestEngineResponse_EnforcesFailedRules(t *testing.T) {
+	audit := kyvernov1.Audit
+	enforce := kyvernov1.Enforce
+	// policy with only the deprecated policy-level action, used to exercise the fallback
+	auditPolicy := NewKyvernoPolicy(&kyvernov1.ClusterPolicy{Spec: kyvernov1.Spec{ValidationFailureAction: audit}})
+	enforcePolicy := NewKyvernoPolicy(&kyvernov1.ClusterPolicy{Spec: kyvernov1.Spec{ValidationFailureAction: enforce}})
+
+	tests := []struct {
+		name   string
+		policy GenericPolicy
+		rules  []RuleResponse
+		want   bool
+	}{{
+		name: "failed Enforce rule after passing Audit rule blocks (issue #16557)",
+		rules: []RuleResponse{
+			*RulePass("require-team", Validation, "", nil).WithValidationFailureAction(audit),
+			*RuleFail("require-owner", Validation, "", nil).WithValidationFailureAction(enforce),
+		},
+		want: true,
+	}, {
+		name: "failed Audit rule after passing Enforce rule does not block (issue #16557)",
+		rules: []RuleResponse{
+			*RulePass("require-team", Validation, "", nil).WithValidationFailureAction(enforce),
+			*RuleFail("require-owner", Validation, "", nil).WithValidationFailureAction(audit),
+		},
+		want: false,
+	}, {
+		name: "both failing, one Enforce blocks",
+		rules: []RuleResponse{
+			*RuleFail("audit-rule", Validation, "", nil).WithValidationFailureAction(audit),
+			*RuleFail("enforce-rule", Validation, "", nil).WithValidationFailureAction(enforce),
+		},
+		want: true,
+	}, {
+		name:   "unstamped failed rule falls back to policy-level Enforce",
+		policy: enforcePolicy,
+		rules:  []RuleResponse{*RuleFail("legacy-rule", Validation, "", nil)},
+		want:   true,
+	}, {
+		name:   "unstamped failed rule falls back to policy-level Audit",
+		policy: auditPolicy,
+		rules:  []RuleResponse{*RuleFail("legacy-rule", Validation, "", nil)},
+		want:   false,
+	}, {
+		name:  "no failed rules never blocks",
+		rules: []RuleResponse{*RulePass("ok", Validation, "", nil).WithValidationFailureAction(enforce)},
+		want:  false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			er := EngineResponse{PolicyResponse: PolicyResponse{Rules: tt.rules}}
+			if tt.policy != nil {
+				er = er.WithPolicy(tt.policy)
+			}
+			if got := er.EnforcesFailedRules(); got != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/engine/api/ruleresponse.go
+++ b/pkg/engine/api/ruleresponse.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	pssutils "github.com/kyverno/kyverno/pkg/pss/utils"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -66,6 +67,12 @@ type RuleResponse struct {
 	skipReason SkipReason
 	// properties are the additional properties from the rule that will be added to the policy report result
 	properties map[string]string
+	// validationFailureAction is the effective failureAction resolved for this rule.
+	// It is populated by the engine for validate rules so that the admission block
+	// decision honors each rule's own action instead of a single policy-wide action.
+	// A nil value means no per-rule action was resolved and the policy-level action
+	// should be used as a fallback.
+	validationFailureAction *kyvernov1.ValidationFailureAction
 }
 
 func NewRuleResponse(name string, ruleType RuleType, msg string, status RuleStatus, properties map[string]string) *RuleResponse {
@@ -153,6 +160,13 @@ func (r RuleResponse) WithProperties(m map[string]string) *RuleResponse {
 	return &r
 }
 
+// WithValidationFailureAction records the effective failureAction resolved for this
+// rule so that the admission block decision can honor each rule's action independently.
+func (r RuleResponse) WithValidationFailureAction(action kyvernov1.ValidationFailureAction) *RuleResponse {
+	r.validationFailureAction = &action
+	return &r
+}
+
 func (r *RuleResponse) Stats() ExecutionStats {
 	return r.stats
 }
@@ -207,6 +221,12 @@ func (r *RuleResponse) EmitWarning() bool {
 
 func (r *RuleResponse) Properties() map[string]string {
 	return r.properties
+}
+
+// ValidationFailureAction returns the effective failureAction resolved for this rule,
+// or nil if the engine did not resolve a per-rule action (e.g. non-validate rules).
+func (r *RuleResponse) ValidationFailureAction() *kyvernov1.ValidationFailureAction {
+	return r.validationFailureAction
 }
 
 // HasStatus checks if rule status is in a given list

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -79,6 +79,15 @@ func (e *engine) validate(
 			engineapi.Validation,
 		)
 		matchedResource = resource
+		// Stamp each validate rule response with its effective failureAction so the
+		// admission block decision honors each rule's action independently instead of
+		// collapsing the whole policy to a single action (issue #16557).
+		if rule.HasValidate() {
+			action := engineapi.ResolveValidationFailureAction(rule.Validation, policy.GetSpec(), policyContext.NamespaceLabels(), matchedResource.GetNamespace())
+			for i := range ruleResp {
+				ruleResp[i] = *ruleResp[i].WithValidationFailureAction(action)
+			}
+		}
 		resp.Add(engineapi.NewExecutionStats(startTime, time.Now()), ruleResp...)
 		if applyRules == kyvernov1.ApplyOne && resp.RulesAppliedCount() > 0 {
 			break

--- a/pkg/engine/validation_test.go
+++ b/pkg/engine/validation_test.go
@@ -16,6 +16,7 @@ import (
 	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
 	"github.com/kyverno/kyverno/pkg/registryclient"
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
+	engineutils "github.com/kyverno/kyverno/pkg/utils/engine"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"gotest.tools/assert"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -333,6 +334,99 @@ func TestValidate_Fail_anyPattern(t *testing.T) {
 	msgs := []string{"validation error: A namespace is required. rule check-default-namespace[0] failed at path /metadata/namespace/ rule check-default-namespace[1] failed at path /metadata/namespace/"}
 	for index, r := range er.PolicyResponse.Rules {
 		assert.Equal(t, r.Message(), msgs[index])
+	}
+}
+
+// TestValidate_MixedFailureAction_HonorsPerRuleAction reproduces issue #16557: a single
+// policy that mixes Audit and Enforce validate rules must honor each rule's failureAction
+// independently, so the admission block decision no longer depends on rule order.
+func TestValidate_MixedFailureAction_HonorsPerRuleAction(t *testing.T) {
+	// buildPolicy returns a two-rule Pod policy where the team-label rule and owner-label
+	// rule carry the given failure actions, declared in the given order.
+	buildPolicy := func(firstName, firstAction, secondName, secondAction string) []byte {
+		return []byte(`
+		{
+			"apiVersion": "kyverno.io/v1",
+			"kind": "ClusterPolicy",
+			"metadata": { "name": "team-and-owner" },
+			"spec": {
+			   "rules": [
+				  {
+					 "name": "` + firstName + `",
+					 "match": { "any": [ { "resources": { "kinds": [ "Pod" ] } } ] },
+					 "validate": {
+						"failureAction": "` + firstAction + `",
+						"message": "` + firstName + ` failed",
+						"pattern": { "metadata": { "labels": { "` + firstName + `": "?*" } } }
+					 }
+				  },
+				  {
+					 "name": "` + secondName + `",
+					 "match": { "any": [ { "resources": { "kinds": [ "Pod" ] } } ] },
+					 "validate": {
+						"failureAction": "` + secondAction + `",
+						"message": "` + secondName + ` failed",
+						"pattern": { "metadata": { "labels": { "` + secondName + `": "?*" } } }
+					 }
+				  }
+			   ]
+			}
+		 }`)
+	}
+
+	// Pod carries the "team" label but not "owner", so it passes the team rule and fails
+	// the owner rule regardless of the order the rules are declared in.
+	rawResource := []byte(`
+	{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": { "name": "app", "labels": { "team": "payments" } },
+		"spec": { "containers": [ { "name": "app", "image": "nginx" } ] }
+	}`)
+	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
+	assert.NilError(t, err)
+
+	tests := []struct {
+		name       string
+		rawPolicy  []byte
+		wantBlock  bool
+		wantFailed bool
+	}{{
+		// Audit rule first, failing Enforce rule second: the Enforce rule must block even
+		// though it is not the first validate rule. Before the fix the whole policy
+		// resolved to Audit (the first rule) and the request was wrongly admitted.
+		name:       "audit rule first, failing enforce rule blocks",
+		rawPolicy:  buildPolicy("team", "Audit", "owner", "Enforce"),
+		wantBlock:  true,
+		wantFailed: true,
+	}, {
+		// Enforce rule first (passes), failing Audit rule second: only an Audit rule fails,
+		// so the request must be admitted. Before the fix the policy resolved to Enforce
+		// (the first rule) and the Audit-only failure wrongly blocked the request.
+		name:       "enforce rule first, failing audit rule does not block",
+		rawPolicy:  buildPolicy("team", "Enforce", "owner", "Audit"),
+		wantBlock:  false,
+		wantFailed: true,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var policy kyvernov1.ClusterPolicy
+			err := json.Unmarshal(tt.rawPolicy, &policy)
+			assert.NilError(t, err)
+
+			er := testValidate(
+				context.TODO(),
+				registryclient.NewOrDie(),
+				newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy),
+				cfg,
+				nil,
+			)
+
+			assert.Equal(t, er.IsFailed(), tt.wantFailed)
+			blocked := engineutils.BlockRequest(er, kyvernov1.Fail)
+			assert.Equal(t, blocked, tt.wantBlock)
+		})
 	}
 }
 

--- a/pkg/utils/engine/response.go
+++ b/pkg/utils/engine/response.go
@@ -16,9 +16,7 @@ func IsResponseSuccessful(engineReponses []engineapi.EngineResponse) bool {
 }
 
 // BlockRequest returns true when:
-// 1. a policy fails (i.e. creates a violation) and the failing rule's failureAction is set to 'Enforce'
-// 2. a policy has a processing error and failurePolicy is set to 'Fail`
-//
+// 2. a policy has a processing error and failurePolicy is set to 'Fail'
 // The failure action is evaluated per failing rule so that an Enforce rule blocks the
 // request even when the same policy also contains Audit rules, regardless of rule order
 // (issue #16557).

--- a/pkg/utils/engine/response.go
+++ b/pkg/utils/engine/response.go
@@ -16,10 +16,14 @@ func IsResponseSuccessful(engineReponses []engineapi.EngineResponse) bool {
 }
 
 // BlockRequest returns true when:
-// 1. a policy fails (i.e. creates a violation) and validationFailureAction is set to 'enforce'
+// 1. a policy fails (i.e. creates a violation) and the failing rule's failureAction is set to 'Enforce'
 // 2. a policy has a processing error and failurePolicy is set to 'Fail`
+//
+// The failure action is evaluated per failing rule so that an Enforce rule blocks the
+// request even when the same policy also contains Audit rules, regardless of rule order
+// (issue #16557).
 func BlockRequest(er engineapi.EngineResponse, failurePolicy kyvernov1.FailurePolicyType) bool {
-	if er.IsFailed() && er.GetValidationFailureAction().Enforce() {
+	if er.IsFailed() && er.EnforcesFailedRules() {
 		return true
 	}
 	if er.IsError() && failurePolicy == kyvernov1.Fail {


### PR DESCRIPTION
## Explanation

A `ClusterPolicy`/`Policy` that mixes validate rules with different `failureAction` values (some `Audit`, some `Enforce`) resolved to a single policy-wide action for the admission block decision, taken from the first validate rule in the policy. This means whether a failing `Enforce` rule actually blocked the request depended on where it was declared relative to other rules — an `Enforce` rule listed after an `Audit` rule was silently downgraded to `Audit` (a security-relevant enforcement bypass), and an `Audit`-only failure under an `Enforce`-first policy wrongly blocked the request. This is a fix of existing behavior.

## Related issue

Closes #16557

## What type of PR is this

/kind bug

## Proposed Changes

- `pkg/engine/api/ruleresponse.go`: `RuleResponse` now carries an optional `validationFailureAction`, set via `WithValidationFailureAction`/read via `ValidationFailureAction()`. A `nil` value means no per-rule action was resolved (non-validate rules), signaling callers to fall back to the policy-level action.
- `pkg/engine/api/engineresponse.go`:
  - Added `ResolveValidationFailureAction(validation, spec, namespaceLabels, resourceNamespace)`, which resolves the effective action for a single rule (rule override → rule action → policy override → policy action).
  - Added `EnforcesFailedRules()`, which returns true iff any *failed* rule's resolved action is `Enforce`, using the per-rule stamp when present and falling back to the existing policy-level `GetValidationFailureAction()` otherwise.
  - Extracted the duplicated override-namespace-matching logic (repeated 2x in the original `GetValidationFailureAction`) into a shared `matchesFailureActionOverride` helper — behavior-preserving refactor, covered by the existing `GetValidationFailureAction` test suite.
- `pkg/engine/validation.go`: the engine's `validate()` loop now stamps each validate rule's response with its resolved action right where the concrete (autogen-expanded) rule is known. This matters because autogen rule names are prefixed and truncated to 63 chars, so reverse-mapping a `RuleResponse` back to its spec rule by name elsewhere would be unreliable.
- `pkg/utils/engine/response.go`: `BlockRequest` now calls `EnforcesFailedRules()` instead of `GetValidationFailureAction().Enforce()`.

Responses without a per-rule stamp (mutate rules, image verification, VAP, or responses built outside the engine) fall back to the existing policy-level action, so no other code path changes behavior.

### Proof Manifests

```yaml
# ClusterPolicy with a passing Audit rule and a failing Enforce rule declared second.
# Before the fix: the whole policy resolved to the first rule's action (Audit), so the
# Pod below was wrongly admitted. After the fix: the Enforce rule blocks it regardless
# of rule order.
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: team-and-owner
spec:
  rules:
    - name: require-team-label
      match:
        any:
          - resources:
              kinds:
                - Pod
      validate:
        failureAction: Audit
        message: "team label is required"
        pattern:
          metadata:
            labels:
              team: "?*"
    - name: require-owner-label
      match:
        any:
          - resources:
              kinds:
                - Pod
      validate:
        failureAction: Enforce
        message: "owner label is required"
        pattern:
          metadata:
            labels:
              owner: "?*"
---
apiVersion: v1
kind: Pod
metadata:
  name: app
  labels:
    team: payments
spec:
  containers:
    - name: app
      image: nginx
```

This exact scenario (both rule orderings) is covered end-to-end by `TestValidate_MixedFailureAction_HonorsPerRuleAction` in `pkg/engine/validation_test.go`, which runs the real engine and asserts the `BlockRequest` decision.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the AI Usage Policy. AI assistance (Claude) was used to identify, implement, and verify this fix; disclosed here and in the commit trailers per policy.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

Verified locally with Go 1.26.5:
- `go build ./...` and `go vet ./pkg/engine/... ./pkg/utils/engine/...` clean; `gofmt -l` clean on all changed files.
- New tests: `TestResolveValidationFailureAction`, `TestEngineResponse_EnforcesFailedRules` (`pkg/engine/api/engineresponse_test.go`), and the end-to-end `TestValidate_MixedFailureAction_HonorsPerRuleAction` (`pkg/engine/validation_test.go`).
- Regression proof: temporarily reverted `BlockRequest` to the old `GetValidationFailureAction().Enforce()` logic and confirmed the new end-to-end test fails on both symptoms described in the issue; restored the fix and confirmed it passes.
- Full existing suites unaffected: `pkg/engine` (full), `pkg/engine/api`, `pkg/utils/engine`, `pkg/webhooks/resource/...`, `pkg/webhooks/utils`, and the CLI `processor`/`report` packages (which also call `GetValidationFailureAction`) all pass unchanged.
