### PR TITLE
Fix typos in docs and CLI help text

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -484,7 +484,7 @@ You can run Kyverno locally or in your IDE of choice with a few steps:
 1. There are multiple environment variables that need to be configured. The variables can be found in [here](./.vscode/launch.json). Their values can be set using the command `export $NAME=value`
 1. To run Kyverno locally against the remote cluster you will need to provide `--kubeconfig` and `--serverIP` arguments:
    - `--kubeconfig` must point to your kubeconfig file (usually `~/.kube/config`)
-   - `--serverIP` must be set to `<local ip>:9443` (`<local ip>` is the private ip adress of your local machine)
+   - `--serverIP` must be set to `<local ip>:9443` (`<local ip>` is the private ip address of your local machine)
    - `--backgroundServiceAccountName` must be set to `system:serviceaccount:kyverno:kyverno-background-controller`
    - `--caSecretName` must be set to `kyverno-svc.kyverno.svc.kyverno-tls-ca`
    - `--tlsSecretName` must be set to `kyverno-svc.kyverno.svc.kyverno-tls-pair`

--- a/cmd/cli/kubectl-kyverno/commands/apply/doc.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/doc.go
@@ -28,7 +28,7 @@ var examples = [][]string{
 		"kyverno apply /path/to/policy.yaml --resource /path/to/resource.yaml --set <variable1>=<value1>,<variable2>=<value2>",
 	},
 	{
-		"# Apply multiple policy with variable on multiple resource",
+		"# Apply multiple policies with variables on multiple resources",
 		"kyverno apply /path/to/policy1.yaml /path/to/policy2.yaml --resource /path/to/resource1.yaml --resource /path/to/resource2.yaml -f /path/to/value.yaml",
 	},
 }

--- a/cmd/cli/kubectl-kyverno/commands/oci/doc.go
+++ b/cmd/cli/kubectl-kyverno/commands/oci/doc.go
@@ -3,7 +3,7 @@ package oci
 var websiteUrl = `https://kyverno.io/docs/kyverno-cli/#oci`
 
 var description = []string{
-	`Pulls/pushes images that include policie(s) from/to OCI registries.`,
+	`Pulls/pushes images that include policies from/to OCI registries.`,
 }
 
 var examples = [][]string{

--- a/cmd/cli/kubectl-kyverno/commands/oci/pull/doc.go
+++ b/cmd/cli/kubectl-kyverno/commands/oci/pull/doc.go
@@ -3,7 +3,7 @@ package pull
 var websiteUrl = `https://kyverno.io/docs/kyverno-cli/#pulling`
 
 var description = []string{
-	`Pulls policie(s) that are included in an OCI image from OCI registry and saves them to a local directory.`,
+	`Pulls policies that are included in an OCI image from OCI registry and saves them to a local directory.`,
 }
 
 var examples = [][]string{

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -4,6 +4,6 @@ This folder contains developer documentation.
 
 To get started see: [DEVELOPMENT.md](../../DEVELOPMENT.md).
 
-When you are ready to contribute, you can select issue at [Good First Issues](https://github.com/orgs/kyverno/projects/10). 
+When you are ready to contribute, you can select an issue at [Good First Issues](https://github.com/orgs/kyverno/projects/10). 
 
 For release instructions, see: [create-a-release.md](releases/create-a-release.md).

--- a/docs/dev/reports/README.md
+++ b/docs/dev/reports/README.md
@@ -162,7 +162,7 @@ If we omit the short lived admission reports, this usually means 2 additional re
 - one aggregated admission report
 - one background scan report
 
-Short lived admission reports are ephemeral in nature, as long as they cleaned up correctly they shouldn't impact storage too much.
+Short lived admission reports are ephemeral in nature, as long as they are cleaned up correctly they shouldn't impact storage too much.
 If for some reason Kyverno fails to cleanup those reports fast enough it can become a severe issue though.
 
 Of course not all resources will have background scan reports, some policies can have `background` disabled but you get the picture.
@@ -181,7 +181,7 @@ Sometimes they are too big to be stored in etcd and we split them into multiple 
 
 ### Reports deletion
 
-Quick note about reports deletion, we use the builtin Kubernetes garbage collection mechanism for that. Reports are owned by the resource they apply to and when the resource goes away, reports are garbage collected and deleted automatically.
+Quick note about reports deletion, we use the built-in Kubernetes garbage collection mechanism for that. Reports are owned by the resource they apply to and when the resource goes away, reports are garbage collected and deleted automatically.
 
 ### Conclusion
 

--- a/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/target-preconditions/README.md
+++ b/test/conformance/chainsaw/mutate/clusterpolicy/standard/existing/target-preconditions/README.md
@@ -8,7 +8,7 @@ This test creates three `ConfigMap`s:
 It then creates a `ClusterPolicy` with a mutate existing rule targeting the previously created `ConfigMap`s.
 
 The policy rule uses preconditions on the trigger resource to match only `ConfigMap`s with the `trigger` name.
-The policy rule also uses preconditions on target resources to match only `ConfigMap`s with he label `foo: bar`.
+The policy rule also uses preconditions on target resources to match only `ConfigMap`s with the label `foo: bar`.
 The policy mutates target resources passing preconditions by copying the `data.content` from the trigger `ConfigMap` to the target `ConfigMap`.
 
 Finally, the test creates the trigger config map.


### PR DESCRIPTION

## Explanation

Fixes a few spelling and grammar mistakes in developer docs and CLI help strings. No code behavior changes.

## Related issue

No related issue.

## Milestone of this PR

N/A

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind documentation

## Proposed Changes

- `DEVELOPMENT.md` — "adress" → "address"
- `docs/dev/README.md` — "select issue at" → "select an issue at"
- `docs/dev/reports/README.md` — add missing "are"; "builtin" → "built-in"
- `test/conformance/chainsaw/.../target-preconditions/README.md` — "he label" → "the label"
- `cmd/cli/kubectl-kyverno/commands/oci/doc.go` — "policie(s)" → "policies"
- `cmd/cli/kubectl-kyverno/commands/oci/pull/doc.go` — "policie(s)" → "policies"
- `cmd/cli/kubectl-kyverno/commands/apply/doc.go` — fix pluralization in example comment

### Proof Manifests

Not applicable. Documentation and help text only.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

None.
