### PR TITLE
fix: align dpol CLI reporting for constraint-excluded resources with vpol/mpol

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -860,13 +860,15 @@ func (c *ApplyCommandConfig) applyDeletingPolicies(
 			status := engineapi.RuleStatusPass
 			message := fmt.Sprintf("%s matched", payloadType)
 			if !resp.Match {
-				if resp.PolicyMatched {
-					status = engineapi.RuleStatusFail
-					message = fmt.Sprintf("%s did not match", payloadType)
-				} else {
-					status = engineapi.RuleStatusSkip
-					message = fmt.Sprintf("%s skipped by policy match constraints", payloadType)
+				if !resp.PolicyMatched {
+					// The resource is not selected by the policy's matchConstraints
+					// (resourceRules, objectSelector, namespaceSelector). Align with
+					// the other CEL policy types (vpol/mpol), which emit no result
+					// row for constraint-excluded resources.
+					continue
 				}
+				status = engineapi.RuleStatusFail
+				message = fmt.Sprintf("%s did not match", payloadType)
 			}
 
 			response := engineapi.NewEngineResponse(*resource, genericPolicy, nil)

--- a/cmd/cli/kubectl-kyverno/commands/test/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command_test.go
@@ -994,5 +994,8 @@ func TestRunTestDeletingPolicyObjectSelectorSkipsUnmatchedResource(t *testing.T)
 	}
 
 	assert.Equal(t, engineapi.RuleStatusPass, got["secret-delete"])
-	assert.Equal(t, engineapi.RuleStatusSkip, got["secret-skip"])
+	// Resources excluded by matchConstraints (here: objectSelector) must not
+	// produce any result row, matching vpol/mpol CLI behavior.
+	_, found := got["secret-skip"]
+	assert.False(t, found, "constraint-excluded resource must not produce a rule response")
 }

--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -854,13 +854,15 @@ func applyDeletingPolicies(
 			status := engineapi.RuleStatusPass
 			message := "resource matched"
 			if !resp.Match {
-				if resp.PolicyMatched {
-					status = engineapi.RuleStatusFail
-					message = "resource did not match"
-				} else {
-					status = engineapi.RuleStatusSkip
-					message = "resource skipped by policy match constraints"
+				if !resp.PolicyMatched {
+					// The resource is not selected by the policy's matchConstraints
+					// (resourceRules, objectSelector, namespaceSelector). Align with
+					// the other CEL policy types (vpol/mpol), which emit no result
+					// row for constraint-excluded resources.
+					continue
 				}
+				status = engineapi.RuleStatusFail
+				message = "resource did not match"
 			}
 
 			response := engineapi.NewEngineResponse(*resource, genericPolicy, nil)

--- a/pkg/cel/policies/dpol/engine/engine.go
+++ b/pkg/cel/policies/dpol/engine/engine.go
@@ -17,8 +17,15 @@ import (
 )
 
 type EngineResponse struct {
-	Resource      *unstructured.Unstructured
-	Match         bool
+	// Resource is the resource the policy was evaluated against.
+	Resource *unstructured.Unstructured
+	// Match reports whether the policy's delete conditions evaluated to true.
+	// Only meaningful when the returned error is nil.
+	Match bool
+	// PolicyMatched reports whether the resource was selected by the policy's
+	// matchConstraints (resourceRules, objectSelector, namespaceSelector).
+	// When false, Match is always false and the delete conditions were not
+	// evaluated. Only meaningful when the returned error is nil.
 	PolicyMatched bool
 }
 

--- a/test/cli/test-deleting-policy/object-selector/kyverno-test.yaml
+++ b/test/cli/test-deleting-policy/object-selector/kyverno-test.yaml
@@ -13,9 +13,3 @@ results:
   resources:
   - secret-delete
   result: pass
-- isDeletingPolicy: true
-  kind: Secret
-  policy: cleanup-invalidated-legacy-sa-tokens
-  resources:
-  - secret-skip
-  result: skip


### PR DESCRIPTION
## Explanation

Follow-up to #16431 (merged), which fixed #16409 by reporting resources excluded by a `DeletingPolicy`'s `matchConstraints.objectSelector` as `skip` instead of `fail` in the Kyverno CLI.

While reviewing #16431 we noticed the chosen reporting behavior is not consistent with the other CEL policy types. The established convention across CEL policies is:

- **`matchConstraints` mismatch** (resourceRules, objectSelector, namespaceSelector): ValidatingPolicy and MutatingPolicy emit **no result row at all** — the engine returns a policy response with empty rules (`handlePolicy` in `pkg/cel/policies/vpol/engine/engine.go` and `pkg/cel/policies/mpol/engine/engine.go`), and empty-rule responses are filtered from CLI output.
- **Explicit `skip`** is reserved for CEL `matchConditions` (`RuleSkip` with `SkipReasonMatchConditions`) — which `DeletingPolicy` does not have.

After #16431, dpol had a third behavior no other CEL policy type has: an explicit `skip` row for constraint exclusion. This PR aligns dpol with the vpol/mpol convention: when the resource is not selected by the policy's `matchConstraints`, the CLI emits no rule response for that policy/resource combination.

This keeps the #16409 fix intact (no spurious `fail`), matches how vpol/mpol CLI tests are written (no result rows for non-selected resources), and avoids per-policy×resource `skip` noise in `kyverno apply` output for every resource kind a policy doesn't match.

The engine-level `PolicyMatched` field introduced in #16431 is kept (and now documented) — only the CLI reporting changes.

## Related issue

Relates to #16409 and #16431 (see the desired-behavior discussion on the merged PR).

## Proposed Changes

- `cmd/cli/kubectl-kyverno/commands/test/test.go`, `cmd/cli/kubectl-kyverno/commands/apply/command.go` — in `applyDeletingPolicies`, when `!resp.PolicyMatched`, skip the policy/resource combination instead of emitting a `skip` rule response.
- `pkg/cel/policies/dpol/engine/engine.go` — add godoc comments documenting the `Match` vs `PolicyMatched` semantics (delete conditions vs. matchConstraints selection; only meaningful when `err == nil`).
- `test/cli/test-deleting-policy/object-selector/kyverno-test.yaml` — drop the `result: skip` expectation for the non-selected Secret (consistent with how vpol/mpol CLI tests are written).
- `cmd/cli/kubectl-kyverno/commands/test/command_test.go` — assert the constraint-excluded resource produces no rule response.

### Proof Manifests

Using the fixture from #16431 (`test/cli/test-deleting-policy/object-selector/`): a `DeletingPolicy` with an `objectSelector` on `kubernetes.io/legacy-token-invalid-since`, one matching Secret (`secret-delete`) and one non-matching Secret (`secret-skip`).

Behavior comparison:

| | `secret-delete` | `secret-skip` |
|---|---|---|
| Before #16431 | pass | **fail** (bug, #16409) |
| After #16431 | pass | skip (inconsistent with vpol/mpol) |
| This PR | pass | no result row (consistent with vpol/mpol) |

## What type of PR is this

/kind bug

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

Verified locally: `go build`, full `commands/test` + `commands/apply` + `pkg/cel/policies/dpol` test suites pass, formatting clean.
