### PR TITLE
fix(helm): use request.namespace for vpolExclude matchConditions

### DIFF
--- a/charts/kyverno-policies/templates/_helpers.tpl
+++ b/charts/kyverno-policies/templates/_helpers.tpl
@@ -180,7 +180,7 @@ helm.sh/chart: {{ template "kyverno-policies.chart" . }}
 {{- $conditions := list -}}
 {{- $namespaces := .excludeNamespaces | default list -}}
 {{- if gt (len $namespaces) 0 -}}
-  {{- $conditions = append $conditions (dict "name" "exclude-namespaces" "expression" (printf "!(object.metadata.namespace in [%s])" (include "kyverno-policies.celStringList" $namespaces))) -}}
+  {{- $conditions = append $conditions (dict "name" "exclude-namespaces" "expression" (printf "!(request.namespace in [%s])" (include "kyverno-policies.celStringList" $namespaces))) -}}
 {{- end -}}
 {{- $subjects := .excludeSubjects | default list -}}
 {{- if gt (len $subjects) 0 -}}


### PR DESCRIPTION
## Explanation

Fixes the bug in the `kyverno-policies` Helm chart where `vpolExclude.excludeNamespaces` generates `object.metadata.namespace` in CEL `matchConditions`. On cluster-scoped resources, accessing `object.metadata.namespace` causes a CEL evaluation failure (`failed to load context: no such key: namespace`) during background scans.

Replacing `object.metadata.namespace` with `request.namespace` resolves this, as `request.namespace` is always defined for both namespaced and cluster-scoped resources.


<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #16002

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.19.0

<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind bug

## Proposed Changes

Updated `charts/kyverno-policies/templates/_helpers.tpl` helper `kyverno-policies.vpolExcludeMatchConditions` to use `request.namespace` instead of `object.metadata.namespace` for namespace exclusion matchConditions.

### Proof Manifests

Before fix:

```yaml
matchConditions:
  - name: exclude-namespaces
    expression: "!(object.metadata.namespace in ['kube-system'])"
```

After fix: 

```yaml
matchConditions:
  - name: exclude-namespaces
    expression: "!(request.namespace in ['kube-system'])"
```    

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding pxoof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
