### PR TITLE
test(ivpol/engine): add tests for MatchNames predicate

### DIFF
--- a/pkg/cel/policies/ivpol/engine/predicate_test.go
+++ b/pkg/cel/policies/ivpol/engine/predicate_test.go
@@ -1,0 +1,66 @@
+package engine
+
+import (
+	"testing"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func makeImagePolicy(name string) *policiesv1beta1.ImageValidatingPolicy {
+	return &policiesv1beta1.ImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}
+
+func TestMatchNames(t *testing.T) {
+	tests := []struct {
+		name       string
+		names      []string
+		policyName string
+		want       bool
+	}{{
+		name:       "nil names matches everything",
+		names:      nil,
+		policyName: "any-policy",
+		want:       true,
+	}, {
+		name:       "empty names matches everything",
+		names:      []string{},
+		policyName: "any-policy",
+		want:       true,
+	}, {
+		name:       "single name matches",
+		names:      []string{"my-policy"},
+		policyName: "my-policy",
+		want:       true,
+	}, {
+		name:       "single name does not match",
+		names:      []string{"my-policy"},
+		policyName: "other-policy",
+		want:       false,
+	}, {
+		name:       "multiple names matches first",
+		names:      []string{"policy-a", "policy-b"},
+		policyName: "policy-a",
+		want:       true,
+	}, {
+		name:       "multiple names matches second",
+		names:      []string{"policy-a", "policy-b"},
+		policyName: "policy-b",
+		want:       true,
+	}, {
+		name:       "multiple names no match",
+		names:      []string{"policy-a", "policy-b"},
+		policyName: "policy-c",
+		want:       false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pred := MatchNames(tt.names...)
+			got := pred(makeImagePolicy(tt.policyName))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## What type of PR is this?
/kind test

## What this PR does / why we need it

`pkg/cel/policies/ivpol/engine/predicate.go` had no test file. This PR adds `predicate_test.go` testing `MatchNames` for `ImageValidatingPolicyLike` policies:

- nil names → matches everything
- empty names → matches everything
- single name: match and no-match
- multiple names: match first, match second, no match

## Which issue(s) this PR fixes

Part of ongoing test coverage improvements for the `pkg/cel` package.

## Pre-submission checklist

- [x] The code has been tested locally
- [x] All tests pass