### PR TITLE
fix: cloneList sync deletes all targets when one source is deleted

### DIFF
--- a/pkg/background/generate/cleanup.go
+++ b/pkg/background/generate/cleanup.go
@@ -8,8 +8,10 @@ import (
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
 	"github.com/kyverno/kyverno/pkg/background/common"
+	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"go.uber.org/multierr"
+	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -56,6 +58,13 @@ func (c *GenerateController) handleNonPolicyChanges(policy kyvernov1.PolicyInter
 			kyverno.LabelAppManagedBy: kyverno.ValueKyvernoApp,
 		}
 
+		// When a specific clone source is deleted, scope the downstream deletion to
+		// only the target(s) cloned from that source. Otherwise every target sharing
+		// the same trigger would be deleted.
+		if sourceUID := c.deletedCloneSourceUID(ur); sourceUID != "" {
+			labels[common.GenerateSourceUIDLabel] = sourceUID
+		}
+
 		downstreams, err := c.getDownstreams(rule, labels, &ruleContext)
 		if err != nil {
 			return fmt.Errorf("failed to fetch downstream resources: %v", err)
@@ -81,6 +90,27 @@ func (c *GenerateController) handleNonPolicyChanges(policy kyvernov1.PolicyInter
 	}
 
 	return nil
+}
+
+// deletedCloneSourceUID returns the UID of the clone source that triggered this
+// delete request, or an empty string when the request was not caused by a clone
+// source deletion (e.g. a trigger deletion). It is used to scope cloneList
+// downstream cleanup to the target(s) generated from the deleted source only.
+func (c *GenerateController) deletedCloneSourceUID(ur *kyvernov2.UpdateRequest) string {
+	request := ur.Spec.Context.AdmissionRequestInfo.AdmissionRequest
+	if request == nil || request.Operation != admissionv1.Delete {
+		return ""
+	}
+	_, source, err := admissionutils.ExtractResources(nil, *request)
+	if err != nil {
+		c.log.Error(err, "failed to extract the deleted resource from the admission request")
+		return ""
+	}
+	// only clone sources carry the clone-source tag; triggers do not
+	if _, ok := source.GetLabels()[common.GenerateTypeCloneSourceLabel]; !ok {
+		return ""
+	}
+	return string(source.GetUID())
 }
 
 func (c *GenerateController) getDownstreams(rule kyvernov1.Rule, selector map[string]string, ruleContext *kyvernov2.RuleContext) ([]unstructured.Unstructured, error) {

--- a/pkg/background/generate/cleanup_test.go
+++ b/pkg/background/generate/cleanup_test.go
@@ -2,12 +2,15 @@ package generate
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/kyverno/kyverno/api/kyverno"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	"github.com/kyverno/kyverno/pkg/background/common"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/event"
 	"github.com/stretchr/testify/assert"
@@ -244,4 +247,215 @@ func TestProcessUR_DeleteDownstreamFailure_MarksURFailed(t *testing.T) {
 		"statusControl.Failed() must be called when downstream deletion fails")
 	assert.False(t, statusControl.successCalled,
 		"statusControl.Success() must NOT be called when downstream deletion fails — this is the core regression")
+}
+
+func cloneListDownstreamSecret(name, namespace, sourceUID string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+				"labels": map[string]interface{}{
+					common.GeneratePolicyLabel:          "sync-secrets",
+					common.GeneratePolicyNamespaceLabel: "",
+					kyverno.LabelAppManagedBy:           kyverno.ValueKyvernoApp,
+					// both downstreams share the same trigger (the target Namespace)
+					common.GenerateTriggerGroupLabel:   "",
+					common.GenerateTriggerVersionLabel: "v1",
+					common.GenerateTriggerKindLabel:    "Namespace",
+					common.GenerateTriggerNSLabel:      "",
+					common.GenerateTriggerUIDLabel:     "trigger-uid-123",
+					// each downstream references a distinct clone source
+					common.GenerateSourceUIDLabel: sourceUID,
+				},
+			},
+		},
+	}
+}
+
+// TestHandleNonPolicyChanges_CloneListScopedToDeletedSource is the regression test
+// for https://github.com/kyverno/kyverno/issues/9654 : when a single clone source
+// is deleted, only the downstream cloned from that source is removed, not every
+// downstream sharing the same trigger.
+func TestHandleNonPolicyChanges_CloneListScopedToDeletedSource(t *testing.T) {
+	ds1 := cloneListDownstreamSecret("dummy-secret-1", "certs-replicated", "source-uid-1")
+	ds2 := cloneListDownstreamSecret("dummy-secret-2", "certs-replicated", "source-uid-2")
+
+	scheme := runtime.NewScheme()
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "secrets"}:    "SecretList",
+		{Group: "", Version: "v1", Resource: "namespaces"}: "NamespaceList",
+	}
+	client, err := dclient.NewFakeClient(scheme, gvrToListKind, ds1, ds2)
+	assert.NoError(t, err)
+	client.SetDiscovery(dclient.NewFakeDiscoveryClient(nil))
+
+	controller := &GenerateController{
+		client: client,
+		log:    logr.Discard(),
+	}
+
+	policy := &kyvernov1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "sync-secrets"},
+		Spec: kyvernov1.Spec{
+			Rules: []kyvernov1.Rule{
+				{
+					Name: "sync-secret",
+					Generation: &kyvernov1.Generation{
+						Synchronize: true,
+						GeneratePattern: kyvernov1.GeneratePattern{
+							CloneList: kyvernov1.CloneList{
+								Namespace: "certs",
+								Kinds:     []string{"v1/Secret"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ruleContext := kyvernov2.RuleContext{
+		Rule: "sync-secret",
+		Trigger: kyvernov1.ResourceSpec{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+			Name:       "certs-replicated",
+			UID:        "trigger-uid-123",
+		},
+	}
+
+	// the deleted source secret (dummy-secret-1) carries the clone-source tag
+	deletedSource := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"name":      "dummy-secret-1",
+			"namespace": "certs",
+			"uid":       "source-uid-1",
+			"labels": map[string]interface{}{
+				common.GenerateTypeCloneSourceLabel: "",
+			},
+		},
+	}
+	raw, err := json.Marshal(deletedSource)
+	assert.NoError(t, err)
+
+	ur := &kyvernov2.UpdateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ur"},
+		Spec: kyvernov2.UpdateRequestSpec{
+			Context: kyvernov2.UpdateRequestSpecContext{
+				AdmissionRequestInfo: kyvernov2.AdmissionRequestInfoObject{
+					Operation: admissionv1.Delete,
+					AdmissionRequest: &admissionv1.AdmissionRequest{
+						Operation: admissionv1.Delete,
+						Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"},
+						Namespace: "certs",
+						OldObject: runtime.RawExtension{Raw: raw},
+					},
+				},
+			},
+		},
+	}
+
+	assert.NoError(t, controller.handleNonPolicyChanges(policy, ruleContext, ur))
+
+	// dummy-secret-1's clone must be deleted
+	_, err = client.GetResource(context.TODO(), "v1", "Secret", "certs-replicated", "dummy-secret-1")
+	assert.True(t, apierrors.IsNotFound(err), "dummy-secret-1 clone should have been deleted")
+
+	// dummy-secret-2's clone must be retained
+	remaining, err := client.GetResource(context.TODO(), "v1", "Secret", "certs-replicated", "dummy-secret-2")
+	assert.NoError(t, err, "dummy-secret-2 clone should be retained")
+	assert.NotNil(t, remaining)
+}
+
+// secretRaw marshals a minimal Secret with the given uid and labels.
+func secretRaw(t *testing.T, name, namespace, uid string, labels map[string]interface{}) []byte {
+	t.Helper()
+	meta := map[string]interface{}{"name": name, "namespace": namespace, "uid": uid}
+	if labels != nil {
+		meta["labels"] = labels
+	}
+	raw, err := json.Marshal(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   meta,
+	})
+	assert.NoError(t, err)
+	return raw
+}
+
+// TestDeletedCloneSourceUID exercises every branch of the helper that decides
+// whether a delete request must be scoped to a specific clone source.
+func TestDeletedCloneSourceUID(t *testing.T) {
+	controller := &GenerateController{log: logr.Discard()}
+
+	newUR := func(req *admissionv1.AdmissionRequest) *kyvernov2.UpdateRequest {
+		return &kyvernov2.UpdateRequest{
+			Spec: kyvernov2.UpdateRequestSpec{
+				Context: kyvernov2.UpdateRequestSpecContext{
+					AdmissionRequestInfo: kyvernov2.AdmissionRequestInfoObject{
+						AdmissionRequest: req,
+					},
+				},
+			},
+		}
+	}
+
+	cloneSourceLabels := map[string]interface{}{common.GenerateTypeCloneSourceLabel: ""}
+
+	tests := []struct {
+		name string
+		ur   *kyvernov2.UpdateRequest
+		want string
+	}{
+		{
+			name: "no admission request",
+			ur:   newUR(nil),
+			want: "",
+		},
+		{
+			name: "non-delete operation",
+			ur: newUR(&admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				OldObject: runtime.RawExtension{Raw: secretRaw(t, "s", "certs", "uid-1", cloneSourceLabels)},
+			}),
+			want: "",
+		},
+		{
+			name: "delete but old object is malformed",
+			ur: newUR(&admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				OldObject: runtime.RawExtension{Raw: []byte("{not-json")},
+			}),
+			want: "",
+		},
+		{
+			name: "delete of a non clone source (no clone-source label)",
+			ur: newUR(&admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				Kind:      metav1.GroupVersionKind{Version: "v1", Kind: "Secret"},
+				OldObject: runtime.RawExtension{Raw: secretRaw(t, "trigger", "certs", "uid-2", nil)},
+			}),
+			want: "",
+		},
+		{
+			name: "delete of a clone source",
+			ur: newUR(&admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				Kind:      metav1.GroupVersionKind{Version: "v1", Kind: "Secret"},
+				OldObject: runtime.RawExtension{Raw: secretRaw(t, "dummy-secret-1", "certs", "source-uid-1", cloneSourceLabels)},
+			}),
+			want: "source-uid-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, controller.deletedCloneSourceUID(tt.ur))
+		})
+	}
 }

--- a/pkg/webhooks/resource/generation/handler.go
+++ b/pkg/webhooks/resource/generation/handler.go
@@ -92,7 +92,7 @@ func (h *generationHandler) Handle(
 	if h.backgroundServiceAccountName == policyContext.AdmissionInfo().AdmissionUserInfo.Username {
 		return
 	}
-	h.handleNonTrigger(ctx, policyContext)
+	h.handleNonTrigger(ctx, request, policyContext)
 }
 
 func getAppliedRules(policy kyvernov1.PolicyInterface, applied []engineapi.RuleResponse) []kyvernov1.Rule {
@@ -144,13 +144,14 @@ func (h *generationHandler) handleTrigger(
 
 func (h *generationHandler) handleNonTrigger(
 	ctx context.Context,
+	request admissionv1.AdmissionRequest,
 	policyContext *engine.PolicyContext,
 ) {
 	resource := policyContext.OldResource()
 	labels := resource.GetLabels()
 	if _, ok := labels[common.GenerateTypeCloneSourceLabel]; ok || labels[common.GeneratePolicyLabel] != "" {
 		h.log.V(4).Info("handle non-trigger resource operation for generate")
-		if err := h.processRequest(ctx, policyContext); err != nil {
+		if err := h.processRequest(ctx, request, policyContext); err != nil {
 			h.log.Error(err, "failed to create the UR on non-trigger admission request")
 		}
 	}
@@ -245,7 +246,7 @@ func (h *generationHandler) syncTriggerAction(
 }
 
 // processRequest determine if it needs to re-apply the generate rule to the source or the target changes
-func (h *generationHandler) processRequest(ctx context.Context, policyContext *engine.PolicyContext) (err error) {
+func (h *generationHandler) processRequest(ctx context.Context, request admissionv1.AdmissionRequest, policyContext *engine.PolicyContext) (err error) {
 	var policy kyvernov1.PolicyInterface
 	var labelsList []map[string]string
 	var deleteDownstream bool
@@ -320,6 +321,12 @@ func (h *generationHandler) processRequest(ctx context.Context, policyContext *e
 			Type:        kyvernov2.Generate,
 			Policy:      pKey,
 			RuleContext: make([]kyvernov2.RuleContext, 0),
+		}
+		// carry the admission request when deleting a downstream on source
+		// deletion so the background controller can scope the cleanup to the
+		// target(s) cloned from the deleted source only.
+		if deleteDownstream {
+			urSpec.Context = buildURContext(request, policyContext)
 		}
 
 		for _, rule := range policy.GetSpec().Rules {

--- a/pkg/webhooks/resource/generation/handler_test.go
+++ b/pkg/webhooks/resource/generation/handler_test.go
@@ -5,14 +5,25 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/kyverno/kyverno/api/kyverno"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	"github.com/kyverno/kyverno/pkg/background/common"
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/fake"
+	kyvernov1listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/engine"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/kyverno/kyverno/pkg/engine/jmespath"
+	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestGetAppliedRules(t *testing.T) {
@@ -309,6 +320,121 @@ func TestSyncTriggerActionWithSynchronizeRule(t *testing.T) {
 	if len(urGenerator.applySpec.RuleContext) > 0 && !urGenerator.applySpec.RuleContext[0].DeleteDownstream {
 		t.Error("expected DeleteDownstream to be true for synchronize")
 	}
+}
+
+// TestHandleNonTrigger_CloneSourceDeletion_AttachesAdmissionContext verifies that
+// deleting a clone source produces a delete-downstream UpdateRequest carrying the
+// admission request in its context, which lets the background controller scope the
+// cleanup to the deleted source (https://github.com/kyverno/kyverno/issues/9654).
+// It drives the full non-trigger path (handleNonTrigger -> processRequest).
+func TestHandleNonTrigger_CloneSourceDeletion_AttachesAdmissionContext(t *testing.T) {
+	// downstream target cloned from the source, discoverable by its source-* labels
+	target := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      "dummy-secret-1",
+				"namespace": "certs-replicated",
+				"labels": map[string]interface{}{
+					common.GeneratePolicyLabel:          "sync-secrets",
+					common.GeneratePolicyNamespaceLabel: "",
+					common.GenerateRuleLabel:            "sync-secret",
+					kyverno.LabelAppManagedBy:           kyverno.ValueKyvernoApp,
+					common.GenerateSourceGroupLabel:     "",
+					common.GenerateSourceVersionLabel:   "v1",
+					common.GenerateSourceKindLabel:      "Secret",
+					common.GenerateSourceNSLabel:        "certs",
+					common.GenerateSourceNameLabel:      "dummy-secret-1",
+					common.GenerateSourceUIDLabel:       "source-uid-1",
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "secrets"}:    "SecretList",
+		{Group: "", Version: "v1", Resource: "namespaces"}: "NamespaceList",
+	}
+	client, err := dclient.NewFakeClient(scheme, gvrToListKind, target)
+	assert.NoError(t, err)
+	client.SetDiscovery(dclient.NewFakeDiscoveryClient(nil))
+
+	// cluster policy referenced by the target labels
+	policy := &kyvernov1.ClusterPolicy{}
+	policy.SetName("sync-secrets")
+	policy.Spec = kyvernov1.Spec{
+		Rules: []kyvernov1.Rule{
+			{
+				Name: "sync-secret",
+				MatchResources: kyvernov1.MatchResources{
+					Any: kyvernov1.ResourceFilters{
+						{ResourceDescription: kyvernov1.ResourceDescription{Kinds: []string{"Namespace"}}},
+					},
+				},
+				Generation: &kyvernov1.Generation{
+					Synchronize: true,
+					GeneratePattern: kyvernov1.GeneratePattern{
+						CloneList: kyvernov1.CloneList{
+							Namespace: "certs",
+							Kinds:     []string{"v1/Secret"},
+						},
+					},
+				},
+			},
+		},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	assert.NoError(t, indexer.Add(policy))
+	cpolLister := kyvernov1listers.NewClusterPolicyLister(indexer)
+
+	gen := &mockURGenerator{}
+	h := &generationHandler{
+		log:         logr.Discard(),
+		client:      client,
+		cpolLister:  cpolLister,
+		urGenerator: gen,
+	}
+
+	// the deleted clone source
+	source := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      "dummy-secret-1",
+				"namespace": "certs",
+				"uid":       "source-uid-1",
+				"labels": map[string]interface{}{
+					common.GenerateTypeCloneSourceLabel: "",
+				},
+			},
+		},
+	}
+
+	cfg := config.NewDefaultConfiguration(false)
+	jp := jmespath.New(cfg)
+	policyContext, err := engine.NewPolicyContext(jp, source, kyvernov1.Delete, nil, cfg)
+	assert.NoError(t, err)
+
+	request := admissionv1.AdmissionRequest{
+		Operation: admissionv1.Delete,
+		Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"},
+		Namespace: "certs",
+		Name:      "dummy-secret-1",
+	}
+
+	// invoke via handleNonTrigger so the clone-source dispatch path is exercised
+	// end to end (it recognizes the source by its clone-source label).
+	h.handleNonTrigger(context.TODO(), request, policyContext)
+
+	// a delete-downstream UR was created carrying the admission request so the
+	// background controller can scope the cleanup to the deleted source.
+	assert.True(t, gen.applyCalled, "an UpdateRequest should have been created")
+	assert.Equal(t, "sync-secrets", gen.applySpec.Policy)
+	assert.NotNil(t, gen.applySpec.Context.AdmissionRequestInfo.AdmissionRequest,
+		"the admission request must be attached to the delete-downstream UR")
 }
 
 type mockURGenerator struct {


### PR DESCRIPTION
## Explanation

This is a **bug fix**. For a `generate` policy using `cloneList` with `synchronize: true`, deleting a **single** source resource incorrectly deleted **all** replicated downstream resources sharing the same trigger, instead of only the target cloned from the deleted source. This resulted in unexpected data loss (e.g. all synchronized Secrets in a target namespace disappearing when just one source Secret was removed). This PR scopes the downstream cleanup to the specific deleted source.

## Related issue

Closes #9654

## What type of PR is this

/kind bug

## Proposed Changes

On source deletion, two things were happening:

1. The webhook `processRequest` (`pkg/webhooks/resource/generation/handler.go`) located the correct downstream via the `generate.kyverno.io/source-uid` label, but then built a *delete* `UpdateRequest` keyed **only by the trigger** (the target Namespace), discarding which source was deleted.
2. `getDownstreams` (`pkg/background/generate/cleanup.go`) re-queried the cloneList downstreams using only the policy/rule/trigger labels. Since every cloned resource in a target namespace shares the same trigger, that selector matched **all** of them, so all were deleted.

Fix:

- **handler.go**: attach the admission request to the delete-downstream `UpdateRequest` (only for the `deleteDownstream` case, leaving the source-update and trigger paths unchanged) so the deleted source's identity reaches the background controller.
- **cleanup.go**: a new `deletedCloneSourceUID` helper extracts the deleted object from the admission request and, **only when it carries the `generate.kyverno.io/clone-source` tag** (which distinguishes a source deletion from a trigger/namespace deletion), returns its UID. `getDownstreams` then adds the `generate.kyverno.io/source-uid` label to the cloneList selector, scoping cleanup to just the target(s) cloned from the deleted source.

Using the clone-source tag as the guard means a genuine **trigger** (e.g. Namespace) deletion still removes all of its downstreams — so there is no regression to that behavior or to single-`clone` rules.

A unit test (`pkg/background/generate/cleanup_test.go`) reproduces the bug against `getDownstreams`: two downstreams sharing one trigger with distinct sources; deleting one source must select only its clone. It fails before the fix (selects both) and passes after.

### Proof Manifests

Source secrets in the `certs` namespace:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: dummy-secret-1
  namespace: certs
  labels:
    kyverno.io/watch: "true"
type: Opaque
data:
  foo: YmFy
---
apiVersion: v1
kind: Secret
metadata:
  name: dummy-secret-2
  namespace: certs
  labels:
    kyverno.io/watch: "true"
type: Opaque
data:
  foo: YmFy
```

Policy (from the issue):

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: sync-secrets-with-exclude
spec:
  generateExisting: true
  background: true
  rules:
  - name: sync-secrets-exclude
    match:
      any:
      - resources:
          kinds:
          - Namespace
    exclude:
      any:
      - resources:
          names:
          - kube-node-lease
          - kube-public
          - kube-system
          - kyverno
          - certs
          - default
    generate:
      namespace: "{{request.object.metadata.name}}"
      synchronize: true
      cloneList:
        namespace: certs
        kinds:
          - v1/Secret
        selector:
          matchLabels:
            kyverno.io/watch: "true"
```

Reproduction and result (verified on a live k3s cluster with the patched images):

```
# create the target namespace -> both secrets are cloned
$ kubectl -n certs-replicated get secret
NAME             TYPE     DATA   AGE
dummy-secret-1   Opaque   1      2s
dummy-secret-2   Opaque   1      2s

# delete ONE source secret
$ kubectl -n certs delete secret dummy-secret-1

# only its clone is removed; the other clone is retained
$ kubectl -n certs-replicated get secret
NAME             TYPE     DATA   AGE
dummy-secret-2   Opaque   1      10s
```

Before the fix, deleting `dummy-secret-1` removed **both** clones from `certs-replicated`.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
