### PR TITLE
fix(helm): disable in-process cert controller when cert-manager delegation is enabled

### DIFF
--- a/charts/kyverno/templates/admission-controller/deployment.yaml
+++ b/charts/kyverno/templates/admission-controller/deployment.yaml
@@ -158,6 +158,9 @@ spec:
             - --caSecretName={{ template "kyverno.admission-controller.serviceName" . }}.{{ template "kyverno.namespace" . }}.svc.kyverno-tls-ca
             - --tlsSecretName={{ template "kyverno.admission-controller.serviceName" . }}.{{ template "kyverno.namespace" . }}.svc.kyverno-tls-pair
             - --tlsKeyAlgorithm={{ .Values.admissionController.tlsKeyAlgorithm | default "RSA" }}
+            {{- if .Values.admissionController.certManager.enabled }}
+            - --disableCertManagerController=true
+            {{- end }}
             {{- if .Values.backgroundController.enabled }}
             - --backgroundServiceAccountName=system:serviceaccount:{{ include "kyverno.namespace" . }}:{{ include "kyverno.background-controller.serviceAccountName" . }}
             {{- end }}

--- a/charts/kyverno/templates/cleanup-controller/deployment.yaml
+++ b/charts/kyverno/templates/cleanup-controller/deployment.yaml
@@ -112,6 +112,9 @@ spec:
             - --caSecretName={{ template "kyverno.cleanup-controller.name" . }}.{{ template "kyverno.namespace" . }}.svc.kyverno-tls-ca
             - --tlsSecretName={{ template "kyverno.cleanup-controller.name" . }}.{{ template "kyverno.namespace" . }}.svc.kyverno-tls-pair
             - --tlsKeyAlgorithm={{ .Values.cleanupController.tlsKeyAlgorithm | default "RSA" }}
+            {{- if .Values.cleanupController.certManager.enabled }}
+            - --disableCertManagerController=true
+            {{- end }}
             - --servicePort={{ .Values.cleanupController.service.port }}
             - --resyncPeriod={{ .Values.cleanupController.resyncPeriod | default .Values.global.resyncPeriod }}
             - --cleanupServerPort={{ .Values.cleanupController.server.port }}

--- a/cmd/cleanup-controller/main.go
+++ b/cmd/cleanup-controller/main.go
@@ -80,18 +80,19 @@ func sanityChecks(apiserverClient apiserver.Interface) error {
 
 func main() {
 	var (
-		dumpPayload              bool
-		serverIP                 string
-		servicePort              int
-		webhookServerPort        int
-		maxQueuedEvents          int
-		interval                 time.Duration
-		renewBefore              time.Duration
-		maxAPICallResponseLength int64
-		apiCallTimeout           time.Duration
-		autoDeleteWebhooks       bool
-		tlsKeyAlgorithm          string
-		maxGlobalContextEntries  int
+		dumpPayload                  bool
+		serverIP                     string
+		servicePort                  int
+		webhookServerPort            int
+		maxQueuedEvents              int
+		interval                     time.Duration
+		renewBefore                  time.Duration
+		maxAPICallResponseLength     int64
+		apiCallTimeout               time.Duration
+		autoDeleteWebhooks           bool
+		tlsKeyAlgorithm              string
+		maxGlobalContextEntries      int
+		disableCertManagerController bool
 	)
 	flagset := flag.NewFlagSet("cleanup-controller", flag.ExitOnError)
 	flagset.BoolVar(&dumpPayload, "dumpPayload", false, "Set this flag to activate/deactivate debug mode.")
@@ -113,6 +114,7 @@ func main() {
 	flagset.BoolVar(&autoDeleteWebhooks, "autoDeleteWebhooks", false, "Set this flag to 'true' to enable autodeletion of webhook configurations using finalizers (requires extra permissions).")
 	flagset.StringVar(&tlsKeyAlgorithm, "tlsKeyAlgorithm", "RSA", "Key algorithm for self-signed TLS certificates (RSA, ECDSA, Ed25519)")
 	flagset.IntVar(&maxGlobalContextEntries, "maxGlobalContextEntries", 0, "Maximum number of entries in the global context store. When the limit is reached, new entries are rejected and retried. A value of 0 means unbounded.")
+	flagset.BoolVar(&disableCertManagerController, "disableCertManagerController", false, "Disable the in-process certificate manager controller.")
 	// config
 	appConfig := internal.NewConfiguration(
 		internal.WithProfiling(),
@@ -273,18 +275,21 @@ func main() {
 					tlsSecretName,
 					keyAlgorithm,
 				)
-				certController := internal.NewController(
-					certmanager.ControllerName,
-					certmanager.NewController(
-						caSecret,
-						tlsSecret,
-						renewer,
-						caSecretName,
-						tlsSecretName,
-						config.KyvernoNamespace(),
-					),
-					certmanager.Workers,
-				)
+				var certController internal.Controller
+				if !disableCertManagerController {
+					certController = internal.NewController(
+						certmanager.ControllerName,
+						certmanager.NewController(
+							caSecret,
+							tlsSecret,
+							renewer,
+							caSecretName,
+							tlsSecretName,
+							config.KyvernoNamespace(),
+						),
+						certmanager.Workers,
+					)
+				}
 				policyValidatingWebhookController := internal.NewController(
 					policyWebhookControllerName,
 					genericwebhookcontroller.NewController(
@@ -414,7 +419,9 @@ func main() {
 				}
 				// start leader controllers
 				var wg wait.Group
-				certController.Run(ctx, logger, &wg)
+				if certController != nil {
+					certController.Run(ctx, logger, &wg)
+				}
 				policyValidatingWebhookController.Run(ctx, logger, &wg)
 				ttlWebhookController.Run(ctx, logger, &wg)
 				cleanupController.Run(ctx, logger, &wg)

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -90,8 +90,9 @@ const (
 )
 
 var (
-	caSecretName  string
-	tlsSecretName string
+	caSecretName                 string
+	tlsSecretName                string
+	disableCertManagerController bool
 )
 
 func showWarnings(ctx context.Context, logger logr.Logger) {
@@ -152,14 +153,17 @@ func createrLeaderControllers(
 	stateRecorder webhookcontroller.StateRecorder,
 ) ([]internal.Controller, func(context.Context) error, error) {
 	var leaderControllers []internal.Controller
-	certManager := certmanager.NewController(
-		caInformer,
-		tlsInformer,
-		certRenewer,
-		caSecretName,
-		tlsSecretName,
-		config.KyvernoNamespace(),
-	)
+	if !disableCertManagerController {
+		certManager := certmanager.NewController(
+			caInformer,
+			tlsInformer,
+			certRenewer,
+			caSecretName,
+			tlsSecretName,
+			config.KyvernoNamespace(),
+		)
+		leaderControllers = append(leaderControllers, internal.NewController(certmanager.ControllerName, certManager, certmanager.Workers))
+	}
 	webhookController := webhookcontroller.NewController(
 		dynamicClient.Discovery(),
 		kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations(),
@@ -285,7 +289,6 @@ func createrLeaderControllers(
 		reportsServiceAccountName,
 		stateRecorder,
 	)
-	leaderControllers = append(leaderControllers, internal.NewController(certmanager.ControllerName, certManager, certmanager.Workers))
 	leaderControllers = append(leaderControllers, internal.NewController(webhookcontroller.ControllerName, webhookController, webhookcontroller.Workers))
 	leaderControllers = append(leaderControllers, internal.NewController(exceptionWebhookControllerName, exceptionWebhookController, 1))
 	leaderControllers = append(leaderControllers, internal.NewController(celExceptionWebhookControllerName, celExceptionWebhookController, 1))
@@ -412,6 +415,7 @@ func main() {
 	flagset.StringVar(&reportsServiceAccountName, "reportsServiceAccountName", "", "Reports controller service account name.")
 	flagset.StringVar(&caSecretName, "caSecretName", "", "Name of the secret containing CA.")
 	flagset.StringVar(&tlsSecretName, "tlsSecretName", "", "Name of the secret containing TLS pair.")
+	flagset.BoolVar(&disableCertManagerController, "disableCertManagerController", false, "Disable the in-process certificate manager controller.")
 	flagset.Int64Var(&maxAPICallResponseLength, "maxAPICallResponseLength", 10*1000*1000, "Configure the value of maximum allowed GET response size from API Calls")
 	flagset.DurationVar(&apiCallTimeout, "apiCallTimeout", 30*time.Second, "Timeout for HTTP API calls made by policies. A value of 0 means no timeout.")
 	flagset.DurationVar(&renewBefore, "renewBefore", 15*24*time.Hour, "The certificate renewal time before expiration")


### PR DESCRIPTION
## Problem

Issue: #16103

When Helm users enable cert-manager delegation (`admissionController.certManager.enabled=true` and/or `cleanupController.certManager.enabled=true`), Kyverno still starts its in-process `certmanager-controller` because the chart always passes `--caSecretName` / `--tlsSecretName` and the binaries always register that controller.

Result: cert-manager and Kyverno both reconcile the same TLS Secrets, causing repeated Secret overwrite/re-issue loops.

## Root cause

- Chart cert-manager integration only creates `Certificate` resources; it did not disable Kyverno's internal cert rotation controller.
- `cmd/kyverno` and `cmd/cleanup-controller` always started `pkg/controllers/certmanager`.
- Both reconcilers target the same Secret names (`*.kyverno-tls-ca`, `*.kyverno-tls-pair`).

## Fix

### Runtime changes

Added a new flag to both binaries:

- `--disableCertManagerController` (default: `false`)

Updated startup logic:

- `cmd/kyverno/main.go`: gate registration of `certmanager-controller` behind `!disableCertManagerController`.
- `cmd/cleanup-controller/main.go`: gate creation/start of `certmanager-controller` behind `!disableCertManagerController`.

This disables only Kyverno's in-process certificate writer while preserving CA/TLS Secret name usage required by other components (webhook CA injection, TLS serving).

### Helm chart wiring

Updated:

- `charts/kyverno/templates/admission-controller/deployment.yaml`
- `charts/kyverno/templates/cleanup-controller/deployment.yaml`

Behavior:

- If `admissionController.certManager.enabled=true`, chart adds `--disableCertManagerController=true` to admission controller args.
- If `cleanupController.certManager.enabled=true`, chart adds `--disableCertManagerController=true` to cleanup controller args.

## Why this is safe

- Default behavior is unchanged (`--disableCertManagerController` defaults to `false`).
- Cert-manager delegation mode now explicitly disables the conflicting internal reconciler.
- Existing `caSecretName`/`tlsSecretName` args remain for consumers that read those secrets.

Closes #16103
