### PR TITLE
fix: correctly skip YAML document separators and clean up Makefile TODOs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -832,7 +832,6 @@ codegen-api-bump: ## Regenerate everything affected by a github.com/kyverno/api 
 codegen-api-bump: codegen-all-code
 codegen-api-bump: codegen-all-docs
 
-# TODO: are we using this ?
 .PHONY: codegen-helm-update-versions
 codegen-helm-update-versions: ## Update helm charts versions
 	@echo Updating Chart.yaml files... >&2

--- a/ext/yaml/empty.go
+++ b/ext/yaml/empty.go
@@ -8,7 +8,7 @@ import (
 func IsEmptyDocument(document document) bool {
 	for _, line := range strings.Split(string(document), "\n") {
 		line := strings.TrimSpace(line)
-		if line != "" && !strings.HasPrefix(line, "#") {
+		if line != "" && line != "---" && !strings.HasPrefix(line, "#") {
 			return false
 		}
 	}

--- a/ext/yaml/split_test.go
+++ b/ext/yaml/split_test.go
@@ -49,7 +49,6 @@ func TestSplitDocuments(t *testing.T) {
 		},
 		wantErr: false,
 	},
-		// TODO those tests should fail IMHO
 		{
 			name: "empty doc",
 			args: args{
@@ -66,19 +65,15 @@ func TestSplitDocuments(t *testing.T) {
 			args: args{
 				[]byte("---\n---\n"),
 			},
-			wantDocuments: []string{
-				"---\n",
-			},
+			wantDocuments: nil,
 			wantErr: false,
 		},
 		{
-			name: "only separators",
+			name: "only separators with newlines",
 			args: args{
 				[]byte("---\n\n\n---\n"),
 			},
-			wantDocuments: []string{
-				"---\n\n\n",
-			},
+			wantDocuments: nil,
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
## Explanation:

1. YAML Parser Edge Case Fix: The `IsEmptyDocument` function previously failed to recognize the `---` document separator as "empty", meaning streams containing only separators or trailing separators would return dummy documents instead of being properly filtered out. I've updated the logic to safely ignore `---` lines and updated the `split_test.go` assertions to expect an empty slice (`nil`) for separator-only streams. This resolves the `// TODO those tests should fail IMHO` comment.

2. **Makefile**: Removed the `# TODO: are we using this ?` comment above the `codegen-helm-update-versions` target. ichecked the codebase and it confirms this target is ACTUALLY required in `docs/dev/releases/create-a-release.md`.

## Related issue
- ```ext/yaml/split_test.go```: // TODO those tests should fail IMHO
- Makefile: # TODO: are we using this ?


## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR does contains new or altered behavior to Kyverno. it only makes sure the test case is in align with what was supposed to be happening.

### Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:

> /kind cleanup

## Proposed Changes

Resolves outstanding TODO comments in the codebase related to edge cases in the YAML parser (`ext/yaml`) and the one OLD comment in the `Makefile`. 

### Proof Manifests

Not applicable..

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.