### PR TITLE
feat: add User Namespaces support to PSS require-run-as-nonroot policies

### DIFF
--- a/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.cel.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.cel.yaml
@@ -35,6 +35,9 @@ spec:
   {{ end }}
   validations:
     - expression: >-
+        {{- if .Values.podSecurityUserNamespaces }}
+        (object.spec.?hostUsers.orValue(true) == false) ||
+        {{- end }}
         (!has(object.spec.securityContext) || 
          !has(object.spec.securityContext.runAsUser) || 
          object.spec.securityContext.runAsUser != 0) &&

--- a/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-non-root-user.yaml
@@ -65,8 +65,12 @@ spec:
           spec.containers[*].securityContext.runAsUser, spec.initContainers[*].securityContext.runAsUser,
           and spec.ephemeralContainers[*].securityContext.runAsUser must be unset or
           set to a number greater than zero.
-        pattern:
-          spec:
+        anyPattern:
+        {{- if .Values.podSecurityUserNamespaces }}
+        - spec:
+            hostUsers: false
+        {{- end }}
+        - spec:
             =(securityContext):
               =(runAsUser): ">0"
             =(ephemeralContainers):

--- a/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.cel.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.cel.yaml
@@ -42,6 +42,9 @@ spec:
         object.spec.?ephemeralContainers.orValue([])
   validations:
     - expression: |-
+        {{- if .Values.podSecurityUserNamespaces }}
+        object.spec.?hostUsers.orValue(true) == false || 
+        {{- end }}
         (object.spec.?securityContext.?runAsNonRoot.orValue(false) == true
         && variables.ctnrs.all(c, c.?securityContext.?runAsNonRoot.orValue(true) == true))
         || variables.ctnrs.all(c, c.?securityContext.?runAsNonRoot.orValue(false) == true)

--- a/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
+++ b/charts/kyverno-policies/templates/restricted/require-run-as-nonroot.yaml
@@ -67,6 +67,10 @@ spec:
           spec.initContainers[*].securityContext.runAsNonRoot, and spec.ephemeralContainers[*].securityContext.runAsNonRoot
           must be set to `true`.
         anyPattern:
+        {{- if .Values.podSecurityUserNamespaces }}
+        - spec:
+            hostUsers: false
+        {{- end }}
         - spec:
             securityContext:
               runAsNonRoot: true

--- a/charts/kyverno-policies/values.yaml
+++ b/charts/kyverno-policies/values.yaml
@@ -15,6 +15,14 @@ podSecurityStandard: baseline
 # -- Pod Security Standard severity (`low`, `medium`, `high`).
 podSecuritySeverity: medium
 
+# -- Enable support for Kubernetes User Namespaces (hostUsers: false).
+# When enabled, policies like require-run-as-nonroot and require-run-as-non-root-user
+# will allow pods with spec.hostUsers set to false, as user namespaces map
+# container UID 0 to a non-root host UID, relaxing the PSS requirement.
+# Requires Kubernetes v1.33+ with UserNamespacesPodSecurityStandards feature gate.
+# For more info: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
+podSecurityUserNamespaces: false
+
 # -- Define podSecuritySeverity overrides for specific policies.
 # Override the global `podSecuritySeverity` with an individual severity for individual policies.
 # An empty string per-policy entry suppresses the annotation entirely.


### PR DESCRIPTION
## Explanation

Kubernetes v1.33 enables user namespaces by default. When `spec.hostUsers` is set to `false` on a Pod, the pod runs in an isolated user namespace where container UID 0 maps to a non-root host UID. This relaxes the Pod Security Standard (PSS) requirements for the "Running as Non-root" and "Running as Non-root user" controls.

Currently, Kyverno's PSS policies for these controls reject any pod that does not set `runAsNonRoot: true` or `runAsUser: >0`, even when the pod uses an isolated user namespace (`hostUsers: false`).

This PR adds support for user namespaces by allowing `spec.hostUsers: false` as an additional valid condition in both the ClusterPolicy (kyverno.io/v1) and ValidatingPolicy (CEL) variants.

## Related issue

Closes #13692

## What type of PR is this

/kind feature

## Proposed Changes

### New Helm value: `podSecurityUserNamespaces` (default: `false`)

This value controls whether user namespace support is enabled. When `false` (default), the policies behave exactly as before. When `true`, pods with `hostUsers: false` are allowed.

This is configurable because not all Kubernetes implementations support user namespaces, and the feature is gated behind the `UserNamespacesPodSecurityStandards` feature gate.

### Policy changes

1. **require-run-as-nonroot** (ClusterPolicy, `require-run-as-nonroot.yaml`):
   - Adds `hostUsers: false` as an additional `anyPattern` entry when `podSecurityUserNamespaces` is true

2. **require-run-as-nonroot** (ValidatingPolicy/CEL, `require-run-as-nonroot.cel.yaml`):
   - Prepends `object.spec.?hostUsers.orValue(true) == false ||` to the validation expression

3. **require-run-as-non-root-user** (ClusterPolicy, `require-run-as-non-root-user.yaml`):
   - Converts from `pattern` to `anyPattern` to allow multiple valid conditions
   - Adds `hostUsers: false` entry when `podSecurityUserNamespaces` is true

4. **require-run-as-non-root-user** (ValidatingPolicy/CEL, `require-run-as-non-root-user.cel.yaml`):
   - Prepends `(object.spec.?hostUsers.orValue(true) == false) ||` to the validation expression

### Compatibility

- **Backward compatible**: When `podSecurityUserNamespaces` is `false` (default), behavior is identical to the current release.
- **No breaking changes**: Existing configurations continue to work unchanged.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the AI Usage Policy. If I used AI assistance, I have disclosed it in my commit(s).
- [x] I have signed my commits.
- [x] This is a feature and I have added Helm chart tests that are applicable (verified with `helm lint` + `helm template`).
