### PR TITLE
feat: introduce JMESPath extension library for CEL policies

### DIFF
--- a/pkg/cel/compiler/env.go
+++ b/pkg/cel/compiler/env.go
@@ -9,6 +9,8 @@ import (
 	"github.com/kyverno/sdk/extensions/cel/libs/image"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/cel/library"
+	
+	"github.com/kyverno/kyverno/pkg/cel/libs/jmespath"
 )
 
 // breaking change history is stored inside the library structure. each policy compiler can pass a kyverno
@@ -71,6 +73,8 @@ func defaultEnvOptionsWithHomogeneousAggregateEnforcement(enforce bool) []cel.En
 		ext.Regex(ext.RegexVersion(1)),
 		// register kubernetes libs
 		library.CIDR(),
+		// register kyverno JMESPath extension
+		jmespath.Lib(),
 		library.Format(),
 		library.IP(),
 		library.Lists(),

--- a/pkg/cel/libs/jmespath/impl.go
+++ b/pkg/cel/libs/jmespath/impl.go
@@ -1,0 +1,26 @@
+package jmespath
+
+import (
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	gojmespath "github.com/kyverno/go-jmespath"
+	"github.com/kyverno/sdk/extensions/cel/utils"
+)
+
+type jmesfuncs struct {
+	types.Adapter
+}
+
+func (f *jmesfuncs) match_string_dyn(queryVal ref.Val, objVal ref.Val) ref.Val {
+	query, err := utils.ConvertToNative[string](queryVal)
+	if err != nil {
+		return types.WrapErr(err)
+	}
+
+	result, err := gojmespath.Search(query, objVal.Value())
+	if err != nil {
+		return types.NewErr("jmespath evaluation failed: %v", err)
+	}
+
+	return f.NativeToValue(result)
+}

--- a/pkg/cel/libs/jmespath/impl_test.go
+++ b/pkg/cel/libs/jmespath/impl_test.go
@@ -1,0 +1,85 @@
+package jmespath
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+)
+
+func TestJMESPath(t *testing.T) {
+	env, err := cel.NewEnv(Lib())
+	if err != nil {
+		t.Fatalf("failed to create env: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		expr    string
+		vars    map[string]any
+		want    any
+		wantErr bool
+	}{
+		{
+			name: "simple object match",
+			expr: `jmespath("a", object)`,
+			vars: map[string]any{
+				"object": map[string]any{"a": "b"},
+			},
+			want: "b",
+		},
+		{
+			name: "array projection",
+			expr: `jmespath("items[].name", object)`,
+			vars: map[string]any{
+				"object": map[string]any{
+					"items": []any{
+						map[string]any{"name": "foo"},
+						map[string]any{"name": "bar"},
+					},
+				},
+			},
+			want: []any{"foo", "bar"},
+		},
+		{
+			name: "bad query",
+			expr: `jmespath("items[", object)`,
+			vars: map[string]any{
+				"object": map[string]any{"items": []any{}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, iss := env.Compile(tt.expr)
+			if iss.Err() != nil {
+				t.Fatalf("failed to compile: %v", iss.Err())
+			}
+
+			prg, err := env.Program(ast)
+			if err != nil {
+				t.Fatalf("failed to create program: %v", err)
+			}
+
+			out, _, err := prg.Eval(tt.vars)
+			if tt.wantErr {
+				if err == nil {
+					// Eval doesn't necessarily return a go error for CEL errors (it returns an error ref.Val sometimes)
+					if _, isErr := out.Value().(error); !isErr {
+						t.Errorf("expected error, got %v", out.Value())
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("evaluation failed: %v", err)
+			}
+
+			if !reflect.DeepEqual(out.Value(), tt.want) {
+				t.Errorf("got %v, want %v", out.Value(), tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cel/libs/jmespath/lib.go
+++ b/pkg/cel/libs/jmespath/lib.go
@@ -1,0 +1,48 @@
+package jmespath
+
+import (
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+)
+
+const libraryName = "kyverno.jmespath"
+
+type lib struct{}
+
+func Lib() cel.EnvOption {
+	return cel.Lib(&lib{})
+}
+
+func (*lib) LibraryName() string {
+	return libraryName
+}
+
+func (c *lib) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		c.extendEnv,
+	}
+}
+
+func (*lib) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}
+
+func (c *lib) extendEnv(env *cel.Env) (*cel.Env, error) {
+	impl := &jmesfuncs{Adapter: env.CELTypeAdapter()}
+	libraryDecls := map[string][]cel.FunctionOpt{
+		"jmespath": {
+			cel.Overload(
+				"jmespath_string_dyn",
+				[]*cel.Type{types.StringType, types.DynType},
+				types.DynType,
+				cel.BinaryBinding(impl.match_string_dyn),
+			),
+		},
+	}
+	
+	var options []cel.EnvOption
+	for name, overloads := range libraryDecls {
+		options = append(options, cel.Function(name, overloads...))
+	}
+	return env.Extend(options...)
+}


### PR DESCRIPTION
Fixes #16788

## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->
This PR introduces a new feature that allows users to use JMESPath filtering natively inside the modern CEL evaluation engine. It addresses a major pain point for users migrating legacy Kyverno policies to CEL by providing a familiar, backward-compatible way to query and filter deeply nested JSON arrays directly within CEL expressions.

## Related issue
closes #16788 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind feature

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->
As Kyverno transitions its evaluation engine towards Kubernetes' native Common Expression Language (CEL), users face challenges when attempting to migrate legacy policies that rely heavily on complex JSON array filtering. This PR natively exposes JMESPath capabilities inside Kyverno's CEL compiler environments. 

It introduces a new scoped CEL library at `pkg/cel/libs/jmespath` which exposes a `jmespath(query, object)` function to the global CEL environment. The implementation acts as a bridge, utilizing Kyverno's internal `github.com/kyverno/go-jmespath` dependency and mapping the CEL `ref.Val` objects natively so evaluations are safe and memory-efficient.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

# Kubernetes resource

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
spec:
  containers:
  - name: app
    image: nginx:latest
  - name: debug-sidecar
    image: debug-tools:v1
```

# Kyverno CLI test manifest 

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: block-debug-images-cel
spec:
  validationFailureAction: Enforce
  rules:
    - name: check-debug-images
      match:
        any:
        - resources:
            kinds:
              - Pod
      validate:
        cel:
          expressions:
            - expression: "jmespath('spec.containers[?contains(image, `debug`)].image', object).size() == 0"
              message: "Debug images are strictly prohibited in this environment."
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
**Alternatives Considered & Rejected:**
1. **Relying solely on CEL macros (Status Quo):** Forcing users to rewrite complex JMESPath filters using chained CEL `.filter()` and `.map()` macros degrades the UX and makes migrating legacy policies unnecessarily verbose.
2. **Adding highly specific custom CEL functions:** Building custom wrappers for every niche use-case (e.g., `extract_image_tags()`) bloats the Kyverno CEL library instead of providing one versatile query tool.
3. **Transpiling JMESPath to CEL ASTs:** Compiling JMESPath strings directly into CEL AST nodes introduces immense architectural complexity compared to simply evaluating it at runtime using our existing `go-jmespath` dependency.
