### PR TITLE
ci: migrate pr-branch-updater to GitHub App auth

### DIFF
--- a/.github/workflows/pr-branch-updater.yml
+++ b/.github/workflows/pr-branch-updater.yml
@@ -16,8 +16,11 @@ concurrency:
 
 jobs:
   update:
-    uses: kyverno/.github/.github/workflows/pr-branch-updater.yml@995416156c093fc5d1d6d905fd619d5bb40081dd
+    uses: kyverno/.github/.github/workflows/pr-branch-updater.yml@36a967326e724e5e5fe6c93d7f45d6c1a3436301
     secrets:
-      # Use the bot token so update-branch can also handle PRs that touch
-      # workflow files (requires workflow write permission).
-      GH_TOKEN: ${{ secrets.PR_UPDATE_TOKEN }}
+      # Use a GitHub App installation token (instead of a PAT) so
+      # update-branch can also handle PRs that touch workflow files, even
+      # when the PR's fork branch is stale relative to workflows on main
+      # (requires workflow write permission).
+      APP_CLIENT_ID: ${{ secrets.PR_UPDATER_APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.PR_UPDATER_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

The `PR Branch Auto-Updater` workflow (`.github/workflows/pr-branch-updater.yml`) calls the reusable `kyverno/.github/.github/workflows/pr-branch-updater.yml` workflow, pinned to an old commit that authenticates with a classic PAT (`PR_UPDATE_TOKEN`).

This causes intermittent `403` failures:
```
refusing to allow a Personal Access Token to create or update workflow `.github/workflows/<file>.yaml` without `workflow` scope
```
This happens whenever `gh pr update-branch` needs to merge `main` into a contributor's fork branch and that fork's copy of a workflow file is stale relative to `main` -- even though the PR's own "Files changed" diff never shows the workflow file, since it is introduced by the merge itself. PAT scope alone does not reliably solve this across all forks.

## Fix

The reusable workflow in `kyverno/.github` has since been rewritten to mint a GitHub App installation token (via `actions/create-github-app-token`) with explicit `permission-workflows: write`, instead of relying on a PAT's OAuth scopes.

This PR:
- Bumps the pinned commit SHA for `kyverno/.github/.github/workflows/pr-branch-updater.yml` to `36a967326e724e5e5fe6c93d7f45d6c1a3436301` (current `main`).
- Switches the `secrets:` block from `GH_TOKEN: secrets.PR_UPDATE_TOKEN` to `APP_CLIENT_ID` / `APP_PRIVATE_KEY`.

## Follow-up required (repo admin action, outside this PR)

Before this workflow will succeed, a GitHub App needs to be created/installed on `kyverno/kyverno` with `contents:write`, `pull-requests:write`, and `workflows:write` permissions, and its credentials stored as:
- `PR_UPDATER_APP_CLIENT_ID`
- `PR_UPDATER_APP_PRIVATE_KEY`

The old `PR_UPDATE_TOKEN` secret can be removed once this is confirmed working.
