### PR TITLE
docs: add agent guidance for engine

### DIFF
--- a/pkg/engine/AGENTS.md
+++ b/pkg/engine/AGENTS.md
@@ -1,0 +1,128 @@
+# Engine Agent Guide
+
+This file provides guidance for coding agents working in `pkg/engine/`.
+The repository-level `AGENTS.md` also applies.
+
+## Scope
+
+`pkg/engine` contains the core policy evaluation logic used by Kyverno.
+
+The main engine implementation is created by `NewEngine` in `engine.go` and
+implements the interfaces defined in `pkg/engine/api`.
+
+Primary evaluation entry points include:
+
+- `Validate` — evaluates validation and verify-image checks.
+- `Mutate` — evaluates mutation rules and returns the patched resource.
+- `Generate` — evaluates generate rules.
+- `VerifyAndPatchImages` — evaluates image verification rules that may mutate
+  the resource.
+- `ApplyBackgroundChecks` — evaluates generate and mutate-existing rules for
+  background processing.
+
+## Evaluation Flow
+
+Validation, mutation, and image verification generally follow this flow:
+
+1. Match the policy against the policy context.
+2. Expand applicable rules with `autogen.Default.ComputeRules`.
+3. Select the handler for the rule type.
+4. Call `invokeRuleHandler`.
+5. Match the rule against the resource.
+6. Load rule context.
+7. Evaluate preconditions.
+8. Substitute rule properties.
+9. Resolve policy exceptions.
+10. Process the selected handler.
+11. Collect rule responses and execution statistics.
+
+`invokeRuleHandler` is shared infrastructure for this flow. Changes to it can
+affect multiple rule types.
+
+Generate and background processing use `filterRule` to determine whether
+generate or mutate-existing rules apply. Do not assume they follow the same
+handler path as validation and mutation.
+
+## Important Packages
+
+- `api/` — engine interfaces, policy context, responses, rule status/type, and
+  execution statistics.
+- `context/` — JSON evaluation context and context loading infrastructure.
+- `handlers/validation/` — handlers for validation-related rules.
+- `handlers/mutation/` — handlers for mutation and image mutation.
+- `internal/` — shared internal evaluation helpers.
+- `jmespath/` — JMESPath integration.
+- `mutate/` — mutation and patch processing.
+- `pattern/` — pattern matching.
+- `policycontext/` — policy context implementation and helpers.
+- `utils/` — engine resource/rule matching and related utilities.
+- `validate/` — validation helpers.
+- `variables/` — variable substitution and condition evaluation.
+
+## Context Safety
+
+The policy JSON context is mutable evaluation state.
+
+Evaluation paths use `Checkpoint` and `Restore` to isolate context changes.
+`invokeRuleHandler` also adds a patched resource back to the JSON context so
+subsequent evaluation sees the current resource.
+
+When changing evaluation flow:
+
+- preserve checkpoint/restore boundaries;
+- do not leak rule-specific context into later rule evaluation;
+- verify whether subsequent rules must observe a patched resource;
+- test old-resource behavior for update/delete-related paths when relevant.
+
+## Rule Processing
+
+Rules may be expanded by `autogen.Default.ComputeRules`. A change that appears
+to affect one policy rule can therefore affect generated rules as well.
+
+Respect `spec.applyRules`. Paths using `ApplyOne` may stop processing after an
+applicable rule has produced a result.
+
+Policy exceptions are part of evaluation and must not be bypassed when adding
+new rule-processing paths.
+
+## Making Changes
+
+Prefer the smallest package that owns the behavior.
+
+When changing shared code such as `engine.go`, `internal/`, `api/`, context
+handling, matching, or variable evaluation, inspect callers across the engine
+before changing semantics.
+
+Avoid mixing behavior changes with unrelated refactoring.
+
+Changes to engine API types or interfaces can have callers outside
+`pkg/engine`; search the repository before changing them.
+
+## Testing
+
+Run tests for the package you changed first:
+
+```sh
+go test ./pkg/engine/<package>
+```
+
+For changes to shared engine behavior, run the full engine package tree:
+
+```sh
+go test ./pkg/engine/...
+```
+
+For changes to top-level evaluation behavior, inspect and update the relevant
+tests in `pkg/engine`, including validation, mutation, image verification,
+background processing, and exceptions as applicable.
+
+Before submitting a code change, also follow the repository-level formatting,
+linting, code-generation, and testing requirements in `/AGENTS.md`.
+
+## Generated Files
+
+Do not manually edit generated files.
+
+The repository-level `AGENTS.md` documents generated-code locations and the
+required code-generation commands. Changes to API definitions may require
+regeneration outside this directory.


### PR DESCRIPTION
## Explanation

This PR adds directory-level `AGENTS.md` guidance for `pkg/engine` to help coding agents understand Kyverno's policy engine and make changes with appropriate context.

The guide documents the main engine evaluation entry points and execution flow, important engine packages, JSON context safety, rule processing considerations, testing guidance, and generated-file boundaries.

This is an addition to the repository's existing agent guidance and contributes to the AI-readiness work proposed in #16665.

## Related issue

Related to #16665

## Milestone of this PR

N/A

<!--
Add the milestone label by commenting `/milestone 1.2.3`.
-->

## Documentation (required for features)

This PR does not introduce new or altered user-facing Kyverno behavior, so a documentation PR to the website repository is not required.

## What type of PR is this

/kind documentation

## Proposed Changes

Add `pkg/engine/AGENTS.md` with engine-specific guidance covering:

- the primary policy engine entry points;
- validation, mutation, image verification, generation, and background evaluation flows;
- important packages under `pkg/engine`;
- JSON context checkpoint/restore behavior and context safety;
- autogen, `ApplyOne`, and policy exception considerations;
- guidance for changing shared engine code;
- targeted and full engine test commands;
- generated-file considerations.

The goal is to provide coding agents with localized context for working safely in `pkg/engine` while keeping repository-wide requirements in the root `AGENTS.md`.

### Proof Manifests

Not applicable. This PR is documentation-only and does not change Kyverno runtime or user-facing behavior.

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
- [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This PR is intentionally scoped to `pkg/engine` rather than adding directory-level guidance across multiple subsystems at once. This keeps the guidance focused and reviewable while contributing to the directory-level agent instructions proposed in #16665.