### PR TITLE
fix: strip cross-namespace ownerReferences in CEL-based generation

### DIFF
--- a/pkg/cel/libs/context.go
+++ b/pkg/cel/libs/context.go
@@ -238,21 +238,26 @@ func (cp *contextProvider) GenerateResources(namespace string, dataList []map[st
 				item.SetOwnerReferences(nil)
 			}
 
+			// Clean up server-populated metadata that must not be copied to the
+			// generated resource, mirroring the legacy clone behavior
+			// (see pkg/background/generate/clone.go). In particular, a non-nil
+			// managedFields is rejected by server-side apply.
+			item.SetUID("")
+			item.SetSelfLink("")
+			item.SetCreationTimestamp(metav1.Time{})
+			item.SetManagedFields(nil)
+			item.SetResourceVersion("")
+
 			// In CLI evaluation mode, we do not create the resource in the cluster
 			// but just store it in the generated resources list.
 			if cp.cliEvaluation {
-				item.SetUID("")
-				item.SetManagedFields(nil)
 				item.SetAnnotations(nil)
 				item.SetNamespace(targetNamespace)
-				item.SetResourceVersion("")
-				item.SetCreationTimestamp(metav1.Time{})
 				cp.generatedResources = append(cp.generatedResources, item)
 				continue
 			}
 			cp.addGenerateLabels(item)
 			item.SetNamespace(targetNamespace)
-			item.SetResourceVersion("")
 			// check if the resource already exists
 			existing, err := cp.client.GetResource(
 				context.TODO(),

--- a/pkg/cel/libs/context.go
+++ b/pkg/cel/libs/context.go
@@ -238,25 +238,30 @@ func (cp *contextProvider) GenerateResources(namespace string, dataList []map[st
 				item.SetOwnerReferences(nil)
 			}
 
+			// In CLI evaluation mode, we do not create the resource in the cluster
+			// but just store it in the generated resources list.
+			if cp.cliEvaluation {
+				item.SetUID("")
+				item.SetManagedFields(nil)
+				item.SetAnnotations(nil)
+				item.SetNamespace(targetNamespace)
+				item.SetResourceVersion("")
+				item.SetCreationTimestamp(metav1.Time{})
+				cp.generatedResources = append(cp.generatedResources, item)
+				continue
+			}
+			cp.addGenerateLabels(item)
 			// Clean up server-populated metadata that must not be copied to the
 			// generated resource, mirroring the legacy clone behavior
 			// (see pkg/background/generate/clone.go). In particular, a non-nil
-			// managedFields is rejected by server-side apply.
+			// managedFields is rejected by server-side apply. This must run after
+			// addGenerateLabels, which reads the source UID and resourceVersion to
+			// set the generate.kyverno.io/source-uid label.
 			item.SetUID("")
 			item.SetSelfLink("")
 			item.SetCreationTimestamp(metav1.Time{})
 			item.SetManagedFields(nil)
 			item.SetResourceVersion("")
-
-			// In CLI evaluation mode, we do not create the resource in the cluster
-			// but just store it in the generated resources list.
-			if cp.cliEvaluation {
-				item.SetAnnotations(nil)
-				item.SetNamespace(targetNamespace)
-				cp.generatedResources = append(cp.generatedResources, item)
-				continue
-			}
-			cp.addGenerateLabels(item)
 			item.SetNamespace(targetNamespace)
 			// check if the resource already exists
 			existing, err := cp.client.GetResource(

--- a/pkg/cel/libs/context.go
+++ b/pkg/cel/libs/context.go
@@ -227,6 +227,17 @@ func (cp *contextProvider) GenerateResources(namespace string, dataList []map[st
 				targetNamespace = ""
 			}
 
+			// When generating a namespaced resource into a different namespace than
+			// its source (the typical cross-namespace clone case), inherited
+			// ownerReferences may point to a namespaced owner that does not exist in
+			// the target namespace, causing the garbage collector to delete the
+			// generated resource almost immediately. Mirror the legacy clone behavior
+			// (see pkg/background/generate/clone.go) by stripping all ownerReferences
+			// when the source namespace is set and differs from the target.
+			if srcNamespace := item.GetNamespace(); srcNamespace != "" && srcNamespace != targetNamespace && item.GetOwnerReferences() != nil {
+				item.SetOwnerReferences(nil)
+			}
+
 			// In CLI evaluation mode, we do not create the resource in the cluster
 			// but just store it in the generated resources list.
 			if cp.cliEvaluation {

--- a/pkg/cel/libs/context_generate_test.go
+++ b/pkg/cel/libs/context_generate_test.go
@@ -284,8 +284,18 @@ func TestGenerateResources_CrossNamespaceStripsOwnerReferences(t *testing.T) {
 		"apiVersion": "v1",
 		"kind":       "ConfigMap",
 		"metadata": map[string]any{
-			"name":      "example",
-			"namespace": "kyverno",
+			"name":              "example",
+			"namespace":         "kyverno",
+			"uid":               "5b7dc768-9a06-4b25-b3e1-02b0e7b8d02a",
+			"resourceVersion":   "12345",
+			"creationTimestamp": "2026-01-01T00:00:00Z",
+			"managedFields": []any{
+				map[string]any{
+					"apiVersion": "v1",
+					"manager":    "external-secrets",
+					"operation":  "Update",
+				},
+			},
 			"ownerReferences": []any{
 				map[string]any{
 					"apiVersion":         "external-secrets.io/v1",
@@ -305,6 +315,9 @@ func TestGenerateResources_CrossNamespaceStripsOwnerReferences(t *testing.T) {
 	generated := cp.GetGeneratedResources()[0]
 	assert.Equal(t, "tenant-ns", generated.GetNamespace())
 	assert.Empty(t, generated.GetOwnerReferences(), "cross-namespace generation must strip ownerReferences")
+	assert.Nil(t, generated.GetManagedFields(), "server-populated managedFields must not be copied")
+	creationTimestamp := generated.GetCreationTimestamp()
+	assert.True(t, creationTimestamp.IsZero(), "server-populated creationTimestamp must not be copied")
 }
 
 // Companion case: generating into the same namespace as the source must keep

--- a/pkg/cel/libs/context_generate_test.go
+++ b/pkg/cel/libs/context_generate_test.go
@@ -264,6 +264,88 @@ func TestGenerateResources_RestoreCacheReportsExistingButDoesNotCreate(t *testin
 	assert.Error(t, err, "restoreCache must not create resources that don't exist yet")
 }
 
+// Regression test for kyverno/kyverno#15444: a resource cloned from another
+// namespace (e.g. a Secret synced by External Secrets that carries an
+// ownerReference to an ExternalSecret CR) must have its ownerReferences
+// stripped, otherwise the owner does not exist in the target namespace and
+// the garbage collector deletes the generated resource almost immediately.
+func TestGenerateResources_CrossNamespaceStripsOwnerReferences(t *testing.T) {
+	fakeClient, err := dclient.NewFakeClient(runtime.NewScheme(), nil)
+	require.NoError(t, err)
+	fakeClient.SetDiscovery(dclient.NewFakeDiscoveryClient(nil))
+
+	cp := &contextProvider{
+		client:     fakeClient,
+		restMapper: generateTestRESTMapper(),
+	}
+	cp.SetGenerateContext("test-gpol", "", "trigger", "tenant-ns", "v1", "", "Namespace", "trigger-uid", false, false)
+
+	cm := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name":      "example",
+			"namespace": "kyverno",
+			"ownerReferences": []any{
+				map[string]any{
+					"apiVersion":         "external-secrets.io/v1",
+					"blockOwnerDeletion": true,
+					"controller":         true,
+					"kind":               "ExternalSecret",
+					"name":               "example",
+					"uid":                "16401acc-ab37-4b5d-b4e2-fbd6f952f602",
+				},
+			},
+		},
+	}
+	err = cp.GenerateResources("tenant-ns", []map[string]any{cm})
+	require.NoError(t, err)
+	require.Len(t, cp.GetGeneratedResources(), 1)
+
+	generated := cp.GetGeneratedResources()[0]
+	assert.Equal(t, "tenant-ns", generated.GetNamespace())
+	assert.Empty(t, generated.GetOwnerReferences(), "cross-namespace generation must strip ownerReferences")
+}
+
+// Companion case: generating into the same namespace as the source must keep
+// the ownerReferences intact, as they remain valid there.
+func TestGenerateResources_SameNamespaceKeepsOwnerReferences(t *testing.T) {
+	fakeClient, err := dclient.NewFakeClient(runtime.NewScheme(), nil)
+	require.NoError(t, err)
+	fakeClient.SetDiscovery(dclient.NewFakeDiscoveryClient(nil))
+
+	cp := &contextProvider{
+		client:     fakeClient,
+		restMapper: generateTestRESTMapper(),
+	}
+	cp.SetGenerateContext("test-gpol", "", "trigger", "tenant-ns", "v1", "", "Namespace", "trigger-uid", false, false)
+
+	cm := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name":      "example",
+			"namespace": "tenant-ns",
+			"ownerReferences": []any{
+				map[string]any{
+					"apiVersion": "external-secrets.io/v1",
+					"kind":       "ExternalSecret",
+					"name":       "example",
+					"uid":        "16401acc-ab37-4b5d-b4e2-fbd6f952f602",
+				},
+			},
+		},
+	}
+	err = cp.GenerateResources("tenant-ns", []map[string]any{cm})
+	require.NoError(t, err)
+	require.Len(t, cp.GetGeneratedResources(), 1)
+
+	generated := cp.GetGeneratedResources()[0]
+	assert.Equal(t, "tenant-ns", generated.GetNamespace())
+	require.Len(t, generated.GetOwnerReferences(), 1, "same-namespace generation must keep ownerReferences")
+	assert.Equal(t, "ExternalSecret", generated.GetOwnerReferences()[0].Kind)
+}
+
 func TestContextProvider_CloneIsolatesPerEvaluationState(t *testing.T) {
 	original := &contextProvider{
 		generatedResources: []*unstructured.Unstructured{

--- a/pkg/cel/libs/context_generate_test.go
+++ b/pkg/cel/libs/context_generate_test.go
@@ -318,6 +318,8 @@ func TestGenerateResources_CrossNamespaceStripsOwnerReferences(t *testing.T) {
 	assert.Nil(t, generated.GetManagedFields(), "server-populated managedFields must not be copied")
 	creationTimestamp := generated.GetCreationTimestamp()
 	assert.True(t, creationTimestamp.IsZero(), "server-populated creationTimestamp must not be copied")
+	assert.Equal(t, "5b7dc768-9a06-4b25-b3e1-02b0e7b8d02a", generated.GetLabels()[common.GenerateSourceUIDLabel],
+		"metadata cleanup must not run before addGenerateLabels reads the source UID/resourceVersion")
 }
 
 // Companion case: generating into the same namespace as the source must keep


### PR DESCRIPTION
## Explanation

`GeneratingPolicy` fails to clone resources that carry `ownerReferences` into a different namespace. A typical case is a Secret synced from Vault by External Secrets, which owns it via an `ExternalSecret` CR: the CEL-based generator (`generator.Apply()`) copies the source object verbatim, including its `ownerReferences`. Since the referenced owner does not exist in the target namespace, the Kubernetes garbage collector deletes the freshly created resource almost immediately — the resource "never gets cloned".

This ports the existing legacy-clone behavior (`pkg/background/generate/clone.go`) to the CEL-based generator: when the source namespace is explicitly set and differs from the target namespace, `ownerReferences` are stripped before creation (both the live-creation and CLI-evaluation paths). Same-namespace generation keeps valid owner references intact; objects without an explicit source namespace are not affected.

This supersedes #16354, which had the right approach but did not compile — its test called `SetGenerateContext` with the stale 8-argument signature (it now takes 10 arguments). This PR carries the same fix, rebased on latest `main`, with compiling tests and all review feedback from #16354 incorporated (only strip when the source namespace is non-empty and differs; accurate code comments).

## Related issue

Closes #15444.

## Proposed Changes

- `pkg/cel/libs/context.go` — in `GenerateResources()`:
  - strip `ownerReferences` when the source namespace is set and differs from the target namespace, mirroring the legacy clone behavior in `pkg/background/generate/clone.go`;
  - clean up server-populated metadata (`uid`, `selfLink`, `creationTimestamp`, `managedFields`, `resourceVersion`) in the live cluster path too, matching the legacy clone path. Previously only the CLI-evaluation path did this; a non-nil `managedFields` is rejected by server-side apply, and a stale `uid` conflicts with the server-assigned one.
- `pkg/cel/libs/context_generate_test.go` — regression tests:
  - `TestGenerateResources_CrossNamespaceStripsOwnerReferences` reproduces #15444 (object sourced from the `kyverno` namespace with an `ExternalSecret` ownerReference plus server-populated metadata, generated into `tenant-ns`) and asserts the generated resource has no `ownerReferences`, `managedFields`, or `creationTimestamp`.
  - `TestGenerateResources_SameNamespaceKeepsOwnerReferences` asserts same-namespace generation preserves `ownerReferences`.

## Proof Manifests

Source Secret (as reported in #15444, owned by an ExternalSecret CR):

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: example
  namespace: kyverno
  ownerReferences:
  - apiVersion: external-secrets.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: ExternalSecret
    name: example
    uid: 16401acc-ab37-4b5d-b4e2-fbd6f952f602
type: kubernetes.io/dockerconfigjson
data:
  .dockerconfigjson: eyJhdXRocyI6e319
```

Policy:

```yaml
apiVersion: policies.kyverno.io/v1
kind: GeneratingPolicy
metadata:
  name: test
spec:
  matchConstraints:
    resourceRules:
    - apiGroups: [""]
      apiVersions: [v1]
      operations: [CREATE, UPDATE]
      resources: [namespaces]
  variables:
  - name: namespace
    expression: object.metadata.name
  - name: secret
    expression: resource.Get("v1", "secrets", "kyverno", "example")
  generate:
  - expression: generator.Apply(variables.namespace, [variables.secret])
```

Before this fix, creating a namespace results in the cloned Secret being garbage-collected right after creation (it never appears). With this fix, the Secret is cloned into the new namespace without `ownerReferences` and persists.

## What type of PR is this

/kind bug

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

Verified locally: `go build ./pkg/cel/...`, `go test -race ./pkg/cel/libs/` (all pass), `goimports`/`gofmt` clean.
