### PR TITLE
fix(cli): allow raw JSON payloads in --resource for JSON mode policies

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -1059,9 +1059,7 @@ func (c *ApplyCommandConfig) loadResources(out io.Writer, paths []string, polici
 				}
 			}
 		}
-		if len(jsonPayloads) > 0 {
-			err = nil
-		} else {
+		if len(jsonPayloads) == 0 {
 			return resources, nil, fmt.Errorf("failed to load resources (%w)", err)
 		}
 	}

--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -1049,19 +1049,33 @@ func (c *ApplyCommandConfig) loadResources(out io.Writer, paths []string, polici
 		Timeout:         5 * time.Minute,
 	}
 	resources, err := common.GetResourceAccordingToResourcePath(out, nil, paths, c.Cluster, policies, dClient, c.Namespace, c.PolicyReport, c.ClusterWideResources, "", resourceOptions, c.ShowPerformance)
+	var jsonPayloads []*unstructured.Unstructured
 	if err != nil {
-		return resources, nil, fmt.Errorf("failed to load resources (%w)", err)
+		for _, path := range paths {
+			p, loadErr := payload.Load(path)
+			if loadErr == nil && p != nil {
+				if m, ok := p.(map[string]interface{}); ok {
+					jsonPayloads = append(jsonPayloads, &unstructured.Unstructured{Object: m})
+				}
+			}
+		}
+		if len(jsonPayloads) > 0 {
+			err = nil
+		} else {
+			return resources, nil, fmt.Errorf("failed to load resources (%w)", err)
+		}
 	}
 	resources = test.ProcessResources(resources)
-	var jsonPayloads []*unstructured.Unstructured
 	if len(c.JSONPaths) > 0 {
 		for _, path := range c.JSONPaths {
-			payload, err := payload.Load(path)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to load JSON payload (%w)", err)
+			p, loadErr := payload.Load(path)
+			if loadErr != nil {
+				return nil, nil, fmt.Errorf("failed to load JSON payload (%w)", loadErr)
 			}
 
-			jsonPayloads = append(jsonPayloads, &unstructured.Unstructured{Object: payload.(map[string]interface{})})
+			if m, ok := p.(map[string]interface{}); ok {
+				jsonPayloads = append(jsonPayloads, &unstructured.Unstructured{Object: m})
+			}
 		}
 	}
 	return resources, jsonPayloads, nil

--- a/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command_test.go
@@ -708,6 +708,22 @@ func Test_Apply_ValidatingPolicies(t *testing.T) {
 		},
 		{
 			config: ApplyCommandConfig{
+				PolicyPaths:   []string{"../../../../../test/cli/test-validating-policy/json-check-dockerfile/policy.yaml"},
+				ResourcePaths: []string{"../../../../../test/cli/test-validating-policy/json-check-dockerfile/payload.json"},
+				PolicyReport:  true,
+			},
+			expectedReports: []openreportsv1alpha1.Report{{
+				Summary: openreportsv1alpha1.ReportSummary{
+					Pass:  1,
+					Fail:  1,
+					Skip:  0,
+					Error: 0,
+					Warn:  0,
+				},
+			}},
+		},
+		{
+			config: ApplyCommandConfig{
 				PolicyPaths:   []string{"../../../../../test/cli/test-validating-policy/exceptions-check-deployment-labels/policy.yaml"},
 				ResourcePaths: []string{"../../../../../test/cli/test-validating-policy/exceptions-check-deployment-labels/skipped-deployment.yaml"},
 				Exception:     []string{"../../../../../test/cli/test-validating-policy/exceptions-check-deployment-labels/exception.yaml"},


### PR DESCRIPTION
## Explanation

Evaluating `ValidatingPolicy` rules against non Kubernetes JSON files (such as Terraform plan JSON outputs) using `kyverno apply --resource` previously failed with a resource loading error due to missing Kubernetes `kind` fields.

Falling back to raw JSON payload parsing when Kubernetes resource decoding fails on `--resource` paths allows `kyverno apply` to evaluate non Kubernetes JSON files directly against JSON-mode policies.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #15106 

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
/milestone 1.19.0
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

- Updated `loadResources` in `cmd/cli/kubectl-kyverno/commands/apply/command.go` to fall back to `payload.Load(path)` when a `--resource` path fails Kubernetes `unstructured` object decoding due to missing `kind`/`apiVersion`.
- Added unit test case in `cmd/cli/kubectl-kyverno/commands/apply/command_test.go` verifying that raw JSON payloads supplied via `ResourcePaths` (simulating `--resource`) evaluate properly and generate policy reports.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

#### `plan.json` (Terraform Plan JSON input without `kind`/`apiVersion`):
```json 
{
  "format_version": "1.2",
  "terraform_version": "1.10.5",
  "planned_values": {
    "root_module": {
      "resources": [
        {
          "type": "google_storage_bucket",
          "name": "example",
          "values": {
            "name": "test-bucket",
            "public_access_prevention": "inherited"
          }
        }
      ]
    }
  }
}
```

#### `policy.yaml` (`ValidatingPolicy` with `evaluation.mode: JSON`):
```yaml
apiVersion: policies.kyverno.io/v1
kind: ValidatingPolicy
metadata:
  name: gcp-bucket-check
spec:
  evaluation:
    mode: JSON
  matchConditions:
    - name: is-terraform-plan
      expression: 'has(object.planned_values) && has(object.terraform_version)'
  validations:
    - message: 'GCP bucket public_access_prevention must be enforced'
      expression: |
        object.planned_values.root_module.resources.all(resource,
          resource.type != 'google_storage_bucket' ||
          resource.values.public_access_prevention == 'enforced'
        )
```

#### CLI execution result:

```bash
$ kyverno apply policy.yaml --resource plan.json
Applying 1 policy rule(s) to 1 resource(s)...
policy gcp-bucket-check -> resource JSON payload failed:
1 - GCP bucket public_access_prevention must be enforced
pass: 0, fail: 1, warn: 0, error: 0, skip: 0
```

#### Unit test results:
```
=== RUN   Test_Apply_ValidatingPolicies
--- PASS: Test_Apply_ValidatingPolicies (3.47s)
PASS
ok      github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/apply       64.784s
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
N.A.