### PR TITLE
fix: match wildcard groups in GroupVersionMatches

### DIFF
--- a/cmd/cli/kubectl-kyverno/utils/common/common_test.go
+++ b/cmd/cli/kubectl-kyverno/utils/common/common_test.go
@@ -107,3 +107,25 @@ func Test_getSubresourceKind(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, subresourceKind, "Eviction")
 }
+
+func Test_getSubresourceKind_wildcardGroupVersion(t *testing.T) {
+	// ParseKindSelector("Pod/eviction") yields group "*" and version "*", which getKind
+	// renders as the group version "*/*" before resolving the subresource offline.
+	podAPIResource := metav1.APIResource{Name: "pods", SingularName: "", Namespaced: true, Version: "v1", Kind: "Pod"}
+	podEvictionAPIResource := metav1.APIResource{Name: "pods/eviction", SingularName: "", Namespaced: true, Group: "policy", Version: "v1", Kind: "Eviction"}
+
+	subresources := []v1alpha1.Subresource{
+		{
+			Subresource:    podEvictionAPIResource,
+			ParentResource: podAPIResource,
+		},
+	}
+
+	for _, groupVersion := range []string{"*/*", "*/v1"} {
+		t.Run(groupVersion, func(t *testing.T) {
+			subresourceKind, err := getSubresourceKind(groupVersion, "Pod", "eviction", subresources)
+			assert.NilError(t, err)
+			assert.Equal(t, subresourceKind, "Eviction")
+		})
+	}
+}

--- a/pkg/utils/kube/kind.go
+++ b/pkg/utils/kube/kind.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/kyverno/kyverno/ext/wildcard"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -101,20 +102,37 @@ func ContainsKind(list []string, kind string) bool {
 }
 
 // GroupVersionMatches - check if the given group version matches the server resource group version.
-// If the group version contains a wildcard, it will match any version, but the group must match. Returns false if the
-// supplied group version is empty, that condition should be checked before calling this function.
+// The group and the version may each contain a wildcard, in which case that half matches anything.
+// Returns false if the supplied group version is empty, that condition should be checked before
+// calling this function.
 func GroupVersionMatches(groupVersion, serverResourceGroupVersion string) bool {
-	if strings.Contains(groupVersion, "*") {
-		return strings.HasPrefix(serverResourceGroupVersion, strings.TrimSuffix(groupVersion, "*"))
-	}
-
-	gv, err := schema.ParseGroupVersion(groupVersion)
-	if err == nil {
+	if !strings.Contains(groupVersion, "*") {
+		gv, err := schema.ParseGroupVersion(groupVersion)
+		if err != nil {
+			return false
+		}
 		serverResourceGV, _ := schema.ParseGroupVersion(serverResourceGroupVersion)
 		return gv.Group == serverResourceGV.Group && gv.Version == serverResourceGV.Version
 	}
 
-	return false
+	// A bare "*" carries no separator and matches any group and any version.
+	if groupVersion == "*" {
+		return true
+	}
+
+	serverResourceGV, err := schema.ParseGroupVersion(serverResourceGroupVersion)
+	if err != nil {
+		return false
+	}
+
+	// Split on the separator rather than using ParseGroupVersion, because a wildcard is not a
+	// valid group name and the two halves have to be matched independently.
+	group, version := "", groupVersion
+	if i := strings.Index(groupVersion, "/"); i >= 0 {
+		group, version = groupVersion[:i], groupVersion[i+1:]
+	}
+
+	return wildcard.Match(group, serverResourceGV.Group) && wildcard.Match(version, serverResourceGV.Version)
 }
 
 // IsSubresource returns true if the resource is a subresource

--- a/pkg/utils/kube/kind_test.go
+++ b/pkg/utils/kube/kind_test.go
@@ -214,3 +214,89 @@ func TestParseKindSelector(t *testing.T) {
 		})
 	}
 }
+
+func TestGroupVersionMatches(t *testing.T) {
+	tests := []struct {
+		name                       string
+		groupVersion               string
+		serverResourceGroupVersion string
+		want                       bool
+	}{{
+		name:                       "wildcard group and version matches core group",
+		groupVersion:               "*/*",
+		serverResourceGroupVersion: "v1",
+		want:                       true,
+	}, {
+		name:                       "wildcard group and version matches named group",
+		groupVersion:               "*/*",
+		serverResourceGroupVersion: "apps/v1",
+		want:                       true,
+	}, {
+		name:                       "wildcard group with fixed version matches named group",
+		groupVersion:               "*/v1",
+		serverResourceGroupVersion: "apps/v1",
+		want:                       true,
+	}, {
+		name:                       "wildcard group with fixed version matches core group",
+		groupVersion:               "*/v1",
+		serverResourceGroupVersion: "v1",
+		want:                       true,
+	}, {
+		name:                       "wildcard group does not match a different version",
+		groupVersion:               "*/v2",
+		serverResourceGroupVersion: "apps/v1",
+		want:                       false,
+	}, {
+		name:                       "fixed group with wildcard version matches",
+		groupVersion:               "apps/*",
+		serverResourceGroupVersion: "apps/v1",
+		want:                       true,
+	}, {
+		name:                       "fixed group with wildcard version does not match a different group",
+		groupVersion:               "apps/*",
+		serverResourceGroupVersion: "batch/v1",
+		want:                       false,
+	}, {
+		name:                       "bare wildcard matches anything",
+		groupVersion:               "*",
+		serverResourceGroupVersion: "apps/v1",
+		want:                       true,
+	}, {
+		name:                       "bare wildcard matches the core group",
+		groupVersion:               "*",
+		serverResourceGroupVersion: "v1",
+		want:                       true,
+	}, {
+		name:                       "exact core group version matches",
+		groupVersion:               "v1",
+		serverResourceGroupVersion: "v1",
+		want:                       true,
+	}, {
+		name:                       "exact group version matches",
+		groupVersion:               "apps/v1",
+		serverResourceGroupVersion: "apps/v1",
+		want:                       true,
+	}, {
+		name:                       "exact group version does not match a different version",
+		groupVersion:               "apps/v1",
+		serverResourceGroupVersion: "apps/v2",
+		want:                       false,
+	}, {
+		name:                       "exact group version does not match a different group",
+		groupVersion:               "apps/v1",
+		serverResourceGroupVersion: "batch/v1",
+		want:                       false,
+	}, {
+		name:                       "core group version does not match a named group",
+		groupVersion:               "v1",
+		serverResourceGroupVersion: "apps/v1",
+		want:                       false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GroupVersionMatches(tt.groupVersion, tt.serverResourceGroupVersion); got != tt.want {
+				t.Errorf("GroupVersionMatches(%q, %q) = %v, want %v", tt.groupVersion, tt.serverResourceGroupVersion, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Explanation

`GroupVersionMatches` never matches when the **group** half is a wildcard. It handled wildcards by stripping a trailing `*` and doing a prefix comparison:

```go
if strings.Contains(groupVersion, "*") {
	return strings.HasPrefix(serverResourceGroupVersion, strings.TrimSuffix(groupVersion, "*"))
}
```

`TrimSuffix` only strips a **trailing** `*`. When the wildcard is in the group, the trimmed pattern still begins with `*`, and no real group version begins with `*`, so the prefix test can never succeed:

```
GroupVersionMatches("*/*",  "v1")      = false
GroupVersionMatches("*/*",  "apps/v1") = false
GroupVersionMatches("*/v1", "apps/v1") = false
GroupVersionMatches("*/v1", "v1")      = false
```

This is reachable from normal CLI usage. `ParseKindSelector` returns `*` for an unspecified group:

```
ParseKindSelector("Pod/eviction")   -> group="*" version="*"  kind="Pod"
ParseKindSelector("v1/Pod/status")  -> group="*" version="v1" kind="Pod"
```

`getKind` renders that as a group version and, when the CLI runs without a cluster connection (`dClient == nil`), passes it to `getSubresourceKind`, which gates on `GroupVersionMatches`. Because the gate always fails, the subresource is never found and the command reports:

```
subresource eviction not found for parent resource Pod
```

even when the user has correctly declared that subresource. The only selectors that work today are fully qualified `group/version/Kind/subresource` ones.

## Related issue

No existing issue. Found while reading `pkg/utils/kube`.

## Proposed Changes

Match the group and version halves independently using `ext/wildcard`, which is already used for this kind of matching elsewhere in the tree (`pkg/utils/match`, `pkg/pss`):

- Patterns with no wildcard keep the existing exact `ParseGroupVersion` comparison.
- A bare `*` still matches anything.
- Otherwise the pattern is split on the first `/` and each half is wildcard-matched. Splitting manually rather than via `ParseGroupVersion` is deliberate: a wildcard is not a valid group name.

`wildcard.Match("*", "")` is true, so the core group (empty) matches a wildcard group correctly.

## Proof Manifests

Not a policy-behavior change, so there are no policy/resource manifests to attach. The proof is at the unit level, and both new tests were confirmed to fail before the change and pass after.

Against the **current** implementation, the new `TestGroupVersionMatches` fails on exactly the four wildcard-group cases while every previously-working case still passes:

```
--- FAIL: TestGroupVersionMatches/wildcard_group_and_version_matches_core_group
    GroupVersionMatches("*/*", "v1") = false, want true
--- FAIL: TestGroupVersionMatches/wildcard_group_and_version_matches_named_group
    GroupVersionMatches("*/*", "apps/v1") = false, want true
--- FAIL: TestGroupVersionMatches/wildcard_group_with_fixed_version_matches_named_group
    GroupVersionMatches("*/v1", "apps/v1") = false, want true
--- FAIL: TestGroupVersionMatches/wildcard_group_with_fixed_version_matches_core_group
    GroupVersionMatches("*/v1", "v1") = false, want true
```

And the new CLI-level test reproduces the user-visible symptom against the current implementation:

```
--- FAIL: Test_getSubresourceKind_wildcardGroupVersion/*/*
    assertion failed: error is not nil: subresource eviction not found for parent resource Pod
--- FAIL: Test_getSubresourceKind_wildcardGroupVersion/*/v1
    assertion failed: error is not nil: subresource eviction not found for parent resource Pod
```

Both pass with this change. `go build ./...` is clean, and `./pkg/utils/kube/...`, `./cmd/cli/kubectl-kyverno/utils/common/...` and `./pkg/clients/dclient/...` all pass.

### Why this was not caught

`GroupVersionMatches` had no test at all. The existing `Test_getSubresourceKind` passes an empty group version, which short-circuits on `groupVersion == ""` before `GroupVersionMatches` is ever called. Both gaps are now covered.

## What type of PR is this

/kind bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved matching for Kubernetes API group and version patterns, including wildcard combinations and exact matches.
  - Correctly handles wildcard group versions when resolving subresource kinds, such as Pod evictions.

- **Tests**
  - Added coverage for wildcard group/version matching and subresource kind resolution across supported patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->