### PR TITLE
feat(cli): support admission operation simulation for policy testing

### DIFF
--- a/cmd/cli/kubectl-kyverno/apis/v1alpha1/test_result.go
+++ b/cmd/cli/kubectl-kyverno/apis/v1alpha1/test_result.go
@@ -53,6 +53,17 @@ type TestResultBase struct {
 	// Kind mentions the kind of the resource on which the policy is to be applied.
 	Kind string `json:"kind"`
 
+	// Operation mentions the admission operation to simulate when applying policies
+	// on the resources of this test result. Possible values are CREATE, UPDATE and
+	// DELETE. If unset, the operation defaults to CREATE, or to the operation
+	// declared via the `request.operation` global value in the values file.
+	// For UPDATE, both object and oldObject are set to the resource. For DELETE,
+	// object is null and oldObject is set to the resource, mirroring the API server.
+	// It is not supported for deleting policies and JSON payloads.
+	// +optional
+	// +kubebuilder:validation:Enum=CREATE;UPDATE;DELETE
+	Operation string `json:"operation,omitempty"`
+
 	// PatchedResource takes a resource configuration file in yaml format from
 	// the user to compare it against the Kyverno mutated resource configuration.
 	// Multiple resources can be passed in the same file

--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -292,6 +292,9 @@ func (c *ApplyCommandConfig) applyCommandHelper(out io.Writer) (*processor.Resul
 	if err != nil {
 		return nil, nil, skippedInvalidPolicies, nil, fmt.Errorf("failed to decode yaml (%w)", err)
 	}
+	if _, err := processor.NormalizeValuesOperation(variables.GlobalOperation()); err != nil {
+		return nil, nil, skippedInvalidPolicies, nil, err
+	}
 	var store store.Store
 
 	kpols, polexs, celpolexs, vaps, vapBindings, maps, mapBindings, vps, ivps, gps, dps, cps, mps, envoyPols, httpPols, err := c.loadPolicies()

--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -55,7 +55,6 @@ import (
 	utils "github.com/kyverno/kyverno/pkg/utils/restmapper"
 	policyvalidation "github.com/kyverno/kyverno/pkg/validation/policy"
 	"github.com/spf13/cobra"
-	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -463,7 +462,7 @@ func (c *ApplyCommandConfig) applyCommandHelper(out io.Writer) (*processor.Resul
 	if err != nil {
 		return rc, resources1, skippedInvalidPolicies, responses1, err
 	}
-	responses4, err := c.applyImageValidatingPolicies(ivps, jsonPayloads, resources1, celExceptions, variables.Namespace, userInfo, rc, dClient)
+	responses4, err := c.applyImageValidatingPolicies(ivps, jsonPayloads, resources1, celExceptions, variables.Namespace, userInfo, rc, dClient, variables.GlobalOperation())
 	if err != nil {
 		return rc, resources1, skippedInvalidPolicies, responses4, err
 	}
@@ -666,6 +665,7 @@ func (c *ApplyCommandConfig) applyImageValidatingPolicies(
 	userInfo *kyvernov2.RequestInfo,
 	rc *processor.ResultCounts,
 	dclient dclient.Interface,
+	operation string,
 ) ([]engineapi.EngineResponse, error) {
 	if len(ivps) == 0 {
 		return nil, nil
@@ -722,6 +722,7 @@ func (c *ApplyCommandConfig) applyImageValidatingPolicies(
 		if userInfo != nil {
 			user = userInfo.AdmissionUserInfo
 		}
+		op, object, oldObject := processor.AdmissionRequestShape(operation, resource)
 		request := celengine.Request(
 			contextProvider,
 			resource.GroupVersionKind(),
@@ -729,10 +730,10 @@ func (c *ApplyCommandConfig) applyImageValidatingPolicies(
 			"",
 			resource.GetName(),
 			resource.GetNamespace(),
-			admissionv1.Create,
+			op,
 			user,
-			resource,
-			nil,
+			object,
+			oldObject,
 			false,
 			nil,
 		)

--- a/cmd/cli/kubectl-kyverno/commands/test/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command_test.go
@@ -999,3 +999,82 @@ func TestRunTestDeletingPolicyObjectSelectorSkipsUnmatchedResource(t *testing.T)
 	_, found := got["secret-skip"]
 	assert.False(t, found, "constraint-excluded resource must not produce a rule response")
 }
+
+func Test_OperationDelete(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err, "Failed to get working directory")
+	rootDir := filepath.Join(wd, "..", "..", "..", "..", "..")
+	testDir := filepath.Join(rootDir, "test", "cli", "test-validating-policy", "operation-delete")
+
+	testFile := filepath.Join(testDir, "kyverno-test.yaml")
+	testCases := test.LoadTest(nil, testFile)
+	require.Len(t, testCases, 1, "Expected exactly one test case in %s", testFile)
+	testCase := testCases[0]
+
+	out := &bytes.Buffer{}
+	testResponse, err := runTest(out, testCase, false)
+	require.NoError(t, err, "Failed to run test")
+
+	resourceKey := "v1,Pod,test-ns,protected-pod"
+
+	t.Run("DELETE run evaluates DELETE-scoped policy against oldObject", func(t *testing.T) {
+		require.Contains(t, testResponse.TriggerByOperation, "DELETE")
+		responses := testResponse.TriggerByOperation["DELETE"][resourceKey]
+		require.NotEmpty(t, responses)
+		var found bool
+		for _, response := range responses {
+			if response.Policy().GetName() != "deny-protected-deletion" {
+				continue
+			}
+			for _, rule := range response.PolicyResponse.Rules {
+				if rule.Status() == engineapi.RuleStatusFail {
+					found = true
+				}
+			}
+		}
+		assert.True(t, found, "expected a failing rule for deny-protected-deletion in the DELETE run")
+	})
+
+	t.Run("default run skips the DELETE-scoped policy", func(t *testing.T) {
+		responses := testResponse.Trigger[resourceKey]
+		require.NotEmpty(t, responses)
+		for _, response := range responses {
+			if response.Policy().GetName() == "deny-protected-deletion" {
+				assert.Empty(t, response.PolicyResponse.Rules, "DELETE-scoped policy must not match the default CREATE run")
+			}
+		}
+	})
+
+	t.Run("default run evaluates the CREATE-scoped policy", func(t *testing.T) {
+		responses := testResponse.Trigger[resourceKey]
+		var found bool
+		for _, response := range responses {
+			if response.Policy().GetName() != "require-env-label" {
+				continue
+			}
+			for _, rule := range response.PolicyResponse.Rules {
+				if rule.Status() == engineapi.RuleStatusFail {
+					found = true
+				}
+			}
+		}
+		assert.True(t, found, "expected a failing rule for require-env-label in the default run")
+	})
+}
+
+func Test_InvalidResultOperation(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err, "Failed to get working directory")
+	rootDir := filepath.Join(wd, "..", "..", "..", "..", "..")
+	testDir := filepath.Join(rootDir, "test", "cli", "test-validating-policy", "operation-delete")
+
+	testFile := filepath.Join(testDir, "kyverno-test.yaml")
+	testCases := test.LoadTest(nil, testFile)
+	require.Len(t, testCases, 1)
+	testCase := testCases[0]
+	testCase.Test.Results[0].Operation = "CONNECT"
+
+	_, err = runTest(io.Discard, testCase, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid operation")
+}

--- a/cmd/cli/kubectl-kyverno/commands/test/output.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/output.go
@@ -179,11 +179,17 @@ func printTestResult(
 ) error {
 	testCount := 1
 	for _, test := range tests {
+		// results declaring an explicit operation are checked against the
+		// responses of the dedicated evaluation run for that operation
+		trigger := responses.Trigger
+		if test.Operation != "" {
+			trigger = responses.TriggerByOperation[test.Operation]
+		}
 		var resources []string
 		// The test specifies certain resources to check, results will be checked for those resources only
 		if test.Resources != nil {
 			for _, r := range test.Resources {
-				for _, m := range []map[string][]engineapi.EngineResponse{responses.Target, responses.Trigger} {
+				for _, m := range []map[string][]engineapi.EngineResponse{responses.Target, trigger} {
 					for resourceGVKAndName := range m {
 						nameParts := strings.Split(resourceGVKAndName, ",")
 						nsAndName := strings.Split(r, "/")
@@ -201,7 +207,7 @@ func printTestResult(
 				}
 			}
 			for _, resourceSpec := range test.ResourceSpecs {
-				for _, m := range []map[string][]engineapi.EngineResponse{responses.Target, responses.Trigger} {
+				for _, m := range []map[string][]engineapi.EngineResponse{responses.Target, trigger} {
 					for resourceGVKAndName := range m {
 						nameParts := strings.Split(resourceGVKAndName, ",")
 						if resourceSpec.Group == "" {
@@ -229,7 +235,7 @@ func printTestResult(
 			for r := range responses.Target {
 				resources = append(resources, r)
 			}
-			for r := range responses.Trigger {
+			for r := range trigger {
 				resources = append(resources, r)
 			}
 		}
@@ -237,8 +243,8 @@ func printTestResult(
 		for _, resource := range resources {
 			var rows []table.Row
 			var resourceSkipped bool
-			if _, ok := responses.Trigger[resource]; ok {
-				for _, response := range responses.Trigger[resource] {
+			if _, ok := trigger[resource]; ok {
+				for _, response := range trigger[resource] {
 					polNameNs := strings.Split(test.Policy, "/")
 					if response.Policy().GetName() != polNameNs[len(polNameNs)-1] {
 						continue

--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -437,6 +437,9 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 	}
 	// validate the operations declared on test results and collect the distinct
 	// explicit operations, each of which triggers a dedicated evaluation run
+	if _, err := processor.NormalizeValuesOperation(vars.GlobalOperation()); err != nil {
+		return nil, err
+	}
 	explicitOperations := sets.New[string]()
 	for _, res := range testCase.Test.Results {
 		if _, err := processor.NormalizeOperation(res.Operation); err != nil {

--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -47,7 +47,6 @@ import (
 	eval "github.com/kyverno/kyverno/pkg/image/verification/evaluator"
 	utils "github.com/kyverno/kyverno/pkg/utils/restmapper"
 	policyvalidation "github.com/kyverno/kyverno/pkg/validation/policy"
-	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -55,14 +54,20 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 type TestResponse struct {
-	Trigger         map[string][]engineapi.EngineResponse
-	Target          map[string][]engineapi.EngineResponse
-	SkippedPolicies map[string]string
+	Trigger map[string][]engineapi.EngineResponse
+	// TriggerByOperation holds the responses of the additional evaluation runs
+	// performed for test results that declare an explicit admission operation.
+	// The outer key is the operation (CREATE, UPDATE or DELETE), the inner key
+	// is the resource key.
+	TriggerByOperation map[string]map[string][]engineapi.EngineResponse
+	Target             map[string][]engineapi.EngineResponse
+	SkippedPolicies    map[string]string
 }
 
 func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestResponse, error) {
@@ -425,13 +430,29 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 	var engineResponses []engineapi.EngineResponse
 	var resultCounts processor.ResultCounts
 	testResponse := TestResponse{
-		Trigger:         map[string][]engineapi.EngineResponse{},
-		Target:          map[string][]engineapi.EngineResponse{},
-		SkippedPolicies: skippedPolicyNames,
+		Trigger:            map[string][]engineapi.EngineResponse{},
+		TriggerByOperation: map[string]map[string][]engineapi.EngineResponse{},
+		Target:             map[string][]engineapi.EngineResponse{},
+		SkippedPolicies:    skippedPolicyNames,
 	}
-	for _, resource := range uniques {
+	// validate the operations declared on test results and collect the distinct
+	// explicit operations, each of which triggers a dedicated evaluation run
+	explicitOperations := sets.New[string]()
+	for _, res := range testCase.Test.Results {
+		if _, err := processor.NormalizeOperation(res.Operation); err != nil {
+			return nil, fmt.Errorf("invalid test result for policy %s: %w", res.Policy, err)
+		}
+		if res.Operation == "" {
+			continue
+		}
+		if res.IsDeletingPolicy {
+			return nil, fmt.Errorf("invalid test result for policy %s: operation is not supported for deleting policies", res.Policy)
+		}
+		explicitOperations.Insert(res.Operation)
+	}
+	evalResource := func(resource *unstructured.Unstructured, operation string, defaultRun bool) ([]engineapi.EngineResponse, error) {
 		// the policy processor is for multiple policies at once
-		processor := processor.PolicyProcessor{
+		pp := processor.PolicyProcessor{
 			Store:                             &store,
 			Policies:                          validPolicies,
 			ValidatingAdmissionPolicies:       results.VAPs,
@@ -443,6 +464,7 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 			MutatingAdmissionPolicyBindings:   results.MAPBindings,
 			TargetResources:                   targetResources,
 			Resource:                          *resource,
+			Operation:                         operation,
 			PolicyExceptions:                  polexLoader.Exceptions,
 			CELExceptions:                     polexLoader.CELExceptions,
 			ParameterResources:                paramObjectsArr,
@@ -464,7 +486,7 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 			RESTMapper:                        restMapper,
 			CrdPaths:                          crdPaths,
 		}
-		ers, err := processor.ApplyPoliciesOnResource()
+		ers, err := pp.ApplyPoliciesOnResource()
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply policies on resource %v (%w)", resource.GetName(), err)
 		}
@@ -485,14 +507,16 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 				!(len(testCase.Test.ClusterResources) > 0),
 				restMapper,
 				gceMap,
+				operation,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to apply policies on resource %v (%w)", resource.GetName(), err)
 			}
 			ers = append(ers, ivpols...)
 		}
-
-		if len(results.DeletingPolicies) != 0 {
+		// deleting policies are not admission driven, they are only evaluated in
+		// the default run
+		if defaultRun && len(results.DeletingPolicies) != 0 {
 			dpols, err := applyDeletingPolicies(
 				results.DeletingPolicies,
 				[]*unstructured.Unstructured{resource},
@@ -512,10 +536,29 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 			}
 			ers = append(ers, dpols...)
 		}
-
+		return ers, nil
+	}
+	for _, resource := range uniques {
 		resourceKey := generateResourceKey(resource)
+		// default run, honoring the values file operation when set
+		ers, err := evalResource(resource, "", true)
+		if err != nil {
+			return nil, err
+		}
 		engineResponses = append(engineResponses, ers...)
 		testResponse.Trigger[resourceKey] = ers
+		// one additional run per distinct operation explicitly declared on results
+		for _, operation := range sets.List(explicitOperations) {
+			ers, err := evalResource(resource, operation, false)
+			if err != nil {
+				return nil, err
+			}
+			engineResponses = append(engineResponses, ers...)
+			if testResponse.TriggerByOperation[operation] == nil {
+				testResponse.TriggerByOperation[operation] = map[string][]engineapi.EngineResponse{}
+			}
+			testResponse.TriggerByOperation[operation][resourceKey] = ers
+		}
 	}
 
 	for _, jp := range jsonPayloads {
@@ -571,6 +614,7 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool) (*TestR
 				true,
 				restMapper,
 				gceMap,
+				"",
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to apply validating policies on JSON payload %s (%w)", jp.name, err)
@@ -653,6 +697,7 @@ func applyImageValidatingPolicies(
 	isFake bool,
 	restMapper meta.RESTMapper,
 	gceMap map[string]interface{},
+	operation string,
 ) ([]engineapi.EngineResponse, error) {
 	provider, err := ivpolengine.NewProvider(ivps, celExceptions)
 	if err != nil {
@@ -709,6 +754,7 @@ func applyImageValidatingPolicies(
 		if userInfo != nil {
 			user = userInfo.AdmissionUserInfo
 		}
+		op, object, oldObject := processor.AdmissionRequestShape(operation, resource)
 		request := celengine.Request(
 			contextProvider,
 			resource.GroupVersionKind(),
@@ -716,10 +762,10 @@ func applyImageValidatingPolicies(
 			"",
 			resource.GetName(),
 			resource.GetNamespace(),
-			admissionv1.Create,
+			op,
 			user,
-			resource,
-			nil,
+			object,
+			oldObject,
 			false,
 			nil,
 		)

--- a/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
@@ -294,6 +294,20 @@ spec:
                   description: Kind mentions the kind of the resource on which the
                     policy is to be applied.
                   type: string
+                operation:
+                  description: |-
+                    Operation mentions the admission operation to simulate when applying policies
+                    on the resources of this test result. Possible values are CREATE, UPDATE and
+                    DELETE. If unset, the operation defaults to CREATE, or to the operation
+                    declared via the `request.operation` global value in the values file.
+                    For UPDATE, both object and oldObject are set to the resource. For DELETE,
+                    object is null and oldObject is set to the resource, mirroring the API server.
+                    It is not supported for deleting policies and JSON payloads.
+                  enum:
+                  - CREATE
+                  - UPDATE
+                  - DELETE
+                  type: string
                 patchedResources:
                   description: |-
                     PatchedResource takes a resource configuration file in yaml format from

--- a/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
@@ -294,6 +294,20 @@ spec:
                   description: Kind mentions the kind of the resource on which the
                     policy is to be applied.
                   type: string
+                operation:
+                  description: |-
+                    Operation mentions the admission operation to simulate when applying policies
+                    on the resources of this test result. Possible values are CREATE, UPDATE and
+                    DELETE. If unset, the operation defaults to CREATE, or to the operation
+                    declared via the `request.operation` global value in the values file.
+                    For UPDATE, both object and oldObject are set to the resource. For DELETE,
+                    object is null and oldObject is set to the resource, mirroring the API server.
+                    It is not supported for deleting policies and JSON payloads.
+                  enum:
+                  - CREATE
+                  - UPDATE
+                  - DELETE
+                  type: string
                 patchedResources:
                   description: |-
                     PatchedResource takes a resource configuration file in yaml format from

--- a/cmd/cli/kubectl-kyverno/processor/operation.go
+++ b/cmd/cli/kubectl-kyverno/processor/operation.go
@@ -19,6 +19,20 @@ func NormalizeOperation(operation string) (string, error) {
 	}
 }
 
+// NormalizeValuesOperation validates a `request.operation` global value from a
+// values file. In addition to the operations supported by admission request
+// simulation, CONNECT is accepted for backward compatibility with classic
+// policies that evaluate `request.operation` in preconditions; it is not
+// simulated for CEL policy types, which fall back to the CREATE request shape.
+func NormalizeValuesOperation(operation string) (string, error) {
+	switch operation {
+	case "", "CREATE", "UPDATE", "DELETE", "CONNECT":
+		return operation, nil
+	default:
+		return "", fmt.Errorf("invalid request.operation value %q, must be one of CREATE, UPDATE, DELETE, CONNECT", operation)
+	}
+}
+
 // AdmissionRequestShape maps a CLI-declared operation to the admission operation
 // and the (object, oldObject) pair, mirroring the API server semantics:
 //   - CREATE (default): object is the resource, oldObject is null
@@ -29,7 +43,9 @@ func AdmissionRequestShape(operation string, resource *unstructured.Unstructured
 	case "UPDATE":
 		return admissionv1.Update, resource, resource.DeepCopy()
 	case "DELETE":
-		return admissionv1.Delete, nil, resource
+		// deep copy so downstream mutations of the old state cannot leak into
+		// the shared resource object
+		return admissionv1.Delete, nil, resource.DeepCopy()
 	default:
 		return admissionv1.Create, resource, nil
 	}
@@ -37,7 +53,8 @@ func AdmissionRequestShape(operation string, resource *unstructured.Unstructured
 
 // resolveOperation returns the effective operation for the processor: the
 // explicitly configured operation takes precedence, then the `request.operation`
-// global value from the values file, then the default (CREATE).
+// global value from the values file, then the default (CREATE). CONNECT from the
+// values file is not simulated and maps to the default request shape.
 func (p *PolicyProcessor) resolveOperation() string {
 	if p.Operation != "" {
 		return p.Operation

--- a/cmd/cli/kubectl-kyverno/processor/operation.go
+++ b/cmd/cli/kubectl-kyverno/processor/operation.go
@@ -1,0 +1,51 @@
+package processor
+
+import (
+	"fmt"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// NormalizeOperation validates a CLI-declared admission operation. An empty
+// string is valid and means "use the default operation".
+func NormalizeOperation(operation string) (string, error) {
+	switch operation {
+	case "", "CREATE", "UPDATE", "DELETE":
+		return operation, nil
+	default:
+		return "", fmt.Errorf("invalid operation %q, must be one of CREATE, UPDATE, DELETE", operation)
+	}
+}
+
+// AdmissionRequestShape maps a CLI-declared operation to the admission operation
+// and the (object, oldObject) pair, mirroring the API server semantics:
+//   - CREATE (default): object is the resource, oldObject is null
+//   - UPDATE: object and oldObject are both the resource
+//   - DELETE: object is null, oldObject is the resource
+func AdmissionRequestShape(operation string, resource *unstructured.Unstructured) (admissionv1.Operation, runtime.Object, runtime.Object) {
+	switch operation {
+	case "UPDATE":
+		return admissionv1.Update, resource, resource.DeepCopy()
+	case "DELETE":
+		return admissionv1.Delete, nil, resource
+	default:
+		return admissionv1.Create, resource, nil
+	}
+}
+
+// resolveOperation returns the effective operation for the processor: the
+// explicitly configured operation takes precedence, then the `request.operation`
+// global value from the values file, then the default (CREATE).
+func (p *PolicyProcessor) resolveOperation() string {
+	if p.Operation != "" {
+		return p.Operation
+	}
+	if p.Variables != nil {
+		if op, err := NormalizeOperation(p.Variables.GlobalOperation()); err == nil {
+			return op
+		}
+	}
+	return ""
+}

--- a/cmd/cli/kubectl-kyverno/processor/operation_test.go
+++ b/cmd/cli/kubectl-kyverno/processor/operation_test.go
@@ -1,0 +1,92 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestNormalizeOperation(t *testing.T) {
+	tests := []struct {
+		operation string
+		want      string
+		wantErr   bool
+	}{
+		{operation: "", want: ""},
+		{operation: "CREATE", want: "CREATE"},
+		{operation: "UPDATE", want: "UPDATE"},
+		{operation: "DELETE", want: "DELETE"},
+		{operation: "CONNECT", wantErr: true},
+		{operation: "delete", wantErr: true},
+		{operation: "foo", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.operation, func(t *testing.T) {
+			got, err := NormalizeOperation(tt.operation)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestAdmissionRequestShape(t *testing.T) {
+	resource := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": "test-pod"},
+	}}
+	t.Run("default is CREATE", func(t *testing.T) {
+		op, object, oldObject := AdmissionRequestShape("", resource)
+		assert.Equal(t, admissionv1.Create, op)
+		assert.Equal(t, resource, object)
+		assert.Nil(t, oldObject)
+	})
+	t.Run("CREATE", func(t *testing.T) {
+		op, object, oldObject := AdmissionRequestShape("CREATE", resource)
+		assert.Equal(t, admissionv1.Create, op)
+		assert.Equal(t, resource, object)
+		assert.Nil(t, oldObject)
+	})
+	t.Run("UPDATE sets object and oldObject", func(t *testing.T) {
+		op, object, oldObject := AdmissionRequestShape("UPDATE", resource)
+		assert.Equal(t, admissionv1.Update, op)
+		assert.Equal(t, resource, object)
+		assert.Equal(t, resource.Object, oldObject.(*unstructured.Unstructured).Object)
+	})
+	t.Run("DELETE sets only oldObject", func(t *testing.T) {
+		op, object, oldObject := AdmissionRequestShape("DELETE", resource)
+		assert.Equal(t, admissionv1.Delete, op)
+		assert.Nil(t, object)
+		assert.Equal(t, resource, oldObject)
+	})
+}
+
+func TestResolveOperation(t *testing.T) {
+	t.Run("explicit operation wins", func(t *testing.T) {
+		p := &PolicyProcessor{Operation: "DELETE"}
+		assert.Equal(t, "DELETE", p.resolveOperation())
+	})
+	t.Run("empty without variables", func(t *testing.T) {
+		p := &PolicyProcessor{}
+		assert.Equal(t, "", p.resolveOperation())
+	})
+}
+
+func TestAdmissionRequestShapeUpdateDeepCopy(t *testing.T) {
+	// the oldObject for UPDATE must be a copy so mutations of the object do not
+	// leak into the old state
+	resource := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": "test-pod"},
+	}}
+	_, object, oldObject := AdmissionRequestShape("UPDATE", resource)
+	object.(*unstructured.Unstructured).SetLabels(map[string]string{"mutated": "true"})
+	assert.Empty(t, oldObject.(*unstructured.Unstructured).GetLabels())
+}

--- a/cmd/cli/kubectl-kyverno/processor/operation_test.go
+++ b/cmd/cli/kubectl-kyverno/processor/operation_test.go
@@ -35,6 +35,32 @@ func TestNormalizeOperation(t *testing.T) {
 	}
 }
 
+func TestNormalizeValuesOperation(t *testing.T) {
+	tests := []struct {
+		operation string
+		wantErr   bool
+	}{
+		{operation: ""},
+		{operation: "CREATE"},
+		{operation: "UPDATE"},
+		{operation: "DELETE"},
+		{operation: "CONNECT"},
+		{operation: "connect", wantErr: true},
+		{operation: "foo", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.operation, func(t *testing.T) {
+			got, err := NormalizeValuesOperation(tt.operation)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.operation, got)
+			}
+		})
+	}
+}
+
 func TestAdmissionRequestShape(t *testing.T) {
 	resource := &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "v1",
@@ -63,7 +89,7 @@ func TestAdmissionRequestShape(t *testing.T) {
 		op, object, oldObject := AdmissionRequestShape("DELETE", resource)
 		assert.Equal(t, admissionv1.Delete, op)
 		assert.Nil(t, object)
-		assert.Equal(t, resource, oldObject)
+		assert.Equal(t, resource.Object, oldObject.(*unstructured.Unstructured).Object)
 	})
 }
 

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -796,16 +796,19 @@ func (p *PolicyProcessor) makePolicyContext(
 	}
 	// an explicitly configured operation (e.g. from the test result entry) takes
 	// precedence over the values file
-	switch p.Operation {
-	case "CREATE":
-		operation = kyvernov1.Create
-	case "DELETE":
-		operation = kyvernov1.Delete
-	case "UPDATE":
-		operation = kyvernov1.Update
-	}
-	if resourceValues != nil {
-		resourceValues["request.operation"] = string(operation)
+	if p.Operation != "" {
+		switch p.Operation {
+		case "CREATE":
+			operation = kyvernov1.Create
+		case "DELETE":
+			operation = kyvernov1.Delete
+		case "UPDATE":
+			operation = kyvernov1.Update
+		}
+		if resourceValues == nil {
+			resourceValues = map[string]interface{}{}
+		}
+		resourceValues["request.operation"] = p.Operation
 	}
 
 	var newResource unstructured.Unstructured

--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -51,7 +51,6 @@ import (
 	"github.com/kyverno/sdk/extensions/registryclient"
 	"go.yaml.in/yaml/v3"
 	"gomodules.xyz/jsonpatch/v2"
-	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -81,12 +80,16 @@ type PolicyProcessor struct {
 	TargetResources                   []*unstructured.Unstructured
 	Resource                          unstructured.Unstructured
 	JsonPayload                       unstructured.Unstructured
-	PolicyExceptions                  []*kyvernov2.PolicyException
-	CELExceptions                     []*policiesv1beta1.PolicyException
-	MutateLogPath                     string
-	MutateLogPathIsDir                bool
-	Variables                         *variables.Variables
-	ParameterResources                []runtime.Object
+	// Operation is the admission operation to simulate (CREATE, UPDATE or DELETE).
+	// When empty, the `request.operation` global value from the values file is
+	// honored, defaulting to CREATE.
+	Operation          string
+	PolicyExceptions   []*kyvernov2.PolicyException
+	CELExceptions      []*policiesv1beta1.PolicyException
+	MutateLogPath      string
+	MutateLogPathIsDir bool
+	Variables          *variables.Variables
+	ParameterResources []runtime.Object
 	// TODO
 	ContextFs                 billy.Filesystem
 	ContextPath               string
@@ -345,6 +348,7 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 				user = p.UserInfo.AdmissionUserInfo
 			}
 			// create engine request
+			operation, object, oldObject := AdmissionRequestShape(p.resolveOperation(), &resource)
 			request := celengine.Request(
 				contextProvider,
 				gvk,
@@ -352,10 +356,10 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 				"",
 				resource.GetName(),
 				resource.GetNamespace(),
-				admissionv1.Create,
+				operation,
 				user,
-				&resource,
-				nil,
+				object,
+				oldObject,
 				false,
 				nil,
 			)
@@ -550,6 +554,7 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 					user = p.UserInfo.AdmissionUserInfo
 				}
 				// create engine request
+				operation, object, oldObject := AdmissionRequestShape(p.resolveOperation(), &resource)
 				request := celengine.Request(
 					contextProvider,
 					gvk,
@@ -558,11 +563,10 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 					"",
 					resource.GetName(),
 					resource.GetNamespace(),
-					// TODO: how to manage other operations ?
-					admissionv1.Create,
+					operation,
 					user,
-					&resource,
-					nil,
+					object,
+					oldObject,
 					false,
 					nil,
 				)
@@ -691,6 +695,7 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 				user = p.UserInfo.AdmissionUserInfo
 			}
 			// create engine request
+			operation, object, oldObject := AdmissionRequestShape(p.resolveOperation(), &resource)
 			request := celengine.Request(
 				contextProvider,
 				gvk,
@@ -698,10 +703,10 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 				"",
 				resource.GetName(),
 				resource.GetNamespace(),
-				admissionv1.Create,
+				operation,
 				user,
-				&resource,
-				nil,
+				object,
+				oldObject,
 				false,
 				nil,
 			)
@@ -788,6 +793,19 @@ func (p *PolicyProcessor) makePolicyContext(
 		operation = kyvernov1.Delete
 	case "UPDATE":
 		operation = kyvernov1.Update
+	}
+	// an explicitly configured operation (e.g. from the test result entry) takes
+	// precedence over the values file
+	switch p.Operation {
+	case "CREATE":
+		operation = kyvernov1.Create
+	case "DELETE":
+		operation = kyvernov1.Delete
+	case "UPDATE":
+		operation = kyvernov1.Update
+	}
+	if resourceValues != nil {
+		resourceValues["request.operation"] = string(operation)
 	}
 
 	var newResource unstructured.Unstructured

--- a/cmd/cli/kubectl-kyverno/variables/variables.go
+++ b/cmd/cli/kubectl-kyverno/variables/variables.go
@@ -70,6 +70,20 @@ func (v Variables) Namespace(name string) *corev1.Namespace {
 	return nil
 }
 
+// GlobalOperation returns the admission operation declared via the
+// `request.operation` global value, or an empty string if unset.
+func (v Variables) GlobalOperation() string {
+	if v.values == nil {
+		return ""
+	}
+	if op, ok := v.values.GlobalValues["request.operation"]; ok {
+		if s, ok := op.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
 func (v Variables) ComputeVariables(s *store.Store, policy, resource, kind string, kindMap sets.Set[string], variables ...string) (map[string]interface{}, error) {
 	resourceValues := map[string]interface{}{}
 	// first apply global values

--- a/docs/user/cli/crd/index.html
+++ b/docs/user/cli/crd/index.html
@@ -1675,6 +1675,24 @@ string
 </tr>
 <tr>
 <td>
+<code>operation</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Operation mentions the admission operation to simulate when applying policies
+on the resources of this test result. Possible values are CREATE, UPDATE and
+DELETE. If unset, the operation defaults to CREATE, or to the operation
+declared via the <code>request.operation</code> global value in the values file.
+For UPDATE, both object and oldObject are set to the resource. For DELETE,
+object is null and oldObject is set to the resource, mirroring the API server.
+It is not supported for deleting policies and JSON payloads.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>patchedResources</code><br/>
 <em>
 string

--- a/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
+++ b/docs/user/cli/crd/kyverno_kubectl.v1alpha1.html
@@ -3691,6 +3691,39 @@ Possible values are pass, fail and skip.</p>
     
     
       <tr>
+        <td><code>operation</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>Operation mentions the admission operation to simulate when applying policies
+on the resources of this test result. Possible values are CREATE, UPDATE and
+DELETE. If unset, the operation defaults to CREATE, or to the operation
+declared via the <code>request.operation</code> global value in the values file.
+For UPDATE, both object and oldObject are set to the resource. For DELETE,
+object is null and oldObject is set to the resource, mirroring the API server.
+It is not supported for deleting policies and JSON payloads.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
         <td><code>patchedResources</code>
           
           <span style="color:blue;"> *</span>

--- a/test/cli/test-validating-policy/operation-delete/kyverno-test.yaml
+++ b/test/cli/test-validating-policy/operation-delete/kyverno-test.yaml
@@ -7,17 +7,13 @@ policies:
 resources:
 - resource.yaml
 results:
-# DELETE-scoped policy evaluated with a simulated DELETE admission request:
-# object is null, oldObject is the resource
 - isValidatingPolicy: true
   kind: Pod
-  policy: deny-protected-deletion
   operation: DELETE
+  policy: deny-protected-deletion
   resources:
   - protected-pod
   result: fail
-# CREATE-scoped policy evaluated with the default CREATE admission request
-# in the same test file
 - isValidatingPolicy: true
   kind: Pod
   policy: require-env-label

--- a/test/cli/test-validating-policy/operation-delete/kyverno-test.yaml
+++ b/test/cli/test-validating-policy/operation-delete/kyverno-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: vpol-operation-delete
+policies:
+- policy.yaml
+resources:
+- resource.yaml
+results:
+# DELETE-scoped policy evaluated with a simulated DELETE admission request:
+# object is null, oldObject is the resource
+- isValidatingPolicy: true
+  kind: Pod
+  policy: deny-protected-deletion
+  operation: DELETE
+  resources:
+  - protected-pod
+  result: fail
+# CREATE-scoped policy evaluated with the default CREATE admission request
+# in the same test file
+- isValidatingPolicy: true
+  kind: Pod
+  policy: require-env-label
+  resources:
+  - protected-pod
+  result: fail

--- a/test/cli/test-validating-policy/operation-delete/policy.yaml
+++ b/test/cli/test-validating-policy/operation-delete/policy.yaml
@@ -1,0 +1,35 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: deny-protected-deletion
+spec:
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: [v1]
+      operations:  [DELETE]
+      resources:   [pods]
+  validations:
+    - expression: >-
+        !(has(oldObject.metadata.labels) && 'protected' in oldObject.metadata.labels && oldObject.metadata.labels['protected'] == 'true')
+      message: "protected pods cannot be deleted"
+---
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: require-env-label
+spec:
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: [v1]
+      operations:  [CREATE]
+      resources:   [pods]
+  validations:
+    - expression: >-
+        has(object.metadata.labels) && 'env' in object.metadata.labels
+      message: "pods must have an env label"

--- a/test/cli/test-validating-policy/operation-delete/resource.yaml
+++ b/test/cli/test-validating-policy/operation-delete/resource.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: protected-pod
+  namespace: test-ns
+  labels:
+    protected: "true"
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.25

--- a/test/cli/test/conditional-delete-operation-result-field/kyverno-test.yaml
+++ b/test/cli/test/conditional-delete-operation-result-field/kyverno-test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: conditional-delete-test-result-field
+policies:
+- policy.yaml
+resources:
+- resource.yaml
+results:
+# the DELETE operation is declared on the result entry instead of values.yaml
+- kind: Pod
+  policy: deny-delete-prod
+  operation: DELETE
+  resources:
+  - prod-app
+  result: fail
+  rule: block-prod-deletion

--- a/test/cli/test/conditional-delete-operation-result-field/kyverno-test.yaml
+++ b/test/cli/test/conditional-delete-operation-result-field/kyverno-test.yaml
@@ -7,10 +7,9 @@ policies:
 resources:
 - resource.yaml
 results:
-# the DELETE operation is declared on the result entry instead of values.yaml
 - kind: Pod
-  policy: deny-delete-prod
   operation: DELETE
+  policy: deny-delete-prod
   resources:
   - prod-app
   result: fail

--- a/test/cli/test/conditional-delete-operation-result-field/policy.yaml
+++ b/test/cli/test/conditional-delete-operation-result-field/policy.yaml
@@ -1,0 +1,27 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-delete-prod
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+    - name: block-prod-deletion
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+            selector:
+              matchLabels:
+                env: production
+            operations:
+              - DELETE
+      validate:
+        message: "Deleting production pods is forbidden!"
+        deny:
+          conditions:
+            all:
+            - key: "{{request.operation}}"
+              operator: Equals
+              value: DELETE

--- a/test/cli/test/conditional-delete-operation-result-field/resource.yaml
+++ b/test/cli/test/conditional-delete-operation-result-field/resource.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: prod-app
+  labels:
+    env: production
+spec:
+  containers:
+  - name: nginx
+    image: nginx


### PR DESCRIPTION
## Explanation

The CLI hardcoded `admissionv1.Create` (with `oldObject: nil`) when building admission requests for the CEL policy types, so policies matching only `DELETE`/`UPDATE` in `matchConstraints` silently never matched in `kyverno test`/`kyverno apply`, and `oldObject` was always null in CEL expressions. PR #14710 fixed this for classic `ClusterPolicy`/`Policy` only.

This PR makes CLI testing operation-aware for **all admission-driven policy types** (`ValidatingPolicy`, `MutatingPolicy`, `ImageValidatingPolicy`, `GeneratingPolicy`, namespaced variants, and classic `ClusterPolicy`/`Policy`), per the design posted in https://github.com/kyverno/kyverno/issues/15475\#issuecomment-5089402093.

### 1. Per-result `operation` field in `kyverno-test.yaml` (primary UX)

```yaml
results:
- kind: Pod
  policy: deny-protected-deletion
  operation: DELETE      # optional: CREATE | UPDATE | DELETE, defaults to CREATE
  resources: [protected-pod]
  result: fail
```

- Each distinct explicit operation triggers a dedicated evaluation run; results are matched against the responses of their operation's run, so CREATE/UPDATE/DELETE expectations can be mixed in one test file.
- The field is uniform across policy types, including classic cpol (fed into `makePolicyContext`).
- Invalid values and `operation` on `isDeletingPolicy` results are rejected (deleting policies are not admission driven).

### 2. `values.yaml` fallback (cpol parity + `kyverno apply`)

When no per-result operation is set, the CEL policy types now honor `globalValues: request.operation` exactly like cpol — this also gives `kyverno apply` DELETE/UPDATE simulation in CI pipelines. Precedence: per-result `operation` > `values.yaml` > `CREATE`.

### Admission request semantics (mirrors the API server)

| Operation | `request.object` | `request.oldObject` |
|---|---|---|
| CREATE (default) | resource | null |
| UPDATE | resource | resource (old == new, same limitation as cpol today) |
| DELETE | **null** | resource |

### Implementation notes

- New shared helper (`processor/operation.go`): `NormalizeOperation`, `AdmissionRequestShape`, `resolveOperation` — used at all five previously hardcoded call sites (vpol/mpol/gpol in the policy processor, ivpol in both `test` and `apply`).
- `TestResponse.TriggerByOperation` keys the additional runs; the default run and its `Trigger` map are untouched, so existing tests see zero behavior change and zero extra evaluations.
- **CLI-only change**: `pkg/cel/` and all in-cluster components are untouched — the engines already support every operation in-cluster.
- Fully backward compatible: absent field + absent values key = today's CREATE behavior, bit-for-bit.

## Proof manifests

`test/cli/test-validating-policy/operation-delete/` (vpol, DELETE via result field + CREATE-scoped policy in the same test file):

```console
$ kyverno test test/cli/test-validating-policy/operation-delete/
│ ID │ POLICY                  │ RULE │ RESOURCE                     │ RESULT │ REASON │
│ 1  │ deny-protected-deletion │      │ v1/Pod/test-ns/protected-pod │ Pass   │ Ok     │
│ 2  │ require-env-label       │      │ v1/Pod/test-ns/protected-pod │ Pass   │ Ok     │
Test Summary: 2 tests passed and 0 tests failed
```

`test/cli/test/conditional-delete-operation-result-field/` (classic cpol, DELETE via result field, no values.yaml):

```console
$ kyverno test test/cli/test/conditional-delete-operation-result-field/
│ 1  │ deny-delete-prod │ block-prod-deletion │ v1/Pod/default/prod-app │ Pass │ Ok │
Test Summary: 1 tests passed and 0 tests failed
```

`kyverno apply` with the values.yaml fallback (vpol matching DELETE only):

```console
$ kyverno apply policy.yaml --resource pod.yaml -f values.yaml   # request.operation: DELETE
policy deny-protected-deletion -> resource test-ns/Pod/protected-pod failed:
1 -  protected pods cannot be deleted
pass: 0, fail: 1, warn: 0, error: 0, skip: 0
```

Regression: the existing `test/cli/test/conditional-delete-operation/` cpol fixture still passes; full unit test suites of all touched packages pass; golangci-lint reports 0 issues.

## Related issue

Closes #15475
Related: #14412, #14710, #15904

## Milestone of this PR

/milestone 1.19.0

## What type of PR is this

/kind feature

## Documentation (required for features)

- [ ] Website docs PR to follow (kyverno-test.yaml `operation` field + apply/values behavior).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a feature and I have added CLI tests that are applicable.
