### PR TITLE
Validate cleanup-controller TLS certificates in readiness probes

### DIFF
--- a/cmd/cleanup-controller/main.go
+++ b/cmd/cleanup-controller/main.go
@@ -59,21 +59,6 @@ var (
 	tlsSecretName string
 )
 
-// TODO:
-// - helm review labels / selectors
-// - implement probes
-// - supports certs in cronjob
-
-type probes struct{}
-
-func (probes) IsReady(context.Context) bool {
-	return true
-}
-
-func (probes) IsLive(context.Context) bool {
-	return true
-}
-
 func sanityChecks(apiserverClient apiserver.Interface) error {
 	return kubeutils.CRDsInstalled(apiserverClient, "cleanuppolicies.kyverno.io", "clustercleanuppolicies.kyverno.io")
 }
@@ -165,6 +150,20 @@ func main() {
 			setup.Logger.Error(fmt.Errorf("unsupported key algorithm: %s (supported: RSA, ECDSA, Ed25519)", tlsKeyAlgorithm), "invalid tlsKeyAlgorithm flag")
 			os.Exit(1)
 		}
+		certRenewer := tls.NewCertRenewer(
+			setup.KubeClient.CoreV1().Secrets(config.KyvernoNamespace()),
+			tls.CertRenewalInterval,
+			tls.CAValidityDuration,
+			tls.TLSValidityDuration,
+			renewBefore,
+			serverIP,
+			config.KyvernoServiceName(),
+			config.DnsNames(config.KyvernoServiceName(), config.KyvernoNamespace()),
+			config.KyvernoNamespace(),
+			caSecretName,
+			tlsSecretName,
+			keyAlgorithm,
+		)
 
 		// certificates informers
 		caSecret := informers.NewSecretInformer(setup.KubeClient, config.KyvernoNamespace(), caSecretName, setup.ResyncPeriod)
@@ -261,20 +260,6 @@ func main() {
 				)
 
 				// controllers
-				renewer := tls.NewCertRenewer(
-					setup.KubeClient.CoreV1().Secrets(config.KyvernoNamespace()),
-					tls.CertRenewalInterval,
-					tls.CAValidityDuration,
-					tls.TLSValidityDuration,
-					renewBefore,
-					serverIP,
-					config.KyvernoServiceName(),
-					config.DnsNames(config.KyvernoServiceName(), config.KyvernoNamespace()),
-					config.KyvernoNamespace(),
-					caSecretName,
-					tlsSecretName,
-					keyAlgorithm,
-				)
 				var certController internal.Controller
 				if !disableCertManagerController {
 					certController = internal.NewController(
@@ -282,7 +267,7 @@ func main() {
 						certmanager.NewController(
 							caSecret,
 							tlsSecret,
-							renewer,
+							certRenewer,
 							caSecretName,
 							tlsSecretName,
 							config.KyvernoNamespace(),
@@ -453,7 +438,12 @@ func main() {
 			webhooks.DebugModeOptions{
 				DumpPayload: dumpPayload,
 			},
-			probes{},
+			probes{
+				logger:          setup.Logger.WithName("probes"),
+				certValidator:   certRenewer,
+				caSecretSynced:  caSecret.Informer().HasSynced,
+				tlsSecretSynced: tlsSecret.Informer().HasSynced,
+			},
 			setup.Configuration,
 		)
 		// start server

--- a/cmd/cleanup-controller/probes.go
+++ b/cmd/cleanup-controller/probes.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/kyverno/kyverno/pkg/tls"
+	"k8s.io/client-go/tools/cache"
+)
+
+type probes struct {
+	logger          logr.Logger
+	certValidator   tls.CertValidator
+	caSecretSynced  cache.InformerSynced
+	tlsSecretSynced cache.InformerSynced
+}
+
+func (p probes) IsReady(ctx context.Context) bool {
+	if !p.caSecretSynced() || !p.tlsSecretSynced() {
+		return false
+	}
+	valid, err := p.certValidator.ValidateCert(ctx)
+	if err != nil {
+		p.logger.Error(err, "failed to validate certificates")
+		return false
+	}
+	return valid
+}
+
+func (probes) IsLive(context.Context) bool {
+	return true
+}

--- a/cmd/cleanup-controller/probes_test.go
+++ b/cmd/cleanup-controller/probes_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/kyverno/kyverno/pkg/config"
+	"github.com/kyverno/kyverno/pkg/webhooks"
+)
+
+type testCertValidator func(context.Context) (bool, error)
+
+func (f testCertValidator) ValidateCert(ctx context.Context) (bool, error) {
+	return f(ctx)
+}
+
+type testContextKey struct{}
+
+func TestProbesIsReady(t *testing.T) {
+	validationErr := errors.New("validation failed")
+	tests := []struct {
+		name                string
+		caSecretSynced      bool
+		tlsSecretSynced     bool
+		valid               bool
+		validationErr       error
+		want                bool
+		wantCASecretChecks  int
+		wantTLSSecretChecks int
+		wantValidationCalls int
+	}{
+		{
+			name:                "certificates are valid",
+			caSecretSynced:      true,
+			tlsSecretSynced:     true,
+			valid:               true,
+			want:                true,
+			wantCASecretChecks:  1,
+			wantTLSSecretChecks: 1,
+			wantValidationCalls: 1,
+		},
+		{
+			name:               "CA secret informer is unsynced",
+			caSecretSynced:     false,
+			tlsSecretSynced:    true,
+			want:               false,
+			wantCASecretChecks: 1,
+		},
+		{
+			name:                "TLS secret informer is unsynced",
+			caSecretSynced:      true,
+			tlsSecretSynced:     false,
+			want:                false,
+			wantCASecretChecks:  1,
+			wantTLSSecretChecks: 1,
+		},
+		{
+			name:                "certificates are invalid",
+			caSecretSynced:      true,
+			tlsSecretSynced:     true,
+			valid:               false,
+			want:                false,
+			wantCASecretChecks:  1,
+			wantTLSSecretChecks: 1,
+			wantValidationCalls: 1,
+		},
+		{
+			name:                "certificate validation fails",
+			caSecretSynced:      true,
+			tlsSecretSynced:     true,
+			validationErr:       validationErr,
+			want:                false,
+			wantCASecretChecks:  1,
+			wantTLSSecretChecks: 1,
+			wantValidationCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var caSecretChecks, tlsSecretChecks, validationCalls int
+			ctx := context.WithValue(context.Background(), testContextKey{}, tt.name)
+			var validationContext context.Context
+			probe := probes{
+				logger: logr.Discard(),
+				certValidator: testCertValidator(func(ctx context.Context) (bool, error) {
+					validationCalls++
+					validationContext = ctx
+					return tt.valid, tt.validationErr
+				}),
+				caSecretSynced: func() bool {
+					caSecretChecks++
+					return tt.caSecretSynced
+				},
+				tlsSecretSynced: func() bool {
+					tlsSecretChecks++
+					return tt.tlsSecretSynced
+				},
+			}
+
+			if got := probe.IsReady(ctx); got != tt.want {
+				t.Errorf("IsReady() = %v, want %v", got, tt.want)
+			}
+			if caSecretChecks != tt.wantCASecretChecks {
+				t.Errorf("CA secret sync checks = %d, want %d", caSecretChecks, tt.wantCASecretChecks)
+			}
+			if tlsSecretChecks != tt.wantTLSSecretChecks {
+				t.Errorf("TLS secret sync checks = %d, want %d", tlsSecretChecks, tt.wantTLSSecretChecks)
+			}
+			if validationCalls != tt.wantValidationCalls {
+				t.Errorf("validation calls = %d, want %d", validationCalls, tt.wantValidationCalls)
+			}
+			if validationCalls > 0 && validationContext != ctx {
+				t.Error("ValidateCert() did not receive the request context")
+			}
+		})
+	}
+}
+
+func TestProbesIsLive(t *testing.T) {
+	if !(probes{}).IsLive(context.Background()) {
+		t.Error("IsLive() = false, want true")
+	}
+}
+
+func TestServerProbeStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		certsAreValid  bool
+		wantStatusCode int
+	}{
+		{name: "ready", certsAreValid: true, wantStatusCode: http.StatusOK},
+		{name: "not ready", certsAreValid: false, wantStatusCode: http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probe := probes{
+				logger:          logr.Discard(),
+				certValidator:   testCertValidator(func(context.Context) (bool, error) { return tt.certsAreValid, nil }),
+				caSecretSynced:  func() bool { return true },
+				tlsSecretSynced: func() bool { return true },
+			}
+			cleanupServer, ok := NewServer(
+				func() ([]byte, []byte, error) { return nil, nil, nil },
+				nil,
+				nil,
+				nil,
+				webhooks.DebugModeOptions{},
+				probe,
+				nil,
+			).(*server)
+			if !ok {
+				t.Fatal("NewServer() did not return a *server")
+			}
+
+			request := httptest.NewRequest(http.MethodGet, config.ReadinessServicePath, nil)
+			response := httptest.NewRecorder()
+			cleanupServer.server.Handler.ServeHTTP(response, request)
+			if response.Code != tt.wantStatusCode {
+				t.Errorf("readiness status code = %d, want %d", response.Code, tt.wantStatusCode)
+			}
+		})
+	}
+}

--- a/pkg/tls/renewer.go
+++ b/pkg/tls/renewer.go
@@ -146,16 +146,16 @@ func (c *certRenewer) RenewTLS(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to read CA (%w)", err)
 	}
-	secret, _, cert, err := c.decodeTLSSecret(ctx)
+	secret, _, certs, err := c.decodeTLSSecret(ctx)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to read TLS (%w)", err)
 	}
 	now := time.Now()
-	if cert != nil {
+	if len(certs) != 0 {
 		valid, err := c.ValidateCert(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to validate cert: %w", err)
-		} else if valid && !allCertificatesExpired(now.Add(c.renewBefore), cert) {
+		} else if valid && !allCertificatesExpired(now.Add(c.renewBefore), certs[0]) {
 			return nil
 		}
 	}
@@ -182,11 +182,11 @@ func (c *certRenewer) ValidateCert(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	_, _, cert, err := c.decodeTLSSecret(ctx)
+	_, _, certs, err := c.decodeTLSSecret(ctx)
 	if err != nil {
 		return false, err
 	}
-	return validateCert(time.Now(), cert, caCerts...), nil
+	return validateCert(time.Now(), certs, caCerts...), nil
 }
 
 func (c *certRenewer) getSecret(ctx context.Context, name string) (*corev1.Secret, error) {
@@ -225,18 +225,8 @@ func (c *certRenewer) decodeCASecret(ctx context.Context) (*corev1.Secret, crypt
 	return c.decodeSecret(ctx, c.caSecret)
 }
 
-func (c *certRenewer) decodeTLSSecret(ctx context.Context) (*corev1.Secret, crypto.PrivateKey, *x509.Certificate, error) {
-	secret, key, certs, err := c.decodeSecret(ctx, c.pairSecret)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	if len(certs) == 0 {
-		return secret, key, nil, nil
-	} else if len(certs) == 1 {
-		return secret, key, certs[0], nil
-	} else {
-		return nil, nil, nil, err
-	}
+func (c *certRenewer) decodeTLSSecret(ctx context.Context) (*corev1.Secret, crypto.PrivateKey, []*x509.Certificate, error) {
+	return c.decodeSecret(ctx, c.pairSecret)
 }
 
 func (c *certRenewer) writeSecret(ctx context.Context, name string, key crypto.PrivateKey, certs ...*x509.Certificate) error {

--- a/pkg/tls/renewer_test.go
+++ b/pkg/tls/renewer_test.go
@@ -1,0 +1,177 @@
+package tls
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	cryptotls "crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type certRenewerTestClient struct {
+	secrets map[string]*corev1.Secret
+}
+
+func (c *certRenewerTestClient) Get(_ context.Context, name string, _ metav1.GetOptions) (*corev1.Secret, error) {
+	secret, ok := c.secrets[name]
+	if !ok {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, name)
+	}
+	return secret, nil
+}
+
+func (c *certRenewerTestClient) Create(_ context.Context, secret *corev1.Secret, _ metav1.CreateOptions) (*corev1.Secret, error) {
+	c.secrets[secret.Name] = secret
+	return secret, nil
+}
+
+func (c *certRenewerTestClient) Update(_ context.Context, secret *corev1.Secret, _ metav1.UpdateOptions) (*corev1.Secret, error) {
+	c.secrets[secret.Name] = secret
+	return secret, nil
+}
+
+func (c *certRenewerTestClient) Delete(_ context.Context, name string, _ metav1.DeleteOptions) error {
+	delete(c.secrets, name)
+	return nil
+}
+
+func TestCertRenewerValidateCertTLSChain(t *testing.T) {
+	rootKey, rootCert, err := generateCA(nil, 365*24*time.Hour, ECDSA)
+	require.NoError(t, err)
+	intermediateKey, intermediateCert := generateIntermediateCA(t, rootCert, rootKey)
+
+	servingKey, servingCert, err := generateTLS("", intermediateCert, intermediateKey, 24*time.Hour, "serving.kyverno.svc", nil, ECDSA)
+	require.NoError(t, err)
+	servingChainPEM := certificateToPem(servingCert, intermediateCert)
+	servingKeyPEM, err := privateKeyToPem(servingKey)
+	require.NoError(t, err)
+	_, err = cryptotls.X509KeyPair(servingChainPEM, servingKeyPEM)
+	require.NoError(t, err, "a standard serving chain should be accepted by tls.X509KeyPair")
+
+	directServingKey, directServingCert, err := generateTLS("", rootCert, rootKey, 24*time.Hour, "direct.kyverno.svc", nil, ECDSA)
+	require.NoError(t, err)
+
+	untrustedKey, untrustedCert, err := generateCA(nil, 365*24*time.Hour, ECDSA)
+	require.NoError(t, err)
+	untrustedServingKey, untrustedServingCert, err := generateTLS("", untrustedCert, untrustedKey, 24*time.Hour, "untrusted.kyverno.svc", nil, ECDSA)
+	require.NoError(t, err)
+
+	malformedIntermediate := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not a certificate")})
+	malformedChainPEM := append(certificateToPem(servingCert), malformedIntermediate...)
+
+	tests := []struct {
+		name    string
+		tls     *corev1.Secret
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "valid serving chain",
+			tls:  newTLSSecret(t, servingChainPEM, servingKey),
+			want: true,
+		},
+		{
+			name: "single serving certificate",
+			tls:  newTLSSecret(t, certificateToPem(directServingCert), directServingKey),
+			want: true,
+		},
+		{
+			name: "missing intermediate certificate",
+			tls:  newTLSSecret(t, certificateToPem(servingCert), servingKey),
+			want: false,
+		},
+		{
+			name: "untrusted intermediate certificate",
+			tls:  newTLSSecret(t, certificateToPem(untrustedServingCert, untrustedCert), untrustedServingKey),
+			want: false,
+		},
+		{
+			name: "malformed intermediate certificate",
+			tls:  newTLSSecret(t, malformedChainPEM, servingKey),
+			want: false,
+		},
+		{
+			name: "malformed private key",
+			tls: &corev1.Secret{
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       certificateToPem(directServingCert),
+					corev1.TLSPrivateKeyKey: []byte("not a private key"),
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			renewer := &certRenewer{
+				client: &certRenewerTestClient{secrets: map[string]*corev1.Secret{
+					"ca": {
+						Data: map[string][]byte{corev1.TLSCertKey: certificateToPem(rootCert)},
+					},
+					"tls": tt.tls,
+				}},
+				caSecret:   "ca",
+				pairSecret: "tls",
+			}
+
+			valid, err := renewer.ValidateCert(t.Context())
+			if tt.wantErr {
+				require.Error(t, err)
+				require.False(t, valid)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, valid)
+		})
+	}
+}
+
+func newTLSSecret(t *testing.T, certPEM []byte, key crypto.PrivateKey) *corev1.Secret {
+	t.Helper()
+	keyPEM, err := privateKeyToPem(key)
+	require.NoError(t, err)
+	return &corev1.Secret{
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certPEM,
+			corev1.TLSPrivateKeyKey: keyPEM,
+		},
+	}
+}
+
+func generateIntermediateCA(t *testing.T, issuer *x509.Certificate, issuerKey crypto.PrivateKey) (crypto.PrivateKey, *x509.Certificate) {
+	t.Helper()
+	key, err := generatePrivateKey(ECDSA)
+	require.NoError(t, err)
+	publicKey, err := getPublicKey(key)
+	require.NoError(t, err)
+
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "intermediate.kyverno.svc"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            0,
+		MaxPathLenZero:        true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, issuer, publicKey, issuerKey)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return key, cert
+}

--- a/pkg/tls/utils.go
+++ b/pkg/tls/utils.go
@@ -94,7 +94,11 @@ func allCertificatesExpired(now time.Time, certs ...*x509.Certificate) bool {
 	return true
 }
 
-func validateCert(now time.Time, cert *x509.Certificate, caCerts ...*x509.Certificate) bool {
+func validateCert(now time.Time, certs []*x509.Certificate, caCerts ...*x509.Certificate) bool {
+	if len(certs) == 0 {
+		return false
+	}
+	cert := certs[0]
 	if cert == nil || len(cert.Raw) == 0 {
 		return false
 	}
@@ -109,7 +113,17 @@ func validateCert(now time.Time, cert *x509.Certificate, caCerts ...*x509.Certif
 	if !added {
 		return false
 	}
-	_, err := cert.Verify(x509.VerifyOptions{Roots: pool, CurrentTime: now})
+	intermediates := x509.NewCertPool()
+	for _, intermediate := range certs[1:] {
+		if intermediate != nil && len(intermediate.Raw) != 0 {
+			intermediates.AddCert(intermediate)
+		}
+	}
+	_, err := cert.Verify(x509.VerifyOptions{
+		Roots:         pool,
+		Intermediates: intermediates,
+		CurrentTime:   now,
+	})
 	return err == nil
 }
 


### PR DESCRIPTION


## Explanation

The cleanup-controller readiness probe previously returned healthy unconditionally, allowing a pod with an expired or untrusted serving certificate to remain in the Service’s ready endpoints.

This change makes readiness reflect the cleanup-controller’s ability to serve trusted TLS traffic while keeping liveness unconditionally healthy.

  ## Changes

  - Move construction of the existing TLS certificate renewer outside the leader-election callback.
  - Share its CertValidator with every cleanup-controller replica.
  - Require the CA and serving certificate Secret informer caches to be synchronized before reporting ready.
  - Validate the serving certificate against the configured CA and current time.
  - Return not ready when certificate validation fails or reports an invalid certificate.
  - Continue reporting live during certificate failures to avoid restart loops while the certificate is repaired.
  - Remove the obsolete cleanup-controller TODO block.
  - Add unit tests for:
      - valid certificates;
      - unsynchronized CA and serving Secret caches;
      - invalid certificates;
      - validator errors;
      - request-context propagation;
      - unconditional liveness; and
      - HTTP 200/500 probe responses.

Only the always-running TLS Secret informers gate readiness. Leader-only informer caches are intentionally excluded because follower replicas still serve admission requests without starting those informers.

This fix validates certificate trust and validity using the existing tls.CertValidator. DNS SAN validation is not currently performed by that validator and remains outside the scope of this issue.

## Related issue 

Fixes #16852 

## Documentation (required for features)
Not applicable. This is an internal bug fix to the existing cleanup-controller readiness probe. It introduces no new API, CLI, configuration, Helm value, or user workflow.
  

## What type of PR is this

> /kind bug

## Proposed Changes

This PR replaces the cleanup-controller’s placeholder readiness probe with certificate-aware readiness checks. A replica reports ready only after its TLS Secret informer caches are synchronized and its serving certificate is valid and trusted by the configured CA.

Liveness remains always healthy to avoid restart loops while certificates are repaired. The existing certificate renewer is shared with the readiness probe, and unit tests cover valid, invalid, error, and unsynchronized-cache cases.

### Proof Manifests

This is controller runtime behavior and cannot be tested with the Kyverno CLI. It was verified using a locally built cleanup-controller in a dedicated KinD cluster.

  ```yaml
  apiVersion: kyverno.io/v2
  kind: CleanupPolicy
  metadata:
    name: cleanup-readiness-proof
    namespace: default
  spec:
    match:
      any:
        - resources:
            kinds:
              - Pod
    schedule: "0 * * * *"
  ```

  Validation:

  1. Deployed with:

     ```bash
     make kind-create-cluster KIND_NAME=kyverno-16852 KIND_CONFIG=codegen
     make kind-deploy-kyverno KIND_NAME=kyverno-16852
     ```

  2. With valid certificates:

     ```text
     liveness=200
     readiness=200
     pod Ready=True
     EndpointSlice ready=true
     CleanupPolicy server-side admission succeeded
     ```

  3. Replaced only the serving certificate with a valid keypair signed by an unrelated CA, after disabling automatic certificate repair:

     ```text
     liveness=200
     readiness=500
     pod Ready=False but remained Running with zero restarts
     EndpointSlice ready=false
     CleanupPolicy admission failed because no ready backend remained
     ```

  4. Restored the original certificate:

     ```text
     readiness=200
     pod Ready=True without restarting
     EndpointSlice ready=true
     CleanupPolicy admission succeeded
     ```

  5. Deleted the dedicated cluster:

     ```bash
     make kind-delete-cluster KIND_NAME=kyverno-16852
     ```
    
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
- [ ] CLI support should be added and my PR doesn't contain that functionality.

