### PR TITLE
test: point ivpol cosign tests at the kyverno test-images registry

### DIFF
--- a/pkg/image/verifiers/ivpol/cosign/opts_test.go
+++ b/pkg/image/verifiers/ivpol/cosign/opts_test.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
+	// Public key matching the key used to sign the key-based test images, from
+	// cosign/examples/cosign.pub in kyverno/test-images.
 	testPublicKey = `-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIOJTQ992VBJyyx52p3s1W/lqwNxI
-rFxZI4BL3S6ZGyJFockpfppxOycEkUaGVTUvL0Tp7Yi0eYRJ4TtKxs1lXQ==
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPEDZl3iOJwr77T2bS9vgonwzERmG
+PKd/xnmHKfvkbLquVC6NnH8dgPVq8p0H45H2H9CqzqGv+rn99xAWGLE30A==
 -----END PUBLIC KEY-----`
 
 	testIssuer  = "https://token.actions.githubusercontent.com"

--- a/pkg/image/verifiers/ivpol/cosign/verifier_test.go
+++ b/pkg/image/verifiers/ivpol/cosign/verifier_test.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Test images from cosign test repository
-	testRegistry           = "ghcr.io/lucchmielowski/kyverno-cosign-testbed"
+	testRegistry           = "ghcr.io/kyverno/test-images/cosign"
 	unsignedImage          = testRegistry + ":unsigned"
 	githubAttestationImage = testRegistry + ":github-attestation"
 	v2KeyBasedImage        = testRegistry + ":v2-traditional"
@@ -23,7 +23,7 @@ const (
 	v3BundleImage          = testRegistry + ":v3-bundle"
 
 	// GitHub Actions OIDC configuration for keyless signing
-	githubWorkflowID = "https://github.com/lucchmielowski/kyverno-cosign-testbed/.github/workflows/ci.yml@refs/heads/main"
+	githubWorkflowID = "https://github.com/kyverno/test-images/.github/workflows/cosign.yml@refs/heads/main"
 )
 
 const (
@@ -763,7 +763,7 @@ func Test_GitHubAttestationVerification(t *testing.T) {
 		require.NoError(t, err)
 
 		// Use an image that should have SLSA provenance attestations
-		// Based on the policy: ghcr.io/lucchmielowski/kyverno-cosign-testbed:*
+		// Based on the policy: ghcr.io/kyverno/test-images/cosign:*
 		// The image must have SLSA provenance attestations signed with GitHub Actions
 		img, err := idf.FetchImageData(context.TODO(), githubAttestationImage)
 		if err != nil {


### PR DESCRIPTION
# Explanation

Moves the `ivpol` Cosign tests off a personal registry and onto the org one, `ghcr.io/kyverno/test-images/cosign`, as @JimBugwadia  suggested.

Three things had to change together, not just the registry:

- the keyless identity (the org signs via `cosign.yml`, not `ci.yml`)
- the public key (the org signs with a different key, so key-based tests would otherwise fail)

I took the identity from the published signature's Fulcio certificate rather than the README, which still says `ci-images` from before the rename. so will do a follow up for that in the test-images repo .

# Verification

- Ran the suite before and after: **49 pass, 0 skip, 0 fail** both ways, identical test-by-test.
- Worth noting these tests skip when an image isn't reachable, so I checked the skip count rather than trusting `"ok"`.
- Also sanity-checked the other way: with the old identity or old key against the new images, the tests do fail, so they're really verifying.