### PR TITLE
test(cmd/internal): add tests for CheckCacheSync

### DIFF
--- a/cmd/internal/informer_test.go
+++ b/cmd/internal/informer_test.go
@@ -1,0 +1,60 @@
+package internal
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckCacheSync(t *testing.T) {
+	logger := logr.Discard()
+
+	tests := []struct {
+		name   string
+		status map[reflect.Type]bool
+		want   bool
+	}{{
+		name:   "nil map",
+		status: nil,
+		want:   true,
+	}, {
+		name:   "empty map",
+		status: map[reflect.Type]bool{},
+		want:   true,
+	}, {
+		name: "all synced",
+		status: map[reflect.Type]bool{
+			reflect.TypeOf(0):   true,
+			reflect.TypeOf(""):  true,
+		},
+		want: true,
+	}, {
+		name: "one not synced",
+		status: map[reflect.Type]bool{
+			reflect.TypeOf(0): false,
+		},
+		want: false,
+	}, {
+		name: "mixed synced and not synced",
+		status: map[reflect.Type]bool{
+			reflect.TypeOf(0):   true,
+			reflect.TypeOf(""):  false,
+		},
+		want: false,
+	}, {
+		name: "all not synced",
+		status: map[reflect.Type]bool{
+			reflect.TypeOf(0):   false,
+			reflect.TypeOf(""):  false,
+		},
+		want: false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CheckCacheSync(logger, tt.status)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## What type of PR is this?
/kind test

## What this PR does / why we need it

`cmd/internal/informer.go` had no test coverage. This PR adds `informer_test.go` testing the `CheckCacheSync` generic helper:

- nil map → true (nothing failed)
- empty map → true
- all types synced → true
- one type not synced → false
- mixed synced/not-synced → false
- all types not synced → false

## Which issue(s) this PR fixes

Part of ongoing test coverage improvements for the `cmd/internal` package.

## Pre-submission checklist

- [x] The code has been tested locally
- [x] All tests pass