### PR TITLE
fix: correct ephemeralContainers SELinux paths and runAsNonRoot allowed values

### DIFF
--- a/pkg/pss/utils/mapping.go
+++ b/pkg/pss/utils/mapping.go
@@ -347,7 +347,7 @@ var PSS_controls = map[string][]RestrictedField{
 			},
 		},
 		{
-			Path: "spec.ephemeralContainers[*].seLinuxOptions.user",
+			Path: "spec.ephemeralContainers[*].securityContext.seLinuxOptions.user",
 			AllowedValues: []interface{}{
 				"",
 			},
@@ -373,7 +373,7 @@ var PSS_controls = map[string][]RestrictedField{
 			},
 		},
 		{
-			Path: "spec.ephemeralContainers[*].seLinuxOptions.role",
+			Path: "spec.ephemeralContainers[*].securityContext.seLinuxOptions.role",
 			AllowedValues: []interface{}{
 				"",
 			},
@@ -567,14 +567,14 @@ var PSS_controls = map[string][]RestrictedField{
 		{
 			Path: "spec.initContainers[*].securityContext.runAsNonRoot",
 			AllowedValues: []interface{}{
-				false,
+				true,
 				nil,
 			},
 		},
 		{
 			Path: "spec.ephemeralContainers[*].securityContext.runAsNonRoot",
 			AllowedValues: []interface{}{
-				false,
+				true,
 				nil,
 			},
 		},


### PR DESCRIPTION
## Explanation

This is a fix to existing behavior in the Pod Security Standards control table (`pkg/pss/utils/mapping.go`). Two sets of entries there describe the wrong thing about the controls they belong to. This PR corrects them.

To be precise about scope up front: `PSS_controls` populates `RestrictedFields` on `RuleResponse.Checks`. Actual admission enforcement comes from `k8s.io/pod-security-admission` via `CheckPod`, and nothing in Kyverno reads `RestrictedFields` back to make a decision. **So this does not change any admission outcome** — it corrects the metadata Kyverno reports about which fields a control covers. I'd rather state that clearly than have it read as a security fix.

## Related issue

No existing issue. Found while reading the pod security library.

## Proposed Changes

**1. `seLinuxOptions` — two ephemeralContainers paths are missing `.securityContext`**

```
spec.ephemeralContainers[*].seLinuxOptions.user
spec.ephemeralContainers[*].seLinuxOptions.role
```

Every sibling entry for this control includes the segment — `containers` and `initContainers` for both `user` and `role`, and the `ephemeralContainers` entry for `type` directly above them:

```
spec.ephemeralContainers[*].securityContext.seLinuxOptions.type   ← has it
spec.ephemeralContainers[*].seLinuxOptions.user                   ← missing
```

The field is at `spec.ephemeralContainers[*].securityContext.seLinuxOptions`, matching `EphemeralContainerCommon.SecurityContext`. Corrected both.

**2. `runAsNonRoot` — `false` listed as an allowed value for init and ephemeral containers**

The control is *Running as Non-root*. `containers` correctly allows `{true, nil}`, but `initContainers` and `ephemeralContainers` allow `{false, nil}` — `false` is the value this control exists to reject. Corrected both to `{true, nil}` to match the container entry and the PSS definition.

## Proof Manifests

Not applicable — there is no user-facing behavior change, so there is no admission result to demonstrate. The change is a 4-line data correction; the diff itself is the evidence, and the reasoning above is checkable against the surrounding entries in the same file.

`go build ./pkg/pss/...` and `go test ./pkg/pss/...` both pass.

## What type of PR is this

/kind bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected security context mappings for ephemeral containers.
  * Updated validation for non-root execution settings on init and ephemeral containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->