### PR TITLE
fix: IVPOL mutateDigest unimplemented stub

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -698,6 +698,7 @@ func (c *ApplyCommandConfig) applyImageValidatingPolicies(
 		matching.NewMatcher(),
 		lister,
 		imageverifycache.DisabledImageVerifyCache(),
+		config.NewDefaultConfiguration(false),
 	)
 
 	restMapper, err := utils.GetRESTMapper(dclient)

--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -727,6 +727,7 @@ func applyImageValidatingPolicies(
 		matching.NewMatcher(),
 		lister,
 		imageverifycache.DisabledImageVerifyCache(),
+		config.NewDefaultConfiguration(false),
 	)
 
 	if restMapper == nil {

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -788,6 +788,7 @@ func main() {
 				matching.NewMatcher(),
 				setup.RegistrySecretLister,
 				setup.ImageVerifyCacheClient,
+				setup.Configuration,
 			), metrics.AdmissionRequest)
 			mpolEngine = mpolengine.NewMetricWrapper(mpolengine.NewEngine(
 				mpolProvider,

--- a/pkg/cel/policies/ivpol/engine/engine.go
+++ b/pkg/cel/policies/ivpol/engine/engine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/cel/engine"
 	"github.com/kyverno/kyverno/pkg/cel/libs"
 	"github.com/kyverno/kyverno/pkg/cel/matching"
+	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
 	eval "github.com/kyverno/kyverno/pkg/image/verification/evaluator"
@@ -20,6 +21,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
@@ -133,10 +135,11 @@ func (e *engineImpl) HandleValidating(ctx context.Context, request EngineRequest
 // could forge and that would be trusted if the mutating webhook was ever
 // skipped (see https://github.com/kyverno/kyverno/issues/16336).
 //
-// HandleMutating is therefore limited to true mutation responsibilities
-// (e.g. pinning image tags to digests). No such mutation is implemented
-// for ImageValidatingPolicy yet, so this returns the resource unchanged
-// with no patches and no policy results.
+// HandleMutating is therefore limited to true mutation responsibilities:
+// for every policy with mutateDigest enabled (the default) that matches the
+// request, it pins the tag of images matched by the policy's
+// matchImageReferences to their resolved digest. No signature or
+// attestation verification is performed here.
 func (e *engineImpl) HandleMutating(ctx context.Context, request EngineRequest, predicate Predicate) (eval.ImageVerifyEngineResponse, []jsonpatch.JsonPatchOperation, error) {
 	var response eval.ImageVerifyEngineResponse
 	// load objects
@@ -148,7 +151,104 @@ func (e *engineImpl) HandleMutating(ctx context.Context, request EngineRequest, 
 	if response.Resource.Object == nil {
 		response.Resource = &oldObject
 	}
-	return response, nil, nil
+	// fetch compiled policies
+	policies, err := e.provider.Fetch(ctx)
+	if err != nil {
+		return response, nil, err
+	}
+	// default dry run
+	dryRun := false
+	if request.Request.DryRun != nil {
+		dryRun = *request.Request.DryRun
+	}
+	// create admission attributes
+	attr := admission.NewAttributesRecord(
+		&object,
+		&oldObject,
+		schema.GroupVersionKind(request.Request.Kind),
+		request.Request.Namespace,
+		request.Request.Name,
+		schema.GroupVersionResource(request.Request.Resource),
+		request.Request.SubResource,
+		admission.Operation(request.Request.Operation),
+		nil,
+		dryRun,
+		admissionpolicy.NewUser(request.Request.UserInfo),
+	)
+	// resolve namespace
+	var namespace runtime.Object
+	if ns := request.Request.Namespace; ns != "" {
+		namespace = e.nsResolver(ns)
+	}
+	// evaluate policies
+	var relevant []Policy
+	if predicate != nil {
+		for _, policy := range policies {
+			if !predicate(policy.Policy) {
+				continue
+			}
+			relevant = append(relevant, policy)
+		}
+	} else {
+		relevant = policies
+	}
+	patches, err := e.handleMutation(ctx, relevant, attr, &request.Request, namespace, *response.Resource, request.Context)
+	if err != nil {
+		return response, nil, err
+	}
+	return response, patches, nil
+}
+
+func (e *engineImpl) handleMutation(
+	ctx context.Context,
+	policies []Policy,
+	attr admission.Attributes,
+	request *admissionv1.AdmissionRequest,
+	namespace runtime.Object,
+	resource unstructured.Unstructured,
+	libctx libs.Context,
+) ([]jsonpatch.JsonPatchOperation, error) {
+	// leave remote and name options blank, each compiled policy will provide
+	// its own credentials or the default global ones.
+	ictx, err := imagedataloader.NewImageContext(e.lister, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	cfg := config.NewDefaultConfiguration(false)
+	c := eval.NewCompiler(ictx, e.lister, request.RequestResource, imageverifycache.DisabledImageVerifyCache())
+
+	var patches []jsonpatch.JsonPatchOperation
+	seen := map[string]bool{}
+	for _, ivpol := range policies {
+		validationCfg := ivpol.Policy.GetSpec().ValidationConfigurations
+		if validationCfg.MutateDigest != nil && !*validationCfg.MutateDigest {
+			continue
+		}
+		matches, err := e.matchPolicy(ivpol, attr, namespace)
+		if err != nil {
+			return nil, err
+		}
+		if !matches {
+			continue
+		}
+		compiled, errList := c.Compile(ivpol.Policy, ivpol.Exceptions)
+		if errList != nil {
+			// compile errors are surfaced by the validating webhook, skip mutation
+			continue
+		}
+		polPatches, err := compiled.MutateDigest(ctx, ictx, attr, request, namespace, resource, cfg)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range polPatches {
+			if seen[p.Path] {
+				continue
+			}
+			seen[p.Path] = true
+			patches = append(patches, p)
+		}
+	}
+	return patches, nil
 }
 
 func (e *engineImpl) matchPolicy(policy Policy, attr admission.Attributes, namespace runtime.Object) (bool, error) {

--- a/pkg/cel/policies/ivpol/engine/engine.go
+++ b/pkg/cel/policies/ivpol/engine/engine.go
@@ -43,11 +43,12 @@ type Engine interface {
 type NamespaceResolver = engine.NamespaceResolver
 
 type engineImpl struct {
-	provider   Provider
-	nsResolver NamespaceResolver
-	matcher    matching.Matcher
-	lister     corev1listers.SecretLister
-	ivCache    imageverifycache.Client
+	provider      Provider
+	nsResolver    NamespaceResolver
+	matcher       matching.Matcher
+	lister        corev1listers.SecretLister
+	ivCache       imageverifycache.Client
+	configuration config.Configuration
 }
 
 func NewEngine(
@@ -56,13 +57,15 @@ func NewEngine(
 	matcher matching.Matcher,
 	lister corev1listers.SecretLister,
 	ivCache imageverifycache.Client,
+	configuration config.Configuration,
 ) Engine {
 	return &engineImpl{
-		provider:   provider,
-		nsResolver: nsResolver,
-		matcher:    matcher,
-		lister:     lister,
-		ivCache:    ivCache,
+		provider:      provider,
+		nsResolver:    nsResolver,
+		matcher:       matcher,
+		lister:        lister,
+		ivCache:       ivCache,
+		configuration: configuration,
 	}
 }
 
@@ -214,7 +217,6 @@ func (e *engineImpl) handleMutation(
 	if err != nil {
 		return nil, err
 	}
-	cfg := config.NewDefaultConfiguration(false)
 	c := eval.NewCompiler(ictx, e.lister, request.RequestResource, imageverifycache.DisabledImageVerifyCache())
 
 	var patches []jsonpatch.JsonPatchOperation
@@ -236,7 +238,7 @@ func (e *engineImpl) handleMutation(
 			// compile errors are surfaced by the validating webhook, skip mutation
 			continue
 		}
-		polPatches, err := compiled.MutateDigest(ctx, ictx, attr, request, namespace, resource, cfg)
+		polPatches, err := compiled.MutateDigest(ctx, ictx, attr, request, namespace, resource, e.configuration)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cel/policies/ivpol/engine/engine.go
+++ b/pkg/cel/policies/ivpol/engine/engine.go
@@ -145,11 +145,14 @@ func (e *engineImpl) HandleValidating(ctx context.Context, request EngineRequest
 // matchImageReferences to their resolved digest. No signature or
 // attestation verification is performed here.
 //
-// Digest pinning is best effort and never blocks admission on its own. A
-// policy whose digests cannot be resolved yields an error result rather than
-// an error return, so the remaining policies still get their patches and the
-// admission decision is left to the validating webhook, which evaluates the
-// same policies and attributes any failure to them.
+// Digest pinning is not best effort. A policy whose digests cannot be resolved
+// yields an error result rather than an error return, so the remaining policies
+// still contribute their patches, but that result is surfaced by the webhook
+// handler and denies the request when the policy's validationActions include
+// Deny. This mirrors ClusterPolicy, where a failing handleMutateDigest appends a
+// RuleError that blocks the request under failurePolicy Fail
+// (pkg/engine/internal/imageverifier.go). Failing open here would silently admit
+// unpinned images, which is the very problem this handler exists to fix.
 func (e *engineImpl) HandleMutating(ctx context.Context, request EngineRequest, predicate Predicate) (eval.ImageVerifyEngineResponse, []jsonpatch.JsonPatchOperation, error) {
 	var response eval.ImageVerifyEngineResponse
 	// load objects
@@ -249,12 +252,13 @@ func (e *engineImpl) handleMutation(
 		}
 		polPatches, err := compiled.MutateDigest(ctx, ictx, attr, request, namespace, resource, e.configuration)
 		if err != nil {
-			// Digest pinning is best effort: record the failure as a policy result and
-			// carry on with the remaining policies rather than failing the admission
-			// request. This mirrors ClusterPolicy, where a failing handleMutateDigest
-			// appends a RuleError and continues (pkg/engine/internal/imageverifier.go).
-			// Whether the resource is admitted is decided by the validating webhook,
-			// which evaluates the same policy and reports the error against it.
+			// Record the failure as a policy result and carry on with the remaining
+			// policies rather than returning an error, which would abandon their
+			// patches and deny with an unattributed message. This mirrors
+			// ClusterPolicy, where a failing handleMutateDigest appends a RuleError
+			// and continues (pkg/engine/internal/imageverifier.go). The webhook
+			// handler turns this result into a denial when the policy's
+			// validationActions include Deny.
 			logging.WithName("ivpol/mutateDigest").Error(err, "failed to update digest",
 				"policy", ivpol.Policy.GetName())
 			responses = append(responses, eval.ImageVerifyPolicyResponse{
@@ -263,7 +267,8 @@ func (e *engineImpl) handleMutation(
 				Exceptions: ivpol.Exceptions,
 				Result:     *engineapi.RuleError("mutateDigest", engineapi.ImageVerify, "failed to update digest", err, nil),
 			})
-			continue
+			// deliberately no continue: MutateDigest resolves each image on its own, so
+			// the images it did pin keep their patch even though another one failed
 		}
 		for _, p := range polPatches {
 			if seen[p.Path] {

--- a/pkg/cel/policies/ivpol/engine/engine.go
+++ b/pkg/cel/policies/ivpol/engine/engine.go
@@ -14,6 +14,7 @@ import (
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
 	eval "github.com/kyverno/kyverno/pkg/image/verification/evaluator"
+	"github.com/kyverno/kyverno/pkg/logging"
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	"github.com/kyverno/sdk/extensions/imagedataloader"
 	"golang.org/x/exp/maps"
@@ -143,6 +144,12 @@ func (e *engineImpl) HandleValidating(ctx context.Context, request EngineRequest
 // request, it pins the tag of images matched by the policy's
 // matchImageReferences to their resolved digest. No signature or
 // attestation verification is performed here.
+//
+// Digest pinning is best effort and never blocks admission on its own. A
+// policy whose digests cannot be resolved yields an error result rather than
+// an error return, so the remaining policies still get their patches and the
+// admission decision is left to the validating webhook, which evaluates the
+// same policies and attributes any failure to them.
 func (e *engineImpl) HandleMutating(ctx context.Context, request EngineRequest, predicate Predicate) (eval.ImageVerifyEngineResponse, []jsonpatch.JsonPatchOperation, error) {
 	var response eval.ImageVerifyEngineResponse
 	// load objects
@@ -195,10 +202,11 @@ func (e *engineImpl) HandleMutating(ctx context.Context, request EngineRequest, 
 	} else {
 		relevant = policies
 	}
-	patches, err := e.handleMutation(ctx, relevant, attr, &request.Request, namespace, *response.Resource, request.Context)
+	patches, responses, err := e.handleMutation(ctx, relevant, attr, &request.Request, namespace, *response.Resource, request.Context)
 	if err != nil {
 		return response, nil, err
 	}
+	response.Policies = append(response.Policies, responses...)
 	return response, patches, nil
 }
 
@@ -210,16 +218,17 @@ func (e *engineImpl) handleMutation(
 	namespace runtime.Object,
 	resource unstructured.Unstructured,
 	libctx libs.Context,
-) ([]jsonpatch.JsonPatchOperation, error) {
+) ([]jsonpatch.JsonPatchOperation, []eval.ImageVerifyPolicyResponse, error) {
 	// leave remote and name options blank, each compiled policy will provide
 	// its own credentials or the default global ones.
 	ictx, err := imagedataloader.NewImageContext(e.lister, nil, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	c := eval.NewCompiler(ictx, e.lister, request.RequestResource, imageverifycache.DisabledImageVerifyCache())
 
 	var patches []jsonpatch.JsonPatchOperation
+	var responses []eval.ImageVerifyPolicyResponse
 	seen := map[string]bool{}
 	for _, ivpol := range policies {
 		validationCfg := ivpol.Policy.GetSpec().ValidationConfigurations
@@ -228,7 +237,7 @@ func (e *engineImpl) handleMutation(
 		}
 		matches, err := e.matchPolicy(ivpol, attr, namespace)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if !matches {
 			continue
@@ -240,7 +249,21 @@ func (e *engineImpl) handleMutation(
 		}
 		polPatches, err := compiled.MutateDigest(ctx, ictx, attr, request, namespace, resource, e.configuration)
 		if err != nil {
-			return nil, err
+			// Digest pinning is best effort: record the failure as a policy result and
+			// carry on with the remaining policies rather than failing the admission
+			// request. This mirrors ClusterPolicy, where a failing handleMutateDigest
+			// appends a RuleError and continues (pkg/engine/internal/imageverifier.go).
+			// Whether the resource is admitted is decided by the validating webhook,
+			// which evaluates the same policy and reports the error against it.
+			logging.WithName("ivpol/mutateDigest").Error(err, "failed to update digest",
+				"policy", ivpol.Policy.GetName())
+			responses = append(responses, eval.ImageVerifyPolicyResponse{
+				Policy:     ivpol.Policy,
+				Actions:    ivpol.Actions,
+				Exceptions: ivpol.Exceptions,
+				Result:     *engineapi.RuleError("mutateDigest", engineapi.ImageVerify, "failed to update digest", err, nil),
+			})
+			continue
 		}
 		for _, p := range polPatches {
 			if seen[p.Path] {
@@ -250,7 +273,7 @@ func (e *engineImpl) handleMutation(
 			patches = append(patches, p)
 		}
 	}
-	return patches, nil
+	return patches, responses, nil
 }
 
 func (e *engineImpl) matchPolicy(policy Policy, attr admission.Attributes, namespace runtime.Object) (bool, error) {

--- a/pkg/cel/policies/ivpol/engine/engine_test.go
+++ b/pkg/cel/policies/ivpol/engine/engine_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/cel/engine"
 	"github.com/kyverno/kyverno/pkg/cel/libs"
 	"github.com/kyverno/kyverno/pkg/cel/matching"
+	"github.com/kyverno/kyverno/pkg/config"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/admission/v1"
@@ -162,7 +163,7 @@ func Test_ImageVerifyEngine_MutatingPinsDigest(t *testing.T) {
 		},
 		Context: libs.NewFakeContextProvider(),
 	}
-	engine := NewEngine(ProviderFunc(providerFunc), nsResolver, matching.NewMatcher(), nil, nil)
+	engine := NewEngine(ProviderFunc(providerFunc), nsResolver, matching.NewMatcher(), nil, nil, config.NewDefaultConfiguration(false))
 
 	resp, patches, err := engine.HandleMutating(context.Background(), engineRequest, nil)
 	assert.NoError(t, err)
@@ -199,7 +200,7 @@ func Test_ImageVerifyEngine_MutatingDisabled(t *testing.T) {
 		},
 		Context: libs.NewFakeContextProvider(),
 	}
-	engine := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil)
+	engine := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil, config.NewDefaultConfiguration(false))
 
 	resp, patches, err := engine.HandleMutating(context.Background(), engineRequest, nil)
 	assert.NoError(t, err)
@@ -261,7 +262,7 @@ func TestHandleValidatingDoesNotTrustImageVerificationOutcomesAnnotation(t *test
 		},
 		Context: libs.NewFakeContextProvider(),
 	}
-	eng := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil)
+	eng := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil, config.NewDefaultConfiguration(false))
 	resp, err := eng.HandleValidating(context.Background(), engineRequest, nil)
 	assert.NoError(t, err)
 	if assert.Len(t, resp.Policies, 1) {
@@ -314,7 +315,7 @@ func TestHandleValidatingDoesNotRequireOutcomeAnnotation(t *testing.T) {
 		},
 		Context: libs.NewFakeContextProvider(),
 	}
-	eng := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil)
+	eng := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil, config.NewDefaultConfiguration(false))
 	resp, err := eng.HandleValidating(context.Background(), engineRequest, nil)
 	assert.NoError(t, err)
 	if assert.Len(t, resp.Policies, 1) {
@@ -377,7 +378,7 @@ func TestHandleValidatingEphemeralContainersSubresourceIsEvaluated(t *testing.T)
 		},
 		Context: libs.NewFakeContextProvider(),
 	}
-	eng := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil)
+	eng := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil, config.NewDefaultConfiguration(false))
 	resp, err := eng.HandleValidating(context.Background(), engineRequest, nil)
 	assert.NoError(t, err)
 	if assert.Len(t, resp.Policies, 1) {

--- a/pkg/cel/policies/ivpol/engine/engine_test.go
+++ b/pkg/cel/policies/ivpol/engine/engine_test.go
@@ -208,6 +208,45 @@ func Test_ImageVerifyEngine_MutatingDisabled(t *testing.T) {
 	assert.Empty(t, patches)
 }
 
+// A malformed image reference must not cause the mutating webhook to deny the request.
+// Digest pinning is best effort: the failure is recorded as a policy result and the
+// admission decision is left to the validating webhook. Mirrors ClusterPolicy, where a
+// failing handleMutateDigest appends a RuleError instead of returning an error.
+func Test_ImageVerifyEngine_MutatingMalformedImageDoesNotFail(t *testing.T) {
+	badPod := `{
+	"apiVersion": "v1",
+	"kind": "Pod",
+	"metadata": {"name": "test-pod", "namespace": ""},
+	"spec": {
+	   "containers": [{"name": "nginx", "image": "ghcr.io/kyverno/test-verify-image::signed"}]
+	}
+ }
+`
+	engineRequest := engine.EngineRequest{
+		Request: v1.AdmissionRequest{
+			Operation: v1.Create,
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Resource:  metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			Object: apiruntime.RawExtension{
+				Raw: []byte(badPod),
+			},
+			RequestResource: &metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+		},
+		Context: libs.NewFakeContextProvider(),
+	}
+	engine := NewEngine(ProviderFunc(providerFunc), nsResolver, matching.NewMatcher(), nil, nil, config.NewDefaultConfiguration(false))
+
+	resp, patches, err := engine.HandleMutating(context.Background(), engineRequest, nil)
+	assert.NoError(t, err)
+	assert.Empty(t, patches)
+	// the failure is surfaced as an error result attributed to the policy, not swallowed
+	if assert.Len(t, resp.Policies, 1) {
+		assert.Equal(t, ivpol.GetName(), resp.Policies[0].Policy.GetName())
+		assert.Equal(t, engineapi.RuleStatusError, resp.Policies[0].Result.Status())
+		assert.Contains(t, resp.Policies[0].Result.Message(), "failed to update digest")
+	}
+}
+
 func TestHandleValidatingDoesNotTrustImageVerificationOutcomesAnnotation(t *testing.T) {
 	policy := &policiesv1beta1.ImageValidatingPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "ivpol-forged-annotation"},

--- a/pkg/cel/policies/ivpol/engine/engine_test.go
+++ b/pkg/cel/policies/ivpol/engine/engine_test.go
@@ -149,7 +149,7 @@ uOKpF5rWAruB5PCIrquamOejpXV9aQA/K2JQDuc0mcKz
 `
 )
 
-func Test_ImageVerifyEngine_MutatingNoOp(t *testing.T) {
+func Test_ImageVerifyEngine_MutatingPinsDigest(t *testing.T) {
 	engineRequest := engine.EngineRequest{
 		Request: v1.AdmissionRequest{
 			Operation: v1.Create,
@@ -163,6 +163,43 @@ func Test_ImageVerifyEngine_MutatingNoOp(t *testing.T) {
 		Context: libs.NewFakeContextProvider(),
 	}
 	engine := NewEngine(ProviderFunc(providerFunc), nsResolver, matching.NewMatcher(), nil, nil)
+
+	resp, patches, err := engine.HandleMutating(context.Background(), engineRequest, nil)
+	assert.NoError(t, err)
+	assert.Empty(t, resp.Policies)
+	if assert.Len(t, patches, 1) {
+		assert.Equal(t, "replace", patches[0].Operation)
+		assert.Equal(t, "/spec/containers/0/image", patches[0].Path)
+		assert.Equal(t, signedImage, patches[0].Value.(string)[:len(signedImage)])
+		assert.Contains(t, patches[0].Value, "@sha256:")
+	}
+}
+
+func Test_ImageVerifyEngine_MutatingDisabled(t *testing.T) {
+	falseVal := false
+	disabledIvpol := ivpol.DeepCopy()
+	disabledIvpol.Spec.ValidationConfigurations.MutateDigest = &falseVal
+	provider := ProviderFunc(func(context.Context) ([]Policy, error) {
+		return []Policy{
+			{
+				Policy:  disabledIvpol,
+				Actions: sets.Set[admissionregistrationv1.ValidationAction]{admissionregistrationv1.Deny: sets.Empty{}},
+			},
+		}, nil
+	})
+	engineRequest := engine.EngineRequest{
+		Request: v1.AdmissionRequest{
+			Operation: v1.Create,
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Resource:  metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			Object: apiruntime.RawExtension{
+				Raw: []byte(pod),
+			},
+			RequestResource: &metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+		},
+		Context: libs.NewFakeContextProvider(),
+	}
+	engine := NewEngine(provider, nsResolver, matching.NewMatcher(), nil, nil)
 
 	resp, patches, err := engine.HandleMutating(context.Background(), engineRequest, nil)
 	assert.NoError(t, err)

--- a/pkg/cel/policies/ivpol/engine/engine_test.go
+++ b/pkg/cel/policies/ivpol/engine/engine_test.go
@@ -208,11 +208,12 @@ func Test_ImageVerifyEngine_MutatingDisabled(t *testing.T) {
 	assert.Empty(t, patches)
 }
 
-// A malformed image reference must not cause the mutating webhook to deny the request.
-// Digest pinning is best effort: the failure is recorded as a policy result and the
-// admission decision is left to the validating webhook. Mirrors ClusterPolicy, where a
-// failing handleMutateDigest appends a RuleError instead of returning an error.
-func Test_ImageVerifyEngine_MutatingMalformedImageDoesNotFail(t *testing.T) {
+// A malformed image reference is recorded as an error result against the policy rather than
+// returned as an error from the engine, so the remaining policies still contribute their
+// patches. Mirrors ClusterPolicy, where a failing handleMutateDigest appends a RuleError and
+// continues. Turning that result into a denial is the webhook handler's job (see
+// mutationResponse), which is why the engine itself returns no error here.
+func Test_ImageVerifyEngine_MutatingMalformedImageIsRecordedAsPolicyError(t *testing.T) {
 	badPod := `{
 	"apiVersion": "v1",
 	"kind": "Pod",

--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -292,6 +292,7 @@ func (s *scanner) ScanResource(
 				matching.NewMatcher(),
 				s.secretLister,
 				imageverifycache.DisabledImageVerifyCache(),
+				s.config,
 			), metrics.BackgroundScan)
 			request := celengine.Request(
 				libs.GetLibsCtx(),

--- a/pkg/controllers/webhook/controller.go
+++ b/pkg/controllers/webhook/controller.go
@@ -1564,8 +1564,15 @@ func (c *controller) getNamespacedImageValidatingPolicies() ([]engineapi.Generic
 }
 
 // ivpolsNeedingMutation filters ivpol/nivpol policies to those that actually
-// require a mutating webhook (i.e. MutateDigest or VerifyDigest is enabled).
-// Both fields default to true when nil, so an unset spec always qualifies.
+// require a mutating webhook, i.e. those with MutateDigest enabled (it defaults
+// to true when nil, so an unset spec always qualifies).
+//
+// VerifyDigest is deliberately not considered here: digest pinning is the only
+// mutation the ivpol mutating webhook performs. Asserting that an image carries
+// a digest is a validation concern handled by the validating webhook (mirroring
+// v1, where VerifyDigest is enforced in the validate_image handler), so a policy
+// with mutateDigest disabled and verifyDigest enabled would otherwise get a
+// mutating webhook that can never produce a patch.
 func ivpolsNeedingMutation(policies []engineapi.GenericPolicy) []engineapi.GenericPolicy {
 	result := make([]engineapi.GenericPolicy, 0, len(policies))
 	for _, p := range policies {
@@ -1574,9 +1581,7 @@ func ivpolsNeedingMutation(policies []engineapi.GenericPolicy) []engineapi.Gener
 			continue
 		}
 		spec := ivpol.GetSpec()
-		mutateDigest := spec.ValidationConfigurations.MutateDigest == nil || *spec.ValidationConfigurations.MutateDigest
-		verifyDigest := spec.ValidationConfigurations.VerifyDigest == nil || *spec.ValidationConfigurations.VerifyDigest
-		if mutateDigest || verifyDigest {
+		if spec.ValidationConfigurations.MutateDigest == nil || *spec.ValidationConfigurations.MutateDigest {
 			result = append(result, p)
 		}
 	}

--- a/pkg/controllers/webhook/utils_test.go
+++ b/pkg/controllers/webhook/utils_test.go
@@ -933,13 +933,30 @@ func TestIvpolsNeedingMutation(t *testing.T) {
 			expectedCount: 1,
 		},
 		{
-			name: "VerifyDigest true -- needs mutation",
+			// VerifyDigest is a validation concern (the validating webhook asserts the
+			// image carries a digest); it never requires a mutating webhook, which can
+			// only ever pin digests.
+			name: "VerifyDigest true but MutateDigest false -- does not need mutation",
 			ivpols: []engineapi.GenericPolicy{
 				engineapi.NewImageValidatingPolicy(&policiesv1beta1.ImageValidatingPolicy{
 					Spec: policiesv1beta1.ImageValidatingPolicySpec{
 						ValidationConfigurations: policiesv1alpha1.ValidationConfiguration{
 							MutateDigest: &falseVal,
 							VerifyDigest: &trueVal,
+						},
+					},
+				}),
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "nil MutateDigest defaults to true even when VerifyDigest is false -- needs mutation",
+			ivpols: []engineapi.GenericPolicy{
+				engineapi.NewImageValidatingPolicy(&policiesv1beta1.ImageValidatingPolicy{
+					Spec: policiesv1beta1.ImageValidatingPolicySpec{
+						ValidationConfigurations: policiesv1alpha1.ValidationConfiguration{
+							MutateDigest: nil,
+							VerifyDigest: &falseVal,
 						},
 					},
 				}),

--- a/pkg/image/verification/evaluator/policy.go
+++ b/pkg/image/verification/evaluator/policy.go
@@ -14,13 +14,16 @@ import (
 	engine "github.com/kyverno/kyverno/pkg/cel/compiler"
 	"github.com/kyverno/kyverno/pkg/cel/libs"
 	"github.com/kyverno/kyverno/pkg/cel/matching"
+	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/image/verification/variables"
+	apiutils "github.com/kyverno/kyverno/pkg/utils/api"
 	"github.com/kyverno/sdk/extensions/cel/libs/globalcontext"
 	"github.com/kyverno/sdk/extensions/cel/libs/imagedata"
 	"github.com/kyverno/sdk/extensions/cel/libs/resource"
 	"github.com/kyverno/sdk/extensions/cel/utils"
 	"github.com/kyverno/sdk/extensions/imagedataloader"
 	"go.uber.org/multierr"
+	"gomodules.xyz/jsonpatch/v2"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,6 +42,7 @@ type EvaluationResult struct {
 
 type CompiledPolicy interface {
 	Evaluate(context.Context, imagedataloader.ImageContext, admission.Attributes, interface{}, runtime.Object, bool, libs.Context) (*EvaluationResult, error)
+	MutateDigest(context.Context, imagedataloader.ImageContext, admission.Attributes, interface{}, runtime.Object, unstructured.Unstructured, config.Configuration) ([]jsonpatch.JsonPatchOperation, error)
 }
 
 type compiledPolicy struct {
@@ -202,6 +206,73 @@ func (c *compiledPolicy) Evaluate(ctx context.Context, ictx imagedataloader.Imag
 		return nil, err
 	}
 	return &EvaluationResult{Result: true, AuditAnnotations: auditAnnotations}, nil
+}
+
+// MutateDigest pins the tag of every image matched by the policy's matchImageReferences
+// to its resolved digest, provided the image does not already carry a digest. It only
+// applies to images extracted from well-known container fields (containers, initContainers,
+// ephemeralContainers) of the resource, mirroring the built-in CEL image extractors.
+func (c *compiledPolicy) MutateDigest(
+	ctx context.Context,
+	ictx imagedataloader.ImageContext,
+	attr admission.Attributes,
+	request interface{},
+	namespace runtime.Object,
+	resource unstructured.Unstructured,
+	cfg config.Configuration,
+) ([]jsonpatch.JsonPatchOperation, error) {
+	matched, err := c.match(ctx, attr, request, namespace, c.matchConditions)
+	if err != nil {
+		return nil, err
+	}
+	if !matched {
+		return nil, nil
+	}
+	// skip mutation if the resource matches an exception; the validating webhook
+	// will skip the corresponding validation for the same resource
+	for _, polex := range c.exceptions {
+		match, err := c.match(ctx, attr, request, namespace, polex.MatchConditions)
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			return nil, nil
+		}
+	}
+
+	// images are extracted from the well-known container fields directly (rather than
+	// through the policy's CEL image extractors) because we need the JSON pointer to the
+	// image reference within the resource in order to build a patch
+	imagesByCategory, err := apiutils.ExtractImagesFromResource(resource, nil, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var patches []jsonpatch.JsonPatchOperation
+	for _, infos := range imagesByCategory {
+		for _, info := range infos {
+			if info.Digest != "" {
+				// already pinned to a digest, nothing to do
+				continue
+			}
+			image := info.String()
+			if apply, err := matching.MatchImage(image, c.matchImageReferences...); err != nil {
+				return nil, err
+			} else if !apply {
+				continue
+			}
+			data, err := ictx.Get(ctx, image, c.authOpts, c.nameOpts)
+			if err != nil {
+				return nil, err
+			}
+			patches = append(patches, jsonpatch.JsonPatchOperation{
+				Operation: "replace",
+				Path:      info.Pointer,
+				Value:     image + "@" + data.Digest,
+			})
+		}
+	}
+	return patches, nil
 }
 
 func (c *compiledPolicy) evaluateAuditAnnotations(ctx context.Context, data map[string]any) (map[string]string, error) {

--- a/pkg/image/verification/evaluator/policy.go
+++ b/pkg/image/verification/evaluator/policy.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/cel/matching"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/image/verification/variables"
-	"github.com/kyverno/kyverno/pkg/logging"
 	apiutils "github.com/kyverno/kyverno/pkg/utils/api"
 	"github.com/kyverno/sdk/extensions/cel/libs/globalcontext"
 	"github.com/kyverno/sdk/extensions/cel/libs/imagedata"
@@ -213,6 +212,14 @@ func (c *compiledPolicy) Evaluate(ctx context.Context, ictx imagedataloader.Imag
 // to its resolved digest, provided the image does not already carry a digest. It only
 // applies to images extracted from well-known container fields (containers, initContainers,
 // ephemeralContainers) of the resource, mirroring the built-in CEL image extractors.
+//
+// An image that cannot be resolved is an error, not a silent skip: the caller records it
+// against the policy and the webhook denies the request when the policy's validationActions
+// include Deny, so an unreachable registry cannot quietly admit an unpinned image.
+//
+// Resolution is per image. The returned patches cover every image that could be pinned even
+// when the returned error is non-nil, so one unresolvable image does not cost the others their
+// digest, matching how ClusterPolicy pins each image independently.
 func (c *compiledPolicy) MutateDigest(
 	ctx context.Context,
 	ictx imagedataloader.ImageContext,
@@ -250,6 +257,7 @@ func (c *compiledPolicy) MutateDigest(
 	}
 
 	var patches []jsonpatch.JsonPatchOperation
+	var errs []error
 	for _, infos := range imagesByCategory {
 		for _, info := range infos {
 			if info.Digest != "" {
@@ -264,13 +272,12 @@ func (c *compiledPolicy) MutateDigest(
 			}
 			data, err := ictx.Get(ctx, image, c.authOpts, c.nameOpts)
 			if err != nil {
-				// mutation is best-effort digest pinning, not verification: if the image
-				// can't be resolved (unreachable registry, bad reference, ...) skip the
-				// patch instead of failing the whole (potentially unrelated) admission
-				// request. The validating webhook still runs signature/attestation
-				// verification against the original tag and will deny/audit as configured
-				// if the image truly can't be resolved.
-				logging.WithName("ivpol/mutateDigest").Error(err, "failed to resolve image digest, skipping mutation", "image", image)
+				// Record the failure and carry on: an image that cannot be resolved must not
+				// cost the images that can their digest. ClusterPolicy pins each image
+				// independently for the same reason, appending a RuleError for the one it
+				// could not resolve while keeping the patches for the rest
+				// (pkg/engine/internal/imageverifier.go).
+				errs = append(errs, fmt.Errorf("failed to resolve digest for image %s: %w", image, err))
 				continue
 			}
 			patches = append(patches, jsonpatch.JsonPatchOperation{
@@ -280,7 +287,7 @@ func (c *compiledPolicy) MutateDigest(
 			})
 		}
 	}
-	return patches, nil
+	return patches, multierr.Combine(errs...)
 }
 
 func (c *compiledPolicy) evaluateAuditAnnotations(ctx context.Context, data map[string]any) (map[string]string, error) {

--- a/pkg/image/verification/evaluator/policy.go
+++ b/pkg/image/verification/evaluator/policy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/cel/matching"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/image/verification/variables"
+	"github.com/kyverno/kyverno/pkg/logging"
 	apiutils "github.com/kyverno/kyverno/pkg/utils/api"
 	"github.com/kyverno/sdk/extensions/cel/libs/globalcontext"
 	"github.com/kyverno/sdk/extensions/cel/libs/imagedata"
@@ -263,7 +264,14 @@ func (c *compiledPolicy) MutateDigest(
 			}
 			data, err := ictx.Get(ctx, image, c.authOpts, c.nameOpts)
 			if err != nil {
-				return nil, err
+				// mutation is best-effort digest pinning, not verification: if the image
+				// can't be resolved (unreachable registry, bad reference, ...) skip the
+				// patch instead of failing the whole (potentially unrelated) admission
+				// request. The validating webhook still runs signature/attestation
+				// verification against the original tag and will deny/audit as configured
+				// if the image truly can't be resolved.
+				logging.WithName("ivpol/mutateDigest").Error(err, "failed to resolve image digest, skipping mutation", "image", image)
+				continue
 			}
 			patches = append(patches, jsonpatch.JsonPatchOperation{
 				Operation: "replace",

--- a/pkg/webhooks/resource/ivpol/handler.go
+++ b/pkg/webhooks/resource/ivpol/handler.go
@@ -84,7 +84,9 @@ func (h *handler) mutate(ctx context.Context, admissionRequest handlers.Admissio
 		return admissionutils.Response(admissionRequest.UID, err)
 	}
 	rawPatches := jsonutils.JoinPatches(patch.ConvertPatches(patches...)...)
-	return h.mutationResponse(request, response, rawPatches)
+	admissionResponse := h.mutationResponse(request, response, rawPatches)
+	h.mutationEvents(ctx, response, !admissionResponse.Allowed)
+	return admissionResponse
 }
 
 // ValidateClustered serves the /ivpol/validate route, so it only evaluates cluster scoped policies.
@@ -115,8 +117,18 @@ func (h *handler) validate(ctx context.Context, logger logr.Logger, admissionReq
 }
 
 func (h *handler) mutationResponse(request celengine.EngineRequest, response eval.ImageVerifyEngineResponse, rawPatches []byte) handlers.AdmissionResponse {
+	var errs []error
 	var warnings []string
 	for _, policy := range response.Policies {
+		if policy.Actions.Has(admissionregistrationv1.Deny) {
+			switch policy.Result.Status() {
+			case engineapi.RuleStatusFail:
+				errs = append(errs, fmt.Errorf("Policy %s failed: %s", policy.Policy.GetName(), policy.Result.Message()))
+			case engineapi.RuleStatusError:
+				errs = append(errs, fmt.Errorf("Policy %s error: %s", policy.Policy.GetName(), policy.Result.Message()))
+			}
+		}
+
 		if policy.Actions.Has(admissionregistrationv1.Warn) {
 			switch policy.Result.Status() {
 			case engineapi.RuleStatusFail:
@@ -126,7 +138,37 @@ func (h *handler) mutationResponse(request celengine.EngineRequest, response eva
 			}
 		}
 	}
+	if len(errs) > 0 {
+		return admissionutils.Response(request.AdmissionRequest().UID, multierr.Combine(errs...), warnings...)
+	}
+
 	return admissionutils.MutationResponse(request.AdmissionRequest().UID, rawPatches, warnings...)
+}
+
+// mutationEvents reports digest pinning failures as events against the policy and the resource.
+// Only failures reach it: handleMutation records a policy result solely when a policy errors, so a
+// mutation that pins every image (or has nothing to pin) is silent.
+//
+// Unlike the validating phase this deliberately creates no admission report. When the failure is not
+// blocking, the request carries on to the validating webhook, which evaluates the same policies and
+// reports against them, so reporting here as well would duplicate that. When it is blocking the
+// request is rejected outright and no report is produced, matching ClusterPolicy, which likewise
+// skips handleAudit for a blocked request (pkg/webhooks/resource/imageverification/handler.go).
+func (h *handler) mutationEvents(ctx context.Context, response eval.ImageVerifyEngineResponse, blocked bool) {
+	if len(response.Policies) == 0 || response.Resource == nil {
+		return
+	}
+	responses := make([]engineapi.EngineResponse, 0, len(response.Policies))
+	for _, r := range response.Policies {
+		engineResponse := engineapi.EngineResponse{
+			Resource: *response.Resource,
+			PolicyResponse: engineapi.PolicyResponse{
+				Rules: []engineapi.RuleResponse{r.Result},
+			},
+		}
+		responses = append(responses, engineResponse.WithPolicy(engineapi.NewImageValidatingPolicyFromLike(r.Policy)))
+	}
+	h.admissionEvent(ctx, responses, blocked)
 }
 
 func (h *handler) validationResponse(request celengine.EngineRequest, response eval.ImageVerifyEngineResponse) handlers.AdmissionResponse {

--- a/test/conformance/chainsaw/image-validating-policies/autogen/none/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/autogen/none/policy.yaml
@@ -25,6 +25,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/autogen/none/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/autogen/none/policy.yaml
@@ -23,6 +23,8 @@ spec:
         has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/autogen/should-not-autogen/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/autogen/should-not-autogen/policy.yaml
@@ -26,6 +26,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/autogen/should-not-autogen/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/autogen/should-not-autogen/policy.yaml
@@ -24,6 +24,8 @@ spec:
         has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/context/imagedata/imagereference/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/context/imagedata/imagereference/policy.yaml
@@ -24,6 +24,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/context/imagedata/imagereference/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/context/imagedata/imagereference/policy.yaml
@@ -22,6 +22,8 @@ spec:
         Deployment must be have images from ghcr and images should be tagged
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/context/resource/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/context/resource/policy.yaml
@@ -27,6 +27,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/context/resource/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/context/resource/policy.yaml
@@ -25,6 +25,8 @@ spec:
         Deployment labels must be env=prod
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/exceptions/regular/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/exceptions/regular/policy.yaml
@@ -22,6 +22,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/exceptions/regular/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/exceptions/regular/policy.yaml
@@ -20,6 +20,8 @@ spec:
         has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/exceptions/wrong-exception/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/exceptions/wrong-exception/policy.yaml
@@ -22,6 +22,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/exceptions/wrong-exception/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/exceptions/wrong-exception/policy.yaml
@@ -20,6 +20,8 @@ spec:
         has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/match-conditions/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/match-conditions/policy.yaml
@@ -22,6 +22,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/match-conditions/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/match-conditions/policy.yaml
@@ -20,6 +20,8 @@ spec:
         has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/mutate-digest-disabled/assert-pod.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/mutate-digest-disabled/assert-pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mutate-digest-disabled-pod
+  namespace: default
+spec:
+  containers:
+    - name: test
+      image: ghcr.io/kyverno/test-verify-image:signed-keyless

--- a/test/conformance/chainsaw/image-validating-policies/mutate-digest-disabled/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/mutate-digest-disabled/chainsaw-test.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-digest-disabled
+spec:
+  concurrent: false
+  steps:
+  - name: create policy
+    use:
+      template: ../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait-image-validating-policy-ready
+    use:
+      template: ../../_step-templates/image-validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: ivpol-mutate-digest-disabled
+  - name: create pod referencing image by tag
+    try:
+    - create:
+        file: pod.yaml
+    - assert:
+        file: assert-pod.yaml

--- a/test/conformance/chainsaw/image-validating-policies/mutate-digest-disabled/pod.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/mutate-digest-disabled/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mutate-digest-disabled-pod
+  namespace: default
+spec:
+  containers:
+    - name: test
+      image: ghcr.io/kyverno/test-verify-image:signed-keyless

--- a/test/conformance/chainsaw/image-validating-policies/mutate-digest-disabled/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/mutate-digest-disabled/policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ImageValidatingPolicy
+metadata:
+  name: ivpol-mutate-digest-disabled
+spec:
+  webhookConfiguration:
+    timeoutSeconds: 20
+  failurePolicy: Fail
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+  matchImageReferences:
+    - glob: ghcr.io/**
+  validationConfigurations:
+    mutateDigest: false
+    verifyDigest: false
+    required: false
+  attestors: []
+  validations:
+    - expression: "true"

--- a/test/conformance/chainsaw/image-validating-policies/mutate-digest/assert-pod.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/mutate-digest/assert-pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mutate-digest-pod
+  namespace: default
+spec:
+  containers:
+    - name: test
+      image: ghcr.io/kyverno/test-verify-image:signed-keyless@sha256:445a99db22e9add9bfb15ddb1980861a329e5dff5c88d7eec9cbf08b6b2f4eb1

--- a/test/conformance/chainsaw/image-validating-policies/mutate-digest/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/mutate-digest/chainsaw-test.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-digest
+spec:
+  concurrent: false
+  steps:
+  - name: create policy
+    use:
+      template: ../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait-image-validating-policy-ready
+    use:
+      template: ../../_step-templates/image-validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: ivpol-mutate-digest
+  - name: create pod referencing image by tag
+    try:
+    - create:
+        file: pod.yaml
+    - assert:
+        file: assert-pod.yaml

--- a/test/conformance/chainsaw/image-validating-policies/mutate-digest/pod.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/mutate-digest/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mutate-digest-pod
+  namespace: default
+spec:
+  containers:
+    - name: test
+      image: ghcr.io/kyverno/test-verify-image:signed-keyless

--- a/test/conformance/chainsaw/image-validating-policies/mutate-digest/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/mutate-digest/policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ImageValidatingPolicy
+metadata:
+  name: ivpol-mutate-digest
+spec:
+  webhookConfiguration:
+    timeoutSeconds: 20
+  failurePolicy: Fail
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+  matchImageReferences:
+    - glob: ghcr.io/**
+  validationConfigurations:
+    mutateDigest: true
+    verifyDigest: false
+    required: false
+  attestors: []
+  validations:
+    - expression: "true"

--- a/test/conformance/chainsaw/image-validating-policies/mutate-then-validate/assert-pod.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/mutate-then-validate/assert-pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mutate-then-validate-pod
+  namespace: default
+spec:
+  containers:
+    - name: test
+      image: ghcr.io/kyverno/test-verify-image:signed-keyless@sha256:445a99db22e9add9bfb15ddb1980861a329e5dff5c88d7eec9cbf08b6b2f4eb1

--- a/test/conformance/chainsaw/image-validating-policies/mutate-then-validate/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/mutate-then-validate/chainsaw-test.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-then-validate
+spec:
+  description: >-
+    Verifies that the object mutated by the ImageValidatingPolicy mutating
+    webhook (tag pinned to a digest via mutateDigest) is the object seen by
+    the validating webhook, not the original request object. The policy's
+    validation expression only passes if the image already contains a
+    digest, so admission succeeding proves the mutated object was passed
+    down to validation, consistent with Kubernetes admission control
+    semantics (all mutating webhooks run and their patches are applied
+    before any validating webhooks are invoked).
+  concurrent: false
+  steps:
+  - name: create policy
+    use:
+      template: ../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait-image-validating-policy-ready
+    use:
+      template: ../../_step-templates/image-validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: ivpol-mutate-then-validate
+  - name: create pod referencing image by tag
+    try:
+    - create:
+        file: pod.yaml
+    - assert:
+        file: assert-pod.yaml

--- a/test/conformance/chainsaw/image-validating-policies/mutate-then-validate/pod.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/mutate-then-validate/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mutate-then-validate-pod
+  namespace: default
+spec:
+  containers:
+    - name: test
+      image: ghcr.io/kyverno/test-verify-image:signed-keyless

--- a/test/conformance/chainsaw/image-validating-policies/mutate-then-validate/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/mutate-then-validate/policy.yaml
@@ -1,0 +1,31 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ImageValidatingPolicy
+metadata:
+  name: ivpol-mutate-then-validate
+spec:
+  webhookConfiguration:
+    timeoutSeconds: 20
+  failurePolicy: Fail
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+  matchImageReferences:
+    - glob: ghcr.io/**
+  validationConfigurations:
+    mutateDigest: true
+    verifyDigest: false
+    required: false
+  attestors: []
+  validations:
+    # this validation only passes if the image reference already contains a
+    # digest, proving the validating webhook receives the object *after* the
+    # mutating webhook has pinned the tag to a digest, not the original
+    # tag-only reference submitted by the client.
+    - expression: >-
+        images.containers.map(image, image.contains('@sha256:')).all(e, e)
+      message: image must already be pinned to a digest by the mutating webhook

--- a/test/conformance/chainsaw/image-validating-policies/report/admission/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/report/admission/policy.yaml
@@ -34,6 +34,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/report/admission/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/report/admission/policy.yaml
@@ -32,6 +32,8 @@ spec:
   failurePolicy: Ignore
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/report/background/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/report/background/policy.yaml
@@ -35,6 +35,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/report/background/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/report/background/policy.yaml
@@ -33,6 +33,8 @@ spec:
   failurePolicy: Ignore
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/report/with-exception/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/report/with-exception/policy.yaml
@@ -35,6 +35,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/report/with-exception/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/report/with-exception/policy.yaml
@@ -33,6 +33,8 @@ spec:
   failurePolicy: Ignore
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/security/forged-verification-annotation/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/security/forged-verification-annotation/policy.yaml
@@ -15,6 +15,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/security/forged-verification-annotation/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/security/forged-verification-annotation/policy.yaml
@@ -13,6 +13,8 @@ spec:
         resources: ["pods"]
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/standard/notary-basic/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/standard/notary-basic/policy.yaml
@@ -22,6 +22,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/standard/notary-basic/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/standard/notary-basic/policy.yaml
@@ -20,6 +20,8 @@ spec:
         has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/standard/notary-configmap-cert/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/standard/notary-configmap-cert/policy.yaml
@@ -26,6 +26,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/standard/notary-configmap-cert/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/standard/notary-configmap-cert/policy.yaml
@@ -24,6 +24,8 @@ spec:
         resource.get("v1", "configmaps", object.metadata.namespace, "keys")
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/subresources/block-ephemeral-containers/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/subresources/block-ephemeral-containers/policy.yaml
@@ -18,6 +18,8 @@ spec:
         resources: ["pods", "pods/ephemeralcontainers"]
   matchImageReferences:
     - glob: "*"
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/subresources/block-ephemeral-containers/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/subresources/block-ephemeral-containers/policy.yaml
@@ -20,6 +20,8 @@ spec:
     - glob: "*"
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/validation-actions/audit/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-actions/audit/policy.yaml
@@ -21,6 +21,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/validation-actions/audit/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-actions/audit/policy.yaml
@@ -19,6 +19,8 @@ spec:
         has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/validation-actions/deny/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-actions/deny/policy.yaml
@@ -21,6 +21,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/validation-actions/deny/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-actions/deny/policy.yaml
@@ -19,6 +19,8 @@ spec:
         has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/validation-actions/none/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-actions/none/policy.yaml
@@ -19,6 +19,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/validation-actions/none/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-actions/none/policy.yaml
@@ -17,6 +17,8 @@ spec:
         has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/validation-actions/warn/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-actions/warn/policy.yaml
@@ -21,6 +21,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/validation-actions/warn/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-actions/warn/policy.yaml
@@ -19,6 +19,8 @@ spec:
         has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/validation-rules/accept/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-rules/accept/policy.yaml
@@ -19,6 +19,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/validation-rules/accept/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-rules/accept/policy.yaml
@@ -17,6 +17,8 @@ spec:
         has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/validation-rules/reject/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-rules/reject/policy.yaml
@@ -19,6 +19,8 @@ spec:
     - glob: ghcr.io/*
   validationConfigurations:
     mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/validation-rules/reject/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/validation-rules/reject/policy.yaml
@@ -17,6 +17,8 @@ spec:
         has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
   attestors:
     - name: notary
       notary:

--- a/test/integration/framework/ivpol.go
+++ b/test/integration/framework/ivpol.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"github.com/kyverno/kyverno/pkg/cel/matching"
 	ivpolengine "github.com/kyverno/kyverno/pkg/cel/policies/ivpol/engine"
+	"github.com/kyverno/kyverno/pkg/config"
 	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
@@ -31,7 +32,7 @@ func NewIvpolEngine(mgr ctrl.Manager, kubeClient kubernetes.Interface) (ivpoleng
 	}
 
 	nsResolver := func(ns string) *corev1.Namespace { return nil }
-	engine := ivpolengine.NewEngine(provider, nsResolver, matching.NewMatcher(), secretLister(kubeClient), imageverifycache.DisabledImageVerifyCache())
+	engine := ivpolengine.NewEngine(provider, nsResolver, matching.NewMatcher(), secretLister(kubeClient), imageverifycache.DisabledImageVerifyCache(), config.NewDefaultConfiguration(false))
 	return engine, provider, nil
 }
 
@@ -47,6 +48,6 @@ func NewIvpolEngineWithExceptions(mgr ctrl.Manager, kubeClient kubernetes.Interf
 	}
 
 	nsResolver := func(ns string) *corev1.Namespace { return nil }
-	engine := ivpolengine.NewEngine(provider, nsResolver, matching.NewMatcher(), secretLister(kubeClient), imageverifycache.DisabledImageVerifyCache())
+	engine := ivpolengine.NewEngine(provider, nsResolver, matching.NewMatcher(), secretLister(kubeClient), imageverifycache.DisabledImageVerifyCache(), config.NewDefaultConfiguration(false))
 	return engine, provider, nil
 }

--- a/test/integration/ivpol/handler_test.go
+++ b/test/integration/ivpol/handler_test.go
@@ -5,6 +5,7 @@ package ivpol_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"github.com/kyverno/kyverno/test/integration/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -192,6 +194,41 @@ func podRawWithImage(t *testing.T, name, namespace, image string) []byte {
 	return raw
 }
 
+// mutatePodRaw runs the mutating webhook route for an already built pod payload and returns the raw
+// admission response. The mutating route only pins image tags to digests, it never verifies (issue
+// #16336), so the response reflects digest pinning alone.
+func mutatePodRaw(t *testing.T, policyName, podName, namespace string, raw []byte) admissionv1.AdmissionResponse {
+	t.Helper()
+	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
+	ctx := framework.ContextWithPolicies(context.Background(), policyName)
+	return h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest(podName, namespace, raw), "", time.Now())
+}
+
+// mutatePod runs the mutating webhook route for a pod carrying a single image.
+func mutatePod(t *testing.T, policyName, podName, namespace, image string) admissionv1.AdmissionResponse {
+	t.Helper()
+	return mutatePodRaw(t, policyName, podName, namespace, podRawWithImage(t, podName, namespace, image))
+}
+
+// podRawWithImages builds a Pod whose containers run the given images, in order, so a test can mix
+// resolvable and unresolvable references in one resource.
+func podRawWithImages(t *testing.T, name, namespace string, images ...string) []byte {
+	t.Helper()
+	containers := make([]any, 0, len(images))
+	for i, image := range images {
+		containers = append(containers, map[string]any{"name": fmt.Sprintf("app-%d", i), "image": image})
+	}
+	pod := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": name, "namespace": namespace},
+		"spec":       map[string]any{"containers": containers},
+	}
+	raw, err := json.Marshal(pod)
+	require.NoError(t, err)
+	return raw
+}
+
 // TestValidate_UnverifiableImage_FailsClosed is the fail-closed baseline: when an image cannot be
 // verified (it is unsigned, and the hermetic run has no registry egress to complete the check
 // either), a Deny policy refuses the pod rather than admitting it unverified.
@@ -287,21 +324,56 @@ func TestValidate_SameNameClusterAndNamespacedPolicies_DoNotCollide(t *testing.T
 	assert.NotEmpty(t, clusterResp.Warnings, "the cluster Warn policy must surface a warning")
 }
 
-// TestMutate_IsNoOp confirms the mutating webhook no longer verifies images or stamps an outcome
-// annotation (issue #16336): verification moved entirely to the validating phase. Even a pod whose
-// image would fail verification is admitted unchanged, with no patch, by the mutating route.
-func TestMutate_IsNoOp(t *testing.T) {
-	createIvpolWithCleanup(t, newIvpol("mutate-noop"))
-	waitForPolicyReady(t, "mutate-noop", "")
+// TestMutate_UnresolvableImage_Denies covers the fail closed half of digest pinning. The mutating
+// route pins tags to digests, so an image it cannot resolve means the policy's mutateDigest
+// guarantee cannot be honoured. Admitting the pod anyway would leave it running an unpinned tag
+// with no signal, which is the class of silent no-op that issue #16808 was about, so the request is
+// denied when the policy asks for Deny. This matches ClusterPolicy, where a failing
+// handleMutateDigest raises a RuleError that blocks under failurePolicy Fail.
+func TestMutate_UnresolvableImage_Denies(t *testing.T) {
+	createIvpolWithCleanup(t, newIvpol("mutate-unresolvable"))
+	waitForPolicyReady(t, "mutate-unresolvable", "")
 
-	h := ivpol.New(engine, testEnv.ContextProvider, nil, false, &framework.MockEventGen{})
+	resp := mutatePod(t, "mutate-unresolvable", "app", "default", unverifiableImage)
 
-	raw := podRawWithImage(t, "app", "default", unverifiableImage)
-	ctx := framework.ContextWithPolicies(context.Background(), "mutate-noop")
-	resp := h.MutateClustered(ctx, logr.Discard(), framework.PodAdmissionRequest("app", "default", raw), "", time.Now())
+	assert.False(t, resp.Allowed, "an image whose digest cannot be resolved must not be admitted")
+	require.NotNil(t, resp.Result)
+	assert.Contains(t, resp.Result.Message, "failed to update digest",
+		"the denial must be attributed to digest pinning, not to signature verification")
+	assert.Empty(t, resp.Patch, "a denied request must carry no partial patch")
+}
 
-	assert.True(t, resp.Allowed, "the mutating route must admit the pod")
-	assert.Empty(t, resp.Patch, "the mutating route must not patch the pod (no verification, no stamped outcome)")
+// TestMutate_UnresolvableImage_AdmitsWithoutDenyAction is the fail open half: validationActions
+// governs whether a policy blocks, so a policy that only audits or warns must not have its digest
+// pinning failure turned into a denial by the mutating route.
+func TestMutate_UnresolvableImage_AdmitsWithoutDenyAction(t *testing.T) {
+	createIvpolWithCleanup(t, newIvpol("mutate-unresolvable-warn", admissionregistrationv1.Warn))
+	waitForPolicyReady(t, "mutate-unresolvable-warn", "")
+
+	resp := mutatePod(t, "mutate-unresolvable-warn", "app", "default", unverifiableImage)
+
+	assert.True(t, resp.Allowed, "a warn only policy must not block on a digest pinning failure")
+	assert.Empty(t, resp.Patch, "an unresolvable image cannot be pinned, so there is nothing to patch")
+	assert.NotEmpty(t, resp.Warnings, "the failure must still be surfaced as a warning")
+}
+
+// TestMutate_DoesNotVerifyOrStampOutcomeAnnotation guards the invariant from issue #16336: the
+// mutating route pins digests but performs no verification and stamps no image verification outcome
+// annotation for the validating route to trust. The image here can never resolve, so the route
+// cannot have reached a registry; what matters is that the rejection is a digest pinning error and
+// that nothing was written to the pod. The successful pinning counterpart, which proves the patch
+// touches only the image field, lives in the registry tagged tests.
+func TestMutate_DoesNotVerifyOrStampOutcomeAnnotation(t *testing.T) {
+	createIvpolWithCleanup(t, newIvpol("mutate-no-stamp"))
+	waitForPolicyReady(t, "mutate-no-stamp", "")
+
+	resp := mutatePod(t, "mutate-no-stamp", "app", "default", unverifiableImage)
+
+	require.NotNil(t, resp.Result)
+	assert.NotContains(t, resp.Result.Message, "verifyImageSignatures",
+		"the mutating route must not run the policy's verification expressions")
+	assert.Empty(t, resp.Patch,
+		"the mutating route must never stamp an image verification outcome annotation (issue #16336)")
 }
 
 // TestValidate_MatchConditionNotMet_SkipsVerification covers the common "only enforce on production

--- a/test/integration/ivpol/registry_test.go
+++ b/test/integration/ivpol/registry_test.go
@@ -13,6 +13,8 @@ package ivpol_test
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -229,4 +231,68 @@ func TestValidate_NotarySignedImage_Admits(t *testing.T) {
 	allowed, _ := validatePod(t, "notary-signed", "notary-pod", "default", signedImage)
 
 	assert.True(t, allowed, "a notary signed image must be admitted")
+}
+
+// TestMutate_PinsDigestAndStampsNothingElse is the success path of digest pinning, and the reason
+// issue #16808 was filed: mutateDigest defaults to true but the mutating handler used to be a stub,
+// so tags were never pinned. A real image is resolved here and the route must emit exactly one
+// replace patch, targeting the container image field and carrying the resolved digest.
+//
+// The patch is also asserted to be the only one, which is the issue #16336 invariant on the path
+// where mutation actually succeeds: the route must not additionally stamp an image verification
+// outcome annotation for the validating route to trust.
+func TestMutate_PinsDigestAndStampsNothingElse(t *testing.T) {
+	requireImageReachable(t, signedImage)
+
+	createIvpolWithCleanup(t, cosignKeyedPolicy("mutate-pin-digest", cosignPubKey))
+	waitForPolicyReady(t, "mutate-pin-digest", "")
+
+	resp := mutatePod(t, "mutate-pin-digest", "pinned-pod", "default", signedImage)
+	require.True(t, resp.Allowed, "a resolvable image must be admitted by the mutating route")
+	require.NotEmpty(t, resp.Patch, "mutateDigest is enabled, so the tag must be pinned (issue #16808)")
+
+	var patches []map[string]any
+	require.NoError(t, json.Unmarshal(resp.Patch, &patches))
+	require.Len(t, patches, 1, "digest pinning must be the only mutation the route performs")
+
+	assert.Equal(t, "replace", patches[0]["op"])
+	assert.Equal(t, "/spec/containers/0/image", patches[0]["path"],
+		"the patch must target the image field, not an annotation (issue #16336)")
+
+	value, ok := patches[0]["value"].(string)
+	require.True(t, ok, "the patched image must be a string")
+	assert.True(t, strings.HasPrefix(value, signedImage+"@sha256:"),
+		"the image must keep its original reference and gain a digest, got %q", value)
+}
+
+// TestMutate_PinsResolvableImageDespiteUnresolvableOne proves digest pinning is per image. A pod
+// with one resolvable and one unresolvable image still gets the resolvable one pinned: abandoning
+// every patch because a single image could not be resolved would leave images unpinned that the
+// policy was perfectly able to pin. ClusterPolicy resolves each image independently for the same
+// reason. The policy only warns here, so the failure does not block and the partial patch is
+// observable in the response.
+func TestMutate_PinsResolvableImageDespiteUnresolvableOne(t *testing.T) {
+	requireImageReachable(t, signedImage)
+
+	policy := cosignKeyedPolicy("mutate-partial-pin", cosignPubKey)
+	policy.Spec.ValidationAction = []admissionregistrationv1.ValidationAction{admissionregistrationv1.Warn}
+	createIvpolWithCleanup(t, policy)
+	waitForPolicyReady(t, "mutate-partial-pin", "")
+
+	raw := podRawWithImages(t, "partial-pod", "default", signedImage, unverifiableImage)
+	resp := mutatePodRaw(t, "mutate-partial-pin", "partial-pod", "default", raw)
+
+	require.True(t, resp.Allowed, "a warn only policy must not block on a digest pinning failure")
+	assert.NotEmpty(t, resp.Warnings, "the image that could not be resolved must still be reported")
+
+	var patches []map[string]any
+	require.NoError(t, json.Unmarshal(resp.Patch, &patches))
+	require.Len(t, patches, 1, "the resolvable image must still be pinned")
+
+	assert.Equal(t, "/spec/containers/0/image", patches[0]["path"],
+		"only the resolvable container must be patched")
+	value, ok := patches[0]["value"].(string)
+	require.True(t, ok, "the patched image must be a string")
+	assert.True(t, strings.HasPrefix(value, signedImage+"@sha256:"),
+		"the resolvable image must gain a digest, got %q", value)
 }


### PR DESCRIPTION
## Explanation

`ImageValidatingPolicy.spec.validationConfigurations.mutateDigest` is documented as replacing image tags with resolved digests, and defaults to `true`, but the mutating admission webhook handler for `ImageValidatingPolicy` was an unimplemented stub that always returned an empty patch list, so this setting silently had no effect. Users relying on it for supply-chain immutability guarantees got no digest pinning at all. 

This PR implements the mutation so `mutateDigest` actually pins tags to digests, as intended.

## Related issue

Closes #16808

## What type of PR is this

/kind bug

## Proposed Changes

- Added a `MutateDigest` method to the `CompiledPolicy` interface (`pkg/image/verification/evaluator/policy.go`). It reuses the policy's existing match conditions/exceptions/`matchImageReferences`, extracts container images via the pointer-aware `apiutils.ExtractImagesFromResource` (so the exact JSON path can be patched), resolves the digest through the image data loader, and builds a `replace` JSON patch for each unpinned, matching image.
- Implemented `HandleMutating` in `pkg/cel/policies/ivpol/engine/engine.go` (previously a no-op stub): it fetches applicable policies, matches admission constraints the same way `HandleValidating` does, skips any policy with `mutateDigest: false`, compiles matching policies, and aggregates/dedupes the resulting patches.
- Mutation stays scoped to tag -> digest pinning only, no signature/attestation verification is performed in the mutating webhook, consistent with the existing design rationale (avoiding duplicate registry calls / forgeable handoff between mutating and validating webhooks, see #16336).
- Because Kubernetes always sends the mutating webhook's patched object on to subsequent validating webhooks, the digest-pinned image is what the validating webhook's CEL `images.containers` extraction and signature/attestation checks see, verified this manually against a live cluster.
- Updated pre-existing chainsaw fixtures that implicitly relied on the previous (broken) no-op behavior (asserting an unmutated image) to explicitly set `mutateDigest: false`, since they test unrelated behavior and the fix now changes the true default.

### Proof Manifests

```yaml
# ImageValidatingPolicy
apiVersion: policies.kyverno.io/v1beta1
kind: ImageValidatingPolicy
metadata:
  name: ivpol-mutate-digest
spec:
  validationConfigurations:
    mutateDigest: true   # THIS IS THE IMPORTANT PART
    verifyDigest: false
    required: false
  webhookConfiguration:
    timeoutSeconds: 20
  failurePolicy: Fail
  validationActions:
    - Deny
  matchConstraints:
    resourceRules:
      - apiGroups: [""]
        apiVersions: ["v1"]
        operations: ["CREATE"]
        resources: ["pods"]
  matchImageReferences:
    - glob: ghcr.io/**
  attestors: []
  validations:
    - expression: "true"
```

```yaml
# Kubernetes resource (before)
apiVersion: v1
kind: Pod
metadata:
  name: mutate-digest-pod
  namespace: default
spec:
  containers:
    - name: test
      image: ghcr.io/kyverno/test-verify-image:signed-keyless
```

Result after admission (previously left unchanged; now correctly pinned):
```
spec.containers[0].image: ghcr.io/kyverno/test-verify-image:signed-keyless@sha256:445a99db22e9add9bfb15ddb1980861a329e5dff5c88d7eec9cbf08b6b2f4eb1
```

Chainsaw conformance tests added:
- `test/conformance/chainsaw/image-validating-policies/mutate-digest` proves the fix (fails on unfixed `main`, passes with this change).
- `test/conformance/chainsaw/image-validating-policies/mutate-digest-disabled` proves `mutateDigest: false` remains a true no-op.

## Checklist

- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] My PR contains new or altered behavior to Kyverno and CLI support should be added