### PR TITLE
fix: drop empty patch arrays in JoinPatches

### DIFF
--- a/pkg/utils/json/utils.go
+++ b/pkg/utils/json/utils.go
@@ -25,6 +25,12 @@ func JoinPatches(patches ...[]byte) []byte {
 			str = strings.TrimSpace(str)
 		}
 
+		// An empty array (`[]`) becomes an empty string here; skip it so it does
+		// not join into the result as a stray, comma-producing operation.
+		if len(str) == 0 {
+			continue
+		}
+
 		patchOperations = append(patchOperations, str)
 	}
 

--- a/pkg/utils/json/utils_test.go
+++ b/pkg/utils/json/utils_test.go
@@ -47,3 +47,29 @@ func Test_JoinPatches(t *testing.T) {
 		assert.Assert(t, false, "patches are not equal %+v %+v", p1p2p3, string(patches))
 	}
 }
+
+func Test_JoinPatches_EmptyArray(t *testing.T) {
+	p := `{ "op": "add", "path": "/hello", "value": ["world"] }`
+	expected := `[{ "op": "add", "path": "/hello", "value": ["world"] }]`
+
+	// An empty patch array must be dropped, not turned into an empty operation
+	// that leaves a stray comma and malformed JSON (#16710).
+	patches := JoinPatches([]byte(`[]`), []byte(p))
+	_, err := jsonpatch.DecodePatch(patches)
+	assert.NilError(t, err, "failed to decode patch %s", string(patches))
+	if !jsonpatch.Equal([]byte(expected), patches) {
+		assert.Assert(t, false, "patches are not equal, got %s", string(patches))
+	}
+
+	// The empty array in the trailing position must not leave a trailing comma either.
+	patches = JoinPatches([]byte(p), []byte(`[]`))
+	_, err = jsonpatch.DecodePatch(patches)
+	assert.NilError(t, err, "failed to decode patch %s", string(patches))
+	if !jsonpatch.Equal([]byte(expected), patches) {
+		assert.Assert(t, false, "patches are not equal, got %s", string(patches))
+	}
+
+	// Only empty arrays collapse to nil, consistent with empty strings.
+	patches = JoinPatches([]byte(`[]`), []byte(`[]`))
+	assert.Assert(t, patches == nil, "expected nil, got %#v", string(patches))
+}


### PR DESCRIPTION
## Explanation

`JoinPatches` in `pkg/utils/json/utils.go` combines serialized JSON patches into a single JSON Patch array. When one of the inputs is an empty array (`[]`), it was stripped down to an empty string but still appended to the list, so joining it with a real patch produced malformed JSON with a stray comma — e.g. `[, {"op":"add",...}]` — which then fails to decode. This is a fix of existing behavior.

The empty check was done before the surrounding brackets were removed, so `[]` (length 2) slipped past it. This adds a second check after the brackets are trimmed, skipping the token once it is empty — consistent with how empty-string inputs are already dropped.

## Related issue

Closes #16710

## What type of PR is this

/kind bug

## Proposed Changes

- `pkg/utils/json/utils.go`: skip a patch token that becomes empty after its surrounding `[` / `]` are removed, so an empty array no longer joins in as a stray, comma-producing operation.
- `pkg/utils/json/utils_test.go`: add `Test_JoinPatches_EmptyArray` covering an empty array in the leading and trailing positions (result must decode and equal the single real patch) and two empty arrays collapsing to `nil`. The test fails on `main` (`[, {...}]` fails to decode) and passes with the fix.

Verified locally: `go test -race ./pkg/utils/json/` passes, `gofmt` and `go vet` are clean.
