### PR TITLE
fix(ivpol): fall back to legacy attestation lookup

### DIFF
--- a/pkg/image/verifiers/ivpol/cosign/verifier.go
+++ b/pkg/image/verifiers/ivpol/cosign/verifier.go
@@ -3,8 +3,10 @@ package cosign
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/name"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/logging"
 	"github.com/kyverno/sdk/extensions/imagedataloader"
@@ -14,6 +16,12 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/policy"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+var (
+	getBundles              = cosign.GetBundles
+	verifyImageSignatures   = cosign.VerifyImageSignatures
+	verifyImageAttestations = cosign.VerifyImageAttestations
 )
 
 type Verifier struct {
@@ -36,7 +44,7 @@ func (v *Verifier) buildCheckOptsWithBundleDetection(ctx context.Context, attest
 	}
 
 	// Auto-detect if new bundle format (cosign v3) is actually present
-	newBundles, _, err := cosign.GetBundles(ctx, image.NameRef(), cOpts.RegistryClientOpts)
+	newBundles, _, err := getBundles(ctx, image.NameRef(), cOpts.RegistryClientOpts)
 	bundleDetected := len(newBundles) > 0 && err == nil
 	cOpts.NewBundleFormat = bundleDetected
 	if bundleDetected && shouldUseSignedTimestamps(cOpts.IgnoreTlog, cOpts.UseSignedTimestamps, cOpts.TrustedMaterial) {
@@ -94,9 +102,9 @@ func (v *Verifier) VerifyImageSignature(ctx context.Context, image *imagedataloa
 	var verified bool
 
 	if cOpts.NewBundleFormat {
-		sigs, verified, err = cosign.VerifyImageAttestations(ctx, image.NameRef(), cOpts)
+		sigs, verified, err = verifyImageAttestations(ctx, image.NameRef(), cOpts)
 	} else {
-		sigs, verified, err = cosign.VerifyImageSignatures(ctx, image.NameRef(), cOpts)
+		sigs, verified, err = verifyImageSignatures(ctx, image.NameRef(), cOpts)
 	}
 	if err != nil {
 		err := errors.Wrapf(err, "failed to verify cosign signatures")
@@ -153,7 +161,7 @@ func (v *Verifier) VerifyAttestationSignature(ctx context.Context, image *imaged
 	// Attestations always use IntotoSubjectClaimVerifier
 	cOpts.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
 
-	sigs, verified, err := cosign.VerifyImageAttestations(ctx, image.NameRef(), cOpts)
+	sigs, verified, err := verifyAttestationsWithFallback(ctx, image.NameRef(), cOpts)
 	if err != nil {
 		err := errors.Wrapf(err, "failed to verify cosign signatures")
 		logger.Error(err, "image verification failed")
@@ -201,4 +209,32 @@ func (v *Verifier) VerifyAttestationSignature(ctx context.Context, image *imaged
 	}
 
 	return nil
+}
+
+func verifyAttestationsWithFallback(ctx context.Context, ref name.Reference, cOpts *cosign.CheckOpts) ([]oci.Signature, bool, error) {
+	v3Opts := *cOpts
+	v3Opts.NewBundleFormat = true
+
+	sigs, verified, err := verifyImageAttestations(ctx, ref, &v3Opts)
+	if err == nil && len(sigs) > 0 {
+		return sigs, verified, nil
+	}
+	if err != nil && !shouldFallbackToLegacyAttestations(err) {
+		return nil, false, err
+	}
+
+	legacyOpts := *cOpts
+	legacyOpts.NewBundleFormat = false
+	return verifyImageAttestations(ctx, ref, &legacyOpts)
+}
+
+func shouldFallbackToLegacyAttestations(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "manifest unknown") ||
+		strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "no matching attestations")
 }

--- a/pkg/image/verifiers/ivpol/cosign/verifier_test.go
+++ b/pkg/image/verifiers/ivpol/cosign/verifier_test.go
@@ -2,12 +2,16 @@ package cosign
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/sdk/extensions/imagedataloader"
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/sigstore/cosign/v3/pkg/oci"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -862,5 +866,68 @@ func Test_GitHubAttestationVerification(t *testing.T) {
 		v := Verifier{log: logr.Discard()}
 		err = v.VerifyAttestationSignature(context.TODO(), img, attestation, attestor)
 		assert.NoError(t, err, "SLSA provenance attestation verification should succeed with GitHub Actions keyless")
+	})
+}
+
+func TestVerifyAttestationsWithFallback(t *testing.T) {
+	ref, err := name.ParseReference(v3KeylessImage)
+	require.NoError(t, err)
+
+	original := verifyImageAttestations
+	t.Cleanup(func() {
+		verifyImageAttestations = original
+	})
+
+	t.Run("falls back when v3 lookup finds no attestations", func(t *testing.T) {
+		var attemptedFormats []bool
+		expected := []oci.Signature{nil}
+
+		verifyImageAttestations = func(_ context.Context, _ name.Reference, co *cosign.CheckOpts, _ ...name.Option) ([]oci.Signature, bool, error) {
+			attemptedFormats = append(attemptedFormats, co.NewBundleFormat)
+			if co.NewBundleFormat {
+				return nil, true, nil
+			}
+			return expected, true, nil
+		}
+
+		sigs, verified, err := verifyAttestationsWithFallback(context.TODO(), ref, &cosign.CheckOpts{})
+		require.NoError(t, err)
+		assert.True(t, verified)
+		assert.Equal(t, expected, sigs)
+		assert.Equal(t, []bool{true, false}, attemptedFormats)
+	})
+
+	t.Run("falls back on missing new-bundle manifest", func(t *testing.T) {
+		var attemptedFormats []bool
+		expected := []oci.Signature{nil}
+
+		verifyImageAttestations = func(_ context.Context, _ name.Reference, co *cosign.CheckOpts, _ ...name.Option) ([]oci.Signature, bool, error) {
+			attemptedFormats = append(attemptedFormats, co.NewBundleFormat)
+			if co.NewBundleFormat {
+				return nil, false, errors.New("MANIFEST_UNKNOWN: manifest unknown")
+			}
+			return expected, true, nil
+		}
+
+		sigs, verified, err := verifyAttestationsWithFallback(context.TODO(), ref, &cosign.CheckOpts{})
+		require.NoError(t, err)
+		assert.True(t, verified)
+		assert.Equal(t, expected, sigs)
+		assert.Equal(t, []bool{true, false}, attemptedFormats)
+	})
+
+	t.Run("does not hide real v3 verification errors", func(t *testing.T) {
+		var attemptedFormats []bool
+
+		verifyImageAttestations = func(_ context.Context, _ name.Reference, co *cosign.CheckOpts, _ ...name.Option) ([]oci.Signature, bool, error) {
+			attemptedFormats = append(attemptedFormats, co.NewBundleFormat)
+			return nil, false, errors.New("bundle verification failed")
+		}
+
+		sigs, verified, err := verifyAttestationsWithFallback(context.TODO(), ref, &cosign.CheckOpts{})
+		require.Error(t, err)
+		assert.Nil(t, sigs)
+		assert.False(t, verified)
+		assert.Equal(t, []bool{true}, attemptedFormats)
 	})
 }


### PR DESCRIPTION
## Explanation

This PR fixes ImageValidatingPolicy attestation verification for cosign v3 attestations stored as OCI referrers. Before this change, Kyverno could treat an attestation-only image as if it only used the legacy `.att` layout, which caused valid attestations to evaluate as missing and could deny workloads with the opaque `policy not evaluated` outcome.

## Related issue

Closes #16678

## Milestone of this PR

/milestone 1.19.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

Kyverno already handles cosign v3 signatures, but the IVPol attestation path depended on `cosign.GetBundles()` to decide whether the image used the new bundle format. `GetBundles()` only inspects signature artifacts, so attestation-only images could be misdetected and never reach the OCI referrer attestation path.

This PR keeps signature verification behavior unchanged and narrows the fix to attestation verification:

1. Try `VerifyImageAttestations` with `NewBundleFormat=true` first for IVPol attestations.
2. Fall back to the legacy lookup only when the new-format lookup returns no attestations or a not-found style error.
3. Add focused tests that cover both fallback cases and prove Kyverno does not hide real verification failures.

### Proof Manifests

Use a cosign v3 attestation stored as an OCI referrer and a matching ImageValidatingPolicy.

```yaml
apiVersion: policies.kyverno.io/v1
kind: ImageValidatingPolicy
metadata:
  name: require-vsa
spec:
  validationActions:
    - Deny
  failurePolicy: Ignore
  webhookConfiguration:
    timeoutSeconds: 30
  evaluation:
    background:
      enabled: false
  matchConstraints:
    resourceRules:
      - apiGroups: [""]
        apiVersions: ["v1"]
        operations: ["CREATE", "UPDATE"]
        resources: ["pods"]
  matchImageReferences:
    - glob: "ghcr.io/myorg/*"
  credentials:
    secrets:
      - registry-pull-secret
  attestations:
    - name: vsa
      intoto:
        type: https://slsa.dev/verification_summary/v1
  attestors:
    - name: producer
      cosign:
        keyless:
          identities:
            - issuer: https://token.actions.githubusercontent.com
              subjectRegExp: <producer workflow SAN regex>
        ctlog:
          url: https://rekor.sigstore.dev
  validationConfigurations:
    mutateDigest: false
    verifyDigest: true
    required: true
  validations:
    - expression: >-
        images.containers.map(image,
          verifyAttestationSignatures(image, attestations.vsa, [attestors.producer])).all(e, e > 0)
      message: image must carry a verified VSA
```

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: attested-pod
spec:
  containers:
    - name: app
      image: ghcr.io/myorg/myimage@sha256:<digest>
```

Attest the image with cosign v3 defaults:

```bash
cosign attest --yes \
  --type "https://slsa.dev/verification_summary/v1" \
  --predicate vsa.json \
  "${IMAGE}@${DIGEST}"
```

Before this PR, Kyverno can evaluate `verifyAttestationSignatures(...)` as `0` for attestation-only OCI referrers and deny the Pod. After this PR, the same attestation is found and verified correctly.

Local proof run for this change:

```bash
go test -run 'TestVerifyAttestationsWithFallback|Test_GitHubAttestationVerification|TestVerifyAttestationSignature_ErrorCases|Test_ImageSignatureVerificationKeyless|TestCosign_V3_Keyless' ./pkg/image/verifiers/ivpol/cosign
./.tools/golangci-lint run ./pkg/image/verifiers/ivpol/cosign/...
make verify-codegen
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

`make imports-check` and `make fmt-check` are clean after the commit. `make verify-codegen` is also clean after the commit. The targeted attestation and verifier tests listed above pass locally, and package lint is clean for `pkg/image/verifiers/ivpol/cosign`.
