### PR TITLE
bench(ext/wildcard): add benchmarks for wildcard matching hot paths

### DIFF
--- a/ext/wildcard/bench_test.go
+++ b/ext/wildcard/bench_test.go
@@ -1,0 +1,91 @@
+package wildcard
+
+import "testing"
+
+var benchPatterns = []string{
+	"kyverno-*",
+	"default",
+	"kube-*",
+	"prod-*-ns",
+	"*",
+}
+
+var benchNames = []string{
+	"kyverno-admission",
+	"default",
+	"kube-system",
+	"prod-east-ns",
+	"other-namespace",
+}
+
+func BenchmarkMatch_Exact(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Match("my-namespace", "my-namespace")
+	}
+}
+
+func BenchmarkMatch_WildcardSuffix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Match("kyverno-*", "kyverno-admission")
+	}
+}
+
+func BenchmarkMatch_WildcardPrefix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Match("*-system", "kube-system")
+	}
+}
+
+func BenchmarkMatch_WildcardBoth(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Match("*-admission-*", "kyverno-admission-controller")
+	}
+}
+
+func BenchmarkMatch_NoMatch(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Match("prod-*", "staging-namespace")
+	}
+}
+
+func BenchmarkMatchPatterns_OnePattern(b *testing.B) {
+	patterns := []string{"kyverno-*"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		MatchPatterns(patterns, benchNames...)
+	}
+}
+
+func BenchmarkMatchPatterns_ManyPatterns(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		MatchPatterns(benchPatterns, benchNames...)
+	}
+}
+
+func BenchmarkCheckPatterns(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CheckPatterns(benchPatterns, benchNames...)
+	}
+}
+
+func BenchmarkContainsWildcard_WithWildcard(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ContainsWildcard("kyverno-*")
+	}
+}
+
+func BenchmarkContainsWildcard_WithoutWildcard(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ContainsWildcard("kyverno-admission")
+	}
+}
+
+func BenchmarkSeperateWildcards(b *testing.B) {
+	input := []string{"kyverno-*", "default", "kube-*", "prod-ns", "staging-*"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		SeperateWildcards(input)
+	}
+}


### PR DESCRIPTION
## What type of PR is this?
/kind test

## What this PR does / why we need it

Adds `go test -bench` coverage for the `ext/wildcard` package, which provides the pattern-matching utilities called on every policy evaluation. This is part of closing the gap described in #16563 — the repository currently has no internal benchmark functions.

**Benchmarks added in `ext/wildcard/bench_test.go`:**

| Benchmark | What it measures |
|---|---|
| `BenchmarkMatch_Exact` | Match with no wildcards (fast path) |
| `BenchmarkMatch_WildcardSuffix` | `kyverno-*` against a matching string |
| `BenchmarkMatch_WildcardPrefix` | `*-system` against a matching string |
| `BenchmarkMatch_WildcardBoth` | `*-admission-*` mid-string pattern |
| `BenchmarkMatch_NoMatch` | Pattern that does not match (short-circuit) |
| `BenchmarkMatchPatterns_OnePattern` | Single pattern against multiple names |
| `BenchmarkMatchPatterns_ManyPatterns` | Five patterns against five names |
| `BenchmarkCheckPatterns` | Boolean-only variant of MatchPatterns |
| `BenchmarkContainsWildcard_WithWildcard` | Wildcard detection (positive case) |
| `BenchmarkContainsWildcard_WithoutWildcard` | Wildcard detection (negative case) |
| `BenchmarkSeperateWildcards` | Partition a mixed list of patterns |

**Sample results (Apple M2):**
```
BenchmarkMatch_Exact-8                   28739161    41.95 ns/op
BenchmarkMatch_WildcardSuffix-8          15577629    76.77 ns/op
BenchmarkMatch_WildcardBoth-8             7790601   135.0  ns/op
BenchmarkMatchPatterns_ManyPatterns-8    15197703    79.14 ns/op
BenchmarkContainsWildcard_WithWildcard-8 359961888    3.33 ns/op
```

## Which issue(s) this PR fixes

Fixes #16563

## Pre-submission checklist

- [x] The code has been tested locally
- [x] All benchmarks pass (`go test ./ext/wildcard/ -bench=. -benchtime=1s`)