### PR TITLE
fix(pss): support the Host Probes / Lifecycle Hooks control and honor the pinned version

### DIFF
--- a/api/kyverno/v1/common_types.go
+++ b/api/kyverno/v1/common_types.go
@@ -548,7 +548,7 @@ type PodSecurity struct {
 type PodSecurityStandard struct {
 	// ControlName specifies the name of the Pod Security Standard control.
 	// See: https://kubernetes.io/docs/concepts/security/pod-security-standards/
-	// +kubebuilder:validation:Enum=HostProcess;Host Namespaces;Privileged Containers;Capabilities;HostPath Volumes;Host Ports;AppArmor;SELinux;/proc Mount Type;Seccomp;Sysctls;Volume Types;Privilege Escalation;Running as Non-root;Running as Non-root user
+	// +kubebuilder:validation:Enum=HostProcess;Host Namespaces;Privileged Containers;Capabilities;HostPath Volumes;Host Ports;AppArmor;SELinux;/proc Mount Type;Seccomp;Sysctls;Volume Types;Privilege Escalation;Running as Non-root;Running as Non-root user;Host Probes / Lifecycle Hooks
 	ControlName string `json:"controlName"`
 
 	// Images selects matching containers and applies the container level PSS.

--- a/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
@@ -4161,6 +4161,7 @@ spec:
                                     - Privilege Escalation
                                     - Running as Non-root
                                     - Running as Non-root user
+                                    - Host Probes / Lifecycle Hooks
                                     type: string
                                   images:
                                     description: |-
@@ -9303,6 +9304,7 @@ spec:
                                         - Privilege Escalation
                                         - Running as Non-root
                                         - Running as Non-root user
+                                        - Host Probes / Lifecycle Hooks
                                         type: string
                                       images:
                                         description: |-
@@ -14222,6 +14224,7 @@ spec:
                                     - Privilege Escalation
                                     - Running as Non-root
                                     - Running as Non-root user
+                                    - Host Probes / Lifecycle Hooks
                                     type: string
                                   images:
                                     description: |-
@@ -19333,6 +19336,7 @@ spec:
                                         - Privilege Escalation
                                         - Running as Non-root
                                         - Running as Non-root user
+                                        - Host Probes / Lifecycle Hooks
                                         type: string
                                       images:
                                         description: |-

--- a/config/crds/kyverno/kyverno.io_policies.yaml
+++ b/config/crds/kyverno/kyverno.io_policies.yaml
@@ -4162,6 +4162,7 @@ spec:
                                     - Privilege Escalation
                                     - Running as Non-root
                                     - Running as Non-root user
+                                    - Host Probes / Lifecycle Hooks
                                     type: string
                                   images:
                                     description: |-
@@ -9305,6 +9306,7 @@ spec:
                                         - Privilege Escalation
                                         - Running as Non-root
                                         - Running as Non-root user
+                                        - Host Probes / Lifecycle Hooks
                                         type: string
                                       images:
                                         description: |-
@@ -14225,6 +14227,7 @@ spec:
                                     - Privilege Escalation
                                     - Running as Non-root
                                     - Running as Non-root user
+                                    - Host Probes / Lifecycle Hooks
                                     type: string
                                   images:
                                     description: |-
@@ -19336,6 +19339,7 @@ spec:
                                         - Privilege Escalation
                                         - Running as Non-root
                                         - Running as Non-root user
+                                        - Host Probes / Lifecycle Hooks
                                         type: string
                                       images:
                                         description: |-

--- a/config/crds/kyverno/kyverno.io_policyexceptions.yaml
+++ b/config/crds/kyverno/kyverno.io_policyexceptions.yaml
@@ -625,6 +625,7 @@ spec:
                       - Privilege Escalation
                       - Running as Non-root
                       - Running as Non-root user
+                      - Host Probes / Lifecycle Hooks
                       type: string
                     images:
                       description: |-
@@ -1266,6 +1267,7 @@ spec:
                       - Privilege Escalation
                       - Running as Non-root
                       - Running as Non-root user
+                      - Host Probes / Lifecycle Hooks
                       type: string
                     images:
                       description: |-

--- a/pkg/pss/evaluate.go
+++ b/pkg/pss/evaluate.go
@@ -29,6 +29,14 @@ func evaluatePSS(level *api.LevelVersion, pod corev1.Pod) (results []pssutils.PS
 			continue
 		}
 
+		// Skip checks that the requested version predates. Check.Versions is sorted by increasing
+		// minimum version, so the first entry is the release the control was introduced in, and
+		// upstream only registers a check from that release onwards. Without this, pinning
+		// podSecurity.version to an older release still enforces controls that did not exist yet.
+		if level.Version.Older(check.Versions[0].MinimumVersion) {
+			continue
+		}
+
 		selectedCheck := check.Versions[0]
 		for i := 1; i < len(check.Versions); i++ {
 			nextCheck := check.Versions[i]

--- a/pkg/pss/hostprobes_test.go
+++ b/pkg/pss/hostprobes_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/pod-security-admission/api"
+	"k8s.io/pod-security-admission/policy"
 )
 
 // hostProbePod mirrors the workloads users reported in #15111: a container whose liveness probe pins
@@ -82,4 +83,16 @@ func Test_HostProbes_RequiresImages(t *testing.T) {
 		Images:      []string{"602401143452.dkr.ecr.*.amazonaws.com/eks/eks-pod-identity-agent:*"},
 	}
 	assert.Assert(t, len(withImages.Validate(path)) == 0)
+}
+
+// Test_AllPodSecurityChecksHaveAControlName guards the gap that let this slip through: the Host Probes
+// check was vendored in with the 1.34 standards but never mapped to a control name, so it could not be
+// excluded and showed up with an empty name in reports. Any future control added upstream fails here
+// until it is mapped.
+func Test_AllPodSecurityChecksHaveAControlName(t *testing.T) {
+	for _, check := range policy.DefaultChecks() {
+		name := pssutils.PSSControlIDToName(string(check.ID))
+		assert.Assert(t, name != "",
+			"pod security check %q has no control name: add it to PSS_control_name_to_ids and to the controlName enum", check.ID)
+	}
 }

--- a/pkg/pss/hostprobes_test.go
+++ b/pkg/pss/hostprobes_test.go
@@ -1,0 +1,85 @@
+package pss
+
+import (
+	"encoding/json"
+	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	pssutils "github.com/kyverno/kyverno/pkg/pss/utils"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/pod-security-admission/api"
+)
+
+// hostProbePod mirrors the workloads users reported in #15111: a container whose liveness probe pins
+// an explicit host, as the EKS Pod Identity agent and the csi-driver-nfs controller both do.
+var hostProbePod = []byte(`{
+	"kind": "Pod",
+	"apiVersion": "v1",
+	"metadata": {"name": "eks-pod-identity-agent", "namespace": "kube-system"},
+	"spec": {
+		"containers": [{
+			"name": "eks-pod-identity-agent",
+			"image": "602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/eks-pod-identity-agent:0.1.0",
+			"livenessProbe": {"httpGet": {"host": "localhost", "path": "/healthz", "port": 2703}}
+		}]
+	}
+}`)
+
+// Test_HostProbes_VersionGating is the regression test for #14521: the Host Probes / Lifecycle Hooks
+// control only exists in the Pod Security Standards from v1.34, so pinning podSecurity.version to an
+// earlier release must not enforce it. Leaving the version unset keeps enforcing it, which is what
+// almost every policy does and what keeps the default strict.
+func Test_HostProbes_VersionGating(t *testing.T) {
+	tests := []struct {
+		version     string
+		wantAllowed bool
+	}{
+		{"", false},
+		{"latest", false},
+		{"v1.35", false},
+		{"v1.34", false},
+		{"v1.33", true},
+		{"v1.29", true},
+	}
+
+	for _, test := range tests {
+		var pod corev1.Pod
+		err := json.Unmarshal(hostProbePod, &pod)
+		assert.NilError(t, err)
+
+		levelVersion, err := ParseVersion(api.LevelBaseline, test.version)
+		assert.NilError(t, err)
+
+		allowed, checks := EvaluatePod(levelVersion, nil, &pod)
+		assert.Equal(t, allowed, test.wantAllowed,
+			"version %q: expected allowed=%v, got %v (%s)", test.version, test.wantAllowed, allowed, FormatChecksPrint(checks))
+	}
+}
+
+// Test_HostProbes_ControlName covers the control being addressable by name at all. Without the
+// mapping the check reported an empty control name, so it could neither be read in a report nor
+// named in an exclusion (#15111).
+func Test_HostProbes_ControlName(t *testing.T) {
+	assert.Equal(t, pssutils.PSSControlIDToName("hostProbesAndHostLifecycle"), "Host Probes / Lifecycle Hooks")
+	assert.Assert(t, len(pssutils.PSS_control_name_to_ids["Host Probes / Lifecycle Hooks"]) == 1)
+	assert.Equal(t, pssutils.PSS_control_name_to_ids["Host Probes / Lifecycle Hooks"][0], "hostProbesAndHostLifecycle")
+}
+
+// Test_HostProbes_RequiresImages checks the control is treated as container level, like the other
+// controls that restrict fields under spec.containers[*]. Excluding it without images would silently
+// match no container, so the policy is rejected with a message that says what to add.
+func Test_HostProbes_RequiresImages(t *testing.T) {
+	path := field.NewPath("spec", "rules[0]", "validate", "podSecurity", "exclude[0]")
+
+	withoutImages := kyvernov1.PodSecurityStandard{ControlName: "Host Probes / Lifecycle Hooks"}
+	errs := withoutImages.Validate(path)
+	assert.Assert(t, len(errs) == 1, "expected the exclusion to be rejected without images, got %v", errs)
+
+	withImages := kyvernov1.PodSecurityStandard{
+		ControlName: "Host Probes / Lifecycle Hooks",
+		Images:      []string{"602401143452.dkr.ecr.*.amazonaws.com/eks/eks-pod-identity-agent:*"},
+	}
+	assert.Assert(t, len(withImages.Validate(path)) == 0)
+}

--- a/pkg/pss/utils/mapping.go
+++ b/pkg/pss/utils/mapping.go
@@ -24,6 +24,7 @@ var PSS_container_level_control = []string{
 	"Host Ports",
 	"/proc Mount Type",
 	"Privilege Escalation",
+	"Host Probes / Lifecycle Hooks",
 }
 
 // Translate PSS control to CheckResult.ID so that we can use PSS control in Kyverno policy
@@ -52,6 +53,10 @@ var PSS_control_name_to_ids = map[string][]string{
 	},
 	"/proc Mount Type": {
 		"procMount",
+	},
+	// Added to the Pod Security Standards in Kubernetes v1.34.
+	"Host Probes / Lifecycle Hooks": {
+		"hostProbesAndHostLifecycle",
 	},
 
 	// Container and pod-level controls
@@ -115,6 +120,36 @@ func PSSControlIDToName(id string) string {
 	return pss_control_id_to_name[id]
 }
 
+// hostProbeAndLifecycleRestrictedFields lists the fields the Host Probes / Lifecycle Hooks control
+// restricts: the host of every probe and lifecycle handler, for each kind of container. They are
+// generated rather than spelled out because the same two handler shapes repeat for every probe and
+// hook. See https://kubernetes.io/docs/concepts/security/pod-security-standards/
+func hostProbeAndLifecycleRestrictedFields() []RestrictedField {
+	containerTypes := []string{"containers", "initContainers", "ephemeralContainers"}
+	handlers := []string{
+		"livenessProbe",
+		"readinessProbe",
+		"startupProbe",
+		"lifecycle.postStart",
+		"lifecycle.preStop",
+	}
+	fields := make([]RestrictedField, 0, len(containerTypes)*len(handlers)*2)
+	for _, containerType := range containerTypes {
+		for _, handler := range handlers {
+			for _, probeType := range []string{"httpGet", "tcpSocket"} {
+				fields = append(fields, RestrictedField{
+					Path: "spec." + containerType + "[*]." + handler + "." + probeType + ".host",
+					AllowedValues: []interface{}{
+						nil,
+						"",
+					},
+				})
+			}
+		}
+	}
+	return fields
+}
+
 var PSS_controls = map[string][]RestrictedField{
 	// Control name as key, same as ID field in CheckResult
 
@@ -170,6 +205,9 @@ var PSS_controls = map[string][]RestrictedField{
 			},
 		},
 	},
+	// Host is forbidden in probes and lifecycle handlers since Kubernetes v1.34. The same handler
+	// shape (httpGet, tcpSocket) is checked for each probe and for both lifecycle hooks.
+	"hostProbesAndHostLifecycle": hostProbeAndLifecycleRestrictedFields(),
 	"procMount": {
 		{
 			Path: "spec.containers[*].securityContext.procMount",


### PR DESCRIPTION
# Explanation

Kubernetes 1.34 added a Pod Security Standards control that forbids setting a host on probes and lifecycle handlers. Kyverno enforced it but never exposed it to users: it was missing from the `controlName` enum, so it could not be excluded, and it had no name in policy reports. Users running the EKS Pod Identity Agent, `csi-driver-nfs`, or MetalLB hit this with no way to exclude the control.

Pinning `podSecurity.version` to an older Kubernetes release did not help either, because the evaluator applied every check regardless of when it was introduced. Both changes restore the documented behavior.

## Related issue

Closes #15111

Also fixes #14521 (closed as stale, but the version-pinning bug is still present)

Needs [https://github.com/kyverno/pod-security-admission/pull/5](https://github.com/kyverno/pod-security-admission/pull/5) merge first so its  draft for now untill that merges 

## Milestone of this PR

`/milestone 1.19.0`

## What type of PR is this

`/kind bug`

## Proposed Changes

- `evaluatePSS` now skips checks whose minimum version is newer than the requested `podSecurity.version`, matching how upstream registers checks. Leaving the version unset still enforces every available check, so the default behavior is unchanged.
- Mapped the `hostProbesAndHostLifecycle` check to the control name **Host Probes / Lifecycle Hooks** (the heading used in the Kubernetes documentation), added it to the CRD enum, and listed its restricted fields.
- Treated it as a container-level control, like the other controls that restrict fields under `spec.containers[*]`. Excluding it without specifying `images` would never match a container, so the policy is now rejected with a message explaining that `images` must be provided.

> **Note**
>
> This depends on a companion change to `kyverno/pod-security-admission`: the check there never populates `ErrList`, and exclusions are matched per field, so without that change the exclusion silently has no effect.[PR LINK](https://github.com/kyverno/pod-security-admission/pull/5)
## Proof Manifests

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: pod-pss-restricted
spec:
  rules:
    - name: baseline
      match:
        any:
          - resources:
              kinds:
                - Pod
      validate:
        podSecurity:
          level: baseline
          exclude:
            - controlName: Host Probes / Lifecycle Hooks
              images:
                - "602401143452.dkr.ecr.*.amazonaws.com/eks/eks-pod-identity-agent:*"
---
apiVersion: v1
kind: Pod
metadata:
  name: eks-pod-identity-agent
spec:
  containers:
    - name: eks-pod-identity-agent
      image: 602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/eks-pod-identity-agent:0.1.0
      livenessProbe:
        httpGet:
          host: localhost
          path: /healthz
          port: 2703
```

The same Pod is admitted without the exclusion when the policy pins `version: v1.33`, since this control did not exist before Kubernetes 1.34.

## Checklist

- [x] I have read the contributing guidelines.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

The control name follows the Kubernetes documentation heading rather than the shorter "Host Probes" from the issue, to stay consistent with the other entries in the enum. Pinning an older Kubernetes version now enforces fewer controls than before, which matches the documented behavior but is worth calling out for anyone relying on the previous implementation.

Added support for excluding the Kubernetes 1.34 **Host Probes / Lifecycle Hooks** Pod Security Standards control, and stopped `podSecurity` from enforcing controls newer than the configured Kubernetes version.