### PR TITLE
fix(gpol): respect failurePolicy=Ignore when CEL matchCondition evaluation errors

### DIFF
--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -658,7 +658,13 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 		compiler := gpolcompiler.NewCompiler()
 		compiledPolicies := make([]gpolengine.Policy, 0, len(p.GeneratingPolicies))
 		for _, pol := range p.GeneratingPolicies {
-			compiled, errs := compiler.Compile(pol, p.CELExceptions)
+			failurePolicy := admissionregistrationv1.Fail
+			if getter, ok := pol.(interface {
+				GetFailurePolicy(bool) admissionregistrationv1.FailurePolicyType
+			}); ok {
+				failurePolicy = getter.GetFailurePolicy(false)
+			}
+			compiled, errs := compiler.Compile(pol, p.CELExceptions, failurePolicy)
 			if len(errs) > 0 {
 				return nil, fmt.Errorf("failed to compile policy %s (%w)", pol.GetName(), errs.ToAggregate())
 			}

--- a/pkg/cel/policies/gpol/compiler/compiler.go
+++ b/pkg/cel/policies/gpol/compiler/compiler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kyverno/sdk/extensions/cel/libs/transform"
 	"github.com/kyverno/sdk/extensions/cel/libs/x509"
 	"github.com/kyverno/sdk/extensions/cel/libs/yaml"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/version"
 	apiservercel "k8s.io/apiserver/pkg/cel"
@@ -37,7 +38,7 @@ var (
 )
 
 type Compiler interface {
-	Compile(policy policiesv1beta1.GeneratingPolicyLike, exceptions []*policiesv1beta1.PolicyException) (*Policy, field.ErrorList)
+	Compile(policy policiesv1beta1.GeneratingPolicyLike, exceptions []*policiesv1beta1.PolicyException, failurePolicy admissionregistrationv1.FailurePolicyType) (*Policy, field.ErrorList)
 }
 
 func NewCompiler() Compiler {
@@ -153,7 +154,7 @@ func (c *compilerImpl) createBaseGpolEnv(libsctx libs.Context, namespace string)
 	return extendedBase, variablesProvider, nil
 }
 
-func (c *compilerImpl) Compile(policy policiesv1beta1.GeneratingPolicyLike, exceptions []*policiesv1beta1.PolicyException) (*Policy, field.ErrorList) {
+func (c *compilerImpl) Compile(policy policiesv1beta1.GeneratingPolicyLike, exceptions []*policiesv1beta1.PolicyException, failurePolicy admissionregistrationv1.FailurePolicyType) (*Policy, field.ErrorList) {
 	var allErrs field.ErrorList
 	env, variablesProvider, err := c.createBaseGpolEnv(libs.GetLibsCtx(), policy.GetNamespace())
 	if err != nil {
@@ -223,6 +224,7 @@ func (c *compilerImpl) Compile(policy policiesv1beta1.GeneratingPolicyLike, exce
 	}
 	return &Policy{
 		namespace:        policy.GetNamespace(),
+		failurePolicy:    failurePolicy,
 		matchConditions:  matchConditions,
 		variables:        variables,
 		generations:      generations,

--- a/pkg/cel/policies/gpol/compiler/compiler_test.go
+++ b/pkg/cel/policies/gpol/compiler/compiler_test.go
@@ -22,7 +22,7 @@ func TestCompile(t *testing.T) {
 		}
 		comp := NewCompiler()
 
-		res, errs := comp.Compile(pol, nil)
+		res, errs := comp.Compile(pol, nil, admissionregistrationv1.Fail)
 		assert.NotNil(t, res)
 		assert.Nil(t, errs)
 	})
@@ -40,7 +40,7 @@ func TestCompile(t *testing.T) {
 		}
 		comp := NewCompiler()
 
-		res, errs := comp.Compile(pol, nil)
+		res, errs := comp.Compile(pol, nil, admissionregistrationv1.Fail)
 		assert.Nil(t, res)
 		assert.NotNil(t, errs)
 	})
@@ -57,7 +57,7 @@ func TestCompile(t *testing.T) {
 			},
 		}
 		comp := NewCompiler()
-		res, errs := comp.Compile(pol, nil)
+		res, errs := comp.Compile(pol, nil, admissionregistrationv1.Fail)
 		assert.Nil(t, res)
 		assert.NotNil(t, errs)
 	})
@@ -73,7 +73,7 @@ func TestCompile(t *testing.T) {
 			},
 		}
 		comp := NewCompiler()
-		res, errs := comp.Compile(pol, nil)
+		res, errs := comp.Compile(pol, nil, admissionregistrationv1.Fail)
 		assert.Nil(t, res)
 		assert.NotNil(t, errs)
 	})
@@ -95,7 +95,7 @@ func TestCompile(t *testing.T) {
 			},
 		}
 		comp := NewCompiler()
-		res, errs := comp.Compile(pol, polexs)
+		res, errs := comp.Compile(pol, polexs, admissionregistrationv1.Fail)
 		assert.Nil(t, res)
 		assert.NotNil(t, errs)
 	})
@@ -117,7 +117,7 @@ func TestCompile(t *testing.T) {
 			},
 		}
 		comp := NewCompiler()
-		res, errs := comp.Compile(pol, polexs)
+		res, errs := comp.Compile(pol, polexs, admissionregistrationv1.Fail)
 		assert.NotNil(t, res)
 		assert.Nil(t, errs)
 	})
@@ -155,7 +155,7 @@ func TestCompile(t *testing.T) {
 			},
 		}
 		comp := NewCompiler()
-		res, errs := comp.Compile(pol, nil)
+		res, errs := comp.Compile(pol, nil, admissionregistrationv1.Fail)
 		assert.NotNil(t, res)
 		assert.Nil(t, errs)
 	})
@@ -172,7 +172,7 @@ func TestCompile(t *testing.T) {
 			},
 		}
 		comp := NewCompiler()
-		res, errs := comp.Compile(pol, nil)
+		res, errs := comp.Compile(pol, nil, admissionregistrationv1.Fail)
 		assert.NotNil(t, res)
 		assert.Nil(t, errs)
 	})
@@ -189,7 +189,7 @@ func TestCompile(t *testing.T) {
 			},
 		}
 		comp := NewCompiler()
-		res, errs := comp.Compile(pol, nil)
+		res, errs := comp.Compile(pol, nil, admissionregistrationv1.Fail)
 		assert.Nil(t, res)
 		assert.NotNil(t, errs)
 	})

--- a/pkg/cel/policies/gpol/compiler/policy.go
+++ b/pkg/cel/policies/gpol/compiler/policy.go
@@ -25,6 +25,7 @@ import (
 
 type Policy struct {
 	namespace        string
+	failurePolicy    admissionregistrationv1.FailurePolicyType
 	matchConditions  []cel.Program
 	variables        map[string]cel.Program
 	generations      []Generation
@@ -233,6 +234,8 @@ func (p *Policy) match(
 	}
 	if err := multierr.Combine(errs...); err == nil {
 		return true, nil
+	} else if p.failurePolicy == admissionregistrationv1.Ignore {
+		return false, nil
 	} else {
 		return false, err
 	}

--- a/pkg/cel/policies/gpol/compiler/policy_test.go
+++ b/pkg/cel/policies/gpol/compiler/policy_test.go
@@ -254,4 +254,165 @@ func TestPolicyEvaluate(t *testing.T) {
 		assert.Nil(t, result.GeneratedResources)
 		assert.NotEmpty(t, result.Exceptions)
 	})
+
+	t.Run("failurePolicy=Ignore swallows matchCondition error and skips policy", func(t *testing.T) {
+		// Regression test for https://github.com/kyverno/kyverno/issues/16883:
+		// When failurePolicy is Ignore, a CEL runtime error in a matchCondition must
+		// be swallowed (treated as a non-match) rather than propagated to the caller.
+		policy := &Policy{
+			failurePolicy: v1.Ignore,
+			matchConditions: []cel.Program{
+				&mockProgram{retVal: types.String("not-a-bool")}, // triggers convertToNative error
+			},
+			variables:   map[string]cel.Program{},
+			generations: []Generation{},
+		}
+		res.SetGroupVersionKind(gvk)
+		res.SetName("ignore-match-err")
+		res.SetNamespace("ns")
+
+		result, err := policy.Evaluate(context.TODO(), attr, &request.Request, &ns, &libs.FakeContextProvider{})
+
+		assert.Nil(t, result)
+		assert.NoError(t, err)
+	})
+
+	t.Run("failurePolicy=Fail propagates matchCondition error", func(t *testing.T) {
+		// With the default failurePolicy (Fail), a CEL runtime error in a matchCondition
+		// must still be returned as an error.
+		policy := &Policy{
+			failurePolicy: v1.Fail,
+			matchConditions: []cel.Program{
+				&mockProgram{retVal: types.String("not-a-bool")}, // triggers convertToNative error
+			},
+		}
+		res.SetGroupVersionKind(gvk)
+		res.SetName("fail-match-err")
+		res.SetNamespace("ns")
+
+		result, err := policy.Evaluate(context.TODO(), attr, &request.Request, &ns, &libs.FakeContextProvider{})
+
+		assert.Nil(t, result)
+		assert.Error(t, err)
+	})
+
+	t.Run("compiled real GeneratingPolicy with failurePolicy=Ignore swallows CEL matchCondition error", func(t *testing.T) {
+		gpol := &v1beta1.GeneratingPolicy{
+			Spec: v1beta1.GeneratingPolicySpec{
+				MatchConditions: []v1.MatchCondition{
+					{
+						Name:       "error-triggering-condition",
+						Expression: "int(object.metadata.name) > 0",
+					},
+				},
+				Generation: []v1beta1.Generation{
+					{
+						Expression: `generator.Apply("default", [{"apiVersion": dyn("v1"), "kind": dyn("ConfigMap")}])`,
+					},
+				},
+			},
+		}
+		comp := NewCompiler()
+		compiled, errList := comp.Compile(gpol, nil, v1.Ignore)
+		assert.Nil(t, errList)
+		assert.NotNil(t, compiled)
+
+		res.SetGroupVersionKind(gvk)
+		res.SetName("non-integer-name")
+		res.SetNamespace("default")
+
+		result, err := compiled.Evaluate(context.TODO(), attr, &request.Request, &ns, &libs.FakeContextProvider{})
+		assert.Nil(t, result)
+		assert.NoError(t, err, "CEL matchCondition error should be swallowed when failurePolicy is Ignore")
+	})
+
+	t.Run("compiled real GeneratingPolicy with failurePolicy=Fail propagates CEL matchCondition error", func(t *testing.T) {
+		gpol := &v1beta1.GeneratingPolicy{
+			Spec: v1beta1.GeneratingPolicySpec{
+				MatchConditions: []v1.MatchCondition{
+					{
+						Name:       "error-triggering-condition",
+						Expression: "int(object.metadata.name) > 0",
+					},
+				},
+				Generation: []v1beta1.Generation{
+					{
+						Expression: `generator.Apply("default", [{"apiVersion": dyn("v1"), "kind": dyn("ConfigMap")}])`,
+					},
+				},
+			},
+		}
+		comp := NewCompiler()
+		compiled, errList := comp.Compile(gpol, nil, v1.Fail)
+		assert.Nil(t, errList)
+		assert.NotNil(t, compiled)
+
+		res.SetGroupVersionKind(gvk)
+		res.SetName("non-integer-name")
+		res.SetNamespace("default")
+
+		result, err := compiled.Evaluate(context.TODO(), attr, &request.Request, &ns, &libs.FakeContextProvider{})
+		assert.Nil(t, result)
+		assert.Error(t, err, "CEL matchCondition error should be returned when failurePolicy is Fail")
+	})
+
+	t.Run("compiled real NamespacedGeneratingPolicy with failurePolicy=Ignore swallows CEL matchCondition error", func(t *testing.T) {
+		ngpol := &v1beta1.NamespacedGeneratingPolicy{
+			Spec: v1beta1.GeneratingPolicySpec{
+				MatchConditions: []v1.MatchCondition{
+					{
+						Name:       "error-triggering-condition",
+						Expression: "int(object.metadata.name) > 0",
+					},
+				},
+				Generation: []v1beta1.Generation{
+					{
+						Expression: `generator.Apply("default", [{"apiVersion": dyn("v1"), "kind": dyn("ConfigMap")}])`,
+					},
+				},
+			},
+		}
+		comp := NewCompiler()
+		compiled, errList := comp.Compile(ngpol, nil, v1.Ignore)
+		assert.Nil(t, errList)
+		assert.NotNil(t, compiled)
+
+		res.SetGroupVersionKind(gvk)
+		res.SetName("non-integer-name")
+		res.SetNamespace("default")
+
+		result, err := compiled.Evaluate(context.TODO(), attr, &request.Request, &ns, &libs.FakeContextProvider{})
+		assert.Nil(t, result)
+		assert.NoError(t, err, "CEL matchCondition error should be swallowed when failurePolicy is Ignore")
+	})
+
+	t.Run("compiled real NamespacedGeneratingPolicy with failurePolicy=Fail propagates CEL matchCondition error", func(t *testing.T) {
+		ngpol := &v1beta1.NamespacedGeneratingPolicy{
+			Spec: v1beta1.GeneratingPolicySpec{
+				MatchConditions: []v1.MatchCondition{
+					{
+						Name:       "error-triggering-condition",
+						Expression: "int(object.metadata.name) > 0",
+					},
+				},
+				Generation: []v1beta1.Generation{
+					{
+						Expression: `generator.Apply("default", [{"apiVersion": dyn("v1"), "kind": dyn("ConfigMap")}])`,
+					},
+				},
+			},
+		}
+		comp := NewCompiler()
+		compiled, errList := comp.Compile(ngpol, nil, v1.Fail)
+		assert.Nil(t, errList)
+		assert.NotNil(t, compiled)
+
+		res.SetGroupVersionKind(gvk)
+		res.SetName("non-integer-name")
+		res.SetNamespace("default")
+
+		result, err := compiled.Evaluate(context.TODO(), attr, &request.Request, &ns, &libs.FakeContextProvider{})
+		assert.Nil(t, result)
+		assert.Error(t, err, "CEL matchCondition error should be returned when failurePolicy is Fail")
+	})
 }

--- a/pkg/cel/policies/gpol/compiler/template_integration_test.go
+++ b/pkg/cel/policies/gpol/compiler/template_integration_test.go
@@ -36,7 +36,7 @@ metadata:
 `,
 			},
 		})
-		compiled, errs := NewCompiler().Compile(pol, nil)
+		compiled, errs := NewCompiler().Compile(pol, nil, admissionregistrationv1.Fail)
 		assert.Nil(t, errs)
 		assert.NotNil(t, compiled)
 	})
@@ -45,13 +45,13 @@ metadata:
 			Expression: `generator.Apply("ns", [])`,
 			Template:   &v1beta1.GenerationTemplate{Value: "apiVersion: v1\nkind: ConfigMap"},
 		})
-		compiled, errs := NewCompiler().Compile(pol, nil)
+		compiled, errs := NewCompiler().Compile(pol, nil, admissionregistrationv1.Fail)
 		assert.Nil(t, compiled)
 		assert.Contains(t, errs.ToAggregate().Error(), "only one of expression or template")
 	})
 	t.Run("rejects entry with neither expression nor template", func(t *testing.T) {
 		pol := newPolicy(v1beta1.Generation{})
-		compiled, errs := NewCompiler().Compile(pol, nil)
+		compiled, errs := NewCompiler().Compile(pol, nil, admissionregistrationv1.Fail)
 		assert.Nil(t, compiled)
 		assert.Contains(t, errs.ToAggregate().Error(), "one of expression or template must be set")
 	})
@@ -67,7 +67,7 @@ metadata:
 `,
 			},
 		})
-		compiled, errs := NewCompiler().Compile(pol, nil)
+		compiled, errs := NewCompiler().Compile(pol, nil, admissionregistrationv1.Fail)
 		assert.Nil(t, compiled)
 		assert.Contains(t, errs.ToAggregate().Error(), "spec.generate[0].template.value")
 		assert.Contains(t, errs.ToAggregate().Error(), "invalid placeholder expression")
@@ -86,7 +86,7 @@ data:
 `,
 			},
 		})
-		compiled, errs := NewCompiler().Compile(pol, nil)
+		compiled, errs := NewCompiler().Compile(pol, nil, admissionregistrationv1.Fail)
 		assert.Nil(t, compiled)
 		assert.Contains(t, errs.ToAggregate().Error(), "placeholders are not supported in mapping keys")
 	})
@@ -100,7 +100,7 @@ func TestEvaluateTemplateGeneration(t *testing.T) {
 
 	evaluate := func(t *testing.T, policy v1beta1.GeneratingPolicyLike) (*EvaluationResult, error) {
 		t.Helper()
-		compiled, errs := NewCompiler().Compile(policy, nil)
+		compiled, errs := NewCompiler().Compile(policy, nil, admissionregistrationv1.Fail)
 		require.Nil(t, errs)
 		return compiled.Evaluate(context.TODO(), attr, &request.Request, &ns, &libs.FakeContextProvider{})
 	}

--- a/pkg/cel/policies/gpol/engine/engine_test.go
+++ b/pkg/cel/policies/gpol/engine/engine_test.go
@@ -193,7 +193,7 @@ func TestHandle(t *testing.T) {
 			},
 		}
 		comp := compiler.NewCompiler()
-		compiledGpol, _ := comp.Compile(gpol, nil)
+		compiledGpol, _ := comp.Compile(gpol, nil, admissionregistrationv1.Fail)
 
 		pol := Policy{
 			Exceptions:     nil,
@@ -235,7 +235,7 @@ func TestHandle(t *testing.T) {
 			},
 		}
 		comp := compiler.NewCompiler()
-		_, errList := comp.Compile(ngpol, nil)
+		_, errList := comp.Compile(ngpol, nil, admissionregistrationv1.Fail)
 		assert.NotNil(t, errList, "namespace arg must be rejected at compile time for namespaced policies")
 	})
 
@@ -277,7 +277,7 @@ func TestHandle(t *testing.T) {
 			},
 		}
 		comp := compiler.NewCompiler()
-		compiledGpol, _ := comp.Compile(gpol, exceptions)
+		compiledGpol, _ := comp.Compile(gpol, exceptions, admissionregistrationv1.Fail)
 
 		pol := Policy{
 			Exceptions:     exceptions,
@@ -302,7 +302,7 @@ func TestHandle(t *testing.T) {
 			},
 		}
 		comp := compiler.NewCompiler()
-		compiledGpol, errs := comp.Compile(gpol, nil)
+		compiledGpol, errs := comp.Compile(gpol, nil, admissionregistrationv1.Fail)
 		assert.Nil(t, errs)
 
 		pol := Policy{

--- a/pkg/cel/policies/gpol/engine/fetch.go
+++ b/pkg/cel/policies/gpol/engine/fetch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/cel/engine"
 	"github.com/kyverno/kyverno/pkg/cel/policies/gpol/compiler"
 	policiesv1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/policies.kyverno.io/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -76,7 +77,13 @@ func (fp *fetchProvider) Get(ctx context.Context, name string) (Policy, error) {
 			}
 		}
 	}
-	compiled, errList := fp.compiler.Compile(policy, matchedExceptions)
+	failurePolicy := admissionregistrationv1.Fail
+	if getter, ok := policy.(interface {
+		GetFailurePolicy(bool) admissionregistrationv1.FailurePolicyType
+	}); ok {
+		failurePolicy = getter.GetFailurePolicy(false)
+	}
+	compiled, errList := fp.compiler.Compile(policy, matchedExceptions, failurePolicy)
 	if errList != nil {
 		return Policy{}, errList.ToAggregate()
 	}

--- a/pkg/cel/policies/gpol/validate.go
+++ b/pkg/cel/policies/gpol/validate.go
@@ -6,6 +6,7 @@ import (
 	gpolcompiler "github.com/kyverno/kyverno/pkg/cel/policies/gpol/compiler"
 	"github.com/kyverno/kyverno/pkg/cel/policies/gpol/template"
 	"github.com/kyverno/kyverno/pkg/toggle"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -22,8 +23,16 @@ func Validate(gpol v1beta1.GeneratingPolicyLike) ([]string, error) {
 		return warnings, err.ToAggregate()
 	}
 
+	failurePolicy := admissionregistrationv1.Fail
+	if getter, ok := gpol.(interface {
+		GetFailurePolicy(bool) admissionregistrationv1.FailurePolicyType
+	}); ok {
+		failurePolicy = getter.GetFailurePolicy(false)
+	}
+
 	c := gpolcompiler.NewCompiler()
-	_, errList := c.Compile(gpol, nil)
+	_, errList := c.Compile(gpol, nil, failurePolicy)
+
 	if errList != nil {
 		err = errList
 	}


### PR DESCRIPTION
## What's the problem?

When a `GeneratingPolicy` has `failurePolicy: Ignore` configured and one of its
`matchConditions` throws a CEL runtime error (not a false result — an actual error,
like a type mismatch or missing field), the error was always bubbled up to the caller
and treated as a hard failure. The `failurePolicy` setting was completely ignored.

This is inconsistent with how `ValidatingPolicy` and `MutatingPolicy` handle the same
situation — both of them correctly swallow the error and skip the policy when
`failurePolicy: Ignore` is set.

Closes #16883

## Root cause

The compiled `Policy` struct in `pkg/cel/policies/gpol/compiler/policy.go` had no
`failurePolicy` field, so the `match()` function had no way to know what the policy
author configured. It always fell through to the `return false, err` path.

The `Compile()` function also never read or stored the failure policy from the incoming
policy object. Interestingly, `GeneratingPolicyLike` doesn't expose a `GetFailurePolicy()`
method in the current API (unlike `ValidatingPolicyLike` which does), so the failure policy
now has to be passed explicitly as a parameter to `Compile()`.

## What changed

**`pkg/cel/policies/gpol/compiler/policy.go`**
- Added `failurePolicy admissionregistrationv1.FailurePolicyType` to the `Policy` struct
- Updated `match()` to check the failure policy when errors accumulate: if
  `failurePolicy == Ignore`, return `(false, nil)` instead of propagating the error

**`pkg/cel/policies/gpol/compiler/compiler.go`**
- Added `failurePolicy admissionregistrationv1.FailurePolicyType` as a third parameter
  to the `Compile()` method (on both the interface and the implementation)
- The compiled `Policy` is now initialized with the passed-in failure policy

**Callers updated** (all default to `admissionregistrationv1.Fail` to preserve existing behaviour):
- `pkg/cel/policies/gpol/engine/fetch.go`
- `pkg/cel/policies/gpol/validate.go`
- `cmd/cli/kubectl-kyverno/processor/policy_processor.go`

**Tests:**
- `pkg/cel/policies/gpol/compiler/policy_test.go` — added two regression tests:
  one confirming that `failurePolicy=Ignore` swallows the error and returns no result,
  one confirming that `failurePolicy=Fail` still propagates the error as before
- Updated all existing `Compile()` call sites in test files

## Testing

✅ pkg/cel/policies/gpol — all tests pass
✅ pkg/cel/policies/gpol/compiler — all tests pass
✅ pkg/cel/policies/gpol/engine — all tests pass 
✅ cmd/cli/kubectl-kyverno/processor — all tests pass 
✅ go build ./... — no errors