### PR TITLE
refactor: optimize JMESPath query parsing in the image extractor

### DIFF
--- a/pkg/utils/api/image.go
+++ b/pkg/utils/api/image.go
@@ -46,7 +46,16 @@ type imageExtractor struct {
 
 func (i *imageExtractor) ExtractFromResource(resource interface{}, cfg config.Configuration) (map[string]ImageInfo, error) {
 	imageInfo := map[string]ImageInfo{}
-	if err := extract(resource, []string{}, i.Key, i.Value, i.Fields, i.JMESPath, &imageInfo, cfg, []string{}); err != nil {
+	var query jmespath.Query
+	if i.JMESPath != "" {
+		jp := jmespath.New(cfg)
+		var err error
+		query, err = jp.Query(i.JMESPath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid jmespath %s: %v", i.JMESPath, err)
+		}
+	}
+	if err := extract(resource, []string{}, i.Key, i.Value, i.Fields, i.JMESPath, query, &imageInfo, cfg, []string{}); err != nil {
 		return nil, err
 	}
 	return imageInfo, nil
@@ -59,6 +68,7 @@ func extract(
 	valuePath string,
 	fields []string,
 	jmesPath string,
+	jmesQuery jmespath.Query,
 	imageInfos *map[string]ImageInfo,
 	cfg config.Configuration,
 	pullSecrets []string,
@@ -70,13 +80,13 @@ func extract(
 		switch typedObj := obj.(type) {
 		case []interface{}:
 			for i, v := range typedObj {
-				if err := extract(v, append(path, strconv.Itoa(i)), keyPath, valuePath, fields[1:], jmesPath, imageInfos, cfg, pullSecrets); err != nil {
+				if err := extract(v, append(path, strconv.Itoa(i)), keyPath, valuePath, fields[1:], jmesPath, jmesQuery, imageInfos, cfg, pullSecrets); err != nil {
 					return err
 				}
 			}
 		case map[string]interface{}:
 			for i, v := range typedObj {
-				if err := extract(v, append(path, i), keyPath, valuePath, fields[1:], jmesPath, imageInfos, cfg, pullSecrets); err != nil {
+				if err := extract(v, append(path, i), keyPath, valuePath, fields[1:], jmesPath, jmesQuery, imageInfos, cfg, pullSecrets); err != nil {
 					return err
 				}
 			}
@@ -113,14 +123,8 @@ func extract(
 			logging.V(4).Info("image information is not present", "pointer", pointer)
 			return nil
 		}
-		if jmesPath != "" {
-			// TODO: should be injected
-			jp := jmespath.New(cfg)
-			q, err := jp.Query(jmesPath)
-			if err != nil {
-				return fmt.Errorf("invalid jmespath %s: %v", jmesPath, err)
-			}
-			result, err := q.Search(value)
+		if jmesQuery != nil {
+			result, err := jmesQuery.Search(value)
 			if err != nil {
 				return fmt.Errorf("failed to apply jmespath %s: %v", jmesPath, err)
 			}
@@ -139,7 +143,7 @@ func extract(
 		return nil
 	}
 	currentPath := fields[0]
-	return extract(output[currentPath], append(path, currentPath), keyPath, valuePath, fields[1:], jmesPath, imageInfos, cfg, pullSecrets)
+	return extract(output[currentPath], append(path, currentPath), keyPath, valuePath, fields[1:], jmesPath, jmesQuery, imageInfos, cfg, pullSecrets)
 }
 
 func BuildStandardExtractors(tags ...string) []imageExtractor {


### PR DESCRIPTION
## Explanation

I noticed a todo saying jmespath ready to use query should be INJECTED ..
so, basically,, whenever Kyverno dug through a Kubernetes resource (like checking a list of containers), it was re-reading and re-compiling the EXACT SAME search query from scratch every single time it HIT a new item. 
Eg: If a pod had 10 containers, it did the exact same expensive setup work 10 times..

In this this PR, I now compile that search query just ONCE  at the very beginning. 
Then, as the code digs through the resource, it simply passes that ready-to-use query down the chain. This stops the system from doing unnecessary, repetitive work and speeds things up,, **especially when evaluating large or complex resources.**

## Related issue

Resolves the `TODO: should be injected` in `pkg/utils/api/image.go`.


## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR DOES NOT contain any new or altered behavior to Kyverno. 


## What type of PR is this


/kind cleanup


## Proposed Changes

- Refactored `ExtractFromResource` in `pkg/utils/api/image.go` to pre-compile the JMESPath query.
- Modified the internal `extract` function signature to accept the pre-compiled query `jmesQuery jmespath.Query`.
- Injected `jmesQuery` down into all recursive calls of `extract` inside the resource traversals.
- Cleaned up the `// TODO: should be injected` comment.

### Proof Manifests
*Not applicable. Internal unit tests continue to pass.*

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.


