### PR TITLE
fix(cli): run checks-only test files in kyverno test

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/checks_only_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/checks_only_test.go
@@ -1,0 +1,70 @@
+package test
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/output/color"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A test file that declares only `checks:` (no `results:`) must still be
+// executed. The check below asserts `status: pass` while the Pod genuinely
+// fails the policy, so the run must report a failure.
+func TestChecksOnlyTestFileIsExecuted(t *testing.T) {
+	color.Init(true)
+	dir := t.TempDir()
+	write := func(name, content string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+	}
+	write("policy.yaml", `
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-labels
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: check-team
+    match:
+      any:
+      - resources:
+          kinds: [Pod]
+    validate:
+      message: "label 'team' is required"
+      pattern:
+        metadata:
+          labels:
+            team: "?*"
+`)
+	write("resource.yaml", `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod
+spec:
+  containers:
+  - name: c
+    image: nginx
+`)
+	write("kyverno-test.yaml", `
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: checks-only
+policies: [policy.yaml]
+resources: [resource.yaml]
+checks:
+- match:
+    resource:
+      kind: Pod
+  assert:
+    status: pass
+`)
+
+	err := testCommandExecute(io.Discard, []string{dir}, "kyverno-test.yaml", "", "policy=*,rule=*,resource=*", "", false, false, false, false, true)
+	assert.Error(t, err, "checks-only test file was silently skipped: the failing assertion was never evaluated")
+}

--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -150,7 +150,7 @@ func testCommandExecute(
 					filteredResults = append(filteredResults, res)
 				}
 			}
-			if len(filteredResults) == 0 {
+			if len(filteredResults) == 0 && len(test.Test.Checks) == 0 {
 				continue
 			}
 			resourcePath := filepath.Dir(test.Path)


### PR DESCRIPTION
## Explanation

this is a bug fix. `kyverno test` was silently skipping any test file that used only the `checks:` assertion block (instead of `results:`), reporting `0 tests passed and 0 tests failed` and exiting `0`, even when the assertions inside `checks:` would have failed. Users relying solely on `checks:` had no signal that their tests were never actually run. This fix makes `kyverno test` correctly execute and evaluate `checks:`-only test files.

---

## What type of PR is this

/kind bug

---

## Proposed Changes

**Root cause:** In `cmd/cli/kubectl-kyverno/commands/test/command.go`, the loop that runs each test file builds `filteredResults` from `test.Test.Results` only, then short-circuits with:

```go
if len(filteredResults) == 0 {
    continue
}
```

This guard predates the `test.Test.Checks` field, which is a separate, independent way to assert on engine results. i have added test file that declares only `checks:` (no `results:`) always has `len(filteredResults) == 0`, so the `continue` fires before `runTest()` or `printCheckResult()` are ever called. The policy is never evaluated and the assertion is silently discarded, with the run still reporting success and exit code 0.

**Fix:** account for `test.Test.Checks` in the same guard, so the test file is only skipped when it has neither `results:` nor `checks:` to evaluate:

```diff
--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -150,7 +150,7 @@ func testCommandExecute(
 				filteredResults = append(filteredResults, res)
 			}
 		}
-		if len(filteredResults) == 0 {
+		if len(filteredResults) == 0 && len(test.Test.Checks) == 0 {
 			continue
 		}
 		resourcePath := filepath.Dir(test.Path)
```

A regression test (`checks_only_test.go`) was added: a `checks:`-only test file with a deliberately false assertion (`status: pass` against a resource that genuinely fails the policy), calling `testCommandExecute` directly and asserting it returns a non-nil error. This fails on unpatched main and passes with the fix. The full `cmd/cli/kubectl-kyverno/commands/test` package suite was run with the fix applied, no regressions.

---

### Proof Manifests

```yaml
# policy.yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: Enforce
  rules:
  - name: check-team
    match:
      any:
      - resources:
          kinds:
          - Pod
    validate:
      message: "label 'team' is required"
      pattern:
        metadata:
          labels:
            team: "?*"
```

```yaml
# resource.yaml
apiVersion: v1
kind: Pod
metadata:
  name: badpod
spec:
  containers:
  - name: c
    image: nginx
```

```yaml
# kyverno-test.yaml
apiVersion: cli.kyverno.io/v1alpha1
kind: Test
metadata:
  name: checks-only
policies:
- policy.yaml
resources:
- resource.yaml
checks:
- match:
    resource:
      kind: Pod
  assert:
    status: pass
```

---

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
