### PR TITLE
ci: run the orphaned conformance suites and guard against new ones

### DIFF
--- a/.github/workflows/check-conformance-coverage.yaml
+++ b/.github/workflows/check-conformance-coverage.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Conformance coverage
+
+permissions: {}
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release-*
+  push:
+    branches:
+      - main
+      - release-*
+
+concurrency:
+  group: ${{ github.workflow_ref }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    name: Verify conformance coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Verify every conformance suite is reachable and referenced
+        run: scripts/verify-conformance-coverage.sh
+
+  sync-issue:
+    if: always() && github.event_name == 'push'
+    needs:
+      - check
+    permissions:
+      issues: write
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Sync issue
+        uses: ./.github/actions/workflow/failure-issue
+        with:
+          conclusion: ${{ contains(needs.*.result, 'failure') && 'failure' || job.status }}
+          needs: ${{ toJSON(needs) }}

--- a/.github/workflows/tests-conformance.yaml
+++ b/.github/workflows/tests-conformance.yaml
@@ -83,6 +83,36 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tests-path: cel/http
 
+  configs:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [v1.33.7, v1.34.3, v1.35.1]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/tests/conformance/run
+        with:
+          k8s-version: ${{ matrix.k8s-version }}
+          kyverno-configs: standard
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tests-path: configs
+
+  flags:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [v1.33.7, v1.34.3, v1.35.1]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/tests/conformance/run
+        with:
+          k8s-version: ${{ matrix.k8s-version }}
+          kyverno-configs: standard
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tests-path: flags/standard
+
   custom-sigstore:
     runs-on: ubuntu-latest
     strategy:

--- a/scripts/verify-conformance-coverage.sh
+++ b/scripts/verify-conformance-coverage.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Check that every chainsaw conformance test is reachable by CI.
+# Usage: scripts/verify-conformance-coverage.sh
+#
+# The conformance action runs `chainsaw test --config .chainsaw.yaml` from the
+# suite directory, so a test only runs if a .chainsaw.yaml sits above it and a
+# workflow names the suite. Fails, listing offenders, when either is missing.
+
+set -e
+
+CHAINSAW_DIR="test/conformance/chainsaw"
+WORKFLOW_DIR=".github"
+
+# Suites deliberately not run by CI. Add a reason with any entry.
+EXEMPT_SUITES=()
+
+if [ ! -d "$CHAINSAW_DIR" ]; then
+  echo "error: $CHAINSAW_DIR not found; run from the repository root" >&2
+  exit 1
+fi
+
+suite_roots=$(find "$CHAINSAW_DIR" -name '.chainsaw.yaml' -printf '%h\n' | sed "s|^$CHAINSAW_DIR/||" | sort -u)
+test_dirs=$(find "$CHAINSAW_DIR" -name 'chainsaw-test.yaml' -printf '%h\n' | sed "s|^$CHAINSAW_DIR/||" | sort -u)
+
+# Suites named by a tests-path input or by a job that cds into one. Either may
+# carry a subdirectory or a matrix expression, so match the first segment.
+referenced=$(
+  {
+    grep -rho -- 'tests-path:[[:space:]]*[^[:space:]]*' "$WORKFLOW_DIR" | sed 's|tests-path:[[:space:]]*||'
+    grep -rho -- "$CHAINSAW_DIR/[A-Za-z0-9_.-]*" "$WORKFLOW_DIR" | sed "s|^$CHAINSAW_DIR/||"
+  } 2>/dev/null | cut -d/ -f1 | grep -v '^\.$' | sort -u
+)
+
+failed=0
+
+for dir in $test_dirs; do
+  covered=false
+  for root in $suite_roots; do
+    case "$dir/" in
+      "$root"/*) covered=true; break ;;
+    esac
+  done
+  if [ "$covered" = false ]; then
+    echo "error: no .chainsaw.yaml above $CHAINSAW_DIR/$dir, so chainsaw never collects it" >&2
+    failed=1
+  fi
+done
+
+for root in $suite_roots; do
+  suite="${root%%/*}"
+  exempted=false
+  for exempt in "${EXEMPT_SUITES[@]}"; do
+    if [ "$suite" = "$exempt" ]; then
+      exempted=true
+    fi
+  done
+  if [ "$exempted" = true ]; then
+    continue
+  fi
+  if ! echo "$referenced" | grep -qx -- "$suite"; then
+    echo "error: no workflow runs $CHAINSAW_DIR/$root" >&2
+    failed=1
+  fi
+done
+
+for suite in $referenced; do
+  if [ ! -d "$CHAINSAW_DIR/$suite" ]; then
+    echo "error: workflows reference $CHAINSAW_DIR/$suite, which does not exist" >&2
+    failed=1
+  fi
+done
+
+if [ "$failed" -ne 0 ]; then
+  echo "add a .chainsaw.yaml at the suite root, add a job in tests-conformance.yaml, or list the suite in EXEMPT_SUITES" >&2
+  exit 1
+fi
+
+echo "ok: $(echo "$suite_roots" | wc -l) conformance suites, all reachable and referenced"

--- a/test/conformance/chainsaw/configs/.chainsaw.yaml
+++ b/test/conformance/chainsaw/configs/.chainsaw.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/configuration-chainsaw-v1alpha2.json
+apiVersion: chainsaw.kyverno.io/v1alpha2
+kind: Configuration
+metadata:
+  name: configuration
+spec:
+  discovery:
+    fullName: true
+  execution:
+    failFast: true
+    # Both tests patch the same kyverno ConfigMap, so they can't run together.
+    parallel: 1
+  namespace:
+    fastDelete: true
+  timeouts:
+    apply: 10s

--- a/test/conformance/chainsaw/flags/standard/.chainsaw.yaml
+++ b/test/conformance/chainsaw/flags/standard/.chainsaw.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/configuration-chainsaw-v1alpha2.json
+apiVersion: chainsaw.kyverno.io/v1alpha2
+kind: Configuration
+metadata:
+  name: configuration
+spec:
+  discovery:
+    fullName: true
+  execution:
+    failFast: true
+    # Tests here patch the admission controller deployment, so they can't run together.
+    parallel: 1
+  namespace:
+    fastDelete: true
+  timeouts:
+    apply: 10s


### PR DESCRIPTION
## Explanation

Three conformance tests in this repo have never run. The suites at `test/conformance/chainsaw/configs` and `test/conformance/chainsaw/flags` are in the tree, get picked up by schema chores, and are never executed, because neither directory has a `.chainsaw.yaml` and no workflow names either path.

This runs them, and adds a check so the next suite added this way fails CI instead of sitting there. It's a fix to CI, nothing in Kyverno itself changes.

## Related issue

Relates to #16665 (Phase 0, CI/test metadata for scoped runs). Doesn't close it. It gives the path-to-suite map something accurate to build on.

## Milestone of this PR

<!-- can set on request -->

## Documentation (required for features)

Not needed, no Kyverno behavior changes here.

## What type of PR is this

/kind failing-test

## Proposed Changes

The conformance action ends with:

```
cd ./test/conformance/chainsaw/${{ inputs.tests-path }}
chainsaw test --config .chainsaw.yaml
```

So a test only runs if there's a `.chainsaw.yaml` above it and some workflow names the suite. All 52 working suites have both. `configs` and `flags` have neither, so these have never executed:

- `configs/emit-success-events-upon-generateSuccessEvents-set-true` (#10741, 2024-09-04)
- `configs/dont-emit-success-events-upon-generateSuccessEvents-set-false` (#10741, 2024-09-04)
- `flags/standard/emit-events` (#9011, 2023-11-24)

`git log -S` over the whole history of `.github/` turns up nothing for either path, so they weren't wired up and later broken. They went in incomplete.

What I changed:

1. Added `.chainsaw.yaml` to `configs/` and `flags/standard/`, same config the  other 28 suites use, with one difference. Both `configs` tests run `kubectl patch configmap kyverno` with opposite values for `generateSuccessEvents`, and the `flags` test patches the admission controller deployment's `--omitEvents` flag. Run those concurrently and they race on shared state, so both suites pin `parallel: 1`. (`namespaced-image-validating-policies` already sets `parallel: 2`, so this isn't a new pattern.)

2. Added `configs` and `flags` jobs to `tests-conformance.yaml`, same shape as the existing ones, 3 k8s versions each. Adds 6 matrix runs.

3. Added `scripts/verify-conformance-coverage.sh` and a check workflow. It verifies the two things that already hold everywhere else: a `chainsaw-test.yaml` has a `.chainsaw.yaml` above it, and a workflow names the suite. It also catches a `tests-path` pointing at a directory that isn't there. No dependencies past coreutils, so the job is a checkout and one command with no tool install.

Verification, on `main`:

```
$ scripts/verify-conformance-coverage.sh
error: no .chainsaw.yaml above test/conformance/chainsaw/configs/dont-emit-success-events-upon-generateSuccessEvents-set-false, so chainsaw never collects it
error: no .chainsaw.yaml above test/conformance/chainsaw/configs/emit-success-events-upon-generateSuccessEvents-set-true, so chainsaw never collects it
error: no .chainsaw.yaml above test/conformance/chainsaw/flags/standard/emit-events, so chainsaw never collects it
```

With this applied:

```
$ scripts/verify-conformance-coverage.sh
ok: 54 conformance suites, all reachable and referenced
```

I also checked the other two failure paths by hand: a suite root nothing references gets reported, and a `tests-path` pointing at a missing directory gets reported.

One thing worth saying up front: these three tests have never run, so I can't tell you from here whether they pass. If any of them fail, that's a second finding rather than something this PR broke, and I'm happy to split the enablement out from the check so the check can go in on its own while the tests get looked at.

### Proof Manifests

N/A, no user facing behavior added or changed.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

I thought about writing the check in Go under `hack/` so it parses the workflow YAML properly instead of matching on `tests-path:` and literal suite paths. I went with the script because those two patterns are stable and it keeps the check dependency free, but happy to redo it in Go if you'd rather not add another shell script.

`EXEMPT_SUITES` is empty on purpose. Everything passes right now, and I'd rather an exemption get added deliberately with a reason than ship the check already weakened.