### PR TITLE
test(integration): align ivpol framework tests with single-phase image verification 

### DIFF
--- a/test/integration/ivpol/handler_test.go
+++ b/test/integration/ivpol/handler_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -30,13 +29,21 @@ var (
 )
 
 // cosignPubKey is the public key for ghcr.io/kyverno/test-verify-image:signed, the same key used by
-// the in-tree cosign verifier tests. Policies here verify against it; the hermetic tests never run
-// the verification (they read a pre-stamped outcome), but the key keeps the policy authentic and
-// lets the reconciler compile it.
+// the in-tree cosign verifier tests. Policies here verify against it. The hermetic tests never reach
+// a registry, so verification of the unsigned or unreachable images they use fails and the policies
+// behave as configured (deny or warn); the registry-tagged tests use this key against the real signed
+// image.
 const cosignPubKey = `-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
 5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
 -----END PUBLIC KEY-----`
+
+// unverifiableImage points at a registry host that can never resolve ("registry.invalid" uses the
+// RFC 6761 reserved .invalid TLD). Verification of it fails fast and closed at name resolution, with
+// no network round trip, so the deny and warn assertions below are deterministic and independent of
+// whether the test host has (or flakily has) registry egress. The real signed/unsigned image checks
+// that need a registry live in the registry-tagged tests.
+const unverifiableImage = "registry.invalid/kyverno/unverifiable:latest"
 
 func TestMain(m *testing.M) {
 	var err error
@@ -84,9 +91,10 @@ func waitForPolicyReady(t *testing.T, name, namespace string) {
 	}, 5*time.Second, 100*time.Millisecond, "policy %q (namespace %q) not reconciled in time", name, namespace)
 }
 
-// ivpolSpec returns an authentic ImageValidatingPolicy spec: match pods on CREATE, only images under
-// ghcr.io, verify a cosign signature against the test key. actions selects the validation actions,
-// defaulting to Deny when none are given.
+// ivpolSpec returns an authentic ImageValidatingPolicy spec: match pods on CREATE, verify a cosign
+// signature on every image against the test key. actions selects the validation actions, defaulting
+// to Deny when none are given. The image glob is "*" (verify all images) so the hermetic tests can
+// point a pod at an unresolvable reference and still have it selected for verification.
 func ivpolSpec(actions ...admissionregistrationv1.ValidationAction) policiesv1beta1.ImageValidatingPolicySpec {
 	if len(actions) == 0 {
 		actions = []admissionregistrationv1.ValidationAction{admissionregistrationv1.Deny}
@@ -94,7 +102,7 @@ func ivpolSpec(actions ...admissionregistrationv1.ValidationAction) policiesv1be
 	return policiesv1beta1.ImageValidatingPolicySpec{
 		MatchConstraints:     framework.PodMatchRules(),
 		ValidationAction:     actions,
-		MatchImageReferences: []policiesv1beta1.MatchImageReference{{Glob: "ghcr.io/*"}},
+		MatchImageReferences: []policiesv1beta1.MatchImageReference{{Glob: "*"}},
 		Attestors: []policiesv1beta1.Attestor{{
 			Name:   "cosign",
 			Cosign: &policiesv1beta1.Cosign{Key: &policiesv1beta1.Key{Data: cosignPubKey}},
@@ -132,10 +140,12 @@ func createNivpolWithCleanup(t *testing.T, policy *policiesv1beta1.NamespacedIma
 	t.Cleanup(func() { _ = testEnv.Client.Delete(context.Background(), policy) })
 }
 
-// podRawWithOutcomes builds a Pod carrying the image-verification-outcomes annotation the validate
-// phase reads. outcomes maps a policy name to a status ("pass"/"fail"/"warning"). This is what the
-// mutate phase would normally stamp; seeding it lets us exercise the validate decision hermetically.
-func podRawWithOutcomes(t *testing.T, name, namespace string, outcomes map[string]string) []byte {
+// podRawWithImageAndOutcomes builds a Pod running the given image and carrying a forged
+// image-verification-outcomes annotation. outcomes maps a policy name to a status ("pass"/"fail").
+// The annotation is what an attacker (or a skipped mutate webhook) could pre-stamp; the validating
+// phase must ignore it and verify the image itself, so tests use this to prove the stamp is not
+// trusted (see issue #16336).
+func podRawWithImageAndOutcomes(t *testing.T, name, namespace, image string, outcomes map[string]string) []byte {
 	t.Helper()
 	stamped := map[string]map[string]string{}
 	for polName, status := range outcomes {
@@ -157,7 +167,7 @@ func podRawWithOutcomes(t *testing.T, name, namespace string, outcomes map[strin
 			"annotations": map[string]string{kyverno.AnnotationImageVerifyOutcomes: string(outcomesJSON)},
 		},
 		"spec": map[string]any{
-			"containers": []any{map[string]any{"name": "app", "image": "ghcr.io/kyverno/test-verify-image:signed"}},
+			"containers": []any{map[string]any{"name": "app", "image": image}},
 		},
 	}
 	raw, err := json.Marshal(pod)
@@ -165,40 +175,8 @@ func podRawWithOutcomes(t *testing.T, name, namespace string, outcomes map[strin
 	return raw
 }
 
-// outcomeStatusFor reports the verification status the mutating phase recorded for a policy in the
-// image-verification-outcomes annotation it patches onto the object. An empty string means no verdict
-// was recorded, i.e. the policy never got as far as verifying an image. Note that a policy which does
-// not apply can still appear with an empty outcome (autogen variants share their parent's name), so
-// the status, not the presence of the name, is what says whether verification actually ran.
-func outcomeStatusFor(t *testing.T, patch []byte, policyName string) string {
-	t.Helper()
-	if len(patch) == 0 {
-		return ""
-	}
-	var ops []struct {
-		Path  string `json:"path"`
-		Value any    `json:"value"`
-	}
-	require.NoError(t, json.Unmarshal(patch, &ops))
-
-	annotationPath := "/metadata/annotations/" + strings.ReplaceAll(kyverno.AnnotationImageVerifyOutcomes, "/", "~1")
-	for _, op := range ops {
-		if op.Path != annotationPath {
-			continue
-		}
-		raw, ok := op.Value.(string)
-		require.True(t, ok, "outcomes annotation value should be a JSON string")
-		outcomes := map[string]struct {
-			Status string `json:"status"`
-		}{}
-		require.NoError(t, json.Unmarshal([]byte(raw), &outcomes))
-		return outcomes[policyName].Status
-	}
-	return ""
-}
-
-// podRawWithImage builds a Pod running the given image and no image-verification-outcomes annotation,
-// i.e. a pod that has not been through the mutating phase yet.
+// podRawWithImage builds a Pod running the given image, with no image-verification-outcomes
+// annotation. This is the normal shape the validating phase verifies.
 func podRawWithImage(t *testing.T, name, namespace, image string) []byte {
 	t.Helper()
 	pod := map[string]any{
@@ -214,53 +192,49 @@ func podRawWithImage(t *testing.T, name, namespace, image string) []byte {
 	return raw
 }
 
-// podRawNoOutcomes builds a Pod with no image-verification-outcomes annotation.
-func podRawNoOutcomes(t *testing.T, name, namespace string) []byte {
-	t.Helper()
-	return podRawWithImage(t, name, namespace, "ghcr.io/kyverno/test-verify-image:signed")
-}
-
-// TestValidate_MissingOutcomesAnnotation_FailsClosed proves the two-phase contract is enforced: if a
-// pod reaches the validating webhook without the outcomes annotation the mutating phase should have
-// stamped, the request is refused rather than admitted unverified.
-func TestValidate_MissingOutcomesAnnotation_FailsClosed(t *testing.T) {
-	createIvpolWithCleanup(t, newIvpol("require-outcomes"))
-	waitForPolicyReady(t, "require-outcomes", "")
+// TestValidate_UnverifiableImage_FailsClosed is the fail-closed baseline: when an image cannot be
+// verified (it is unsigned, and the hermetic run has no registry egress to complete the check
+// either), a Deny policy refuses the pod rather than admitting it unverified.
+func TestValidate_UnverifiableImage_FailsClosed(t *testing.T) {
+	createIvpolWithCleanup(t, newIvpol("require-signed"))
+	waitForPolicyReady(t, "require-signed", "")
 
 	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
 
-	raw := podRawNoOutcomes(t, "unstamped", "default")
-	ctx := framework.ContextWithPolicies(context.Background(), "require-outcomes")
-	resp := h.ValidateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("unstamped", "default", raw), "", time.Now())
+	raw := podRawWithImage(t, "unsigned-pod", "default", unverifiableImage)
+	ctx := framework.ContextWithPolicies(context.Background(), "require-signed")
+	resp := h.ValidateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("unsigned-pod", "default", raw), "", time.Now())
 
-	assert.False(t, resp.Allowed, "a pod without verification outcomes must not be admitted")
+	assert.False(t, resp.Allowed, "a pod whose image cannot be verified must not be admitted")
 }
 
-// TestValidate_PassOutcome_AdmitsPod is the baseline of the annotation contract: a verified image
-// carries a pass outcome and the pod is admitted.
-func TestValidate_PassOutcome_AdmitsPod(t *testing.T) {
-	createIvpolWithCleanup(t, newIvpol("verified-passes"))
-	waitForPolicyReady(t, "verified-passes", "")
+// TestValidate_StampedOutcomeIsNotTrusted proves the annotation-trust hardening from #16336: the
+// validating phase does its own image verification and never trusts a pre-stamped
+// image-verification-outcomes annotation. A pod forges a passing outcome for an image that does not
+// actually verify, and it is still denied. (A genuinely signed image being admitted is covered by
+// the registry-tagged tests, which can reach a registry to complete the signature check.)
+func TestValidate_StampedOutcomeIsNotTrusted(t *testing.T) {
+	createIvpolWithCleanup(t, newIvpol("reverify-stamped"))
+	waitForPolicyReady(t, "reverify-stamped", "")
 
 	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
 
-	raw := podRawWithOutcomes(t, "app", "default", map[string]string{"verified-passes": "pass"})
-	ctx := framework.ContextWithPolicies(context.Background(), "verified-passes")
+	raw := podRawWithImageAndOutcomes(t, "app", "default", unverifiableImage, map[string]string{"reverify-stamped": "pass"})
+	ctx := framework.ContextWithPolicies(context.Background(), "reverify-stamped")
 	resp := h.ValidateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("app", "default", raw), "", time.Now())
 
-	assert.True(t, resp.Allowed, "a pod with a passing verification outcome must be admitted")
-	assert.Empty(t, resp.Warnings, "a passing outcome must not raise warnings")
+	assert.False(t, resp.Allowed, "a forged pass outcome must not be trusted; the image is re-verified and denied")
 }
 
-// TestValidate_WarnAction_AdmitsPodWithWarning covers the rollout path teams use before enforcing:
-// the same failing verification only warns when the policy is in Warn mode.
+// TestValidate_WarnAction_AdmitsPodWithWarning covers the rollout path teams use before enforcing: a
+// failing verification only warns, and does not block, when the policy is in Warn mode.
 func TestValidate_WarnAction_AdmitsPodWithWarning(t *testing.T) {
 	createIvpolWithCleanup(t, newIvpol("warn-only", admissionregistrationv1.Warn))
 	waitForPolicyReady(t, "warn-only", "")
 
 	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
 
-	raw := podRawWithOutcomes(t, "app", "default", map[string]string{"warn-only": "fail"})
+	raw := podRawWithImage(t, "app", "default", unverifiableImage)
 	ctx := framework.ContextWithPolicies(context.Background(), "warn-only")
 	resp := h.ValidateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("app", "default", raw), "", time.Now())
 
@@ -268,21 +242,24 @@ func TestValidate_WarnAction_AdmitsPodWithWarning(t *testing.T) {
 	assert.NotEmpty(t, resp.Warnings, "a Warn policy must surface the failed verification as a warning")
 }
 
-// TestValidate_OutcomeMissingForPolicy_DeniesPod covers the case where the annotation exists but
-// carries no verdict for this policy (for example the policy was created between the two phases):
-// the policy is treated as not evaluated and the pod is denied rather than let through.
-func TestValidate_OutcomeMissingForPolicy_DeniesPod(t *testing.T) {
-	createIvpolWithCleanup(t, newIvpol("late-policy"))
-	waitForPolicyReady(t, "late-policy", "")
+// TestValidate_MultiplePolicies_DenyAndWarnEnforcedIndependently covers a pod matched by two cluster
+// policies at once: a Deny policy and a Warn policy. Both fail verification, so the request is blocked
+// by the Deny policy and still carries the Warn policy's warning, proving the per-policy actions are
+// aggregated rather than one overriding the other.
+func TestValidate_MultiplePolicies_DenyAndWarnEnforcedIndependently(t *testing.T) {
+	createIvpolWithCleanup(t, newIvpol("enforce-signed"))
+	createIvpolWithCleanup(t, newIvpol("observe-signed", admissionregistrationv1.Warn))
+	waitForPolicyReady(t, "enforce-signed", "")
+	waitForPolicyReady(t, "observe-signed", "")
 
 	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
 
-	// The annotation only carries a verdict for some other policy.
-	raw := podRawWithOutcomes(t, "app", "default", map[string]string{"a-different-policy": "pass"})
-	ctx := framework.ContextWithPolicies(context.Background(), "late-policy")
+	raw := podRawWithImage(t, "app", "default", unverifiableImage)
+	ctx := framework.ContextWithPolicies(context.Background(), "enforce-signed", "observe-signed")
 	resp := h.ValidateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("app", "default", raw), "", time.Now())
 
-	assert.False(t, resp.Allowed, "a policy with no recorded verdict must not admit the pod")
+	assert.False(t, resp.Allowed, "the Deny policy must block the pod")
+	assert.NotEmpty(t, resp.Warnings, "the Warn policy must still surface its warning alongside the deny")
 }
 
 // TestValidate_SameNameClusterAndNamespacedPolicies_DoNotCollide covers the hazard called out by the
@@ -298,7 +275,7 @@ func TestValidate_SameNameClusterAndNamespacedPolicies_DoNotCollide(t *testing.T
 
 	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
 	ctx := framework.ContextWithPolicies(context.Background(), "shared-name")
-	raw := podRawWithOutcomes(t, "app", "collide-ns", map[string]string{"shared-name": "fail"})
+	raw := podRawWithImage(t, "app", "collide-ns", unverifiableImage)
 
 	// The namespaced route must pick the namespaced (Deny) policy.
 	nsResp := h.ValidateNamespaced(ctx, logr.Discard(), framework.PodAdmissionRequest("app", "collide-ns", raw), "", time.Now())
@@ -310,30 +287,27 @@ func TestValidate_SameNameClusterAndNamespacedPolicies_DoNotCollide(t *testing.T
 	assert.NotEmpty(t, clusterResp.Warnings, "the cluster Warn policy must surface a warning")
 }
 
-// TestMutateNamespaced_PolicyDoesNotApplyAcrossNamespaces mirrors the validate-phase scoping check on
-// the mutating route: a namespaced policy must not even be evaluated for a pod in another namespace,
-// so no verification runs and no outcomes annotation is stamped.
-func TestMutateNamespaced_PolicyDoesNotApplyAcrossNamespaces(t *testing.T) {
-	framework.CreateNamespace(t, testEnv.KubeClient, "mutate-a")
-	framework.CreateNamespace(t, testEnv.KubeClient, "mutate-b")
-	createNivpolWithCleanup(t, newNivpol("mutate-crossns", "mutate-a"))
-	waitForPolicyReady(t, "mutate-crossns", "mutate-a")
+// TestMutate_IsNoOp confirms the mutating webhook no longer verifies images or stamps an outcome
+// annotation (issue #16336): verification moved entirely to the validating phase. Even a pod whose
+// image would fail verification is admitted unchanged, with no patch, by the mutating route.
+func TestMutate_IsNoOp(t *testing.T) {
+	createIvpolWithCleanup(t, newIvpol("mutate-noop"))
+	waitForPolicyReady(t, "mutate-noop", "")
 
 	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
 
-	raw := podRawNoOutcomes(t, "app", "mutate-b")
-	ctx := framework.ContextWithPolicies(context.Background(), "mutate-crossns")
-	resp := h.MutateNamespaced(ctx, logr.Discard(), framework.PodAdmissionRequest("app", "mutate-b", raw), "", time.Now())
+	raw := podRawWithImage(t, "app", "default", unverifiableImage)
+	ctx := framework.ContextWithPolicies(context.Background(), "mutate-noop")
+	resp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("app", "default", raw), "", time.Now())
 
-	assert.True(t, resp.Allowed, "the mutating route must admit a pod no namespaced policy applies to")
-	assert.Empty(t, outcomeStatusFor(t, resp.Patch, "mutate-crossns"),
-		"a policy from another namespace must not verify the image")
+	assert.True(t, resp.Allowed, "the mutating route must admit the pod")
+	assert.Empty(t, resp.Patch, "the mutating route must not patch the pod (no verification, no stamped outcome)")
 }
 
-// TestMutate_MatchConditionNotMet_SkipsBeforeVerification covers the common "only enforce on
-// production workloads" shape: a pod that does not satisfy the policy matchConditions is admitted
-// without the policy being evaluated at all, so no image is ever pulled and no verdict is recorded.
-func TestMutate_MatchConditionNotMet_SkipsBeforeVerification(t *testing.T) {
+// TestValidate_MatchConditionNotMet_SkipsVerification covers the common "only enforce on production
+// workloads" shape: a pod that does not satisfy the policy matchConditions is not evaluated at all, so
+// its image (which would otherwise fail verification) is never pulled and the pod is admitted.
+func TestValidate_MatchConditionNotMet_SkipsVerification(t *testing.T) {
 	policy := newIvpol("prod-only")
 	policy.Spec.MatchConditions = []admissionregistrationv1.MatchCondition{{
 		Name:       "check-prod-label",
@@ -345,19 +319,19 @@ func TestMutate_MatchConditionNotMet_SkipsBeforeVerification(t *testing.T) {
 	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
 
 	// The pod carries no prod label, so the match condition is not met.
-	raw := podRawNoOutcomes(t, "dev-app", "default")
+	raw := podRawWithImage(t, "dev-app", "default", unverifiableImage)
 	ctx := framework.ContextWithPolicies(context.Background(), "prod-only")
-	resp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("dev-app", "default", raw), "", time.Now())
+	resp := h.ValidateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("dev-app", "default", raw), "", time.Now())
 
 	assert.True(t, resp.Allowed, "a pod outside the policy match conditions must be admitted")
-	assert.Empty(t, outcomeStatusFor(t, resp.Patch, "prod-only"),
-		"a policy whose match conditions are not met must not verify the image")
+	assert.Empty(t, resp.Warnings, "a policy whose match conditions are not met must not verify the image or warn")
 }
 
-// TestMutate_PolicyExceptionSkipsVerification covers the break-glass path: a PolicyException naming
-// the policy exempts the matching pod, and the recorded outcome is a skip rather than a verification
-// verdict, so the image is never pulled.
-func TestMutate_PolicyExceptionSkipsVerification(t *testing.T) {
+// TestValidate_PolicyExceptionSkipsVerification covers the break-glass path: a PolicyException naming
+// the policy exempts the matching pod, so the validating phase skips verification for it. The image
+// is one that would otherwise fail to verify, so admission proves the exception short-circuited
+// before the image was pulled rather than the image happening to pass.
+func TestValidate_PolicyExceptionSkipsVerification(t *testing.T) {
 	exception := &policiesv1beta1.PolicyException{
 		ObjectMeta: metav1.ObjectMeta{Name: "allow-migration-pod", Namespace: "default"},
 		Spec: policiesv1beta1.PolicyExceptionSpec{
@@ -379,18 +353,17 @@ func TestMutate_PolicyExceptionSkipsVerification(t *testing.T) {
 
 	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
 
-	raw := podRawNoOutcomes(t, "skipped-pod", "default")
+	raw := podRawWithImage(t, "skipped-pod", "default", unverifiableImage)
 	ctx := framework.ContextWithPolicies(context.Background(), "exception-verify")
-	resp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("skipped-pod", "default", raw), "", time.Now())
+	resp := h.ValidateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("skipped-pod", "default", raw), "", time.Now())
 
 	assert.True(t, resp.Allowed, "an exempted pod must be admitted")
-	assert.Equal(t, "skip", outcomeStatusFor(t, resp.Patch, "exception-verify"),
-		"the exempted pod must record a skip rather than a verification verdict")
+	assert.Empty(t, resp.Warnings, "an exempted pod must not raise warnings")
 }
 
 // TestMutate_ResourceOutsideMatchConstraints_NotEvaluated confirms matchConstraints filtering reaches
 // the handler: a policy scoped to pods records nothing for a namespace admission request.
-func TestMutate_ResourceOutsideMatchConstraints_NotEvaluated(t *testing.T) {
+func TestValidate_ResourceOutsideMatchConstraints_NotEvaluated(t *testing.T) {
 	createIvpolWithCleanup(t, newIvpol("pods-only"))
 	waitForPolicyReady(t, "pods-only", "")
 
@@ -404,11 +377,10 @@ func TestMutate_ResourceOutsideMatchConstraints_NotEvaluated(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := framework.ContextWithPolicies(context.Background(), "pods-only")
-	resp := h.MutateClustered(ctx, logr.Discard(), framework.NamespaceAdmissionRequest("some-namespace", nsRaw), "", time.Now())
+	resp := h.ValidateClustered(ctx, logr.Discard(), framework.NamespaceAdmissionRequest("some-namespace", nsRaw), "", time.Now())
 
 	assert.True(t, resp.Allowed, "a resource outside the policy match constraints must be admitted")
-	assert.Empty(t, outcomeStatusFor(t, resp.Patch, "pods-only"),
-		"a policy scoped to pods must not verify images for a namespace")
+	assert.Empty(t, resp.Warnings, "a policy scoped to pods must not verify images for a namespace")
 }
 
 // TestImageValidatingPolicy_ReconcilesClusterAndNamespaced guards the single-reconciler invariant the
@@ -424,9 +396,9 @@ func TestImageValidatingPolicy_ReconcilesClusterAndNamespaced(t *testing.T) {
 }
 
 // TestValidateNamespaced_PolicyDoesNotApplyAcrossNamespaces is the core scoping regression: a
-// NamespacedImageValidatingPolicy in ns-a must not enforce against a pod in ns-b. The ns-b pod even
-// carries a stamped "fail" outcome for that policy as a trap; correct namespace scoping filters the
-// ns-a policy out so the trap is never consulted, and the pod is admitted.
+// NamespacedImageValidatingPolicy in ns-a must not enforce against a pod in ns-b. The pod runs an
+// image that would fail verification, so admission proves the ns-a policy was scoped out rather than
+// evaluated.
 func TestValidateNamespaced_PolicyDoesNotApplyAcrossNamespaces(t *testing.T) {
 	framework.CreateNamespace(t, testEnv.KubeClient, "team-a")
 	framework.CreateNamespace(t, testEnv.KubeClient, "team-b")
@@ -435,8 +407,7 @@ func TestValidateNamespaced_PolicyDoesNotApplyAcrossNamespaces(t *testing.T) {
 
 	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
 
-	// Pod in team-b carries a fail verdict for the team-a policy; scoping must ignore it.
-	raw := podRawWithOutcomes(t, "app", "team-b", map[string]string{"req-crossns": "fail"})
+	raw := podRawWithImage(t, "app", "team-b", unverifiableImage)
 	ctx := framework.ContextWithPolicies(context.Background(), "req-crossns")
 	resp := h.ValidateNamespaced(ctx, logr.Discard(), framework.PodAdmissionRequest("app", "team-b", raw), "", time.Now())
 
@@ -452,7 +423,7 @@ func TestValidateNamespaced_PolicyAppliesInOwnNamespace(t *testing.T) {
 
 	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
 
-	raw := podRawWithOutcomes(t, "app", "team-own", map[string]string{"req-ownns": "fail"})
+	raw := podRawWithImage(t, "app", "team-own", unverifiableImage)
 	ctx := framework.ContextWithPolicies(context.Background(), "req-ownns")
 	resp := h.ValidateNamespaced(ctx, logr.Discard(), framework.PodAdmissionRequest("app", "team-own", raw), "", time.Now())
 
@@ -469,7 +440,7 @@ func TestValidateClustered_PolicyAppliesInEveryNamespace(t *testing.T) {
 	ctx := framework.ContextWithPolicies(context.Background(), "cluster-require-signed")
 
 	for _, ns := range []string{"default", "kube-system"} {
-		raw := podRawWithOutcomes(t, "app", ns, map[string]string{"cluster-require-signed": "fail"})
+		raw := podRawWithImage(t, "app", ns, unverifiableImage)
 		resp := h.ValidateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("app", ns, raw), "", time.Now())
 		assert.Falsef(t, resp.Allowed, "cluster policy must deny an unverified pod in namespace %q", ns)
 	}
@@ -485,7 +456,7 @@ func TestValidateNamespaced_IgnoresClusterPolicy(t *testing.T) {
 
 	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
 
-	raw := podRawWithOutcomes(t, "app", "route-ns", map[string]string{"cluster-only": "fail"})
+	raw := podRawWithImage(t, "app", "route-ns", unverifiableImage)
 	ctx := framework.ContextWithPolicies(context.Background(), "cluster-only")
 	resp := h.ValidateNamespaced(ctx, logr.Discard(), framework.PodAdmissionRequest("app", "route-ns", raw), "", time.Now())
 

--- a/test/integration/ivpol/registry_test.go
+++ b/test/integration/ivpol/registry_test.go
@@ -1,9 +1,9 @@
 //go:build integration && registry
 
-// These tests drive the mutating phase against real container registries, so they perform the actual
-// cosign and notary verification instead of reading a pre-stamped outcome. They are kept behind the
-// extra "registry" build tag because they need outbound network (ghcr.io, and Rekor for keyless), and
-// each one costs a registry round trip. Run them with:
+// These tests drive the validating phase against real container registries, so they perform the
+// actual cosign and notary verification. They are kept behind the extra "registry" build tag because
+// they need outbound network (ghcr.io, and Rekor for keyless), and each one costs a registry round
+// trip. Run them with:
 //
 //	go test -tags="integration registry" ./test/integration/ivpol/...
 //
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/go-logr/logr"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	ivpol "github.com/kyverno/kyverno/pkg/webhooks/resource/ivpol"
@@ -28,7 +27,9 @@ import (
 )
 
 const (
-	// Images published by the kyverno test image repositories.
+	// Images published by the kyverno test image repositories. These are real images the
+	// registry-tagged tests pull and verify; the hermetic tests use an unresolvable reference instead
+	// (see unverifiableImage in handler_test.go).
 	signedImage   = "ghcr.io/kyverno/test-verify-image:signed"
 	unsignedImage = "ghcr.io/kyverno/test-verify-image:unsigned"
 
@@ -72,17 +73,6 @@ ByCEQNhtHgN6V20b8KU2oLBZ9vyB8V010dQz0NRTDLhkcvJig00535/LUylECYAJ
 uOKpF5rWAruB5PCIrquamOejpXV9aQA/K2JQDuc0mcKz
 -----END CERTIFICATE-----`
 
-// applyOutcomePatch applies the JSON patch the mutating phase produced to the raw pod, the way the
-// API server applies an admission patch before handing the object to the next webhook.
-func applyOutcomePatch(t *testing.T, raw []byte, patch []byte) []byte {
-	t.Helper()
-	decoded, err := jsonpatch.DecodePatch(patch)
-	require.NoError(t, err)
-	patched, err := decoded.Apply(raw)
-	require.NoError(t, err)
-	return patched
-}
-
 // requireImageReachable skips the test when the registry cannot be reached, matching the convention
 // the in-tree cosign verifier tests use so a developer without egress (or a transient registry
 // outage) sees a skip instead of a spurious failure.
@@ -125,75 +115,74 @@ func cosignKeylessPolicy(name, issuer, subject string) *policiesv1beta1.ImageVal
 	return policy
 }
 
-// mutatePod runs the mutating webhook route for a pod carrying the given image and returns the
-// admission response, which holds the verification outcome the phase recorded.
-func mutatePod(t *testing.T, policyName, podName, namespace, image string) (bool, string) {
+// validatePod runs the validating webhook route for a pod carrying the given image and returns
+// whether the request was admitted along with any warnings. Verification happens entirely in this
+// phase (issue #16336): a signed image is admitted, an unsigned or untrusted one is denied.
+func validatePod(t *testing.T, policyName, podName, namespace, image string) (bool, []string) {
 	t.Helper()
 	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
 	raw := podRawWithImage(t, podName, namespace, image)
 	ctx := framework.ContextWithPolicies(context.Background(), policyName)
-	resp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest(podName, namespace, raw), "", time.Now())
-	return resp.Allowed, outcomeStatusFor(t, resp.Patch, policyName)
+	resp := h.ValidateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest(podName, namespace, raw), "", time.Now())
+	return resp.Allowed, resp.Warnings
 }
 
-// TestMutate_CosignSignedImage_VerifiesSuccessfully is the end to end signature check: a real signed
-// image is pulled from the registry, verified against the policy key, and recorded as passing.
-func TestMutate_CosignSignedImage_VerifiesSuccessfully(t *testing.T) {
+// TestValidate_CosignSignedImage_Admits is the end to end signature check: a real signed image is
+// pulled from the registry, verified against the policy key, and admitted.
+func TestValidate_CosignSignedImage_Admits(t *testing.T) {
 	requireImageReachable(t, signedImage)
 
 	createIvpolWithCleanup(t, cosignKeyedPolicy("cosign-signed", cosignPubKey))
 	waitForPolicyReady(t, "cosign-signed", "")
 
-	allowed, status := mutatePod(t, "cosign-signed", "signed-pod", "default", signedImage)
+	allowed, warnings := validatePod(t, "cosign-signed", "signed-pod", "default", signedImage)
 
 	assert.True(t, allowed, "a correctly signed image must be admitted")
-	assert.Equal(t, "pass", status, "a correctly signed image must record a passing verification")
+	assert.Empty(t, warnings, "a passing verification must not warn")
 }
 
-// TestMutate_UnsignedImage_FailsVerification is the negative control for the check above: the same
-// policy against an unsigned image records a failure.
-func TestMutate_UnsignedImage_FailsVerification(t *testing.T) {
+// TestValidate_UnsignedImage_Denies is the negative control for the check above: the same policy
+// against an unsigned image denies the pod.
+func TestValidate_UnsignedImage_Denies(t *testing.T) {
 	requireImageReachable(t, unsignedImage)
 
 	createIvpolWithCleanup(t, cosignKeyedPolicy("cosign-unsigned", cosignPubKey))
 	waitForPolicyReady(t, "cosign-unsigned", "")
 
-	_, status := mutatePod(t, "cosign-unsigned", "unsigned-pod", "default", unsignedImage)
+	allowed, _ := validatePod(t, "cosign-unsigned", "unsigned-pod", "default", unsignedImage)
 
-	assert.Equal(t, "fail", status, "an unsigned image must record a failed verification")
+	assert.False(t, allowed, "an unsigned image must be denied")
 }
 
-// TestMutate_CosignKeyedOrgImage_VerifiesSuccessfully covers the key based images published by the
-// kyverno test-images repository, which are signed with a different key than test-verify-image.
-func TestMutate_CosignKeyedOrgImage_VerifiesSuccessfully(t *testing.T) {
+// TestValidate_CosignKeyedOrgImage_Admits covers the key based images published by the kyverno
+// test-images repository, which are signed with a different key than test-verify-image.
+func TestValidate_CosignKeyedOrgImage_Admits(t *testing.T) {
 	requireImageReachable(t, keyedOrgImage)
 
 	createIvpolWithCleanup(t, cosignKeyedPolicy("cosign-org-keyed", orgCosignPubKey))
 	waitForPolicyReady(t, "cosign-org-keyed", "")
 
-	allowed, status := mutatePod(t, "cosign-org-keyed", "org-keyed-pod", "default", keyedOrgImage)
+	allowed, _ := validatePod(t, "cosign-org-keyed", "org-keyed-pod", "default", keyedOrgImage)
 
 	assert.True(t, allowed, "an image signed with the org key must be admitted")
-	assert.Equal(t, "pass", status, "an image signed with the org key must record a passing verification")
 }
 
-// TestMutate_CosignKeylessImage_VerifiesSuccessfully covers keyless (OIDC) signing, which also
-// consults the Rekor transparency log.
-func TestMutate_CosignKeylessImage_VerifiesSuccessfully(t *testing.T) {
+// TestValidate_CosignKeylessImage_Admits covers keyless (OIDC) signing, which also consults the Rekor
+// transparency log.
+func TestValidate_CosignKeylessImage_Admits(t *testing.T) {
 	requireImageReachable(t, keylessOrgImage)
 
 	createIvpolWithCleanup(t, cosignKeylessPolicy("cosign-keyless", githubActionsIssuer, githubWorkflowID))
 	waitForPolicyReady(t, "cosign-keyless", "")
 
-	allowed, status := mutatePod(t, "cosign-keyless", "keyless-pod", "default", keylessOrgImage)
+	allowed, _ := validatePod(t, "cosign-keyless", "keyless-pod", "default", keylessOrgImage)
 
 	assert.True(t, allowed, "a keyless signed image from the expected workflow must be admitted")
-	assert.Equal(t, "pass", status, "a keyless signed image must record a passing verification")
 }
 
-// TestMutate_KeylessWrongIdentity_FailsVerification proves the keyless identity is actually enforced:
-// the image is signed, but by a different workflow than the policy trusts.
-func TestMutate_KeylessWrongIdentity_FailsVerification(t *testing.T) {
+// TestValidate_KeylessWrongIdentity_Denies proves the keyless identity is actually enforced: the
+// image is signed, but by a different workflow than the policy trusts.
+func TestValidate_KeylessWrongIdentity_Denies(t *testing.T) {
 	requireImageReachable(t, keylessOrgImage)
 
 	policy := cosignKeylessPolicy("cosign-wrong-identity", githubActionsIssuer,
@@ -201,38 +190,28 @@ func TestMutate_KeylessWrongIdentity_FailsVerification(t *testing.T) {
 	createIvpolWithCleanup(t, policy)
 	waitForPolicyReady(t, "cosign-wrong-identity", "")
 
-	_, status := mutatePod(t, "cosign-wrong-identity", "wrong-identity-pod", "default", keylessOrgImage)
+	allowed, _ := validatePod(t, "cosign-wrong-identity", "wrong-identity-pod", "default", keylessOrgImage)
 
-	assert.NotEqual(t, "pass", status, "an image signed by another workflow identity must not pass")
+	assert.False(t, allowed, "an image signed by another workflow identity must be denied")
 }
 
-// TestMutateThenValidate_TwoPhaseFlowAdmitsVerifiedPod wires both webhook phases together the way the
-// API server does: the mutating phase verifies the image and stamps the outcome, and the validating
-// phase reads that stamp and admits the pod. Neither phase is meaningful on its own.
-func TestMutateThenValidate_TwoPhaseFlowAdmitsVerifiedPod(t *testing.T) {
+// TestValidate_SignedImage_AdmitsInSinglePhase confirms the post-#16336 single-phase model: the pod
+// carries no pre-stamped outcome annotation, so the validating phase verifies the image on its own
+// and admits it, with no mutating phase involved.
+func TestValidate_SignedImage_AdmitsInSinglePhase(t *testing.T) {
 	requireImageReachable(t, signedImage)
 
-	createIvpolWithCleanup(t, cosignKeyedPolicy("two-phase", cosignPubKey))
-	waitForPolicyReady(t, "two-phase", "")
+	createIvpolWithCleanup(t, cosignKeyedPolicy("single-phase", cosignPubKey))
+	waitForPolicyReady(t, "single-phase", "")
 
-	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
-	ctx := framework.ContextWithPolicies(context.Background(), "two-phase")
+	allowed, warnings := validatePod(t, "single-phase", "single-phase-pod", "default", signedImage)
 
-	// Phase 1: verify the image and collect the outcomes the API server would apply to the object.
-	raw := podRawWithImage(t, "two-phase-pod", "default", signedImage)
-	mutateResp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("two-phase-pod", "default", raw), "", time.Now())
-	require.True(t, mutateResp.Allowed, "the mutating phase must admit the pod")
-	require.Equal(t, "pass", outcomeStatusFor(t, mutateResp.Patch, "two-phase"), "the mutating phase must verify the image")
-
-	// Apply the patch, as the API server does, then run the validating phase on the patched pod.
-	patched := applyOutcomePatch(t, raw, mutateResp.Patch)
-	validateResp := h.ValidateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("two-phase-pod", "default", patched), "", time.Now())
-
-	assert.True(t, validateResp.Allowed, "the validating phase must admit a pod the mutating phase verified")
+	assert.True(t, allowed, "the validating phase must verify and admit a signed image on its own")
+	assert.Empty(t, warnings, "a passing verification must not warn")
 }
 
-// TestMutate_NotarySignedImage_VerifiesSuccessfully covers the other supported signature format.
-func TestMutate_NotarySignedImage_VerifiesSuccessfully(t *testing.T) {
+// TestValidate_NotarySignedImage_Admits covers the other supported signature format.
+func TestValidate_NotarySignedImage_Admits(t *testing.T) {
 	requireImageReachable(t, signedImage)
 
 	policy := newIvpol("notary-signed")
@@ -247,8 +226,7 @@ func TestMutate_NotarySignedImage_VerifiesSuccessfully(t *testing.T) {
 	createIvpolWithCleanup(t, policy)
 	waitForPolicyReady(t, "notary-signed", "")
 
-	allowed, status := mutatePod(t, "notary-signed", "notary-pod", "default", signedImage)
+	allowed, _ := validatePod(t, "notary-signed", "notary-pod", "default", signedImage)
 
 	assert.True(t, allowed, "a notary signed image must be admitted")
-	assert.Equal(t, "pass", status, "a notary signed image must record a passing verification")
 }


### PR DESCRIPTION
# Explanation

Fixes the red `main` from #16730. The `ivpol` integration tests were written against the pre-#16336 two-phase model (mutating verifies and stamps an outcome annotation, validating trusts it). #16663 removed that: mutating is now a no-op and validating re-verifies the image directly, so the stamped-annotation tests no longer reflect how the engine works.

This reworks the suite to the single-phase model: verification is asserted through the validating route, the two broken tests become `StampedOutcomeIsNotTrusted` and `Mutate_IsNoOp` (which lock in the #16336 fix), and the registry tests verify through `ValidateClustered` too.

The hermetic tests now point at an unresolvable image (`registry.invalid`, RFC 6761) instead of a real one, so they fail closed at DNS in milliseconds rather than doing a real registry round-trip that can hang on a flaky runner. The suite drops from ~3 minutes to ~17 seconds.

# Verification

- `14/14` hermetic tests pass under `-race`.
- `gofmt` and `go vet` clean.
- Registry test file compiles (runs with `-tags="integration registry"` + egress).