### PR TITLE
fix: parseKinds should return an empty slice for empty array string

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -147,6 +147,9 @@ func parseKinds(in string) []filter {
 	for _, element := range submatchall {
 		element = strings.Trim(element, "[")
 		element = strings.Trim(element, "]")
+		if element == "" {
+			continue
+		}
 		elements := strings.Split(element, ",")
 		if len(elements) == 0 {
 			continue

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -80,10 +80,7 @@ func Test_parseKinds(t *testing.T) {
 		want: []filter{},
 	}, {
 		args: args{"[]"},
-		// TODO: this looks strange
-		want: []filter{
-			{},
-		},
+		want: []filter{},
 	}, {
 		args: args{"[*]"},
 		want: []filter{


### PR DESCRIPTION
## Explanation

This PR fixes a bug in `parseKinds` (`pkg/config/types.go`) where passing an empty array string `"[]"` incorrectly resulted in returning a slice containing a single empty filter `[]filter{{}}` instead of an actual empty slice `[]filter{}`. 

The bug was caused by `strings.Split("", ",")` returning `[]string{""}` (length 1) instead of an empty slice.

## Related issue

Resolves an inline `TODO` in `pkg/config/types_test.go`.

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR DOES NOT contain/add a new or altered behavior to Kyverno. 

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
> /kind bug


## Proposed Changes

- I addded an empty string check in `parseKinds` (`pkg/config/types.go`) after bracket trimming.
- i've pdated the test case in `pkg/config/types_test.go` to expect an empty slice.
- Resolve the `// TODO: this looks strange` comment.

### Proof Manifests

the pr is just solving a very small TODO

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
 
### Further comments
i've tested this small fix locally