### PR TITLE
feat(helm): expose maxGlobalContextEntries in the Kyverno chart

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -371,6 +371,7 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | features.dumpPatches.enabled | bool | `false` | Enables the feature |
 | features.globalContext.maxApiCallResponseLength | int | `2000000` | Maximum allowed response size from API Calls. A value of 0 bypasses checks (not recommended) |
 | features.globalContext.apiCallTimeout | string | `"30s"` | Timeout for HTTP API calls made by policies. A value of 0s means no timeout. |
+| features.globalContext.maxGlobalContextEntries | int | `0` | Maximum number of entries in the global context store. A value of 0 means unbounded. |
 | features.logging.format | string | `"text"` | Logging format |
 | features.logging.verbosity | int | `2` | Logging verbosity |
 | features.omitEvents.eventTypes | list | `["PolicyApplied","PolicySkipped"]` | Events which should not be emitted (possible values `PolicyViolation`, `PolicyApplied`, `PolicyError`, and `PolicySkipped`) |

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -74,6 +74,7 @@
 {{- with .globalContext -}}
   {{- $flags = append $flags (print "--maxAPICallResponseLength=" (int .maxApiCallResponseLength)) -}}
   {{- $flags = append $flags (print "--apiCallTimeout=" .apiCallTimeout) -}}
+  {{- $flags = append $flags (print "--maxGlobalContextEntries=" (int .maxGlobalContextEntries)) -}}
 {{- end -}}
 {{- with .logging -}}
   {{- $flags = append $flags (print "--loggingFormat=" .format) -}}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -894,6 +894,8 @@ features:
     maxApiCallResponseLength: 2000000
     # -- Timeout for HTTP API calls made by policies. A value of 0s means no timeout.
     apiCallTimeout: 30s
+    # -- Maximum number of entries in the global context store. A value of 0 means unbounded.
+    maxGlobalContextEntries: 0
   logging:
     # -- Logging format
     format: text

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -88707,6 +88707,7 @@ spec:
             - --dumpPatches=false
             - --maxAPICallResponseLength=2000000
             - --apiCallTimeout=30s
+            - --maxGlobalContextEntries=0
             - --loggingFormat=text
             - --v=2
             - --omitEvents=PolicyApplied,PolicySkipped
@@ -88883,6 +88884,7 @@ spec:
             - --enableDeferredLoading=true
             - --maxAPICallResponseLength=2000000
             - --apiCallTimeout=30s
+            - --maxGlobalContextEntries=0
             - --loggingFormat=text
             - --v=2
             - --omitEvents=PolicyApplied,PolicySkipped
@@ -89014,6 +89016,7 @@ spec:
             - --dumpPayload=false
             - --maxAPICallResponseLength=2000000
             - --apiCallTimeout=30s
+            - --maxGlobalContextEntries=0
             - --loggingFormat=text
             - --v=2
             - --protectManagedResources=false
@@ -89181,6 +89184,7 @@ spec:
             - --enableDeferredLoading=true
             - --maxAPICallResponseLength=2000000
             - --apiCallTimeout=30s
+            - --maxGlobalContextEntries=0
             - --loggingFormat=text
             - --v=2
             - --omitEvents=PolicyApplied,PolicySkipped


### PR DESCRIPTION
## Explanation

Follow-up to #16560 (part 2 of 2). Exposes the existing --maxGlobalContextEntries flag as a Helm value, so the store bound can be set once in values.yaml instead of repeating extraArgs across all four controllers.

The default is 0 (unbounded), so existing installs are unaffected unless you opt in.

## Related issue

Follow-up to #16560.

## Usage
```
features:
  globalContext:
    maxGlobalContextEntries: 100
```

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind feature

## Proposed Changes

- Add `features.globalContext.maxGlobalContextEntries` to `values.yaml`.
- Include the `--maxGlobalContextEntries` flag in `_helpers.tpl`to be passed to admission, background, cleanup, and reports.
- Updated the chart README and `install-latest-testing.yaml`.


## Verification
```
# Default (unbounded)
$ helm template ./charts/kyverno \
    | grep -o -- '--maxGlobalContextEntries=[0-9]*' | sort | uniq -c
   4 --maxGlobalContextEntries=0

# Custom value
$ helm template ./charts/kyverno \
    --set features.globalContext.maxGlobalContextEntries=25 \
    | grep -o -- '--maxGlobalContextEntries=[0-9]*' | sort | uniq -c
   4 --maxGlobalContextEntries=25
```