### PR TITLE
fix: report passing CEL deny policies

### DIFF
--- a/pkg/webhooks/resource/ivpol/handler.go
+++ b/pkg/webhooks/resource/ivpol/handler.go
@@ -198,7 +198,7 @@ func (h *handler) validationResponse(request celengine.EngineRequest, response e
 func (h *handler) audit(ctx context.Context, logger logr.Logger, admissionRequest handlers.AdmissionRequest, request celengine.EngineRequest, response eval.ImageVerifyEngineResponse) {
 	blocked := false
 	for _, p := range response.Policies {
-		if p.Actions.Has(admissionregistrationv1.Deny) {
+		if webhookutils.BlockRequestByValidationActions(p.Actions, p.Result) {
 			blocked = true
 			break
 		}

--- a/pkg/webhooks/resource/vpol/handler.go
+++ b/pkg/webhooks/resource/vpol/handler.go
@@ -88,7 +88,7 @@ func (h *handler) validate(ctx context.Context, logger logr.Logger, admissionReq
 func (h *handler) audit(ctx context.Context, logger logr.Logger, admissionRequest handlers.AdmissionRequest, request vpolengine.EngineRequest, response vpolengine.EngineResponse) {
 	blocked := false
 	for _, p := range response.Policies {
-		if p.Actions.Has(admissionregistrationv1.Deny) {
+		if webhookutils.BlockRequestByValidationActions(p.Actions, p.Rules...) {
 			blocked = true
 			break
 		}

--- a/pkg/webhooks/resource/vpol/handler_test.go
+++ b/pkg/webhooks/resource/vpol/handler_test.go
@@ -1,0 +1,79 @@
+package vpol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/kyverno/kyverno/pkg/breaker"
+	celengine "github.com/kyverno/kyverno/pkg/cel/engine"
+	fakeclient "github.com/kyverno/kyverno/pkg/client/clientset/versioned/fake"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/kyverno/kyverno/pkg/event"
+	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
+	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestAuditCreatesReportForPassingDenyPolicy(t *testing.T) {
+	breaker.SetReportsBreaker(breaker.NewBreaker("reports", nil))
+	reportutils.NewReportingConfig([]string{"pass"}, "validate")
+	client := fakeclient.NewSimpleClientset()
+	h := &handler{
+		kyvernoClient:    client,
+		admissionReports: true,
+		eventGen:         event.NewFake(),
+	}
+	resource := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "test",
+				"namespace": "default",
+				"uid":       "resource-uid",
+			},
+		},
+	}
+	policy := &policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy"},
+	}
+	request := admissionv1.AdmissionRequest{
+		UID:       types.UID("request-uid"),
+		Kind:      metav1.GroupVersionKind{Version: "v1", Kind: "Pod"},
+		Resource:  metav1.GroupVersionResource{Version: "v1", Resource: "pods"},
+		Namespace: "default",
+		Name:      "test",
+		Operation: admissionv1.Create,
+	}
+	response := celengine.EngineResponse{
+		Resource: resource,
+		Policies: []celengine.ValidatingPolicyResponse{{
+			Actions: sets.New(admissionregistrationv1.Deny),
+			Policy:  policy,
+			Rules:   []engineapi.RuleResponse{*engineapi.RulePass("test", engineapi.Validation, "passed", nil)},
+		}},
+	}
+
+	h.audit(
+		context.Background(),
+		logr.Discard(),
+		handlers.AdmissionRequest{AdmissionRequest: request},
+		celengine.EngineRequest{Request: request},
+		response,
+	)
+
+	reports, err := client.ReportsV1().EphemeralReports("default").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reports.Items) != 1 {
+		t.Fatalf("expected one admission report for a passing Deny policy, got %d", len(reports.Items))
+	}
+}

--- a/pkg/webhooks/utils/block.go
+++ b/pkg/webhooks/utils/block.go
@@ -9,6 +9,8 @@ import (
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	engineutils "github.com/kyverno/kyverno/pkg/utils/engine"
 	"go.yaml.in/yaml/v3"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func getAction(hasViolations bool, i int) string {
@@ -32,6 +34,21 @@ func BlockRequest(engineResponses []engineapi.EngineResponse, failurePolicy kyve
 		}
 	}
 	log.V(4).Info("allowing admission request")
+	return false
+}
+
+// BlockRequestByValidationActions returns true when a Deny action applies to a
+// failed or errored rule.
+func BlockRequestByValidationActions(actions sets.Set[admissionregistrationv1.ValidationAction], rules ...engineapi.RuleResponse) bool {
+	if !actions.Has(admissionregistrationv1.Deny) {
+		return false
+	}
+	for _, rule := range rules {
+		switch rule.Status() {
+		case engineapi.RuleStatusFail, engineapi.RuleStatusError:
+			return true
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
## Explanation

CEL ValidatingPolicy and ImageValidatingPolicy audit handling treated every policy configured with the `Deny` action as blocked, even when its result passed or skipped. Admission was allowed, but Kyverno suppressed the admission report and generated events with the wrong blocked state.

This is a bug fix restoring consistency between the admission response and its reporting/event side effects.

## Related issue

Closes #16841

This PR remains a draft until maintainers accept and triage the issue.

## Milestone of this PR

Maintainers: please assign the appropriate milestone after triage.

## Documentation (required for features)

This is a bug fix to internal report/event handling. The PR documentation guide lists bug fixes as exempt from user-facing documentation updates.

## What type of PR is this

/kind bug

## Proposed Changes

Before this change:

1. A VPol or IVPol configured with `Deny` passed or skipped evaluation.
2. Admission was correctly allowed.
3. The audit path nevertheless marked the request blocked based only on the action.
4. No admission report was created, and events received the wrong blocked state.

This PR:

- centralizes the validation-action block decision in `BlockRequestByValidationActions`;
- requires both `Deny` and a `fail` or `error` result;
- uses the same decision in the VPol and IVPol audit handlers;
- adds a report-creation regression test for a passing Deny VPol.

After this change, passing and skipped Deny policies remain non-blocking for reporting and events, while failed and errored Deny policies remain blocking.

### Proof Manifests

No YAML proof manifests are included because this change concerns an internal audit-side-effect decision and is covered directly through the fake report client in the unit test. Issue #16841 contains end-user reproduction steps.

## Testing

The regression test was first run against current `main` and failed:

```text
expected one admission report for a passing Deny policy, got 0
```

After the fix:

```console
go test ./pkg/webhooks/resource/vpol -run TestAuditCreatesReportForPassingDenyPolicy -count=1
```

Result:

```text
ok github.com/kyverno/kyverno/pkg/webhooks/resource/vpol
```

Also completed:

- `gofmt` on all changed Go files
- `git diff --check`

A broader local package run was not completed because Go compilation exceeded the timeout in the Windows development environment. Repository Linux CI remains authoritative for the full suite.

## Performance impact

The in-memory status check is negligible and stops at the first `fail` or `error`.

The resulting behavior intentionally restores admission-report creation for passing or skipped Deny policies when admission reports and those statuses are enabled. This adds Kubernetes API writes and short-lived report objects proportional to affected admissions. They follow Kyverno's normal ephemeral aggregation and cleanup lifecycle, but clusters configured to report successful results should account for the intended API and etcd load. No additional report traffic occurs when admission reports are disabled or the result status is excluded from reporting.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the AI Usage Policy. OpenAI Codex assistance is disclosed with an `Assisted-by` commit trailer.
- [x] I have read the PR documentation guide; this bug fix is documentation-exempt.
- [x] This is a bug fix and I have added a unit test that proves the fix is effective.
- [ ] This is a feature and I have added applicable CLI tests.
- [ ] My PR needs to be cherry picked to a specific release branch.
- [ ] My PR contains new functionality requiring separate CLI support.

## Further Comments

The commit retains its DCO `Signed-off-by` trailer and adds:

```text
Assisted-by: OpenAI Codex <noreply@openai.com>
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected validation policy enforcement so requests are blocked only when a policy includes a deny action and a rule fails or returns an error.
  - Prevented passing validation rules with a deny action from incorrectly blocking requests.
  - Ensured admission reports are generated correctly for passing validation policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->