### PR TITLE
fix: validate MAP-incompatible MutatingPolicy match conditions

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -72,8 +72,13 @@ import (
 )
 
 type SkippedInvalidPolicies struct {
-	skipped []string
-	invalid []string
+	skipped []PolicyDiagnostic
+	invalid []PolicyDiagnostic
+}
+
+type PolicyDiagnostic struct {
+	name   string
+	reason string
 }
 
 type ApplyCommandConfig struct {
@@ -545,9 +550,9 @@ func (c *ApplyCommandConfig) applyPolicies(
 			log.Log.Error(err, "policy validation error")
 			rc.IncrementError(1)
 			if strings.HasPrefix(err.Error(), "variable 'element.name'") {
-				skipInvalidPolicies.invalid = append(skipInvalidPolicies.invalid, pol.GetName())
+				skipInvalidPolicies.invalid = append(skipInvalidPolicies.invalid, PolicyDiagnostic{name: pol.GetName(), reason: err.Error()})
 			} else {
-				skipInvalidPolicies.skipped = append(skipInvalidPolicies.skipped, pol.GetName())
+				skipInvalidPolicies.skipped = append(skipInvalidPolicies.skipped, PolicyDiagnostic{name: pol.GetName(), reason: err.Error()})
 			}
 			continue
 		}

--- a/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
@@ -69,6 +69,27 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
+func TestPrintSkippedAndInvalidPolicies(t *testing.T) {
+	var out bytes.Buffer
+	printSkippedAndInvalidPolicies(&out, SkippedInvalidPolicies{
+		skipped: []PolicyDiagnostic{{
+			name:   "skipped-policy",
+			reason: "missing variable `request.operation`",
+		}},
+		invalid: []PolicyDiagnostic{{
+			name:   "invalid-policy",
+			reason: "failed to compile policy invalid-policy (spec.matchConditions[0].expression: Forbidden: variables cannot be referenced)",
+		}},
+	})
+
+	printed := out.String()
+	assert.Contains(t, printed, "Policies Skipped:")
+	assert.Contains(t, printed, "1. skipped-policy: missing variable `request.operation`")
+	assert.Contains(t, printed, "Invalid Policies:")
+	assert.Contains(t, printed, "1. invalid-policy: failed to compile policy invalid-policy")
+	assert.Contains(t, printed, "variables cannot be referenced")
+}
+
 func Test_Apply(t *testing.T) {
 	type TestCase struct {
 		expectedReports []openreportsv1alpha1.Report

--- a/cmd/cli/kubectl-kyverno/commands/apply/print.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/print.go
@@ -26,20 +26,28 @@ const divider = "---------------------------------------------------------------
 func printSkippedAndInvalidPolicies(out io.Writer, skipInvalidPolicies SkippedInvalidPolicies) {
 	if len(skipInvalidPolicies.skipped) > 0 {
 		fmt.Fprintln(out, divider)
-		fmt.Fprintln(out, "Policies Skipped (as required variables are not provided by the user):")
-		for i, policyName := range skipInvalidPolicies.skipped {
-			fmt.Fprintf(out, "%d. %s\n", i+1, policyName)
+		fmt.Fprintln(out, "Policies Skipped:")
+		for i, policy := range skipInvalidPolicies.skipped {
+			printPolicyDiagnostic(out, i+1, policy)
 		}
 		fmt.Fprintln(out, divider)
 	}
 	if len(skipInvalidPolicies.invalid) > 0 {
 		fmt.Fprintln(out, divider)
 		fmt.Fprintln(out, "Invalid Policies:")
-		for i, policyName := range skipInvalidPolicies.invalid {
-			fmt.Fprintf(out, "%d. %s\n", i+1, policyName)
+		for i, policy := range skipInvalidPolicies.invalid {
+			printPolicyDiagnostic(out, i+1, policy)
 		}
 		fmt.Fprintln(out, divider)
 	}
+}
+
+func printPolicyDiagnostic(out io.Writer, index int, policy PolicyDiagnostic) {
+	if policy.reason == "" {
+		fmt.Fprintf(out, "%d. %s\n", index, policy.name)
+		return
+	}
+	fmt.Fprintf(out, "%d. %s: %s\n", index, policy.name, policy.reason)
 }
 
 func printReports(out io.Writer, engineResponses []engineapi.EngineResponse, auditWarn bool, outputFormat string) {

--- a/pkg/cel/policies/mpol/compiler/compiler.go
+++ b/pkg/cel/policies/mpol/compiler/compiler.go
@@ -5,8 +5,11 @@ import (
 	"reflect"
 
 	cel "github.com/google/cel-go/cel"
+	celcommon "github.com/google/cel-go/common"
+	celast "github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/ext"
+	"github.com/google/cel-go/parser"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	compiler "github.com/kyverno/kyverno/pkg/cel/compiler"
 	"github.com/kyverno/kyverno/pkg/cel/libs"
@@ -61,6 +64,10 @@ func (c *compilerImpl) Compile(policy policiesv1beta1.MutatingPolicyLike, except
 
 	spec := policy.GetSpec()
 	path := field.NewPath("spec")
+	allErrs = append(allErrs, validateMAPCompatibleMatchConditions(spec)...)
+	if len(allErrs) > 0 {
+		return nil, allErrs
+	}
 
 	variables, errs := compiler.CompileVariables(path.Child("variables"), extendedCompiler, variablesProvider, spec.Variables...)
 	if errs != nil {
@@ -263,4 +270,43 @@ func (c *compilerImpl) newExtendedEnv(libCtx libs.Context, namespace string) (*c
 		return nil, nil, err
 	}
 	return extendedEnv, variablesProvider, nil
+}
+
+func validateMAPCompatibleMatchConditions(spec *policiesv1beta1.MutatingPolicySpec) field.ErrorList {
+	var errs field.ErrorList
+	if spec == nil || !spec.GenerateMutatingAdmissionPolicyEnabled() || len(spec.MatchConditions) == 0 {
+		return nil
+	}
+
+	for i := range spec.MatchConditions {
+		condition := spec.MatchConditions[i]
+		parsed, parseErrs := parser.Parse(celcommon.NewStringSource(condition.Expression, "matchCondition"))
+		if parseErrs != nil && len(parseErrs.GetErrors()) > 0 {
+			continue
+		}
+		if referencesVariables(parsed.Expr()) {
+			errs = append(errs, field.Forbidden(
+				field.NewPath("spec").Child("matchConditions").Index(i).Child("expression"),
+				"variables cannot be referenced in matchConditions when spec.autogen.mutatingAdmissionPolicy.enabled is true; native MutatingAdmissionPolicy evaluates match conditions before variables, so inline the expression instead",
+			))
+		}
+	}
+	return errs
+}
+
+func referencesVariables(expr celast.Expr) bool {
+	if expr == nil {
+		return false
+	}
+
+	found := false
+	celast.PreOrderVisit(expr, celast.NewExprVisitor(func(node celast.Expr) {
+		if found || node == nil {
+			return
+		}
+		if node.Kind() == celast.IdentKind && node.AsIdent() == "variables" {
+			found = true
+		}
+	}))
+	return found
 }

--- a/pkg/cel/policies/mpol/compiler/compiler_test.go
+++ b/pkg/cel/policies/mpol/compiler/compiler_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/stretchr/testify/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	admissionv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	"k8s.io/utils/ptr"
 )
 
 func TestCompile(t *testing.T) {
@@ -21,14 +21,12 @@ func TestCompile(t *testing.T) {
 			name: "valid applyConfiguration mutation",
 			pol: &v1beta1.MutatingPolicy{
 				Spec: v1beta1.MutatingPolicySpec{
-					Mutations: []admissionregistrationv1alpha1.Mutation{
-						{
-							PatchType: admissionregistrationv1alpha1.PatchTypeApplyConfiguration,
-							ApplyConfiguration: &admissionregistrationv1alpha1.ApplyConfiguration{
-								Expression: `Object{spec: Object.spec{containers: [Object.spec.containers{name: "nginx"}]}}`,
-							},
+					Mutations: []admissionregistrationv1alpha1.Mutation{{
+						PatchType: admissionregistrationv1alpha1.PatchTypeApplyConfiguration,
+						ApplyConfiguration: &admissionregistrationv1alpha1.ApplyConfiguration{
+							Expression: `Object{spec: Object.spec{containers: [Object.spec.containers{name: "nginx"}]}}`,
 						},
-					},
+					}},
 				},
 			},
 			polex:   nil,
@@ -39,29 +37,23 @@ func TestCompile(t *testing.T) {
 			pol: &v1beta1.MutatingPolicy{
 				Spec: v1beta1.MutatingPolicySpec{},
 			},
-			polex: []*v1beta1.PolicyException{
-				{
-					Spec: v1beta1.PolicyExceptionSpec{
-						MatchConditions: []admissionv1.MatchCondition{
-							{Expression: "invalid && expression"},
-						},
-					},
+			polex: []*v1beta1.PolicyException{{
+				Spec: v1beta1.PolicyExceptionSpec{
+					MatchConditions: []admissionregistrationv1.MatchCondition{{Expression: "invalid && expression"}},
 				},
-			},
+			}},
 			wantErr: true,
 		},
 		{
 			name: "valid jsonpatch mutation",
 			pol: &v1beta1.MutatingPolicy{
 				Spec: v1beta1.MutatingPolicySpec{
-					Mutations: []admissionregistrationv1alpha1.Mutation{
-						{
-							PatchType: admissionregistrationv1alpha1.PatchTypeJSONPatch,
-							JSONPatch: &admissionregistrationv1alpha1.JSONPatch{
-								Expression: `[JSONPatch{op: "add", path: "/spec/restartPolicy", value: "Always"}]`,
-							},
+					Mutations: []admissionregistrationv1alpha1.Mutation{{
+						PatchType: admissionregistrationv1alpha1.PatchTypeJSONPatch,
+						JSONPatch: &admissionregistrationv1alpha1.JSONPatch{
+							Expression: `[JSONPatch{op: "add", path: "/spec/restartPolicy", value: "Always"}]`,
 						},
-					},
+					}},
 				},
 			},
 			polex:   nil,
@@ -71,20 +63,16 @@ func TestCompile(t *testing.T) {
 			name: "policy with variables",
 			pol: &v1beta1.MutatingPolicy{
 				Spec: v1beta1.MutatingPolicySpec{
-					Variables: []admissionregistrationv1.Variable{
-						{
-							Name:       "foo",
-							Expression: "object.metadata.name",
+					Variables: []admissionregistrationv1.Variable{{
+						Name:       "foo",
+						Expression: "object.metadata.name",
+					}},
+					Mutations: []admissionregistrationv1alpha1.Mutation{{
+						PatchType: admissionregistrationv1alpha1.PatchTypeApplyConfiguration,
+						ApplyConfiguration: &admissionregistrationv1alpha1.ApplyConfiguration{
+							Expression: `Object{}`,
 						},
-					},
-					Mutations: []admissionregistrationv1alpha1.Mutation{
-						{
-							PatchType: admissionregistrationv1alpha1.PatchTypeApplyConfiguration,
-							ApplyConfiguration: &admissionregistrationv1alpha1.ApplyConfiguration{
-								Expression: `Object{}`,
-							},
-						},
-					},
+					}},
 				},
 			},
 			polex:   nil,
@@ -94,12 +82,10 @@ func TestCompile(t *testing.T) {
 			name: "valid matchCondition expression",
 			pol: &v1beta1.MutatingPolicy{
 				Spec: v1beta1.MutatingPolicySpec{
-					MatchConditions: []admissionregistrationv1.MatchCondition{
-						{
-							Name:       "ns-is-test",
-							Expression: `true`,
-						},
-					},
+					MatchConditions: []admissionregistrationv1.MatchCondition{{
+						Name:       "ns-is-test",
+						Expression: `true`,
+					}},
 				},
 			},
 			polex:   nil,
@@ -109,19 +95,17 @@ func TestCompile(t *testing.T) {
 			name: "invalid matchCondition expression",
 			pol: &v1beta1.MutatingPolicy{
 				Spec: v1beta1.MutatingPolicySpec{
-					MatchConditions: []admissionregistrationv1.MatchCondition{
-						{
-							Name:       "ns-is-test",
-							Expression: `this is not a cel`,
-						},
-					},
+					MatchConditions: []admissionregistrationv1.MatchCondition{{
+						Name:       "ns-is-test",
+						Expression: `this is not a cel`,
+					}},
 				},
 			},
 			polex:   nil,
 			wantErr: true,
 		},
 		{
-			name: "variables available in matchCondition",
+			name: "variables allowed in matchConditions when MAP autogen disabled",
 			pol: &v1beta1.MutatingPolicy{
 				Spec: v1beta1.MutatingPolicySpec{
 					MatchConditions: []admissionregistrationv1.MatchCondition{{
@@ -134,6 +118,43 @@ func TestCompile(t *testing.T) {
 					}},
 				},
 			},
+			polex:   nil,
+			wantErr: false,
+		},
+		{
+			name: "variables forbidden in matchConditions when MAP autogen enabled",
+			pol: &v1beta1.MutatingPolicy{
+				Spec: v1beta1.MutatingPolicySpec{
+					Variables: []admissionregistrationv1.Variable{{
+						Name:       "targetName",
+						Expression: `"test"`,
+					}},
+					MatchConditions: []admissionregistrationv1.MatchCondition{{
+						Name:       "uses-variable",
+						Expression: `variables.targetName == "test"`,
+					}},
+					AutogenConfiguration: &v1beta1.MutatingPolicyAutogenConfiguration{
+						MutatingAdmissionPolicy: &v1beta1.MAPGenerationConfiguration{Enabled: ptr.To(true)},
+					},
+				},
+			},
+			polex:   nil,
+			wantErr: true,
+		},
+		{
+			name: "string literals mentioning variables are allowed when MAP autogen enabled",
+			pol: &v1beta1.MutatingPolicy{
+				Spec: v1beta1.MutatingPolicySpec{
+					MatchConditions: []admissionregistrationv1.MatchCondition{{
+						Name:       "string-literal",
+						Expression: `"variables.targetName" == "variables.targetName"`,
+					}},
+					AutogenConfiguration: &v1beta1.MutatingPolicyAutogenConfiguration{
+						MutatingAdmissionPolicy: &v1beta1.MAPGenerationConfiguration{Enabled: ptr.To(true)},
+					},
+				},
+			},
+			polex:   nil,
 			wantErr: false,
 		},
 		{
@@ -171,11 +192,10 @@ func TestCompile(t *testing.T) {
 			name: "invalid jsonPatch expression",
 			pol: &v1beta1.MutatingPolicy{
 				Spec: v1beta1.MutatingPolicySpec{
-					Mutations: []admissionregistrationv1alpha1.Mutation{
-						{
-							PatchType: admissionregistrationv1alpha1.PatchTypeJSONPatch,
-							JSONPatch: &admissionregistrationv1alpha1.JSONPatch{
-								Expression: `contains(object.metadata.labels) ??
+					Mutations: []admissionregistrationv1alpha1.Mutation{{
+						PatchType: admissionregistrationv1alpha1.PatchTypeJSONPatch,
+						JSONPatch: &admissionregistrationv1alpha1.JSONPatch{
+							Expression: `contains(object.metadata.labels) ??
 											[
 												JSONPatch{
 													op: "multiply",
@@ -189,9 +209,8 @@ func TestCompile(t *testing.T) {
 													value: {"managed": "true"}
 												}
 											]`,
-							},
 						},
-					},
+					}},
 				},
 			},
 			polex:   nil,
@@ -201,14 +220,12 @@ func TestCompile(t *testing.T) {
 			name: "invalid jsonPatch expression",
 			pol: &v1beta1.MutatingPolicy{
 				Spec: v1beta1.MutatingPolicySpec{
-					Mutations: []admissionregistrationv1alpha1.Mutation{
-						{
-							PatchType: admissionregistrationv1alpha1.PatchTypeApplyConfiguration,
-							ApplyConfiguration: &admissionregistrationv1alpha1.ApplyConfiguration{
-								Expression: `invalid{spec: Object.spec{containers: [Object.spec.containers{name: "nginx"}]}}`,
-							},
+					Mutations: []admissionregistrationv1alpha1.Mutation{{
+						PatchType: admissionregistrationv1alpha1.PatchTypeApplyConfiguration,
+						ApplyConfiguration: &admissionregistrationv1alpha1.ApplyConfiguration{
+							Expression: `invalid{spec: Object.spec{containers: [Object.spec.containers{name: "nginx"}]}}`,
 						},
-					},
+					}},
 				},
 			},
 			polex:   nil,

--- a/pkg/cel/policies/mpol/validate_test.go
+++ b/pkg/cel/policies/mpol/validate_test.go
@@ -202,6 +202,38 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "variables in match conditions rejected when MAP autogen enabled",
+			pol: &v1beta1.MutatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "invalid-map-compatible-mpol",
+				},
+				Spec: v1beta1.MutatingPolicySpec{
+					MatchConstraints: &v1.MatchResources{
+						ResourceRules: []v1.NamedRuleWithOperations{{
+							RuleWithOperations: v1.RuleWithOperations{
+								Rule: v1.Rule{
+									APIGroups: []string{""},
+									Resources: []string{"pods"},
+								},
+							},
+						}},
+					},
+					Variables: []v1.Variable{{
+						Name:       "targetName",
+						Expression: `"test"`,
+					}},
+					MatchConditions: []v1.MatchCondition{{
+						Name:       "uses-variable",
+						Expression: `variables.targetName == "test"`,
+					}},
+					AutogenConfiguration: &v1beta1.MutatingPolicyAutogenConfiguration{
+						MutatingAdmissionPolicy: &v1beta1.MAPGenerationConfiguration{Enabled: ptr.To(true)},
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #16673

## Summary
- reject MutatingPolicy trigger matchConditions that reference variables when MAP autogen is enabled
- keep the existing permissive behavior when MAP autogen is disabled and add focused compiler/validator coverage
- preserve compiler and validation reasons in `kyverno apply` output for invalid or skipped policies

## Testing
- GOWORK=off go test ./pkg/cel/policies/mpol/compiler ./pkg/cel/policies/mpol ./pkg/cel/policies/mpol/engine
- GOWORK=off go test ./cmd/cli/kubectl-kyverno/commands/apply