### PR TITLE
feat: enforce mTLS client verification for inbound API server requests

### DIFF
--- a/charts/kyverno/templates/admission-controller/deployment.yaml
+++ b/charts/kyverno/templates/admission-controller/deployment.yaml
@@ -176,6 +176,9 @@ spec:
             - --tracingCreds={{ . }}
             {{- end }}
             {{- end }}
+            {{- if .Values.admissionController.verifyApiServerCert }}
+            - --verifyApiServerCert=true
+            {{- end }}
             - --disableMetrics={{ .Values.admissionController.metering.disabled }}
             {{- if not .Values.admissionController.metering.disabled }}
             - --otelConfig={{ .Values.admissionController.metering.config }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -929,6 +929,12 @@ features:
 
 # Admission controller configuration
 admissionController:
+  # -- Enable mutual TLS (mTLS) client certificate verification for inbound webhook requests.
+  # When enabled, Kyverno will require a client cert signed by the Kubernetes cluster root CA mounted at
+  # /var/run/secrets/kubernetes.io/serviceaccount/ca.crt (kube-root-ca.crt in the namespace).
+  # Note: Kubernetes HTTP(S) liveness/readiness probes do not present a client cert; consider switching probes to tcpSocket/exec when enabling this.
+  verifyApiServerCert: false
+
   autoscaling:
     # -- Enable horizontal pod autoscaling
     enabled: false

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -382,6 +382,7 @@ func main() {
 		maxAdmissionReports             int
 		controllerRuntimeMetricsAddress string
 		tlsKeyAlgorithm                 string
+		verifyApiServerCert             bool
 	)
 	flagset := flag.NewFlagSet("kyverno", flag.ExitOnError)
 	flagset.BoolVar(&dumpPayload, "dumpPayload", false, "Set this flag to activate/deactivate debug mode.")
@@ -415,6 +416,7 @@ func main() {
 	flagset.IntVar(&maxAdmissionReports, "maxAdmissionReports", 10000, "Maximum number of admission reports before we stop creating new ones")
 	flagset.StringVar(&controllerRuntimeMetricsAddress, "controllerRuntimeMetricsAddress", "", `Bind address for controller-runtime metrics server. It will be defaulted to ":8080" if unspecified. Set this to "0" to disable the metrics server.`)
 	flagset.StringVar(&tlsKeyAlgorithm, "tlsKeyAlgorithm", "RSA", "Key algorithm for self-signed TLS certificates (RSA, ECDSA, Ed25519)")
+	flagset.BoolVar(&verifyApiServerCert, "verifyApiServerCert", false, "Require and verify client certificates on inbound webhook requests using the Kubernetes CA bundle at /var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 	// config
 	appConfig := internal.NewConfiguration(
 		internal.WithProfiling(),
@@ -937,6 +939,7 @@ func main() {
 			setup.KyvernoDynamicClient.Discovery(),
 			webhookServerHost,
 			int32(webhookServerPort), //nolint:gosec
+			verifyApiServerCert,
 		)
 		// start informers and wait for cache sync
 		// we need to call start again because we potentially registered new informers

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -3,8 +3,10 @@ package webhooks
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -62,6 +64,7 @@ func NewServer(
 	discovery dclient.IDiscovery,
 	webhookServerHost string,
 	webhookServerPort int32,
+	verifyApiServerCert bool,
 ) Server {
 	mux := httprouter.New()
 	resourceLogger := logger.WithName("resource")
@@ -300,32 +303,53 @@ func NewServer(
 	)
 	mux.HandlerFunc("GET", config.LivenessServicePath, handlers.Probe(runtime.IsLive))
 	mux.HandlerFunc("GET", config.ReadinessServicePath, handlers.Probe(runtime.IsReady))
+
+	tlsConfig := &tls.Config{
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			certPem, keyPem, err := tlsProvider()
+			if err != nil {
+				return nil, err
+			}
+			pair, err := tls.X509KeyPair(certPem, keyPem)
+			if err != nil {
+				return nil, err
+			}
+			return &pair, nil
+		},
+		MinVersion: tls.VersionTLS12,
+		CipherSuites: []uint16{
+			// AEADs w/ ECDHE
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		},
+	}
+
+	if verifyApiServerCert {
+		caCertPEM, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+		if err != nil {
+			logger.Error(err, "failed to read Kubernetes CA certificate for webhook authentication")
+			panic(fmt.Errorf("failed to read Kubernetes CA certificate: %w", err))
+		}
+
+		clientCAs := x509.NewCertPool()
+		if ok := clientCAs.AppendCertsFromPEM(caCertPEM); !ok {
+			parseErr := fmt.Errorf("no certificates found in Kubernetes CA certificate PEM (/var/run/secrets/kubernetes.io/serviceaccount/ca.crt)")
+			logger.Error(parseErr, "failed to parse Kubernetes CA certificate")
+			panic(parseErr)
+		}
+
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+		tlsConfig.ClientCAs = clientCAs
+	}
+
 	return &server{
 		server: &http.Server{
-			Addr: fmt.Sprintf("[%s]:%d", webhookServerHost, webhookServerPort),
-			TLSConfig: &tls.Config{
-				GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-					certPem, keyPem, err := tlsProvider()
-					if err != nil {
-						return nil, err
-					}
-					pair, err := tls.X509KeyPair(certPem, keyPem)
-					if err != nil {
-						return nil, err
-					}
-					return &pair, nil
-				},
-				MinVersion: tls.VersionTLS12,
-				CipherSuites: []uint16{
-					// AEADs w/ ECDHE
-					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-				},
-			},
+			Addr:              fmt.Sprintf("[%s]:%d", webhookServerHost, webhookServerPort),
+			TLSConfig:         tlsConfig,
 			Handler:           mux,
 			ReadTimeout:       30 * time.Second,
 			WriteTimeout:      30 * time.Second,

--- a/pkg/webhooks/server_test.go
+++ b/pkg/webhooks/server_test.go
@@ -155,7 +155,7 @@ func TestNewServer(t *testing.T) {
 		ctx, pHandlers, rHandlers, eHandlers, celHandlers, gcHandlers,
 		cfg, metricsMgr, debugOpts, tlsProvider,
 		mwcClient, vwcClient, leaseClient, runtimeMock,
-		rbLister, crbLister, discoveryMock, "localhost", 8080,
+		rbLister, crbLister, discoveryMock, "localhost", 8080, false,
 	)
 
 	assert.NotNil(t, s)
@@ -198,7 +198,7 @@ func buildTestServer(t *testing.T) *httprouter.Router {
 		ctx, pHandlers, rHandlers, eHandlers, celHandlers, gcHandlers,
 		cfg, metricsMgr, debugOpts, tlsProvider,
 		mwcClient, vwcClient, leaseClient, runtimeMock,
-		rbLister, crbLister, discoveryMock, "localhost", 8080,
+		rbLister, crbLister, discoveryMock, "localhost", 8080, false,
 	)
 	srv, ok := s.(*server)
 	require.True(t, ok, "NewServer must return a *server")


### PR DESCRIPTION
## Explanation

This pull request introduces strict mutual TLS (mTLS) client verification for the Kyverno admission webhook server. It allows cluster administrators to cryptographically verify the identity of the Kubernetes API server making inbound requests to Kyverno, mitigating the risk of unauthorized or spoofed admission traffic. This represents a new security feature addition to the webhook infrastructure.

## Related issue

Closes #16559

## Milestone of this PR

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind feature

## Proposed Changes

This PR secures the webhook architecture by adding native support for mTLS client verification.
*   **Backend:** Injected the `--verify-api-server-cert` CLI flag into `cmd/kyverno/main.go` and wired it into `pkg/webhooks/server.go` to enforce client certificate validation during the TLS handshake.
*   **Infrastructure:** Updated the Helm chart (`values.yaml` and `deployment.yaml`) to expose this configuration via `admissionController.verifyApiServerCert`.

### Proof Manifests

# Helm Configuration Proof
# Enabling this feature via values.yaml forces the webhook server to request and verify the API server's client cert against the cluster CA.

```yaml
admissionController:
  verifyApiServerCert: true
  autoscaling:
    enabled: false
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The conditional logic for the Helm deployment relies on a simple boolean toggle to prevent breaking existing user configurations who may not have their API server aggressively configured for outbound client certificate presentation.