### PR TITLE
fix: panic in RedactSecret on empty annotations and unreachable error check

### DIFF
--- a/pkg/utils/kube/secret.go
+++ b/pkg/utils/kube/secret.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	datautils "github.com/kyverno/kyverno/pkg/utils/data"
@@ -37,14 +38,17 @@ func RedactSecret(resource *unstructured.Unstructured) (unstructured.Unstructure
 	updateSecret := map[string]interface{}{}
 	raw, err := json.Marshal(stringSecret)
 	if err != nil {
-		return *resource, nil
+		return *resource, fmt.Errorf("unable to convert secret to object: %w", err)
 	}
 	err = json.Unmarshal(raw, &updateSecret)
 	if err != nil {
 		return *resource, fmt.Errorf("unable to convert object from secret: %w", err)
 	}
 	if secret.Data != nil {
-		v := updateSecret["string_data"].(map[string]interface{})
+		v, ok := updateSecret["string_data"].(map[string]interface{})
+		if !ok {
+			return *resource, errors.New("unable to convert secret string_data to map")
+		}
 		err = unstructured.SetNestedMap(resource.Object, v, "data")
 		if err != nil {
 			return *resource, fmt.Errorf("failed to set secret.data: %w", err)
@@ -55,13 +59,22 @@ func RedactSecret(resource *unstructured.Unstructured) (unstructured.Unstructure
 		if err != nil {
 			return *resource, fmt.Errorf("unable to convert metadata to map: %w", err)
 		}
-		updatedMeta := updateSecret["metadata"].(map[string]interface{})
-		if err != nil {
-			return *resource, fmt.Errorf("unable to convert object from secret: %w", err)
+		updatedMeta, ok := updateSecret["metadata"].(map[string]interface{})
+		if !ok {
+			return *resource, errors.New("unable to convert secret metadata to map")
 		}
-		err = unstructured.SetNestedMap(metadata, updatedMeta["annotations"].(map[string]interface{}), "annotations")
-		if err != nil {
-			return *resource, fmt.Errorf("failed to set secret.annotations: %w", err)
+		// An empty (but non-nil) annotations map is dropped by `omitempty`
+		// during the marshal/unmarshal round trip above; in that case there
+		// is nothing to redact and redaction is a no-op.
+		if updatedAnnotations, found := updatedMeta["annotations"]; found {
+			annotations, ok := updatedAnnotations.(map[string]interface{})
+			if !ok {
+				return *resource, errors.New("unable to convert secret annotations to map")
+			}
+			err = unstructured.SetNestedMap(metadata, annotations, "annotations")
+			if err != nil {
+				return *resource, fmt.Errorf("failed to set secret.annotations: %w", err)
+			}
 		}
 	}
 	return *resource, nil

--- a/pkg/utils/kube/secret_test.go
+++ b/pkg/utils/kube/secret_test.go
@@ -65,6 +65,64 @@ func TestRedactSecret_WithAnnotations(t *testing.T) {
 	assert.Equal(t, "**REDACTED**", annotations["custom-annotation"])
 }
 
+func TestRedactSecret_AnnotationsWithoutData(t *testing.T) {
+	resource := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      "annotated-secret",
+				"namespace": "default",
+				"annotations": map[string]interface{}{
+					"custom-annotation": "sensitive-value",
+				},
+			},
+		},
+	}
+
+	result, err := RedactSecret(resource)
+	require.NoError(t, err)
+
+	metadata, found, err := unstructured.NestedMap(result.Object, "metadata")
+	require.NoError(t, err)
+	assert.True(t, found)
+
+	annotations := metadata["annotations"].(map[string]interface{})
+	assert.Equal(t, "**REDACTED**", annotations["custom-annotation"])
+
+	_, found, err = unstructured.NestedMap(result.Object, "data")
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestRedactSecret_EmptyAnnotations(t *testing.T) {
+	// A Secret with an explicitly empty annotations map survives the
+	// unmarshal into corev1.Secret as a non-nil empty map, but is dropped
+	// by `omitempty` on re-marshal. The previous bare type assertion on
+	// the missing key panicked; redaction must instead be a no-op since
+	// there is nothing to redact.
+	resource := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":        "empty-annotations-secret",
+				"namespace":   "default",
+				"annotations": map[string]interface{}{},
+			},
+		},
+	}
+
+	result, err := RedactSecret(resource)
+	require.NoError(t, err)
+
+	assert.Equal(t, "empty-annotations-secret", result.GetName())
+	annotations, found, err := unstructured.NestedMap(result.Object, "metadata", "annotations")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Empty(t, annotations)
+}
+
 func TestRedactSecret_EmptyData(t *testing.T) {
 	resource := &unstructured.Unstructured{
 		Object: map[string]interface{}{


### PR DESCRIPTION
## Explanation

`RedactSecret` (used to mask Secret data and annotations before admission request payloads are dumped to logs when `--dumpPayload` is enabled) contained an unreachable error check, a silently discarded error, and bare type assertions — one of which is a reachable panic: a valid Secret with an explicitly empty `metadata.annotations: {}` makes `RedactSecret` panic with `interface conversion: interface {} is nil, not map[string]interface {}` inside the admission handler chain. This PR fixes the panic (empty annotations now redact as a graceful no-op), removes the unreachable check that SVACE flagged, and makes the remaining error handling correct and self-consistent.

## Related issue

Closes #15401

The unreachable check was reported by the Linux Verification Center (linuxtesting.org) using SVACE. Related discussion: #15091 ("potential panic").

## Milestone of this PR

<!-- To be set by maintainers, e.g. via `/milestone` -->

## Documentation (required for features)

Not applicable — bug fix in internal error handling, no new or altered user-facing behavior.

## What type of PR is this

/kind bug

## Proposed Changes

In `pkg/utils/kube/secret.go` `RedactSecret`:

- **Fix a reachable panic on empty annotations.** A Secret with `metadata.annotations: {}` unmarshals into `corev1.Secret` as a non-nil empty map (so the `secret.Annotations != nil` branch is taken), but the empty map is then dropped by `omitempty` during the internal marshal/unmarshal round trip, so `updatedMeta["annotations"]` is nil and the bare type assertion panics. Since an empty annotations map has nothing to redact, this case is now a no-op: when the round trip dropped the annotations key, redaction skips `SetNestedMap` instead of panicking (or erroring, which would make `redactPayload` in `pkg/webhooks/handlers/dump.go` drop the entire admission dump for a valid Secret).
- **Remove the unreachable `if err != nil` block** after `updateSecret["metadata"].(map[string]interface{})` — a type assertion never sets `err`, and the previous statement that did (`datautils.ToMap`) already returned on error, so `err` is always nil there (the exact SVACE finding in #15401).
- **Replace the three bare type assertions** (`updateSecret["string_data"]`, `updateSecret["metadata"]`, `updatedMeta["annotations"]`) with checked `, ok` assertions that return descriptive errors instead of panicking. This appears to be what the dead check originally intended.
- **Return the wrapped error from `json.Marshal(stringSecret)`** instead of `return *resource, nil`, which swallowed the error and would have reported an unredacted Secret as successfully redacted.

Added tests:

- `TestRedactSecret_EmptyAnnotations` — regression test for the panic; it fails (panics) on the unfixed code and verifies the no-op behavior on the fixed code.
- `TestRedactSecret_AnnotationsWithoutData` — covers the annotations-only branch (Secret with annotations but no `data`), which had no dedicated test.

### Proof Manifests

Not applicable — the affected code path is the debug admission-dump handler (`--dumpPayload`), not policy behavior. Verified via unit tests:

```
$ go test ./pkg/utils/kube/... -run TestRedactSecret -v
--- PASS: TestRedactSecret_WithData
--- PASS: TestRedactSecret_WithAnnotations
--- PASS: TestRedactSecret_AnnotationsWithoutData
--- PASS: TestRedactSecret_EmptyAnnotations
--- PASS: TestRedactSecret_EmptyData
--- PASS: TestRedactSecret_MultipleDataKeys
--- PASS: TestRedactSecret_PreservesMetadata
--- PASS: TestRedactSecret_TLSSecret
--- PASS: TestRedactSecret_DockerConfigSecret
PASS
ok      github.com/kyverno/kyverno/pkg/utils/kube
```

On the unfixed code, `TestRedactSecret_EmptyAnnotations` panics:

```
--- FAIL: TestRedactSecret_EmptyAnnotations (0.00s)
panic: interface conversion: interface {} is nil, not map[string]interface {} [recovered, repanicked]
```

`go vet`, `golangci-lint run`, and `golangci-lint fmt --diff` are clean for the package.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The scope is slightly wider than deleting the single dead `if` block: the checked type assertions, the empty-annotations no-op, and the un-swallowed marshal error are the same class of defect in the same function, and fixing them together implements what the dead check was evidently meant to do. Happy to narrow the PR if preferred.
