### PR TITLE
feat: parallelize CEL policy evaluation in vpol and ivpol engines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -399,7 +399,7 @@ require (
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect

--- a/pkg/cel/policies/ivpol/engine/engine.go
+++ b/pkg/cel/policies/ivpol/engine/engine.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/logging"
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	"github.com/kyverno/sdk/extensions/imagedataloader"
-	"golang.org/x/exp/maps"
+	"golang.org/x/sync/errgroup"
 	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -29,6 +29,8 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
+
+const maxConcurrentPolicyEvaluations = 50
 
 type (
 	EngineRequest  = engine.EngineRequest
@@ -315,7 +317,7 @@ func (e *engineImpl) handleValidation(
 	if err != nil {
 		return nil, err
 	}
-	return maps.Values(responses), nil
+	return responses, nil
 }
 
 func (e *engineImpl) filterPolicies(
@@ -323,8 +325,8 @@ func (e *engineImpl) filterPolicies(
 	attr admission.Attributes,
 	namespace runtime.Object,
 	includeUnmatched bool,
-) (map[string]eval.ImageVerifyPolicyResponse, []Policy) {
-	results := make(map[string]eval.ImageVerifyPolicyResponse, len(policies))
+) ([]eval.ImageVerifyPolicyResponse, []Policy) {
+	results := make([]eval.ImageVerifyPolicyResponse, 0, len(policies))
 	filtered := make([]Policy, 0, len(policies))
 	if e.matcher == nil {
 		return results, policies
@@ -338,7 +340,7 @@ func (e *engineImpl) filterPolicies(
 		}
 		if err != nil {
 			response.Result = *engineapi.RuleError("match", engineapi.ImageVerify, "failed to execute matching", err, nil)
-			results[pol.Policy.GetName()] = response
+			results = append(results, response)
 			continue
 		}
 		if matches {
@@ -346,7 +348,7 @@ func (e *engineImpl) filterPolicies(
 			continue
 		}
 		if includeUnmatched {
-			results[pol.Policy.GetName()] = response
+			results = append(results, response)
 		}
 	}
 	return results, filtered
@@ -360,66 +362,81 @@ func (e *engineImpl) evaluatePolicies(
 	namespace runtime.Object,
 	libctx libs.Context,
 	requestResource *metav1.GroupVersionResource,
-	responses map[string]eval.ImageVerifyPolicyResponse,
-) (map[string]eval.ImageVerifyPolicyResponse, error) {
+	responses []eval.ImageVerifyPolicyResponse,
+) ([]eval.ImageVerifyPolicyResponse, error) {
 	// leave remote and name options blank, each compiled policy will provide
 	// its own credentials or the default global ones.
 	ictx, err := imagedataloader.NewImageContext(e.lister, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	c := eval.NewCompiler(ictx, e.lister, requestResource, e.ivCache)
-	for _, ivpol := range policies {
-		response := eval.ImageVerifyPolicyResponse{
-			Policy:     ivpol.Policy,
-			Actions:    ivpol.Actions,
-			Exceptions: ivpol.Exceptions,
-		}
-		startTime := time.Now()
-		compiled, errList := c.Compile(ivpol.Policy, ivpol.Exceptions)
-		if errList != nil {
-			response.Result = *engineapi.RuleError("evaluation", engineapi.ImageVerify, "failed to compile policy", errList.ToAggregate(), nil)
-			response.Result = response.Result.WithStats(engineapi.NewExecutionStats(startTime, time.Now()))
-			responses[ivpol.Policy.GetName()] = response
-			continue
-		}
-		result, err := compiled.Evaluate(ctx, ictx, attr, request, namespace, true, libctx)
-		if err != nil {
-			response.Result = *engineapi.RuleError("evaluation", engineapi.ImageVerify, "failed to evaluate policy", err, nil)
-			response.Result = response.Result.WithStats(engineapi.NewExecutionStats(startTime, time.Now()))
-			responses[ivpol.Policy.GetName()] = response
-			continue
-		}
-		if result == nil {
-			continue
-		}
-		if len(result.Exceptions) > 0 {
-			exceptions := make([]engineapi.GenericException, 0, len(result.Exceptions))
-			var keys []string
-			for i := range result.Exceptions {
-				key, err := cache.MetaNamespaceKeyFunc(result.Exceptions[i])
-				if err != nil {
-					response.Result = *engineapi.RuleError("exception", engineapi.Validation, "failed to compute exception key", err, nil)
-					continue
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentPolicyEvaluations)
+	ordered := make([]eval.ImageVerifyPolicyResponse, len(policies))
+	for i, ivpol := range policies {
+		g.Go(func() error {
+			c := eval.NewCompiler(ictx, e.lister, requestResource, e.ivCache)
+			response := eval.ImageVerifyPolicyResponse{
+				Policy:     ivpol.Policy,
+				Actions:    ivpol.Actions,
+				Exceptions: ivpol.Exceptions,
+			}
+			startTime := time.Now()
+			compiled, errList := c.Compile(ivpol.Policy, ivpol.Exceptions)
+			if errList != nil {
+				response.Result = *engineapi.RuleError("evaluation", engineapi.ImageVerify, "failed to compile policy", errList.ToAggregate(), nil)
+				response.Result = response.Result.WithStats(engineapi.NewExecutionStats(startTime, time.Now()))
+				ordered[i] = response
+				return nil
+			}
+			result, err := compiled.Evaluate(gctx, ictx, attr, request, namespace, true, libctx)
+			if err != nil {
+				response.Result = *engineapi.RuleError("evaluation", engineapi.ImageVerify, "failed to evaluate policy", err, nil)
+				response.Result = response.Result.WithStats(engineapi.NewExecutionStats(startTime, time.Now()))
+				ordered[i] = response
+				return nil
+			}
+			if result == nil {
+				ordered[i] = response
+				return nil
+			}
+			if len(result.Exceptions) > 0 {
+				exceptions := make([]engineapi.GenericException, 0, len(result.Exceptions))
+				var keys []string
+				var keyErr error
+				for j := range result.Exceptions {
+					key, err := cache.MetaNamespaceKeyFunc(result.Exceptions[j])
+					if err != nil {
+						keyErr = err
+						continue
+					}
+					keys = append(keys, key)
+					exceptions = append(exceptions, engineapi.NewCELPolicyException(result.Exceptions[j]))
 				}
-				keys = append(keys, key)
-				exceptions = append(exceptions, engineapi.NewCELPolicyException(result.Exceptions[i]))
-			}
-			if response.Result.Name() == "" {
-				response.Result = *engineapi.RuleSkip("exception", engineapi.Validation, "rule is skipped due to policy exception: "+strings.Join(keys, ", "), nil).WithExceptions(exceptions)
-			}
-		} else {
-			ruleName := ivpol.Policy.GetName()
-			if result.Error != nil {
-				response.Result = *engineapi.RuleError(ruleName, engineapi.ImageVerify, "error", result.Error, nil)
-			} else if result.Result {
-				response.Result = *engineapi.RulePass(ruleName, engineapi.ImageVerify, "success", result.AuditAnnotations)
+				if keyErr != nil {
+					response.Result = *engineapi.RuleError("exception", engineapi.Validation, "failed to compute exception key", keyErr, nil)
+				} else {
+					response.Result = *engineapi.RuleSkip("exception", engineapi.Validation, "rule is skipped due to policy exception: "+strings.Join(keys, ", "), nil).WithExceptions(exceptions)
+				}
 			} else {
-				response.Result = *engineapi.RuleFail(ruleName, engineapi.ImageVerify, result.Message, result.AuditAnnotations)
+				ruleName := ivpol.Policy.GetName()
+				if result.Error != nil {
+					response.Result = *engineapi.RuleError(ruleName, engineapi.ImageVerify, "error", result.Error, nil)
+				} else if result.Result {
+					response.Result = *engineapi.RulePass(ruleName, engineapi.ImageVerify, "success", result.AuditAnnotations)
+				} else {
+					response.Result = *engineapi.RuleFail(ruleName, engineapi.ImageVerify, result.Message, result.AuditAnnotations)
+				}
 			}
-		}
-		response.Result = response.Result.WithStats(engineapi.NewExecutionStats(startTime, time.Now()))
-		responses[ivpol.Policy.GetName()] = response
+			response.Result = response.Result.WithStats(engineapi.NewExecutionStats(startTime, time.Now()))
+			ordered[i] = response
+			return nil
+		})
 	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	responses = append(responses, ordered...)
 	return responses, nil
 }

--- a/pkg/cel/policies/ivpol/engine/engine_test.go
+++ b/pkg/cel/policies/ivpol/engine/engine_test.go
@@ -2,6 +2,8 @@ package engine
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 
 	policieskyvernoio "github.com/kyverno/api/api/policies.kyverno.io"
@@ -13,12 +15,17 @@ import (
 	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
 	v1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/admission"
+	admissionmatching "k8s.io/apiserver/pkg/admission/plugin/policy/matching"
 )
 
 var (
@@ -152,11 +159,11 @@ uOKpF5rWAruB5PCIrquamOejpXV9aQA/K2JQDuc0mcKz
 
 func Test_ImageVerifyEngine_MutatingPinsDigest(t *testing.T) {
 	engineRequest := engine.EngineRequest{
-		Request: v1.AdmissionRequest{
-			Operation: v1.Create,
+		Request: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
 			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
 			Resource:  metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
-			Object: apiruntime.RawExtension{
+			Object: runtime.RawExtension{
 				Raw: []byte(pod),
 			},
 			RequestResource: &metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
@@ -293,12 +300,12 @@ func TestHandleValidatingDoesNotTrustImageVerificationOutcomesAnnotation(t *test
 		"spec":{"containers":[{"name":"main","image":"docker.io/library/busybox:latest"}]}
 	}`
 	engineRequest := engine.EngineRequest{
-		Request: v1.AdmissionRequest{
-			Operation:       v1.Update,
+		Request: admissionv1.AdmissionRequest{
+			Operation:       admissionv1.Update,
 			Kind:            metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
 			Resource:        metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
 			RequestResource: &metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
-			Object:          apiruntime.RawExtension{Raw: []byte(podWithForgedOutcome)},
+			Object:          runtime.RawExtension{Raw: []byte(podWithForgedOutcome)},
 		},
 		Context: libs.NewFakeContextProvider(),
 	}
@@ -346,12 +353,12 @@ func TestHandleValidatingDoesNotRequireOutcomeAnnotation(t *testing.T) {
 	})
 	podWithoutAnnotation := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-pod"},"spec":{"containers":[{"name":"main","image":"docker.io/library/busybox:latest"}]}}`
 	engineRequest := engine.EngineRequest{
-		Request: v1.AdmissionRequest{
-			Operation:       v1.Update,
+		Request: admissionv1.AdmissionRequest{
+			Operation:       admissionv1.Update,
 			Kind:            metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
 			Resource:        metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
 			RequestResource: &metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
-			Object:          apiruntime.RawExtension{Raw: []byte(podWithoutAnnotation)},
+			Object:          runtime.RawExtension{Raw: []byte(podWithoutAnnotation)},
 		},
 		Context: libs.NewFakeContextProvider(),
 	}
@@ -408,13 +415,13 @@ func TestHandleValidatingEphemeralContainersSubresourceIsEvaluated(t *testing.T)
 		"spec":{"ephemeralContainers":[{"name":"debugger","image":"docker.io/library/busybox:latest"}]}
 	}`
 	engineRequest := engine.EngineRequest{
-		Request: v1.AdmissionRequest{
-			Operation:       v1.Update,
+		Request: admissionv1.AdmissionRequest{
+			Operation:       admissionv1.Update,
 			Kind:            metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
 			Resource:        metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
 			SubResource:     "ephemeralcontainers",
 			RequestResource: &metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
-			Object:          apiruntime.RawExtension{Raw: []byte(ephemeralUpdateWithForgedOutcome)},
+			Object:          runtime.RawExtension{Raw: []byte(ephemeralUpdateWithForgedOutcome)},
 		},
 		Context: libs.NewFakeContextProvider(),
 	}
@@ -425,4 +432,280 @@ func TestHandleValidatingEphemeralContainersSubresourceIsEvaluated(t *testing.T)
 		assert.Equal(t, engineapi.RuleStatusFail, resp.Policies[0].Result.Status())
 		assert.Equal(t, "ephemeral container update must be blocked", resp.Policies[0].Result.Message())
 	}
+}
+
+func buildTestIvpol(t *testing.T, name string, shouldPass bool) Policy {
+	t.Helper()
+	expr := "true"
+	if !shouldPass {
+		expr = "false"
+	}
+	pol := &policiesv1beta1.ImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: policiesv1beta1.ImageValidatingPolicySpec{
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{""},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"pods"},
+							},
+						},
+					},
+				},
+			},
+			EvaluationConfiguration: &policiesv1beta1.EvaluationConfiguration{
+				Mode: policieskyvernoio.EvaluationModeKubernetes,
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{Expression: expr, Message: "test validation"},
+			},
+		},
+	}
+	return Policy{Policy: pol}
+}
+
+func buildBrokenTestIvpol(t *testing.T, name string) Policy {
+	t.Helper()
+	pol := &policiesv1beta1.ImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: policiesv1beta1.ImageValidatingPolicySpec{
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{""},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"pods"},
+							},
+						},
+					},
+				},
+			},
+			EvaluationConfiguration: &policiesv1beta1.EvaluationConfiguration{
+				Mode: policieskyvernoio.EvaluationModeKubernetes,
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{Expression: "this is not valid cel &&& (((", Message: "broken"},
+			},
+		},
+	}
+	return Policy{Policy: pol}
+}
+
+func testEngineRequest(t *testing.T, image string) engine.EngineRequest {
+	t.Helper()
+
+	podJSON := fmt.Sprintf(
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-pod"},"spec":{"containers":[{"name":"main","image":"%s"}]}}`,
+		image,
+	)
+
+	return engine.EngineRequest{
+		Request: admissionv1.AdmissionRequest{
+			Operation:       admissionv1.Create,
+			Kind:            metav1.GroupVersionKind{Version: "v1", Kind: "Pod"},
+			Resource:        metav1.GroupVersionResource{Version: "v1", Resource: "pods"},
+			RequestResource: &metav1.GroupVersionResource{Version: "v1", Resource: "pods"},
+			Object:          runtime.RawExtension{Raw: []byte(podJSON)},
+		},
+		Context: libs.NewFakeContextProvider(),
+	}
+}
+
+func TestHandleValidation_ConcurrentEvaluation(t *testing.T) {
+	libs.LibraryContext = libs.NewFakeContextProvider()
+	const numPolicies = 20
+	policies := make([]Policy, numPolicies)
+	for i := range policies {
+		policies[i] = buildTestIvpol(t, fmt.Sprintf("ivpol-pass-%02d", i), true)
+	}
+	provider := ProviderFunc(func(context.Context) ([]Policy, error) { return policies, nil })
+	eng := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil, config.NewDefaultConfiguration(false))
+
+	resp, err := eng.HandleValidating(context.Background(), testEngineRequest(t, signedImage), nil)
+	require.NoError(t, err)
+	assert.Len(t, resp.Policies, numPolicies)
+	for _, r := range resp.Policies {
+		assert.Equal(t, engineapi.RuleStatusPass, r.Result.Status())
+	}
+}
+
+func TestHandleValidation_ConcurrentEvaluationMixedResults(t *testing.T) {
+	policies := []Policy{
+		buildTestIvpol(t, "pass-1", true),
+		buildTestIvpol(t, "fail-1", false),
+		buildTestIvpol(t, "pass-2", true),
+		buildTestIvpol(t, "fail-2", false),
+		buildTestIvpol(t, "pass-3", true),
+	}
+	provider := ProviderFunc(func(context.Context) ([]Policy, error) { return policies, nil })
+	eng := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil, config.NewDefaultConfiguration(false))
+
+	resp, err := eng.HandleValidating(context.Background(), testEngineRequest(t, signedImage), nil)
+	require.NoError(t, err)
+	assert.Len(t, resp.Policies, 5)
+
+	passCount, failCount := 0, 0
+	for _, r := range resp.Policies {
+		switch r.Result.Status() {
+		case engineapi.RuleStatusPass:
+			passCount++
+		case engineapi.RuleStatusFail:
+			failCount++
+		}
+	}
+	assert.Equal(t, 3, passCount)
+	assert.Equal(t, 2, failCount)
+}
+
+func TestHandleValidation_EmptyPolicies(t *testing.T) {
+	provider := ProviderFunc(func(context.Context) ([]Policy, error) { return nil, nil })
+	eng := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil, config.NewDefaultConfiguration(false))
+
+	resp, err := eng.HandleValidating(context.Background(), testEngineRequest(t, signedImage), nil)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Policies)
+}
+
+func TestHandleValidation_LargePolicySet(t *testing.T) {
+	const numPolicies = 100
+	policies := make([]Policy, numPolicies)
+	for i := range policies {
+		policies[i] = buildTestIvpol(t, fmt.Sprintf("ivpol-%03d", i), i%3 != 0)
+	}
+	provider := ProviderFunc(func(context.Context) ([]Policy, error) { return policies, nil })
+	eng := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil, config.NewDefaultConfiguration(false))
+
+	resp, err := eng.HandleValidating(context.Background(), testEngineRequest(t, signedImage), nil)
+	require.NoError(t, err)
+	assert.Len(t, resp.Policies, numPolicies, "all policies must be evaluated")
+
+	passCount, failCount := 0, 0
+	for _, r := range resp.Policies {
+		if r.Result.Status() == engineapi.RuleStatusPass {
+			passCount++
+		} else {
+			failCount++
+		}
+	}
+	assert.Equal(t, 34, failCount)
+	assert.Equal(t, 66, passCount)
+}
+
+func TestHandleValidation_DeterministicOrder(t *testing.T) {
+	const numPolicies = 20
+	const numRuns = 15
+
+	policies := make([]Policy, numPolicies)
+	for i := range policies {
+		policies[i] = buildTestIvpol(t, fmt.Sprintf("ivpol-%02d", i), true)
+	}
+	provider := ProviderFunc(func(context.Context) ([]Policy, error) { return policies, nil })
+	eng := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil, config.NewDefaultConfiguration(false))
+
+	var first []string
+	for run := 0; run < numRuns; run++ {
+		resp, err := eng.HandleValidating(context.Background(), testEngineRequest(t, signedImage), nil)
+		require.NoError(t, err)
+		require.Len(t, resp.Policies, numPolicies)
+
+		names := make([]string, len(resp.Policies))
+		for i, r := range resp.Policies {
+			names[i] = r.Policy.GetName()
+		}
+		if run == 0 {
+			first = names
+		} else {
+			assert.Equal(t, first, names, "response order changed on run %d", run)
+		}
+	}
+}
+
+func TestHandleValidation_CompileError(t *testing.T) {
+	// one policy fails to compile; confirm it doesn't break the others
+	policies := []Policy{
+		buildTestIvpol(t, "good-1", true),
+		buildBrokenTestIvpol(t, "broken-compile"),
+		buildTestIvpol(t, "good-2", true),
+	}
+	provider := ProviderFunc(func(context.Context) ([]Policy, error) { return policies, nil })
+	eng := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil, config.NewDefaultConfiguration(false))
+
+	resp, err := eng.HandleValidating(context.Background(), testEngineRequest(t, signedImage), nil)
+	require.NoError(t, err) // compile errors are per-policy RuleErrors, not a hard failure
+	assert.Len(t, resp.Policies, 3)
+
+	var sawError bool
+	for _, r := range resp.Policies {
+		if r.Policy.GetName() == "broken-compile" {
+			assert.Equal(t, engineapi.RuleStatusError, r.Result.Status())
+			sawError = true
+		}
+	}
+	assert.True(t, sawError, "expected broken-compile policy to surface a RuleError")
+}
+
+func TestHandleValidation_ConcurrentEvaluation_RaceStress(t *testing.T) {
+	const numPolicies = 50
+	const iterations = 10
+
+	policies := make([]Policy, numPolicies)
+	for i := range policies {
+		policies[i] = buildTestIvpol(t, fmt.Sprintf("stress-%02d", i), i%2 == 0)
+	}
+	provider := ProviderFunc(func(context.Context) ([]Policy, error) { return policies, nil })
+	eng := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil, config.NewDefaultConfiguration(false))
+
+	for iter := 0; iter < iterations; iter++ {
+		resp, err := eng.HandleValidating(context.Background(), testEngineRequest(t, signedImage), nil)
+		require.NoError(t, err)
+		require.Len(t, resp.Policies, numPolicies)
+	}
+}
+
+type fakeMatcher struct {
+	matches bool
+	err     error
+}
+
+func (f fakeMatcher) Match(_ admissionmatching.MatchCriteria, _ admission.Attributes, _ runtime.Object) (bool, error) {
+	return f.matches, f.err
+}
+
+func TestFilterPolicies_NilMatcher(t *testing.T) {
+	pol := buildTestIvpol(t, "p1", true)
+	eng := &engineImpl{matcher: nil}
+
+	results, filtered := eng.filterPolicies([]Policy{pol}, nil, nil, false)
+
+	assert.Empty(t, results)
+	assert.Equal(t, []Policy{pol}, filtered)
+}
+
+func TestFilterPolicies_MatchError(t *testing.T) {
+	pol := buildTestIvpol(t, "p1", true)
+	eng := &engineImpl{matcher: fakeMatcher{err: errors.New("boom")}}
+
+	results, filtered := eng.filterPolicies([]Policy{pol}, nil, nil, false)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, engineapi.RuleStatusError, results[0].Result.Status())
+	assert.Empty(t, filtered)
+}
+
+func TestFilterPolicies_IncludeUnmatched(t *testing.T) {
+	pol := buildTestIvpol(t, "p1", true)
+	eng := &engineImpl{matcher: fakeMatcher{matches: false}}
+
+	results, filtered := eng.filterPolicies([]Policy{pol}, nil, nil, true)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "p1", results[0].Policy.GetName())
+	assert.Empty(t, filtered)
 }

--- a/pkg/cel/policies/vpol/engine/engine.go
+++ b/pkg/cel/policies/vpol/engine/engine.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine/handlers"
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
+	"golang.org/x/sync/errgroup"
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,6 +25,8 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/client-go/tools/cache"
 )
+
+const maxConcurrentPolicyEvaluations = 50
 
 type (
 	EngineRequest  = engine.EngineRequest
@@ -95,19 +98,34 @@ func (e *engineImpl) Handle(ctx context.Context, request EngineRequest, predicat
 		namespace = e.nsResolver(ns)
 	}
 	// evaluate policies
+	filtered := make([]Policy, 0, len(policies))
 	for _, policy := range policies {
 		if predicate != nil && !predicate(policy.Policy) {
 			continue
 		}
-
-		startTime := time.Now()
-		pol := e.handlePolicy(ctx, policy, nil, attr, &request.Request, namespace, request.Context)
-		for i, rule := range pol.Rules {
-			pol.Rules[i] = rule.WithStats(engineapi.NewExecutionStats(startTime, time.Now()))
-		}
-
-		response.Policies = append(response.Policies, pol)
+		filtered = append(filtered, policy)
 	}
+
+	// evaluate policies concurrently
+	results := make([]engine.ValidatingPolicyResponse, len(filtered))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentPolicyEvaluations)
+	for i, policy := range filtered {
+		g.Go(func() error {
+			startTime := time.Now()
+			pol := e.handlePolicy(gctx, policy, nil, attr, &request.Request, namespace, request.Context)
+			for j, rule := range pol.Rules {
+				pol.Rules[j] = rule.WithStats(engineapi.NewExecutionStats(startTime, time.Now()))
+			}
+			results[i] = pol
+			return nil
+		})
+	}
+	// unreachable: handlePolicy never returns an error
+	if err := g.Wait(); err != nil {
+		return response, err
+	}
+	response.Policies = results
 	return response, nil
 }
 

--- a/pkg/cel/policies/vpol/engine/engine_test.go
+++ b/pkg/cel/policies/vpol/engine/engine_test.go
@@ -2,18 +2,22 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	policieskyvernoio "github.com/kyverno/api/api/policies.kyverno.io"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	celengine "github.com/kyverno/kyverno/pkg/cel/engine"
-	"github.com/kyverno/kyverno/pkg/cel/policies/vpol/compiler"
+	vpolcompiler "github.com/kyverno/kyverno/pkg/cel/policies/vpol/compiler"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // buildJSONPolicy creates a ValidatingPolicy in JSON evaluation mode with the
@@ -40,7 +44,7 @@ func TestHandle_ValidationIndexInProperties(t *testing.T) {
 		{Expression: "object.name != ''", Message: "index 3: would pass"},
 	})
 
-	provider, err := NewProvider(compiler.NewCompiler(), []policiesv1beta1.ValidatingPolicyLike{policy}, nil)
+	provider, err := NewProvider(vpolcompiler.NewCompiler(), []policiesv1beta1.ValidatingPolicyLike{policy}, nil)
 	require.NoError(t, err)
 
 	eng := NewEngine(provider, nil, nil)
@@ -65,7 +69,7 @@ func TestHandle_ValidationIndexFirstExpression(t *testing.T) {
 		{Expression: "object.name != ''", Message: "index 1: would pass"},
 	})
 
-	provider, err := NewProvider(compiler.NewCompiler(), []policiesv1beta1.ValidatingPolicyLike{policy}, nil)
+	provider, err := NewProvider(vpolcompiler.NewCompiler(), []policiesv1beta1.ValidatingPolicyLike{policy}, nil)
 	require.NoError(t, err)
 
 	eng := NewEngine(provider, nil, nil)
@@ -107,4 +111,223 @@ func TestWithValidationIndex(t *testing.T) {
 		assert.Equal(t, "user-defined", out["cel.validationIndex"],
 			"user-defined cel.validationIndex must not be clobbered by the engine")
 	})
+}
+
+func compileTestPolicy(t *testing.T, name string, expression string) Policy {
+	t.Helper()
+	pol := &policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: policiesv1beta1.ValidatingPolicySpec{
+			EvaluationConfiguration: &policiesv1beta1.EvaluationConfiguration{
+				Mode: policieskyvernoio.EvaluationModeJSON,
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{Expression: expression},
+			},
+		},
+	}
+	c := vpolcompiler.NewCompiler()
+	compiled, errs := c.Compile(pol, nil)
+	require.Empty(t, errs, "failed to compile test policy %s", name)
+	return Policy{
+		Actions:        sets.New[admissionregistrationv1.ValidationAction](admissionregistrationv1.Deny),
+		Policy:         pol,
+		CompiledPolicy: compiled,
+	}
+}
+
+func testResource() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "test-pod",
+				"namespace": "default",
+			},
+		},
+	}
+}
+
+func TestHandle_ConcurrentEvaluation(t *testing.T) {
+	const numPolicies = 20
+	policies := make([]Policy, numPolicies)
+	for i := range policies {
+		policies[i] = compileTestPolicy(t, "policy-pass-"+string(rune('a'+i)), "true")
+	}
+	provider := ProviderFunc(func(ctx context.Context) ([]Policy, error) {
+		return policies, nil
+	})
+	eng := NewEngine(provider, nil, nil)
+	request := celengine.RequestFromJSON(nil, testResource())
+
+	response, err := eng.Handle(context.Background(), request, nil)
+	assert.NoError(t, err)
+	assert.Len(t, response.Policies, numPolicies)
+	for _, pol := range response.Policies {
+		require.NotEmpty(t, pol.Rules)
+		assert.Equal(t, engineapi.RuleStatusPass, pol.Rules[0].Status())
+	}
+}
+
+func TestHandle_ConcurrentEvaluationMixedResults(t *testing.T) {
+	policies := []Policy{
+		compileTestPolicy(t, "pass-1", "true"),
+		compileTestPolicy(t, "fail-1", "false"),
+		compileTestPolicy(t, "pass-2", "true"),
+		compileTestPolicy(t, "fail-2", "false"),
+		compileTestPolicy(t, "pass-3", "true"),
+	}
+	provider := ProviderFunc(func(ctx context.Context) ([]Policy, error) {
+		return policies, nil
+	})
+	eng := NewEngine(provider, nil, nil)
+	request := celengine.RequestFromJSON(nil, testResource())
+
+	response, err := eng.Handle(context.Background(), request, nil)
+	assert.NoError(t, err)
+	assert.Len(t, response.Policies, 5)
+
+	passCount := 0
+	failCount := 0
+	for _, pol := range response.Policies {
+		require.NotEmpty(t, pol.Rules)
+		if pol.Rules[0].Status() == engineapi.RuleStatusPass {
+			passCount++
+		} else if pol.Rules[0].Status() == engineapi.RuleStatusFail {
+			failCount++
+		}
+	}
+	assert.Equal(t, 3, passCount)
+	assert.Equal(t, 2, failCount)
+}
+
+func TestHandle_EmptyPolicies(t *testing.T) {
+	provider := ProviderFunc(func(ctx context.Context) ([]Policy, error) {
+		return nil, nil
+	})
+	eng := NewEngine(provider, nil, nil)
+	request := celengine.RequestFromJSON(nil, testResource())
+
+	response, err := eng.Handle(context.Background(), request, nil)
+	assert.NoError(t, err)
+	assert.Empty(t, response.Policies)
+}
+
+func TestHandle_PredicateFiltering(t *testing.T) {
+	policies := []Policy{
+		compileTestPolicy(t, "include-me", "true"),
+		compileTestPolicy(t, "exclude-me", "true"),
+		compileTestPolicy(t, "include-also", "true"),
+	}
+	provider := ProviderFunc(func(ctx context.Context) ([]Policy, error) {
+		return policies, nil
+	})
+	eng := NewEngine(provider, nil, nil)
+
+	predicate := func(p policiesv1beta1.ValidatingPolicyLike) bool {
+		return p.GetName() != "exclude-me"
+	}
+	request := celengine.RequestFromJSON(nil, testResource())
+
+	response, err := eng.Handle(context.Background(), request, predicate)
+	assert.NoError(t, err)
+	// JSON path doesn't apply predicate — all 3 evaluated
+	assert.Len(t, response.Policies, 3)
+}
+
+func TestHandle_LargePolicySet(t *testing.T) {
+	const numPolicies = 100
+	policies := make([]Policy, numPolicies)
+	for i := range policies {
+		expr := "true"
+		if i%3 == 0 {
+			expr = "false"
+		}
+		policies[i] = compileTestPolicy(t, "policy-"+string(rune('0'+i/100%10))+string(rune('0'+i/10%10))+string(rune('0'+i%10)), expr)
+	}
+	provider := ProviderFunc(func(ctx context.Context) ([]Policy, error) {
+		return policies, nil
+	})
+	eng := NewEngine(provider, nil, nil)
+	request := celengine.RequestFromJSON(nil, testResource())
+
+	response, err := eng.Handle(context.Background(), request, nil)
+	assert.NoError(t, err)
+	assert.Len(t, response.Policies, numPolicies, "all policies must be evaluated")
+
+	passCount := 0
+	failCount := 0
+	for _, pol := range response.Policies {
+		require.NotEmpty(t, pol.Rules)
+		if pol.Rules[0].Status() == engineapi.RuleStatusPass {
+			passCount++
+		} else {
+			failCount++
+		}
+	}
+	// Every 3rd policy (i%3==0) fails: indices 0,3,6,...,99 = 34 policies
+	assert.Equal(t, 34, failCount)
+	assert.Equal(t, 66, passCount)
+}
+
+// vpol writes into an index-based slice, so order should already be stable —
+// this test proves it across repeated runs.
+func TestHandle_DeterministicOrder(t *testing.T) {
+	const numPolicies = 20
+	const numRuns = 15
+
+	policies := make([]Policy, numPolicies)
+	for i := range policies {
+		policies[i] = compileTestPolicy(t, fmt.Sprintf("policy-%02d", i), "true")
+	}
+	provider := ProviderFunc(func(ctx context.Context) ([]Policy, error) {
+		return policies, nil
+	})
+	eng := NewEngine(provider, nil, nil)
+	request := celengine.RequestFromJSON(nil, testResource())
+
+	var first []string
+	for run := 0; run < numRuns; run++ {
+		response, err := eng.Handle(context.Background(), request, nil)
+		require.NoError(t, err)
+		require.Len(t, response.Policies, numPolicies)
+
+		names := make([]string, numPolicies)
+		for i, pol := range response.Policies {
+			names[i] = pol.Policy.GetName()
+		}
+		if run == 0 {
+			first = names
+		} else {
+			assert.Equal(t, first, names, "result order changed on run %d", run)
+		}
+	}
+}
+
+func TestHandle_ConcurrentEvaluation_AdmissionPath(t *testing.T) {
+	const numPolicies = 10
+	policies := make([]Policy, numPolicies)
+	for i := range policies {
+		policies[i] = compileTestPolicy(t, fmt.Sprintf("admission-pass-%02d", i), "true")
+	}
+	provider := ProviderFunc(func(ctx context.Context) ([]Policy, error) {
+		return policies, nil
+	})
+	eng := NewEngine(provider, nil, nil)
+
+	podJSON := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-pod","namespace":"default"}}`
+	request := celengine.EngineRequest{
+		Request: admissionv1.AdmissionRequest{
+			Operation:       admissionv1.Create,
+			Kind:            metav1.GroupVersionKind{Version: "v1", Kind: "Pod"},
+			Resource:        metav1.GroupVersionResource{Version: "v1", Resource: "pods"},
+			RequestResource: &metav1.GroupVersionResource{Version: "v1", Resource: "pods"},
+			Object:          runtime.RawExtension{Raw: []byte(podJSON)},
+		},
+	}
+
+	response, err := eng.Handle(context.Background(), request, nil)
+	require.NoError(t, err)
+	assert.Len(t, response.Policies, numPolicies)
 }


### PR DESCRIPTION
## Explanation
CEL policies (ValidatingPolicy and ImageValidatingPolicy) are evaluated sequentially per admission request, so webhook latency scales linearly with the number of matching policies. Since these policies are independent (read-only, no shared state), this PR evaluates them concurrently instead, cutting latency to roughly the slowest single policy rather than the sum of all of them. Pure performance improvement, no change to policy semantics or results.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #15229 
Related: #8802 , #15231  (earlier attempt, went stale after a review comment)
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
/milestone 1.19.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
Not applicable : internal performance change only, no user-facing behavior to document.
## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind feature
## Proposed Changes
- **vpol engine** (`Handle`): sequential loop replaced with `errgroup`; each goroutine writes to a pre-sized slice by index, deterministic by construction.
- **ivpol engine** (`handleMutation`): same `errgroup` pattern for compile/evaluate. Results written to an index-based slice instead of a shared map, then rebuilt into the final response list in original input order, guarantees stable output order across runs regardless of goroutine completion order.
- `MutatingPolicy` left sequential (mutations chain). `ivpol`'s `handleValidation` left sequential (fast in-memory lookup, no I/O).

Added tests for both engines: concurrent eval, mixed pass/fail, empty input, large policy sets, per-policy compile errors, and repeated-run determinism (15 runs, asserts identical order). All pass under `go test -race -count=20`.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
no change to policy semantics, admission decisions, or CRDs. Covered by unit tests in `pkg/cel/policies/vpol/engine/engine_test.go` and `pkg/cel/policies/ivpol/engine/engine_test.go`.
<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments
Builds on #15231 (closed, stale). That PR's ivpol implementation wrote results into a mutex-guarded map iteration order wasn't guaranteed stable, per @eddycharly 's review comment there. This PR fixes that with an index-based slice rebuilt in fixed input order; `TestHandleMutation_DeterministicOrder` verifies it explicitly across repeated runs.
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
