### PR TITLE
fix: ignore empty bracket patches in JoinPatches

### DIFF
--- a/pkg/utils/json/utils.go
+++ b/pkg/utils/json/utils.go
@@ -15,14 +15,14 @@ func JoinPatches(patches ...[]byte) []byte {
 	patchOperations := make([]string, 0, len(patches))
 	for _, patch := range patches {
 		str := strings.TrimSpace(string(patch))
-		if len(str) == 0 {
-			continue
-		}
-
 		if strings.HasPrefix(str, "[") {
 			str = strings.TrimPrefix(str, "[")
 			str = strings.TrimSuffix(str, "]")
 			str = strings.TrimSpace(str)
+		}
+
+		if len(str) == 0 {
+			continue
 		}
 
 		patchOperations = append(patchOperations, str)

--- a/pkg/utils/json/utils_test.go
+++ b/pkg/utils/json/utils_test.go
@@ -46,4 +46,9 @@ func Test_JoinPatches(t *testing.T) {
 	if !jsonpatch.Equal([]byte(p1p2p3), patches) {
 		assert.Assert(t, false, "patches are not equal %+v %+v", p1p2p3, string(patches))
 	}
+
+	// Test joining an empty brackets patch with a valid patch
+	patches = JoinPatches([]byte("[]"), []byte(p1))
+	_, err = jsonpatch.DecodePatch(patches)
+	assert.NilError(t, err, "failed to decode patch %s", string(patches))
 }


### PR DESCRIPTION
## Explanation

This PR fixes a bug in `JoinPatches` inside `pkg/utils/json/utils.go` where combining serialized JSON patches with an empty brackets patch (`[]`) produced malformed, invalid JSON (e.g. `[, {"op": "add"}]`). 

This PR moves the empty-string check (`if len(str) == 0`) to execute after the brackets-stripping logic, ensuring that empty lists of operations (`[]`) are correctly ignored instead of being appended as empty strings.

## Related issue

Closes #16710

## Milestone of this PR

<!-- Maintainers will assign the milestone if needed. -->

## Documentation (required for features)

Not applicable (internal JSON patch utility bug fix with no user-facing changes).

## What type of PR is this

/kind bug

## Proposed Changes

- Modified `JoinPatches` in `pkg/utils/json/utils.go` to perform the `len(str) == 0` check after stripping the `[` and `]` brackets.
- Added a unit test in `pkg/utils/json/utils_test.go` that verifies joining `[]` with a valid patch successfully decodes into valid JSON.

### Proof Manifests

Tested and verified locally using the Go unit test suite:

```bash
$ go test ./pkg/utils/json/...
ok      github.com/kyverno/kyverno/pkg/utils/json       0.007s
