### PR TITLE
fix: guard type assertion in shallow variable substitution to prevent panic

### DIFF
--- a/pkg/engine/variables/vars.go
+++ b/pkg/engine/variables/vars.go
@@ -367,8 +367,10 @@ func substituteVariablesIfAny(log logr.Logger, ctx context.EvalInterface, lookup
 					prefix = string(old[0])
 				}
 
-				if shallowSubstitution && substitutedVar != nil {
-					substitutedVar = strings.ReplaceAll(substitutedVar.(string), "{{", "\\{{")
+				// only strings can carry nested `{{ }}` that need escaping;
+				// numbers, bools, maps and slices are passed through as-is
+				if s, ok := substitutedVar.(string); ok && shallowSubstitution {
+					substitutedVar = strings.ReplaceAll(s, "{{", "\\{{")
 				}
 
 				if value, err = substituteVarInPattern(prefix, value, v, substitutedVar); err != nil {

--- a/pkg/engine/variables/vars_test.go
+++ b/pkg/engine/variables/vars_test.go
@@ -588,6 +588,45 @@ func Test_SubstituteShallow(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to resolve variableWithVariables bar bar2")
 }
 
+// Test_SubstituteShallow_NonString is a regression test: shallow substitution
+// (`{{- var }}`) on a non-string value must not panic. Only strings can carry
+// nested `{{ }}` that need escaping, so numbers, bools and maps should pass
+// through substituteVarInPattern's JSON marshalling untouched.
+func Test_SubstituteShallow_NonString(t *testing.T) {
+	ctx := context.NewContext(jp)
+	data := map[string]interface{}{
+		"myNumber": 3,
+		"myBool":   true,
+		"myObject": map[string]interface{}{"a": "b"},
+	}
+
+	assert.NilError(t, context.AddJSONObject(ctx, data))
+
+	tests := []struct {
+		name     string
+		pattern  string
+		expected string
+	}{
+		{"number", `"prefix-{{- myNumber }}"`, `"prefix-3"`},
+		{"bool", `"prefix-{{- myBool }}"`, `"prefix-true"`},
+		{"object", `"prefix-{{- myObject }}"`, `"prefix-{"a":"b"}"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			action := substituteVariablesIfAny(logr.Discard(), ctx, DefaultVariableResolver)
+			results, err := action(&ju.ActionData{
+				Document: nil,
+				Element:  tc.pattern,
+				Path:     "/",
+			})
+
+			assert.NilError(t, err)
+			assert.Equal(t, results.(string), tc.expected)
+		})
+	}
+}
+
 // TODO: this test fails, not sure how we could merge this !
 // func Test_subVars_withShallowReplaceAll(t *testing.T) {
 // 	patternMap := []byte(`{


### PR DESCRIPTION
## Explanation

This PR fixes a critical bug where using shallow variable substitution (`{{- ... }}`) on non-string values (such as numbers, booleans, maps, or slices) causes an unchecked type assertion panic in `substituteVariablesIfAny`. Non-string values can now be safely substituted without panicking background controller workers or blocking admission requests under `failurePolicy: Fail`. This is a fix of existing behavior.

## Related issue

Fixes #16895

## Milestone of this PR

<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind bug

## Proposed Changes

- **Root Cause Fix:** Updated `substituteVariablesIfAny` in `pkg/engine/variables/vars.go` to use a guarded type assertion (`if s, ok := substitutedVar.(string); ok && shallowSubstitution`). Non-string values bypass string escaping and pass straight through to `substituteVarInPattern`, which already handles JSON marshaling for non-string types correctly.
- **Unit Testing:** Added `Test_SubstituteShallow_NonString` in `pkg/engine/variables/vars_test.go` to cover shallow variable substitution on numbers, booleans, and maps, verifying that they format cleanly (e.g., `prefix-3`, `prefix-true`, `prefix-{"a":"b"}`) without panicking.

### Proof Manifests

# Kubernetes resource and Kyverno policy

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: validate-deployment-replicas
spec:
  rules:
  - name: check-replicas
    match:
      any:
      - resources:
          kinds:
          - Deployment
    validate:
      message: "Configured replicas: {{- request.object.spec.replicas }}"
      pattern:
        spec:
          replicas: ">0"
```

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-deploy
spec:
  replicas: 3
  selector:
    matchLabels:
      app: test
  template:
    metadata:
      labels:
        app: test
    spec:
      containers:
      - name: nginx
        image: nginx
```

# Kyverno CLI test manifest

```yaml
name: test-shallow-non-string-substitution
policies:
  - policy.yaml
resources:
  - resource.yaml
results:
  - policy: validate-deployment-replicas
    rule: check-replicas
    resource: test-deploy
    kind: Deployment
    result: pass
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

Only string values can contain nested `{{` sequences that require escaping during shallow substitution. Numbers, booleans, maps, and slices do not contain template delimiters, so safely passing them through preserves existing JSON marshaling behavior without altering string escaping for valid string templates.