### PR TITLE
perf: cache default manifest verification config

### DIFF
--- a/pkg/engine/handlers/validation/validate_manifest.go
+++ b/pkg/engine/handlers/validation/validate_manifest.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
@@ -38,6 +39,11 @@ type validateManifestHandler struct {
 	client    engineapi.Client
 	isCluster bool
 }
+
+var (
+	defaultConfigOnce sync.Once
+	defaultConfig     *k8smanifest.VerifyResourceOption
+)
 
 func NewValidateManifestHandler(
 	policyContext engineapi.PolicyContext,
@@ -416,11 +422,17 @@ func addConfig(vo, defaultConfig *k8smanifest.VerifyResourceOption) *k8smanifest
 }
 
 func loadDefaultConfig() *k8smanifest.VerifyResourceOption {
-	var defaultConfig *k8smanifest.VerifyResourceOption
-	err := yaml.Unmarshal(engineresources.DefaultConfigBytes, &defaultConfig)
-	if err != nil {
-		return nil
-	}
+	defaultConfigOnce.Do(func() {
+		var cfg *k8smanifest.VerifyResourceOption
+
+		err := yaml.Unmarshal(engineresources.DefaultConfigBytes, &cfg)
+		if err != nil {
+			return
+		}
+
+		defaultConfig = cfg
+	})
+
 	return defaultConfig
 }
 


### PR DESCRIPTION
## What does this PR do?

Earlier, every time `loadDefaultConfig()` was called, it loaded and parsed the same default configuration file again.

In this PR, I used `sync.Once` so that the configuration is loaded only once and then reused for future calls.

This removes repeated YAML parsing and improves performance without changing the existing behavior.

## Testing

- Ran `gofmt`
- Ran `go test ./pkg/engine/handlers/validation/...`