### PR TITLE
fix(helm): remove redundant metricsService guard from background-cont…

### DIFF
--- a/charts/kyverno/templates/background-controller/networkpolicy.yaml
+++ b/charts/kyverno/templates/background-controller/networkpolicy.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.backgroundController.enabled -}}
 {{- if .Values.backgroundController.networkPolicy.enabled -}}
-{{- if .Values.backgroundController.metricsService.create -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -25,6 +24,5 @@ spec:
   ingress:
     - {}
   {{- end }}
-{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
/kind bug

## Explanation

This PR fixes an issue where the background controller `NetworkPolicy` was only rendered when both `backgroundController.networkPolicy.enabled` and `backgroundController.metricsService.create` were enabled.

The `metricsService.create` flag only controls the creation of the metrics `Service` and should not affect whether a `NetworkPolicy` is created. This caused the `NetworkPolicy` to be skipped even when users explicitly enabled it.

This change removes the unnecessary dependency so that the `NetworkPolicy` is rendered whenever `backgroundController.networkPolicy.enabled` is `true`, matching the behavior of the other controller templates.

## Related issue

Closes #16779

## Milestone of this PR

<!-- Add the milestone by commenting:
/milestone 1.19.0
-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.

- [ ] I have sent the draft PR to add or update the documentation and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

- Removed the unnecessary `backgroundController.metricsService.create` guard from `charts/kyverno/templates/background-controller/networkpolicy.yaml`.
- Ensured that `NetworkPolicy` creation depends only on `backgroundController.networkPolicy.enabled`.
- Aligned the background controller behavior with the other controller templates.

### Proof Manifests

## Proof

Verified with `helm template` that the `NetworkPolicy` is correctly rendered when `backgroundController.networkPolicy.enabled=true`, even if `backgroundController.metricsService.create=false`:

```bash
helm template kyverno charts/kyverno/ \
  --set backgroundController.networkPolicy.enabled=true \
  --set backgroundController.metricsService.create=false \
  | grep -A15 "kind: NetworkPolicy"
```

Output:

```yaml
kind: NetworkPolicy
metadata:
  name: kyverno-background-controller
  namespace: default
  labels:
    ...
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/component: background-controller
```

Before this fix, the above command produced no output because the `NetworkPolicy` was not rendered due to the redundant `backgroundController.metricsService.create` guard.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the AI Usage Policy. If I used AI assistance, I have disclosed it in my commit(s).
- [x] I have read the PR documentation guide and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is `<replace>`.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This change removes an unintended dependency between `backgroundController.networkPolicy.enabled` and `backgroundController.metricsService.create`. As a result, the `NetworkPolicy` is rendered whenever it is explicitly enabled, regardless of whether the metrics `Service` is created.