### PR TITLE
feat: reuse image verification cache for ImageValidatingPolicy

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -47,6 +47,7 @@ import (
 	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/engine/factories"
 	"github.com/kyverno/kyverno/pkg/engine/jmespath"
+	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
 	eval "github.com/kyverno/kyverno/pkg/image/verification/evaluator"
 	"github.com/kyverno/kyverno/pkg/utils/conditions"
 	gitutils "github.com/kyverno/kyverno/pkg/utils/git"
@@ -678,6 +679,7 @@ func (c *ApplyCommandConfig) applyImageValidatingPolicies(
 		matching.NewMatcher(),
 		lister,
 		[]imagedataloader.Option{imagedataloader.WithLocalCredentials(c.RegistryAccess)},
+		imageverifycache.DisabledImageVerifyCache(),
 	)
 
 	restMapper, err := utils.GetRESTMapper(dclient)

--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
 	eval "github.com/kyverno/kyverno/pkg/image/verification/evaluator"
 	utils "github.com/kyverno/kyverno/pkg/utils/restmapper"
 	policyvalidation "github.com/kyverno/kyverno/pkg/validation/policy"
@@ -667,6 +668,7 @@ func applyImageValidatingPolicies(
 		matching.NewMatcher(),
 		lister,
 		[]imagedataloader.Option{imagedataloader.WithLocalCredentials(registryAccess)},
+		imageverifycache.DisabledImageVerifyCache(),
 	)
 	if restMapper == nil {
 		var mapErr error

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -780,6 +780,7 @@ func main() {
 				matching.NewMatcher(),
 				setup.KubeClient.CoreV1().Secrets(config.KyvernoNamespace()),
 				nil,
+				setup.ImageVerifyCacheClient,
 			), metrics.AdmissionRequest)
 			mpolEngine = mpolengine.NewMetricWrapper(mpolengine.NewEngine(
 				mpolProvider,

--- a/pkg/cel/libs/imageverify/impl.go
+++ b/pkg/cel/libs/imageverify/impl.go
@@ -74,17 +74,29 @@ func ImageVerifyCELFuncs(
 	}, nil
 }
 
-// attestorCacheRule builds a cache rule key that is specific to the exact set of attestors
-// used in a call, so that different validations in the same policy version don't collide.
-// The names are sorted so the same attestor set produces the same key regardless of the
-// order the CEL expression passed them in.
-func attestorCacheRule(base string, attestors []v1beta1.Attestor) string {
+// attestorCacheRule builds a cache rule key that is specific to a function, an optional
+// qualifier (e.g. an attestation name), and the exact set of attestors used in a call, so
+// that different validations in the same policy version don't collide. Attestor names are
+// sorted so the same set produces the same key regardless of call order, and every part is
+// length-prefixed so a name containing a delimiter character can't be crafted to collide
+// with a different set of parts.
+func attestorCacheRule(fn string, qualifier string, attestors []v1beta1.Attestor) string {
 	names := make([]string, 0, len(attestors))
 	for _, attestor := range attestors {
 		names = append(names, attestor.GetKey())
 	}
 	sort.Strings(names)
-	return base + ":" + strings.Join(names, ",")
+	var b strings.Builder
+	writeCacheKeyPart(&b, fn)
+	writeCacheKeyPart(&b, qualifier)
+	for _, name := range names {
+		writeCacheKeyPart(&b, name)
+	}
+	return b.String()
+}
+
+func writeCacheKeyPart(b *strings.Builder, part string) {
+	fmt.Fprintf(b, "%d:%s|", len(part), part)
 }
 
 func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attestors ref.Val) ref.Val {
@@ -102,7 +114,7 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 			return f.NativeToValue(count)
 		}
 		f.logger.V(4).Info("verifyImageSignatures called", "image", image, "attestorCount", len(attestors))
-		cacheRule := attestorCacheRule(signatureCacheRule, attestors)
+		cacheRule := attestorCacheRule(signatureCacheRule, "", attestors)
 		if f.ivCache != nil {
 			if found, err := f.ivCache.Get(ctx, f.policy, cacheRule, image, true); err != nil {
 				f.logger.Error(err, "error occurred during image verify cache get", "image", image)
@@ -173,7 +185,7 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 			return f.NativeToValue(count)
 		}
 		f.logger.V(4).Info("verifyAttestationSignatures called", "image", image, "attestation", attestation, "attestorCount", len(attestors))
-		cacheRule := attestorCacheRule(attestationCacheRule+":"+attestation, attestors)
+		cacheRule := attestorCacheRule(attestationCacheRule, attestation, attestors)
 		if f.ivCache != nil {
 			if found, err := f.ivCache.Get(ctx, f.policy, cacheRule, image, true); err != nil {
 				f.logger.Error(err, "error occurred during image verify cache get", "image", image)

--- a/pkg/cel/libs/imageverify/impl.go
+++ b/pkg/cel/libs/imageverify/impl.go
@@ -3,6 +3,7 @@ package imageverify
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -75,11 +76,14 @@ func ImageVerifyCELFuncs(
 
 // attestorCacheRule builds a cache rule key that is specific to the exact set of attestors
 // used in a call, so that different validations in the same policy version don't collide.
+// The names are sorted so the same attestor set produces the same key regardless of the
+// order the CEL expression passed them in.
 func attestorCacheRule(base string, attestors []v1beta1.Attestor) string {
 	names := make([]string, 0, len(attestors))
 	for _, attestor := range attestors {
 		names = append(names, attestor.GetKey())
 	}
+	sort.Strings(names)
 	return base + ":" + strings.Join(names, ",")
 }
 

--- a/pkg/cel/libs/imageverify/impl.go
+++ b/pkg/cel/libs/imageverify/impl.go
@@ -3,6 +3,7 @@ package imageverify
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/google/cel-go/common/types"
@@ -10,6 +11,7 @@ import (
 	"github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/cel/compiler"
 	"github.com/kyverno/kyverno/pkg/cel/matching"
+	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
 	"github.com/kyverno/kyverno/pkg/image/verifiers/ivpol/cosign"
 	"github.com/kyverno/kyverno/pkg/image/verifiers/ivpol/notary"
 	"github.com/kyverno/sdk/extensions/cel/utils"
@@ -18,16 +20,23 @@ import (
 	k8scorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
+const (
+	signatureCacheRule   = "verifyImageSignatures"
+	attestationCacheRule = "verifyAttestationSignatures"
+)
+
 type ivfuncs struct {
 	types.Adapter
 
 	logger          logr.Logger
 	imgCtx          imagedataloader.ImageContext
+	policy          v1beta1.ImageValidatingPolicyLike
 	creds           *v1beta1.Credentials
 	imgRules        []compiler.MatchImageReference
 	attestationList map[string]v1beta1.Attestation
 	cosignVerifier  *cosign.Verifier
 	notaryVerifier  *notary.Verifier
+	ivCache         imageverifycache.Client
 }
 
 func ImageVerifyCELFuncs(
@@ -35,6 +44,7 @@ func ImageVerifyCELFuncs(
 	imgCtx imagedataloader.ImageContext,
 	ivpol v1beta1.ImageValidatingPolicyLike,
 	lister k8scorev1.SecretInterface,
+	ivCache imageverifycache.Client,
 	adapter types.Adapter,
 ) (*ivfuncs, error) {
 	if ivpol == nil {
@@ -53,12 +63,24 @@ func ImageVerifyCELFuncs(
 		Adapter:         adapter,
 		logger:          logger,
 		imgCtx:          imgCtx,
+		policy:          ivpol,
 		creds:           spec.Credentials,
 		imgRules:        imgRules,
 		attestationList: attestationMap(ivpol),
 		cosignVerifier:  cosign.NewVerifier(lister, logger),
 		notaryVerifier:  notary.NewVerifier(logger),
+		ivCache:         ivCache,
 	}, nil
+}
+
+// attestorCacheRule builds a cache rule key that is specific to the exact set of attestors
+// used in a call, so that different validations in the same policy version don't collide.
+func attestorCacheRule(base string, attestors []v1beta1.Attestor) string {
+	names := make([]string, 0, len(attestors))
+	for _, attestor := range attestors {
+		names = append(names, attestor.GetKey())
+	}
+	return base + ":" + strings.Join(names, ",")
 }
 
 func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attestors ref.Val) ref.Val {
@@ -76,6 +98,15 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 			return f.NativeToValue(count)
 		}
 		f.logger.V(4).Info("verifyImageSignatures called", "image", image, "attestorCount", len(attestors))
+		cacheRule := attestorCacheRule(signatureCacheRule, attestors)
+		if f.ivCache != nil {
+			if found, err := f.ivCache.Get(ctx, f.policy, cacheRule, image, true); err != nil {
+				f.logger.Error(err, "error occurred during image verify cache get", "image", image)
+			} else if found {
+				f.logger.V(4).Info("image signature verification cache hit", "image", image, "policy", f.policy.GetName())
+				return f.NativeToValue(len(attestors))
+			}
+		}
 		for _, attestor := range attestors {
 			opts := GetRemoteOptsFromPolicy(f.creds)
 			img, err := f.imgCtx.Get(ctx, image, opts...)
@@ -109,6 +140,11 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 			}
 		}
 		f.logger.V(6).Info("verifyImageSignatures returning", "image", image, "verifiedCount", count)
+		if f.ivCache != nil && len(attestors) > 0 && count == len(attestors) {
+			if _, err := f.ivCache.Set(ctx, f.policy, cacheRule, image, true); err != nil {
+				f.logger.Error(err, "error occurred during image verify cache set", "image", image)
+			}
+		}
 		return f.NativeToValue(count)
 	}
 }
@@ -133,6 +169,15 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 			return f.NativeToValue(count)
 		}
 		f.logger.V(4).Info("verifyAttestationSignatures called", "image", image, "attestation", attestation, "attestorCount", len(attestors))
+		cacheRule := attestorCacheRule(attestationCacheRule+":"+attestation, attestors)
+		if f.ivCache != nil {
+			if found, err := f.ivCache.Get(ctx, f.policy, cacheRule, image, true); err != nil {
+				f.logger.Error(err, "error occurred during image verify cache get", "image", image)
+			} else if found {
+				f.logger.V(4).Info("image attestation verification cache hit", "image", image, "policy", f.policy.GetName())
+				return f.NativeToValue(len(attestors))
+			}
+		}
 		for _, attestor := range attestors {
 			attest, ok := f.attestationList[attestation]
 			if !ok {
@@ -172,6 +217,11 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 			}
 		}
 		f.logger.V(6).Info("verifyAttestationSignatures returning", "image", image, "attestation", attestation, "verifiedCount", count)
+		if f.ivCache != nil && len(attestors) > 0 && count == len(attestors) {
+			if _, err := f.ivCache.Set(ctx, f.policy, cacheRule, image, true); err != nil {
+				f.logger.Error(err, "error occurred during image verify cache set", "image", image)
+			}
+		}
 		return f.NativeToValue(count)
 	}
 }

--- a/pkg/cel/libs/imageverify/impl_test.go
+++ b/pkg/cel/libs/imageverify/impl_test.go
@@ -179,7 +179,7 @@ func Test_impl_verify_image_signature_cache_hit(t *testing.T) {
 		ivCache:        ivCache,
 	}
 
-	cacheRule := attestorCacheRule(signatureCacheRule, attestors)
+	cacheRule := attestorCacheRule(signatureCacheRule, "", attestors)
 	stored, err := ivCache.Set(context.TODO(), pol, cacheRule, image, true)
 	assert.NoError(t, err)
 	assert.True(t, stored)
@@ -240,7 +240,7 @@ func Test_impl_verify_image_signature_cache_miss_does_not_cache_failure(t *testi
 	assert.True(t, ok, "expected an integer result, got an error instead: %v", out.Value())
 	assert.Less(t, count, int64(len(attestors)))
 
-	cacheRule := attestorCacheRule(signatureCacheRule, attestors)
+	cacheRule := attestorCacheRule(signatureCacheRule, "", attestors)
 	found, err := ivCache.Get(context.TODO(), pol, cacheRule, image, true)
 	assert.NoError(t, err)
 	assert.False(t, found, "a partial or failed verification must never be cached")

--- a/pkg/cel/libs/imageverify/impl_test.go
+++ b/pkg/cel/libs/imageverify/impl_test.go
@@ -1,13 +1,19 @@
 package imageverify
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
 	"github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
+	"github.com/kyverno/kyverno/pkg/image/verifiers/ivpol/cosign"
+	"github.com/kyverno/kyverno/pkg/image/verifiers/ivpol/notary"
 	"github.com/kyverno/sdk/extensions/imagedataloader"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -62,7 +68,7 @@ func Test_impl_verify_image_signature_string_stringarray(t *testing.T) {
 
 	options := []cel.EnvOption{
 		cel.Variable("attestors", cel.MapType(cel.StringType, cel.DynType)),
-		Lib(nil, imgCtx, ivpol, nil, logr.Discard()),
+		Lib(nil, imgCtx, ivpol, nil, logr.Discard(), nil),
 	}
 	env, err := cel.NewEnv(options...)
 	assert.NoError(t, err)
@@ -100,7 +106,7 @@ func Test_impl_verify_image_attestations_string_string_stringarray(t *testing.T)
 
 	options := []cel.EnvOption{
 		cel.Variable("attestors", cel.MapType(cel.StringType, cel.DynType)),
-		Lib(nil, imgCtx, ivpol, nil, logr.Discard()),
+		Lib(nil, imgCtx, ivpol, nil, logr.Discard(), nil),
 	}
 	env, err := cel.NewEnv(options...)
 	assert.NoError(t, err)
@@ -131,4 +137,111 @@ func Test_impl_verify_image_attestations_string_string_stringarray(t *testing.T)
 	out, _, err := prog.Eval(data)
 	assert.NoError(t, err)
 	assert.Equal(t, out.Value(), int64(1))
+}
+
+func Test_impl_verify_image_signature_cache_hit(t *testing.T) {
+	attestors := []v1beta1.Attestor{
+		{
+			Name: "notary",
+			Notary: &v1beta1.Notary{
+				Certs: &v1beta1.StringOrExpression{
+					Value: cert,
+				},
+			},
+		},
+	}
+	pol := &v1beta1.ImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "cache-policy",
+			UID:             "test-uid",
+			ResourceVersion: "1",
+		},
+		Spec: v1beta1.ImageValidatingPolicySpec{
+			Attestors: attestors,
+		},
+	}
+	image := "ghcr.io/kyverno/test-verify-image:signed"
+
+	ivCache, err := imageverifycache.New(
+		imageverifycache.WithCacheEnableFlag(true),
+		imageverifycache.WithMaxSize(0),
+		imageverifycache.WithTTLDuration(0),
+	)
+	assert.NoError(t, err)
+
+	// imgCtx is left nil on purpose: if the cache is bypassed, fetching image data errors
+	// out, and the test fails, proving a cache hit skips the registry round trip entirely.
+	f := &ivfuncs{
+		Adapter:        types.DefaultTypeAdapter,
+		policy:         pol,
+		cosignVerifier: cosign.NewVerifier(nil, logr.Discard()),
+		notaryVerifier: notary.NewVerifier(logr.Discard()),
+		ivCache:        ivCache,
+	}
+
+	cacheRule := attestorCacheRule(signatureCacheRule, attestors)
+	stored, err := ivCache.Set(context.TODO(), pol, cacheRule, image, true)
+	assert.NoError(t, err)
+	assert.True(t, stored)
+
+	out2 := f.verify_image_signature_string_stringarray(f.NativeToValue(image), f.NativeToValue(attestors))
+	assert.Equal(t, int64(len(attestors)), out2.Value())
+}
+
+func Test_impl_verify_image_signature_cache_miss_does_not_cache_failure(t *testing.T) {
+	// a certificate that doesn't match the image's actual signer, so verification fails
+	// while the image fetch itself still succeeds against the real registry.
+	attestors := []v1beta1.Attestor{
+		{
+			Name: "notary",
+			Notary: &v1beta1.Notary{
+				Certs: &v1beta1.StringOrExpression{
+					Value: "not-a-valid-certificate",
+				},
+			},
+		},
+	}
+	pol := &v1beta1.ImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "cache-policy-miss",
+			UID:             "test-uid-miss",
+			ResourceVersion: "1",
+		},
+		Spec: v1beta1.ImageValidatingPolicySpec{
+			Attestors: attestors,
+		},
+	}
+	// reuse the same signed image as the other tests: the fetch succeeds, but the bogus
+	// cert above means verification never passes, so the count never reaches len(attestors)
+	// and the result must not be cached.
+	image := "ghcr.io/kyverno/test-verify-image:signed"
+
+	imgCtx, err := imagedataloader.NewImageContext(nil)
+	assert.NoError(t, err)
+
+	ivCache, err := imageverifycache.New(
+		imageverifycache.WithCacheEnableFlag(true),
+		imageverifycache.WithMaxSize(0),
+		imageverifycache.WithTTLDuration(0),
+	)
+	assert.NoError(t, err)
+
+	f := &ivfuncs{
+		Adapter:        types.DefaultTypeAdapter,
+		imgCtx:         imgCtx,
+		policy:         pol,
+		cosignVerifier: cosign.NewVerifier(nil, logr.Discard()),
+		notaryVerifier: notary.NewVerifier(logr.Discard()),
+		ivCache:        ivCache,
+	}
+
+	out := f.verify_image_signature_string_stringarray(f.NativeToValue(image), f.NativeToValue(attestors))
+	count, ok := out.Value().(int64)
+	assert.True(t, ok, "expected an integer result, got an error instead: %v", out.Value())
+	assert.Less(t, count, int64(len(attestors)))
+
+	cacheRule := attestorCacheRule(signatureCacheRule, attestors)
+	found, err := ivCache.Get(context.TODO(), pol, cacheRule, image, true)
+	assert.NoError(t, err)
+	assert.False(t, found, "a partial or failed verification must never be cached")
 }

--- a/pkg/cel/libs/imageverify/lib.go
+++ b/pkg/cel/libs/imageverify/lib.go
@@ -5,6 +5,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
 	"github.com/kyverno/sdk/extensions/cel/libs/versions"
 	"github.com/kyverno/sdk/extensions/imagedataloader"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -20,13 +21,14 @@ type lib struct {
 	imgCtx  imagedataloader.ImageContext
 	ivpol   policiesv1beta1.ImageValidatingPolicyLike
 	lister  k8scorev1.SecretInterface
+	ivCache imageverifycache.Client
 }
 
 func Latest() *version.Version {
 	return versions.KyvernoLatest
 }
 
-func Lib(v *version.Version, imgCtx imagedataloader.ImageContext, ivpol policiesv1beta1.ImageValidatingPolicyLike, lister k8scorev1.SecretInterface, logger logr.Logger) cel.EnvOption {
+func Lib(v *version.Version, imgCtx imagedataloader.ImageContext, ivpol policiesv1beta1.ImageValidatingPolicyLike, lister k8scorev1.SecretInterface, logger logr.Logger, ivCache imageverifycache.Client) cel.EnvOption {
 	// create the cel lib env option
 	return cel.Lib(&lib{
 		logger:  logger,
@@ -34,6 +36,7 @@ func Lib(v *version.Version, imgCtx imagedataloader.ImageContext, ivpol policies
 		imgCtx:  imgCtx,
 		ivpol:   ivpol,
 		lister:  lister,
+		ivCache: ivCache,
 	})
 }
 
@@ -56,7 +59,7 @@ func (*lib) ProgramOptions() []cel.ProgramOption {
 }
 
 func (c *lib) extendEnv(env *cel.Env) (*cel.Env, error) {
-	impl, err := ImageVerifyCELFuncs(c.logger, c.imgCtx, c.ivpol, c.lister, env.CELTypeAdapter())
+	impl, err := ImageVerifyCELFuncs(c.logger, c.imgCtx, c.ivpol, c.lister, c.ivCache, env.CELTypeAdapter())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cel/policies/ivpol/engine/engine.go
+++ b/pkg/cel/policies/ivpol/engine/engine.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/cel/libs"
 	"github.com/kyverno/kyverno/pkg/cel/matching"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
 	eval "github.com/kyverno/kyverno/pkg/image/verification/evaluator"
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	"github.com/kyverno/sdk/extensions/imagedataloader"
@@ -49,6 +50,7 @@ type engineImpl struct {
 	matcher      matching.Matcher
 	lister       k8scorev1.SecretInterface
 	registryOpts []imagedataloader.Option
+	ivCache      imageverifycache.Client
 }
 
 func NewEngine(
@@ -57,6 +59,7 @@ func NewEngine(
 	matcher matching.Matcher,
 	lister k8scorev1.SecretInterface,
 	registryOpts []imagedataloader.Option,
+	ivCache imageverifycache.Client,
 ) Engine {
 	return &engineImpl{
 		provider:     provider,
@@ -64,6 +67,7 @@ func NewEngine(
 		matcher:      matcher,
 		lister:       lister,
 		registryOpts: registryOpts,
+		ivCache:      ivCache,
 	}
 }
 
@@ -241,7 +245,7 @@ func (e *engineImpl) handleMutation(
 	if err != nil {
 		return nil, nil, err
 	}
-	c := eval.NewCompiler(ictx, e.lister, request.RequestResource)
+	c := eval.NewCompiler(ictx, e.lister, request.RequestResource, e.ivCache)
 	for _, ivpol := range filteredPolicies {
 		response := eval.ImageVerifyPolicyResponse{
 			Policy:     ivpol.Policy,

--- a/pkg/cel/policies/ivpol/engine/engine_test.go
+++ b/pkg/cel/policies/ivpol/engine/engine_test.go
@@ -163,7 +163,7 @@ func Test_ImageVerifyEngine(t *testing.T) {
 		},
 		Context: libs.NewFakeContextProvider(),
 	}
-	engine := NewEngine(ProviderFunc(providerFunc), nsResolver, matching.NewMatcher(), nil, nil)
+	engine := NewEngine(ProviderFunc(providerFunc), nsResolver, matching.NewMatcher(), nil, nil, nil)
 
 	resp, patches, err := engine.HandleMutating(context.Background(), engineRequest, nil)
 	assert.NoError(t, err)

--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -22,6 +22,7 @@ import (
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/engine/jmespath"
 	gctxstore "github.com/kyverno/kyverno/pkg/globalcontext/store"
+	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
 	"github.com/kyverno/kyverno/pkg/metrics"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
 	"go.uber.org/multierr"
@@ -287,6 +288,7 @@ func (s *scanner) ScanResource(
 				matching.NewMatcher(),
 				s.client.GetKubeClient().CoreV1().Secrets(config.KyvernoNamespace()),
 				nil,
+				imageverifycache.DisabledImageVerifyCache(),
 			), metrics.BackgroundScan)
 			request := celengine.Request(
 				libs.GetLibsCtx(),

--- a/pkg/image/verification/evaluator/compiler.go
+++ b/pkg/image/verification/evaluator/compiler.go
@@ -10,6 +10,7 @@ import (
 	engine "github.com/kyverno/kyverno/pkg/cel/compiler"
 	"github.com/kyverno/kyverno/pkg/cel/libs"
 	"github.com/kyverno/kyverno/pkg/cel/libs/imageverify"
+	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
 	ivpolvar "github.com/kyverno/kyverno/pkg/image/verification/variables"
 	"github.com/kyverno/kyverno/pkg/logging"
 	"github.com/kyverno/kyverno/pkg/toggle"
@@ -42,18 +43,20 @@ type Compiler interface {
 	Compile(policiesv1beta1.ImageValidatingPolicyLike, []*policiesv1beta1.PolicyException) (CompiledPolicy, field.ErrorList)
 }
 
-func NewCompiler(ictx imagedataloader.ImageContext, lister k8scorev1.SecretInterface, reqGVR *metav1.GroupVersionResource) Compiler {
+func NewCompiler(ictx imagedataloader.ImageContext, lister k8scorev1.SecretInterface, reqGVR *metav1.GroupVersionResource, ivCache imageverifycache.Client) Compiler {
 	return &compilerImpl{
-		ictx:   ictx,
-		lister: lister,
-		reqGVR: reqGVR,
+		ictx:    ictx,
+		lister:  lister,
+		reqGVR:  reqGVR,
+		ivCache: ivCache,
 	}
 }
 
 type compilerImpl struct {
-	ictx   imagedataloader.ImageContext
-	lister k8scorev1.SecretInterface
-	reqGVR *metav1.GroupVersionResource
+	ictx    imagedataloader.ImageContext
+	lister  k8scorev1.SecretInterface
+	reqGVR  *metav1.GroupVersionResource
+	ivCache imageverifycache.Client
 }
 
 func (c *compilerImpl) Compile(ivpolicy policiesv1beta1.ImageValidatingPolicyLike, exceptions []*policiesv1beta1.PolicyException) (CompiledPolicy, field.ErrorList) {
@@ -214,6 +217,7 @@ func (c *compilerImpl) createBaseIvpolEnv(libsctx libs.Context, ivpol policiesv1
 		imageverify.Lib(
 			imageverify.Latest(), c.ictx, ivpol, c.lister,
 			logging.WithName("ivpol/imageverify").WithValues("policy", ivpol.GetName(), "namespace", namespace),
+			c.ivCache,
 		),
 		resource.Lib(
 			resource.Context{ContextInterface: libsctx},

--- a/pkg/image/verification/evaluator/eval.go
+++ b/pkg/image/verification/evaluator/eval.go
@@ -6,6 +6,7 @@ import (
 
 	policieskyvernoio "github.com/kyverno/api/api/policies.kyverno.io"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
 	"github.com/kyverno/sdk/extensions/imagedataloader"
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -37,7 +38,7 @@ func Evaluate(ctx context.Context, ivpols []*CompiledImageValidatingPolicy, requ
 
 	policies := filterPolicies(ivpols, isAdmissionRequest)
 
-	c := NewCompiler(ictx, lister, gvr)
+	c := NewCompiler(ictx, lister, gvr, imageverifycache.DisabledImageVerifyCache())
 	results := make(map[string]*EvaluationResult, len(policies))
 	for _, ivpol := range policies {
 		p, errList := c.Compile(ivpol.Policy, ivpol.Exceptions)

--- a/pkg/image/verification/evaluator/validate.go
+++ b/pkg/image/verification/evaluator/validate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kyverno/kyverno/api/kyverno"
 	engine "github.com/kyverno/kyverno/pkg/cel/compiler"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
 	"github.com/kyverno/kyverno/pkg/toggle"
 	"github.com/kyverno/sdk/extensions/imagedataloader"
 	"gomodules.xyz/jsonpatch/v2"
@@ -96,7 +97,7 @@ func Validate(ivpol policiesv1beta1.ImageValidatingPolicyLike, lister k8scorev1.
 		return nil, nil
 	}
 
-	compiler := NewCompiler(ictx, lister, nil)
+	compiler := NewCompiler(ictx, lister, nil, imageverifycache.DisabledImageVerifyCache())
 	_, errList := compiler.Compile(ivpol, nil)
 
 	errs := make(field.ErrorList, 0, len(errList))


### PR DESCRIPTION
ImageValidatingPolicy never reused a verified image signature or attestation across requests. Every admission that matched the same image re-fetched and re-verified it against the registry, even when nothing about the image or the policy had changed. ClusterPolicy already has this covered through the shared image verification cache, but the IVP path builds a fresh SDK image context per request and never touches that cache client.

This wires the existing ImageVerifyCacheClient into verifyImageSignatures and verifyAttestationSignatures in the CEL image verify library. A successful verification gets cached under the image reference, the policy's UID and resource version, and the specific set of attestors (or attestation name) used in that call, so any change to the policy, its attestors, or the expression itself naturally invalidates old entries. Failures and partial verifications are never cached, only full successes, and a cache hit skips the registry round trip entirely. The attestor set is sorted and each part of the key is length-prefixed before joining, so call order doesn't matter and a name containing a delimiter character can't be crafted to collide with a different attestor set.

The cache is only wired up for the admission controller, where setup.ImageVerifyCacheClient already exists and is governed by the same imageVerifyCacheEnabled, imageVerifyCacheMaxSize and imageVerifyCacheTTLDuration settings used for ClusterPolicy. The CLI (apply/test) and the background scan controller keep using a disabled cache client, same as they already do for the classic verifier, since those are one-shot evaluations where caching doesn't apply.

Tested with the existing imageverify and ivpol engine suites, plus two new tests: one that seeds the cache directly and confirms a hit returns without the image context ever being touched, proving it can't be reaching the registry, and one that runs a real but failing verification and confirms nothing gets cached.

This covers the reuse and invalidation part of #16657, but not the hit/miss/eviction metrics it also asks for, the cache client has none of those today for the classic verifier either, so that felt like a separate follow-up rather than something to bundle in here. Not marking this as closing the issue for that reason.

Relates to #16657
