### PR TITLE
fix: validate DeletingPolicy cron schedule at admission

### DIFF
--- a/pkg/cel/policies/dpol/validate.go
+++ b/pkg/cel/policies/dpol/validate.go
@@ -34,8 +34,10 @@ func Validate(dpol v1beta1.DeletingPolicyLike) ([]string, error) {
 
 	// Validate the schedule with the same parser the deleting controller uses to
 	// compute execution times, so a policy that is admitted can always be scheduled.
-	if _, parseErr := cronexpr.Parse(spec.Schedule); parseErr != nil {
-		err = append(err, field.Invalid(field.NewPath("spec").Child("schedule"), spec.Schedule, "schedule spec in the deletingPolicy is not in proper cron format"))
+	if spec.Schedule == "" {
+		err = append(err, field.Required(field.NewPath("spec").Child("schedule"), "schedule is required"))
+	} else if _, parseErr := cronexpr.Parse(spec.Schedule); parseErr != nil {
+		err = append(err, field.Invalid(field.NewPath("spec").Child("schedule"), spec.Schedule, "schedule spec in the deletingPolicy is not in proper cron format: "+parseErr.Error()))
 	}
 
 	if dpol.GetNamespace() != "" && !toggle.AllowHTTPInNamespacedPolicies.Enabled() {

--- a/pkg/cel/policies/dpol/validate.go
+++ b/pkg/cel/policies/dpol/validate.go
@@ -1,6 +1,7 @@
 package dpol
 
 import (
+	"github.com/aptible/supercronic/cronexpr"
 	"github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/cel/compiler"
 	dpolcompiler "github.com/kyverno/kyverno/pkg/cel/policies/dpol/compiler"
@@ -29,6 +30,12 @@ func Validate(dpol v1beta1.DeletingPolicyLike) ([]string, error) {
 
 	if spec.MatchConstraints == nil || len(spec.MatchConstraints.ResourceRules) == 0 {
 		err = append(err, field.Required(field.NewPath("spec").Child("matchConstraints"), "a matchConstraints with at least one resource rule is required"))
+	}
+
+	// Validate the schedule with the same parser the deleting controller uses to
+	// compute execution times, so a policy that is admitted can always be scheduled.
+	if _, parseErr := cronexpr.Parse(spec.Schedule); parseErr != nil {
+		err = append(err, field.Invalid(field.NewPath("spec").Child("schedule"), spec.Schedule, "schedule spec in the deletingPolicy is not in proper cron format"))
 	}
 
 	if dpol.GetNamespace() != "" && !toggle.AllowHTTPInNamespacedPolicies.Enabled() {

--- a/pkg/cel/policies/dpol/validate_test.go
+++ b/pkg/cel/policies/dpol/validate_test.go
@@ -33,9 +33,105 @@ func TestValidate(t *testing.T) {
 							},
 						},
 					},
+					Schedule: "*/5 * * * *",
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "valid policy with six-field schedule",
+			dpol: &v1beta1.DeletingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "six-field-schedule",
+				},
+				Spec: v1beta1.DeletingPolicySpec{
+					MatchConstraints: &v1.MatchResources{
+						ResourceRules: []v1.NamedRuleWithOperations{
+							{
+								RuleWithOperations: v1.RuleWithOperations{
+									Rule: v1.Rule{
+										APIGroups: []string{"apps"},
+										Resources: []string{"deployments"},
+									},
+								},
+							},
+						},
+					},
+					Schedule: "0 */5 * * * *",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid policy with predefined schedule",
+			dpol: &v1beta1.DeletingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "predefined-schedule",
+				},
+				Spec: v1beta1.DeletingPolicySpec{
+					MatchConstraints: &v1.MatchResources{
+						ResourceRules: []v1.NamedRuleWithOperations{
+							{
+								RuleWithOperations: v1.RuleWithOperations{
+									Rule: v1.Rule{
+										APIGroups: []string{"apps"},
+										Resources: []string{"deployments"},
+									},
+								},
+							},
+						},
+					},
+					Schedule: "@daily",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid cron schedule",
+			dpol: &v1beta1.DeletingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bad-schedule",
+				},
+				Spec: v1beta1.DeletingPolicySpec{
+					MatchConstraints: &v1.MatchResources{
+						ResourceRules: []v1.NamedRuleWithOperations{
+							{
+								RuleWithOperations: v1.RuleWithOperations{
+									Rule: v1.Rule{
+										APIGroups: []string{"apps"},
+										Resources: []string{"deployments"},
+									},
+								},
+							},
+						},
+					},
+					Schedule: "not-a-cron",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing schedule",
+			dpol: &v1beta1.DeletingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "no-schedule",
+				},
+				Spec: v1beta1.DeletingPolicySpec{
+					MatchConstraints: &v1.MatchResources{
+						ResourceRules: []v1.NamedRuleWithOperations{
+							{
+								RuleWithOperations: v1.RuleWithOperations{
+									Rule: v1.Rule{
+										APIGroups: []string{"apps"},
+										Resources: []string{"deployments"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
 		},
 		{
 			name: "missing matchConstraints",


### PR DESCRIPTION
## Explanation

Fixes a gap where a DeletingPolicy (or NamespacedDeletingPolicy) with an invalid cron `spec.schedule` was accepted at admission time and then silently never executed. The legacy CleanupPolicy rejected such policies at admission; the new DeletingPolicy path did not. This PR is a fix of existing behavior: invalid schedules are now rejected on create/update with a clear error, matching legacy behavior.

## Related issue

Closes #16726

## Milestone of this PR

/milestone TBD by maintainers

## Documentation (required for features)

Bug fix restoring parity with legacy CleanupPolicy admission behavior — no docs change needed.

## What type of PR is this

/kind bug

## Proposed Changes

- Add a cron format check to `dpol.Validate()` (`pkg/cel/policies/dpol/validate.go`), which serves both DeletingPolicy and NamespacedDeletingPolicy admission.
- The check uses `cronexpr.Parse` from `aptible/supercronic` — the same parser `GetExecutionTime()` uses in the deleting controller — so admission and execution always agree on what is a valid schedule. Deliberately **not** `robfig/cron ParseStandard` (the legacy parser), because that would reject six-field and some predefined expressions that the deleting controller can actually execute.
- Unit tests: invalid schedule rejected, missing schedule rejected, valid five-field/six-field/`@daily` schedules accepted; existing fixtures updated to carry the required `schedule` field.

### Proof Manifests

Before this change the following policy is admitted and never executes (the controller logs a parse error on every reconcile); after this change it is rejected at admission with `spec.schedule: Invalid value: "not-a-cron"`:

```yaml
apiVersion: policies.kyverno.io/v1beta1
kind: DeletingPolicy
metadata:
  name: bad-schedule
spec:
  matchConstraints:
    resourceRules:
      - apiGroups: [""]
        apiVersions: ["v1"]
        operations: ["CREATE"]
        resources: ["pods"]
  schedule: "not-a-cron"
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

`go test ./pkg/cel/policies/dpol/...` passes locally (9/9 subtests in `TestValidate`); `gofmt` and `go vet` clean.