### PR TITLE
docs(test): add documentation for the conformance test suite

### DIFF
--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -1,0 +1,99 @@
+# Kyverno Conformance Testing (`test/conformance`)
+
+Kyverno uses [Chainsaw](https://kyverno.github.io/chainsaw/) to express end-to-end Kubernetes test scenarios declaratively, allowing test cases to be defined as version-controlled YAML rather than imperative scripts. These tests evaluate Kyverno in live Kubernetes clusters, validating policy engines, webhooks, background processing, cleanup policies, reports, and image verification.
+
+## Related Documentation
+
+- [Chainsaw Test Suite Reference](chainsaw/README.md)
+
+## Directory Structure
+
+Conformance tests are organized as scenario directories under `test/conformance/chainsaw/`:
+
+```
+test/conformance/
+├── README.md                           # Conformance testing overview
+└── chainsaw/                           # Chainsaw test scenarios and step templates
+    ├── _step-templates/                # Reusable, parameterized step templates
+    ├── validate/                       # Validation policy tests
+    ├── mutate/                         # Mutation policy tests
+    ├── generate/                       # Generation policy tests
+    ├── verify-images/                  # Image verification tests
+    ├── reports/                        # Policy report tests
+    ├── cleanup/                        # Cleanup and TTL policy tests
+    ├── webhooks/                       # Webhook configuration tests
+    └── ...
+```
+
+## Category Overview
+
+| Category | Description |
+|---|---|
+| `validate/`, `validating-policies/` | Validating policy rules and CEL validation policies |
+| `mutate/`, `mutating-policies/` | Mutating policy rules and JSON patch / overlay operations |
+| `generate/`, `generating-policies/` | Resource generation rules and background generation |
+| `verify-images/`, `custom-sigstore/` | Container image signature and attestation verification |
+| `reports/`, `openreports/` | PolicyReport and ClusterPolicyReport generation and updates |
+| `cleanup/`, `deleting-policies/`, `ttl/` | Resource deletion and scheduled cleanup policies |
+| `webhooks/`, `webhook-configurations/` | Dynamic webhook registration and configuration |
+| `autogen/` | Pod controller rule auto-generation |
+| `globalcontext/` | GlobalContextEntry cached data store evaluation |
+
+## Related Implementation Packages
+
+The table below outlines common relationships between conformance test categories and implementation packages in `pkg/`.
+
+> **Note**: Test execution commonly involves multiple subsystems (e.g., admission webhooks, policy engine evaluation, and report aggregation). The mappings below highlight primary areas exercised by each category.
+
+| Category | Primary Implementation Packages | Target Components |
+|---|---|---|
+| `webhooks/`, `webhook-configurations/` | `pkg/webhooks/`, `pkg/controllers/webhook/` | Admission Webhook Server, Webhook Controller |
+| `mutate/`, `mutating-policies/` | `pkg/engine/mutate/`, `pkg/engine/` | Policy Engine (Mutation), Admission Controller |
+| `validate/`, `validating-policies/`, `cel/` | `pkg/engine/validate/`, `pkg/cel/` | Policy Engine (Validation, CEL Engine) |
+| `generate/`, `generating-policies/` | `pkg/controllers/generate/`, `pkg/background/` | Background Controller, Generate Controller |
+| `cleanup/`, `deleting-policies/`, `ttl/` | `pkg/controllers/cleanup/` | Cleanup Controller, TTL Controller |
+| `reports/`, `openreports/` | `pkg/controllers/report/`, `pkg/reports/` | Reports Controller, Report Aggregator |
+| `autogen/` | `pkg/autogen/` | Policy Engine (Auto-gen Engine) |
+| `verify-images/`, `custom-sigstore/` | `pkg/cosign/`, `pkg/notary/` | Image Verification Engine |
+| `globalcontext/` | `pkg/globalcontext/` | Global Context Controller & Store |
+
+## Test Execution Lifecycle
+
+Conformance tests are organized as scenario directories containing `chainsaw-test.yaml`. During execution, Chainsaw discovers and runs these scenarios according to its configuration:
+
+1. **Namespace Setup**: Depending on the test configuration, Chainsaw creates and manages namespaces for scenario execution.
+2. **Template Resolution**: Steps referencing templates in `_step-templates/` resolve parameterized operations.
+3. **Resource Application**: Policies and workload fixtures are applied to the cluster.
+4. **Assertion Verification**: Assertions check resource state, status conditions, or expected admission rejections.
+5. **Teardown**: Ephemeral namespaces are deleted upon scenario completion.
+
+## Executing Tests
+
+### Prerequisites
+- A local Kubernetes cluster running (e.g., KinD via `make kind-create-cluster`).
+- Kyverno deployed to the cluster (`make kind-deploy-kyverno` or `make kind-deploy-all`).
+- `chainsaw` CLI installed.
+
+### Execution Command
+Run the conformance suite using `chainsaw`:
+
+```bash
+chainsaw test test/conformance/chainsaw
+```
+
+To execute a specific scenario directory (e.g., `webhooks/all-scale`):
+
+```bash
+chainsaw test test/conformance/chainsaw/webhooks/all-scale
+```
+
+## Adding a Test Scenario
+
+1. Select or create the appropriate category folder under `test/conformance/chainsaw/`.
+2. Create a subfolder using a clear, descriptive scenario name.
+3. Common files found in many scenarios include:
+   - `chainsaw-test.yaml`: Scenario step pipeline.
+   - `policy.yaml`: Policy manifest under test.
+   - Resource fixtures (e.g., `pod.yaml`, `resource.yaml`).
+   - Assertion manifests (e.g., `assert.yaml`, `webhooks.yaml`).
+4. Utilize step templates from `_step-templates/` for policy creation and readiness verification.

--- a/test/conformance/chainsaw/README.md
+++ b/test/conformance/chainsaw/README.md
@@ -1,0 +1,83 @@
+# Chainsaw Test Suite (`test/conformance/chainsaw`)
+
+This directory contains declarative end-to-end conformance scenarios executed via [Chainsaw](https://kyverno.github.io/chainsaw/).
+
+## Related Documentation
+
+- [Conformance Overview](../README.md)
+
+## Directory Structure
+
+```
+test/conformance/chainsaw/
+├── .chainsaw.yaml                      # Root configuration settings
+├── _step-templates/                    # Shared step templates
+└── <category>/<scenario-name>/         # Individual test scenarios
+    ├── chainsaw-test.yaml              # Step pipeline definition
+    └── ...
+```
+
+## Shared Step Templates (`_step-templates`)
+
+Common test operations are defined as reusable `StepTemplate` resources in `_step-templates/`:
+
+- `create-policy.yaml`: Applies a policy manifest file passed via variable binding.
+- `cluster-policy-ready.yaml`: Waits for a `ClusterPolicy` to report `Ready: true`.
+- `validating-policy-ready.yaml`: Waits for a `ValidatingPolicy` to report `Ready: true`.
+- `mutating-policy-ready.yaml`: Waits for a `MutatingPolicy` to report `Ready: true`.
+
+Example usage in `chainsaw-test.yaml` (from `test/conformance/chainsaw/webhooks/all-scale/chainsaw-test.yaml`):
+
+```yaml
+steps:
+- name: create policy
+  use:
+    template: ../../_step-templates/create-policy.yaml
+    with:
+      bindings:
+      - name: file
+        value: policy.yaml
+- name: wait policy ready
+  use:
+    template: ../../_step-templates/cluster-policy-ready.yaml
+    with:
+      bindings:
+      - name: name
+        value: require-labels
+```
+
+## Configuration (`.chainsaw.yaml`)
+
+Configuration files (such as `test/conformance/chainsaw/webhooks/.chainsaw.yaml`) define scenario execution controls:
+
+```yaml
+apiVersion: chainsaw.kyverno.io/v1alpha2
+kind: Configuration
+metadata:
+  name: configuration
+spec:
+  discovery:
+    fullName: true
+  execution:
+    failFast: true
+  namespace:
+    fastDelete: true
+  timeouts:
+    apply: 10s
+```
+
+## Debugging Test Failures
+
+1. Inspect output diffs emitted by Chainsaw during step execution.
+2. Run single scenario directories for faster iteration:
+   ```bash
+   chainsaw test test/conformance/chainsaw/<category>/<scenario>
+   ```
+3. Preserve test namespaces on failure using `--keep-resources`:
+   ```bash
+   chainsaw test test/conformance/chainsaw/<category>/<scenario> --keep-resources
+   ```
+4. Check Kyverno controller logs for evaluation details:
+   ```bash
+   kubectl logs -n kyverno -l app.kubernetes.io/instance=kyverno --tail=200
+   ```


### PR DESCRIPTION
## Explanation

This PR adds documentation for the `test/conformance` directory to improve discoverability and onboarding for contributors working with Kyverno's Chainsaw-based conformance tests.

It introduces a high-level overview of the conformance test suite and a dedicated reference for the Chainsaw test layout, common execution patterns, shared step templates, and debugging workflow.

## Related issue

N/A

## Milestone of this PR

N/A

## Documentation (required for features)

My PR does not introduce new or altered Kyverno functionality.

- [ ] I have sent the draft PR to add or update the documentation and the link is:

## What type of PR is this

/kind documentation

## Proposed Changes

- Add `test/conformance/README.md` with an overview of the conformance test suite, category descriptions, related implementation packages, execution lifecycle, and basic usage.
- Add `test/conformance/chainsaw/README.md` documenting the Chainsaw test layout, shared step templates, configuration, and debugging workflow.
- Improve navigation for contributors without changing any test behavior or runtime functionality.

### Proof Manifests

Not applicable. This PR contains documentation changes only.

## Further Comments

Documentation only. No functional changes.