### PR TITLE
fix: correct typos in log messages, CLI help text and comments

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/jp/function/doc.go
+++ b/cmd/cli/kubectl-kyverno/commands/jp/function/doc.go
@@ -3,7 +3,7 @@ package function
 var websiteUrl = `https://kyverno.io/docs/kyverno-cli/usage/jp/`
 
 var description = []string{
-	`Provides function informations.`,
+	`Provides function information.`,
 }
 
 var examples = [][]string{

--- a/pkg/clients/dclient/discovery.go
+++ b/pkg/clients/dclient/discovery.go
@@ -274,7 +274,7 @@ func (c *serverResources) findResources(group, version, kind, subresource string
 		}
 	}
 	resources := map[TopLevelApiDescription]metav1.APIResource{}
-	// first match resouces
+	// first match resources
 	for _, list := range serverGroupsAndResources {
 		gv, err := schema.ParseGroupVersion(list.GroupVersion)
 		if err != nil {

--- a/pkg/controllers/certmanager/controller.go
+++ b/pkg/controllers/certmanager/controller.go
@@ -116,7 +116,7 @@ func (c *controller) ticker(ctx context.Context, logger logr.Logger) {
 						}
 					}
 				} else {
-					logger.Error(err, "falied to list secrets")
+					logger.Error(err, "failed to list secrets")
 				}
 			}
 			{
@@ -128,7 +128,7 @@ func (c *controller) ticker(ctx context.Context, logger logr.Logger) {
 						}
 					}
 				} else {
-					logger.Error(err, "falied to list secrets")
+					logger.Error(err, "failed to list secrets")
 				}
 			}
 		case <-ctx.Done():

--- a/pkg/engine/operator/operator.go
+++ b/pkg/engine/operator/operator.go
@@ -31,7 +31,7 @@ var (
 	NotInRangeRegex = regexp.MustCompile(`^([-|\+]?\d+(?:\.\d+)?[A-Za-z]*)!-([-|\+]?\d+(?:\.\d+)?[A-Za-z]*)$`)
 )
 
-// GetOperatorFromStringPattern parses opeartor from pattern
+// GetOperatorFromStringPattern parses operator from pattern
 func GetOperatorFromStringPattern(pattern string) Operator {
 	if len(pattern) < 2 {
 		return Equal


### PR DESCRIPTION
## Explanation

Fixes four misspellings, three of which are user-visible. No behaviour change.

## Related issue

No existing issue — found while reading the codebase.

## Proposed Changes

**User-visible**

- `pkg/controllers/certmanager/controller.go` — `"falied to list secrets"` → `"failed to list secrets"`, in two log statements. Each sits directly beside a correctly spelled `"failed to enqueue secret"` in the same function, so the intent is unambiguous:

  ```go
  logger.Error(err, "failed to enqueue secret", "name", secret.Name)   // correct
  ...
  logger.Error(err, "falied to list secrets")                          // typo
  ```

- `cmd/cli/kubectl-kyverno/commands/jp/function/doc.go` — `"Provides function informations."` → `"Provides function information."`. "Information" is uncountable. This string is passed to cobra as both `Short` and `Long` in `command.go`, so it is the text printed by `kyverno jp function --help`.

**Comments**

- `pkg/clients/dclient/discovery.go` — `// first match resouces` → `resources`
- `pkg/engine/operator/operator.go` — `parses opeartor from pattern` → `operator`

## Proof Manifests

Not applicable — string and comment changes only, with no policy behaviour to demonstrate. The affected packages build cleanly.

## What type of PR is this

/kind cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling and grammar errors in CLI descriptions, code comments, API documentation, and error messages.
  - Improved the clarity and accuracy of certificate manager error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->