### PR TITLE
fix(gpol): update downstream in-place on trigger UPDATE when sync enabled

### DIFF
--- a/pkg/background/gpol/generate_controller.go
+++ b/pkg/background/gpol/generate_controller.go
@@ -88,9 +88,6 @@ func (c *CELGenerateController) ProcessUR(ur *kyvernov2.UpdateRequest) error {
 			c.watchManager.DeleteDownstreams(ur.Spec.GetPolicyKey(), &ur.Spec.RuleContext[i].Trigger)
 			continue
 		}
-		if ur.Spec.RuleContext[i].Synchronize {
-			c.watchManager.DeleteDownstreams(ur.Spec.GetPolicyKey(), &ur.Spec.RuleContext[i].Trigger)
-		}
 		trigger, err := common.GetTrigger(c.client, ur.Spec, i, c.log)
 		if err != nil || trigger == nil {
 			logger.V(4).Info("the trigger resource does not exist or is pending creation")

--- a/pkg/background/gpol/generate_controller_test.go
+++ b/pkg/background/gpol/generate_controller_test.go
@@ -192,3 +192,85 @@ func TestProcessUR_ConcurrentCacheRestoreAndGenerateExistingDoesNotDeleteDownstr
 	assert.Len(t, client.deleted, 0)
 	assert.Contains(t, wm.dynamicWatchers[configMapGVR].metadataCache, downstream.GetUID())
 }
+
+func TestProcessUR_SynchronizeUpdateDoesNotDeleteDownstream(t *testing.T) {
+	policyName := "test-gpol-sync"
+	trigger := makeUnstructured("", "example.io", "v1", "TestTrigger", "existing-trigger", "tenant-a", "trigger-uid", nil)
+	downstream := makeUnstructured("", "", "v1", "ConfigMap", "test-cm", "tenant-a", "downstream-uid", map[string]string{
+		common.GeneratePolicyLabel:     policyName,
+		common.GenerateTriggerUIDLabel: string(trigger.GetUID()),
+	})
+	configMapGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+	client := &triggerClient{
+		MockClient: &MockClient{},
+		trigger:    trigger,
+	}
+	wm := &WatchManager{
+		client: client,
+		restMapper: &mockRESTMapper{fn: func(gk schema.GroupKind, version string) (*meta.RESTMapping, error) {
+			return &meta.RESTMapping{Resource: configMapGVR}, nil
+		}},
+		dynamicWatchers: map[schema.GroupVersionResource]*watcher{
+			configMapGVR: {
+				watcher: watch.NewFake(),
+				metadataCache: map[types.UID]Resource{
+					downstream.GetUID(): {
+						Name:      downstream.GetName(),
+						Namespace: downstream.GetNamespace(),
+						Labels:    downstream.GetLabels(),
+					},
+				},
+			},
+		},
+		policyRefs: map[string][]schema.GroupVersionResource{policyName: {configMapGVR}},
+		refCount:   map[schema.GroupVersionResource]int{configMapGVR: 1},
+		log:        logging.WithName("test-watch-manager"),
+	}
+
+	policy := &policiesv1beta1.GeneratingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: policyName},
+		Spec: policiesv1beta1.GeneratingPolicySpec{
+			EvaluationConfiguration: &policiesv1beta1.GeneratingPolicyEvaluationConfiguration{
+				SynchronizationConfiguration: &policiesv1beta1.SynchronizationConfiguration{
+					Enabled: ptr.To(true),
+				},
+			},
+		},
+	}
+	controller := &CELGenerateController{
+		client:        client,
+		restMapper:    wm.restMapper,
+		context:       libs.NewFakeContextProvider(),
+		engine:        &testEngine{generated: []*unstructured.Unstructured{downstream.DeepCopy()}},
+		provider:      &testProvider{policy: gpolengine.Policy{Policy: policy}},
+		watchManager:  wm,
+		statusControl: testStatusControl{},
+		eventGen:      testEventGen{},
+		log:           logging.WithName("test-gpol-controller"),
+	}
+
+	ur := &kyvernov2.UpdateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "ur-test-sync"},
+		Spec: kyvernov2.UpdateRequestSpec{
+			Type:   kyvernov2.CELGenerate,
+			Policy: policyName,
+			RuleContext: []kyvernov2.RuleContext{{
+				Rule:        "rule",
+				Synchronize: true,
+				Trigger: kyvernov1.ResourceSpec{
+					APIVersion: trigger.GetAPIVersion(),
+					Kind:       trigger.GetKind(),
+					Namespace:  trigger.GetNamespace(),
+					Name:       trigger.GetName(),
+					UID:        trigger.GetUID(),
+				},
+			}},
+		},
+	}
+
+	require.NoError(t, controller.ProcessUR(ur))
+
+	// verify downstream resource is not deleted on trigger UPDATE
+	assert.Len(t, client.deleted, 0, "downstream resource should not be deleted on trigger UPDATE")
+}


### PR DESCRIPTION
## Explanation

In the `gpol` background controller, trigger resource `UPDATE` events for synchronized `GeneratingPolicy` rules previously caused existing downstream resources to be deleted and recreated rather than updated in-place via Server side Apply (SSA).
Removing the pre-evaluation `DeleteDownstreams` call when `Synchronize` is enabled allows `generator.Apply` (SSA) to patch downstream resources in-place without triggering resource deletion (which fails on downstream resources with bound claims or finalizers).


<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue

Closes #16742 
Slack discussion: https://kubernetes.slack.com/archives/CLGR9BJU9/p1784878618288119
@realshuting 

## Milestone of this PR
/milestone 1.19.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind bug

## Proposed Changes

- Removed pre-evaluation `c.watchManager.DeleteDownstreams` call on `ur.Spec.RuleContext[i].Synchronize` in `pkg/background/gpol/generate_controller.go`.
- Added unit test `TestProcessUR_SynchronizeUpdateDoesNotDeleteDownstream` in `pkg/background/gpol/generate_controller_test.go`.

### Proof Manifests

Unit test Result: 

```go
=== RUN   TestProcessUR_SynchronizeUpdateDoesNotDeleteDownstream
--- PASS: TestProcessUR_SynchronizeUpdateDoesNotDeleteDownstream (0.00s)
PASS
ok      github.com/kyverno/kyverno/pkg/background/gpol  0.204s
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
