### PR TITLE
fix(cosign): resolve bundle artifactType on fallback tag registries

### DIFF
--- a/pkg/image/verifiers/cpol/cosign/sigstore.go
+++ b/pkg/image/verifiers/cpol/cosign/sigstore.go
@@ -102,37 +102,85 @@ func fetchBundles(ref name.Reference, limit int, predicateType string, remoteOpt
 		return nil, nil, fmt.Errorf("failed to fetch referrers: too many referrers found, max limit is %d", limit)
 	}
 	for _, manifestDesc := range referrersDescs.Manifests {
-		if !strings.HasPrefix(manifestDesc.ArtifactType, "application/vnd.dev.sigstore.bundle") {
+		artifactType := manifestDesc.ArtifactType
+		var refImg v1.Image
+		var bundleBytes []byte
+
+		if !strings.HasPrefix(artifactType, "application/vnd.dev.sigstore.bundle") {
+			if artifactType == "" || artifactType == "application/vnd.oci.empty.v1+json" {
+				img, err := remote.Image(ref.Context().Digest(manifestDesc.Digest.String()), remoteOpts...)
+				if err == nil && img != nil {
+					if imgManifest, err := img.Manifest(); err == nil && imgManifest != nil {
+						if strings.HasPrefix(imgManifest.ArtifactType, "application/vnd.dev.sigstore.bundle") {
+							artifactType = imgManifest.ArtifactType
+							refImg = img
+						} else if len(imgManifest.Layers) > 0 && strings.HasPrefix(string(imgManifest.Layers[0].MediaType), "application/vnd.dev.sigstore.bundle") {
+							artifactType = string(imgManifest.Layers[0].MediaType)
+							refImg = img
+						} else if len(imgManifest.Layers) > 0 {
+							layers, err := img.Layers()
+							if err == nil && len(layers) > 0 {
+								layer := layers[0]
+								if layerSize, err := layer.Size(); err == nil && layerSize <= maxLayerSize {
+									if layerBytes, err := layer.Uncompressed(); err == nil {
+										data, err := io.ReadAll(layerBytes)
+										_ = layerBytes.Close()
+										if err == nil {
+											b := &bundle.Bundle{}
+											if err := b.UnmarshalJSON(data); err == nil && b.Bundle != nil {
+												artifactType = "application/vnd.dev.sigstore.bundle"
+												refImg = img
+												bundleBytes = data
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if !strings.HasPrefix(artifactType, "application/vnd.dev.sigstore.bundle") {
 			continue
 		}
-		refImg, err := remote.Image(ref.Context().Digest(manifestDesc.Digest.String()), remoteOpts...)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch referrer image: %w", err)
+
+		if refImg == nil {
+			var err error
+			refImg, err = remote.Image(ref.Context().Digest(manifestDesc.Digest.String()), remoteOpts...)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to fetch referrer image: %w", err)
+			}
 		}
-		layers, err := refImg.Layers()
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch referrer layer: %w", err)
+
+		if bundleBytes == nil {
+			layers, err := refImg.Layers()
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to fetch referrer layer: %w", err)
+			}
+			if len(layers) == 0 {
+				return nil, nil, fmt.Errorf("layers not found")
+			}
+			layer := layers[0]
+			layerSize, err := layer.Size()
+			if err != nil {
+				return nil, nil, err
+			}
+			if layerSize > maxLayerSize {
+				return nil, nil, fmt.Errorf("layer size %d exceeds %d", layerSize, maxLayerSize)
+			}
+			layerBytes, err := layer.Uncompressed()
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to fetch referrer layer: %w", err)
+			}
+			defer layerBytes.Close()
+			bundleBytes, err = io.ReadAll(layerBytes)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to fetch referrer layer: %w", err)
+			}
 		}
-		if len(layers) == 0 {
-			return nil, nil, fmt.Errorf("layers not found")
-		}
-		layer := layers[0]
-		layerSize, err := layer.Size()
-		if err != nil {
-			return nil, nil, err
-		}
-		if layerSize > maxLayerSize {
-			return nil, nil, fmt.Errorf("layer size %d exceeds %d", layerSize, maxLayerSize)
-		}
-		layerBytes, err := layer.Uncompressed()
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch referrer layer: %w", err)
-		}
-		defer layerBytes.Close()
-		bundleBytes, err := io.ReadAll(layerBytes)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch referrer layer: %w", err)
-		}
+
 		b := &bundle.Bundle{}
 		err = b.UnmarshalJSON(bundleBytes)
 		if err != nil {


### PR DESCRIPTION
## Explanation

On container registries that do not support the OCI 1.1 referrers API (e.g. GHCR, which returns HTTP 404 for `/referrers/<digest>`), `go-containerregistry` falls back to fetching referrer manifests via the fallback tag scheme (`sha256-<digest>`).

Descriptors in fallback tag indices generated by Cosign 3.x have `manifestDesc.ArtifactType` set to `application/vnd.oci.empty.v1+json` or `""`, with the actual bundle `artifactType` or `mediaType` residing on the referenced image manifest or layer level. In `pkg/image/verifiers/cpol/cosign/sigstore.go`, filtering strictly on `manifestDesc.ArtifactType` caused all fallback tag bundle descriptors to be discarded, resulting in a false "no signatures found" error.

This PR updates `fetchBundles` in `sigstore.go` so that when `manifestDesc.ArtifactType` is empty or `application/vnd.oci.empty.v1+json`, it inspects the referenced manifest's `ArtifactType`, layer `MediaType`, or bundle structure to resolve valid Cosign bundles.

## Related issue

Closes #16664

## What type of PR is this

/kind bug

## Proposed Changes

- In `fetchBundles` (`pkg/image/verifiers/cpol/cosign/sigstore.go`), when `manifestDesc.ArtifactType` is empty or `application/vnd.oci.empty.v1+json`, fetch the referenced manifest and check its `ArtifactType` and layer `MediaType`.
- Fall back to verifying Sigstore bundle JSON structure if descriptor-level metadata is typed `oci.empty`.
- Preserve existing fast-path prefix filter for standard referrers index descriptors.

### Proof Manifests

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: check-image-signatures
spec:
  validationFailureAction: Enforce
  rules:
  - name: verify-signature
    match:
      any:
      - resources:
          kinds:
          - Pod
    verifyImages:
    - imageReferences:
      - "ghcr.io/my-org/*"
      attestors:
      - entries:
        - keyless:
            issuer: https://token.actions.githubusercontent.com
            subjectRegExp: https://github.com/my-org/.*
            rekor:
              url: https://rekor.sigstore.dev
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have verified the behavior.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
