### PR TITLE
feat: add machine-readable task manifest generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ cmd/background-controller/background-controller
 cmd/readiness-checker/readiness-checker
 coverage.out
 kyverno.tar
+/task-manifest.json

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ GOLANGCI_LINT                      ?= $(TOOLS_DIR)/golangci-lint
 GOLANGCI_LINT_VERSION              ?= v2.11.4
 API_GROUP_RESOURCES                ?= $(TOOLS_DIR)/api-group-resources
 CLIENT_WRAPPER                     ?= $(TOOLS_DIR)/client-wrapper
+TASK_MANIFEST                      ?= $(TOOLS_DIR)/task-manifest
 KUBE_VERSION                       ?= v1.25.0
 TOOLS                              := $(KIND) $(CONTROLLER_GEN) $(CLIENT_GEN) $(LISTER_GEN) $(INFORMER_GEN) $(REGISTER_GEN) $(DEEPCOPY_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GENREF) $(GOIMPORTS) $(HELM) $(HELM_DOCS) $(KO) $(GOLANGCI_LINT) $(CLIENT_WRAPPER)
 ifeq ($(GOOS), darwin)
@@ -1244,3 +1245,11 @@ dev-lab-kwok: ## Deploy kwok
 .PHONY: help
 help: ## Shows the available commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}'
+
+$(TASK_MANIFEST):
+	@echo Install task-manifest... >&2
+	@cd ./hack/task-manifest && GOBIN=$(TOOLS_DIR) go install
+
+.PHONY: task-manifest
+task-manifest: $(TASK_MANIFEST) ## Generate a machine-readable (JSON) index of all documented make targets
+	@$(TASK_MANIFEST) -out task-manifest.json

--- a/hack/task-manifest/main.go
+++ b/hack/task-manifest/main.go
@@ -1,0 +1,126 @@
+// Command task-manifest generates a machine-readable index of the
+// project's `make` targets from the self-documenting `## ` comments
+// already used by `make help`.
+//
+// It reuses the exact same convention `make help` relies on
+// (a target line matching `^[a-zA-Z_-]+:.*## .*$`) so the two never
+// drift apart, and additionally groups targets under the section
+// header comment blocks already present in the Makefile
+// (e.g. "# TOOLS #", "# CODEGEN #") so a caller can filter by area
+// without having to parse the Makefile itself.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// Task describes a single documented `make` target.
+type Task struct {
+	Target      string `json:"target"`
+	Description string `json:"description"`
+	Category    string `json:"category"`
+}
+
+var (
+	targetRe  = regexp.MustCompile(`^([a-zA-Z_-]+):.*?##\s?(.*)$`)
+	hashRunRe = regexp.MustCompile(`^#+$`)
+	// headerRe matches the free-form text between a leading and
+	// trailing '#' (e.g. "# BUILD (LOCAL) #", "# CLI TESTS #").
+	// Section names in this Makefile include punctuation such as
+	// parentheses, so this intentionally does not allowlist
+	// characters — it only requires the line to be hash-delimited.
+	headerRe = regexp.MustCompile(`^#([^#]+)#$`)
+)
+
+func main() {
+	makefilePath := flag.String("makefile", "Makefile", "path to the Makefile to parse")
+	outPath := flag.String("out", "", "output file path (defaults to stdout)")
+	flag.Parse()
+
+	tasks, err := parseMakefile(*makefilePath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "task-manifest:", err)
+		os.Exit(1)
+	}
+
+	out := os.Stdout
+	if *outPath != "" {
+		f, err := os.Create(*outPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "task-manifest:", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		out = f
+	}
+
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(tasks); err != nil {
+		fmt.Fprintln(os.Stderr, "task-manifest:", err)
+		os.Exit(1)
+	}
+}
+
+// parseMakefile extracts every self-documented target from f, in the
+// order they appear, tagged with the nearest preceding section header.
+//
+// Section headers are the existing three-line comment blocks used
+// throughout the Makefile, e.g.:
+//
+//	#########
+//	# TOOLS #
+//	#########
+//
+// A target belongs to a header once that header has been seen and
+// until the next one is; targets before the first header (there are
+// none today, but the parser tolerates it) are tagged "UNCATEGORIZED".
+func parseMakefile(path string) ([]Task, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var (
+		tasks    []Task
+		category = "UNCATEGORIZED"
+		prevHash bool
+	)
+
+	scanner := bufio.NewScanner(f)
+	// Makefile lines (recipe lines, long variable definitions) can
+	// exceed the default 64KiB scanner buffer.
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Three-line "#####\n# NAME #\n#####" section header block.
+		if prevHash {
+			if m := headerRe.FindStringSubmatch(line); m != nil {
+				category = strings.TrimSpace(m[1])
+			}
+		}
+		prevHash = hashRunRe.MatchString(line)
+
+		if m := targetRe.FindStringSubmatch(line); m != nil {
+			tasks = append(tasks, Task{
+				Target:      m[1],
+				Description: strings.TrimSpace(m[2]),
+				Category:    category,
+			})
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}

--- a/hack/task-manifest/main_test.go
+++ b/hack/task-manifest/main_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseMakefile(t *testing.T) {
+	const fixture = `
+#########
+# TOOLS #
+#########
+
+install-tools: ## Install tools
+	@echo installing
+
+undocumented-target:
+	@echo no comment, should be skipped
+
+#################
+# BUILD (LOCAL) #
+#################
+
+build-all: build-kyverno ## Build all binaries
+
+# a plain comment line, not a hash-delimited header, must not change category
+still-build-category: ## Still under BUILD (LOCAL)
+`
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Makefile")
+	if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	got, err := parseMakefile(path)
+	if err != nil {
+		t.Fatalf("parseMakefile: %v", err)
+	}
+
+	want := []Task{
+		{Target: "install-tools", Description: "Install tools", Category: "TOOLS"},
+		{Target: "build-all", Description: "Build all binaries", Category: "BUILD (LOCAL)"},
+		{Target: "still-build-category", Description: "Still under BUILD (LOCAL)", Category: "BUILD (LOCAL)"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseMakefile() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseMakefileMissingFile(t *testing.T) {
+	if _, err := parseMakefile(filepath.Join(t.TempDir(), "does-not-exist")); err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}


### PR DESCRIPTION
Part of the Phase 0 groundwork proposed in #16665 (AI-Ready Kyverno Dev), specifically:

> A machine-readable task index (e.g., `make help`-style JSON/YAML manifest of build/test/lint targets) so agents don't have to parse the Makefile.

Adds `make task-manifest`, generating `task-manifest.json`: every documented `make` target (the same `## ` comment convention `make help` already relies on), grouped by the section header each target falls under (`TOOLS`, `CODEGEN`, `BUILD (LOCAL)`, `CLI TESTS`, etc.), so callers don't have to parse the Makefile themselves.

`hack/task-manifest/main.go` follows the existing `hack/client-wrapper` / `hack/api-group-resources` pattern — a small standalone Go program installed into `.tools/` via `go install`, invoked from a Makefile target.

Verified against the current Makefile (123 documented targets across 16 categories) before opening this — including catching a bug where a naive character-allowlist regex for section headers misses names containing punctuation, e.g. `BUILD (LOCAL)`, `BUILD (KO)`; the header regex here is intentionally permissive (matches on hash-delimiters, not an allowlist) to avoid that failure mode.

Includes unit tests covering categorization across section boundaries, punctuation in header names, and targets without `## ` comments being correctly skipped.