### PR TITLE
bench(ext/yaml): add benchmarks for YAML document splitting

### DIFF
--- a/ext/yaml/bench_test.go
+++ b/ext/yaml/bench_test.go
@@ -1,0 +1,81 @@
+package yaml
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var singleDocYAML = []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+  namespace: default
+data:
+  key: value
+`)
+
+var multiDocYAML = []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: first
+  namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: second
+  namespace: default
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-namespace
+`)
+
+func largeMultiDocYAML(n int) []byte {
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteString("---\n")
+		}
+		fmt.Fprintf(&sb, "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm-%d\n  namespace: default\n", i)
+	}
+	return []byte(sb.String())
+}
+
+func BenchmarkSplitDocuments_Single(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = SplitDocuments(singleDocYAML)
+	}
+}
+
+func BenchmarkSplitDocuments_Three(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = SplitDocuments(multiDocYAML)
+	}
+}
+
+func BenchmarkSplitDocuments_Hundred(b *testing.B) {
+	data := largeMultiDocYAML(100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = SplitDocuments(data)
+	}
+}
+
+func BenchmarkIsEmptyDocument_Empty(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		IsEmptyDocument([]byte("# just a comment\n"))
+	}
+}
+
+func BenchmarkIsEmptyDocument_NotEmpty(b *testing.B) {
+	doc := []byte("apiVersion: v1\nkind: ConfigMap\n")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		IsEmptyDocument(doc)
+	}
+}


### PR DESCRIPTION
## What type of PR is this?
/kind test

## What this PR does / why we need it

Adds `go test -bench` coverage for the `ext/yaml` package, continuing the work started in #16563 (no internal benchmarks existed in the repo). The YAML splitter is called on every policy load.

**Benchmarks:**
- `BenchmarkSplitDocuments_Single` — single-document YAML
- `BenchmarkSplitDocuments_Three` — three-document YAML with `---` separators
- `BenchmarkSplitDocuments_Hundred` — 100-document bulk parse
- `BenchmarkIsEmptyDocument_Empty` — comment-only document (returns true)
- `BenchmarkIsEmptyDocument_NotEmpty` — real YAML document (returns false)

**Sample results (Apple M2):**
```
BenchmarkSplitDocuments_Single-8      595365    1012 ns/op
BenchmarkSplitDocuments_Three-8       350528    1555 ns/op
BenchmarkSplitDocuments_Hundred-8      15022   38419 ns/op
BenchmarkIsEmptyDocument_Empty-8    12782422      46 ns/op
```

## Which issue(s) this PR fixes

Part of #16563

## Pre-submission checklist

- [x] The code has been tested locally
- [x] All benchmarks pass