### PR TITLE
fix(webhooks): record MPOL and NMPOL metrics under WebhookMutating

### DIFF
--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -81,7 +81,7 @@ func NewServer(
 			WithProtection(toggle.FromContext(ctx).ProtectManagedResources()).
 			WithDump(debugModeOpts.DumpPayload).
 			WithRoles(rbLister, crbLister).
-			WithMetrics(resourceLogger, metrics.WebhookValidating).
+			WithMetrics(resourceLogger, metrics.WebhookMutating).
 			WithTopLevelGVK(discovery).
 			WithAdmission(mpolLogger.WithName("mutate")).
 			ToHandlerFunc("MPOL"),
@@ -94,7 +94,7 @@ func NewServer(
 			WithProtection(toggle.FromContext(ctx).ProtectManagedResources()).
 			WithDump(debugModeOpts.DumpPayload).
 			WithRoles(rbLister, crbLister).
-			WithMetrics(resourceLogger, metrics.WebhookValidating).
+			WithMetrics(resourceLogger, metrics.WebhookMutating).
 			WithTopLevelGVK(discovery).
 			WithAdmission(mpolLogger.WithName("mutate")).
 			ToHandlerFunc("NMPOL"),


### PR DESCRIPTION
## Explanation

This PR fixes an incorrect metric classification for CEL-based mutating policy webhook endpoints. The `/mpol/*policies` and `/nmpol/*policies` routes were registering admission metrics as `ValidatingWebhookConfiguration` even though they process mutating admission requests. As a result, telemetry for these webhooks was reported under the validating webhook category. This change updates the metric type to `MutatingWebhookConfiguration` so Prometheus and Grafana correctly classify mutating webhook metrics.

## Related issue

Closes #16890

## Milestone of this PR

```text
/milestone 1.18.0
```

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.

- [ ] I have sent the draft PR to add or update the documentation.

No documentation changes are required because this is an internal telemetry bug fix and does not change user-facing functionality.

## What type of PR is this

```text
/kind bug
```

## Proposed Changes

- Updated the metrics middleware for the `/mpol/*policies` webhook endpoint to use `metrics.WebhookMutating`.
- Updated the metrics middleware for the `/nmpol/*policies` webhook endpoint to use `metrics.WebhookMutating`.
- Corrected the telemetry classification for CEL mutating policy webhooks while leaving admission behavior unchanged.
- Verified the change by running:
  - `go test -v ./pkg/webhooks`
  - `go build ./cmd/kyverno`

### Proof Manifests

Not applicable.

This change only corrects the webhook type used when recording telemetry metrics. It does not modify admission logic, policy evaluation, resource mutation, or Kubernetes API behavior, so no proof manifests are required.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the AI Usage Policy. If I used AI assistance, I have disclosed it in my commit(s) as required.
- [x] I have read the PR documentation guide and determined that proof manifests are not applicable for this telemetry-only bug fix.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
- [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This change aligns the telemetry emitted by the CEL `MutatingPolicy` (`/mpol`) and `NamespacedMutatingPolicy` (`/nmpol`) webhook endpoints with the other mutating webhook registrations in `pkg/webhooks/server.go`, which already use `metrics.WebhookMutating`. It is a low-risk consistency fix that improves the accuracy of Prometheus metrics, Grafana dashboards, and monitoring based on webhook type without affecting admission processing.