### PR TITLE
ci: add a conformance suite map and resolver

### DIFF
--- a/.github/conformance-suite-map.yaml
+++ b/.github/conformance-suite-map.yaml
@@ -1,0 +1,77 @@
+# Which conformance suites a change needs.
+#
+# Used to run a subset of .github/workflows/tests-conformance.yaml instead of
+# the whole matrix. The default is deliberately the safe one: a changed file
+# that matches nothing here runs every suite. Only paths whose blast radius is
+# genuinely narrow are listed, so a wrong entry here costs extra CI time and
+# never costs coverage.
+#
+# Shared packages are absent on purpose. pkg/engine, pkg/cel, pkg/controllers,
+# pkg/webhooks, api/ and config/crds co-change with most suites, so they fall
+# through to the full run.
+#
+# Suite names are directories under test/conformance/chainsaw/ and must match
+# a tests-path in tests-conformance.yaml. scripts/conformance-suites-for.sh
+# reads this file; --verify checks both of those hold.
+
+# Globs that never change conformance results.
+skip:
+  - docs/**
+  - "**/*.md"
+  - .github/ISSUE_TEMPLATE/**
+  - .github/dependabot.yml
+  - .github/labels.yml
+  - .gitignore
+  - LICENSE
+  - NOTICE
+  - codecov.yml
+  - sonar-project.properties
+  - .codeclimate.yml
+  - .semgrepignore
+
+# Globs whose blast radius is a known subset of suites.
+suites:
+  pkg/tls/**:
+    - tls-certificates
+  pkg/controllers/certmanager/**:
+    - tls-certificates
+  pkg/cosign/**:
+    - verify-images
+    - custom-sigstore
+    - sigstore-custom-tuf
+  pkg/notary/**:
+    - verify-images
+  pkg/autogen/**:
+    - autogen
+  pkg/event/**:
+    - events
+  pkg/globalcontext/**:
+    - globalcontext
+  pkg/controllers/globalcontext/**:
+    - globalcontext
+  pkg/webhooks/globalcontext/**:
+    - globalcontext
+  pkg/exceptions/**:
+    - exceptions
+    - policy-exceptions-disabled
+  pkg/controllers/exceptions/**:
+    - exceptions
+    - policy-exceptions-disabled
+  pkg/controllers/ttl/**:
+    - ttl
+  pkg/controllers/cleanup/**:
+    - cleanup
+  pkg/openreports/**:
+    - openreports
+    - reports
+  pkg/leaderelection/**:
+    - lease
+  cmd/cli/**:
+    - cli
+  pkg/cli/**:
+    - cli
+  cmd/cleanup-controller/**:
+    - cleanup
+    - ttl
+    - deleting-policies
+    - namespaced-deleting-policies

--- a/.github/workflows/check-conformance-map.yaml
+++ b/.github/workflows/check-conformance-map.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Conformance map
+
+permissions: {}
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release-*
+  push:
+    branches:
+      - main
+      - release-*
+
+concurrency:
+  group: ${{ github.workflow_ref }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    name: Verify conformance suite map
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install yq
+        uses: ./.github/actions/tools/yq
+      - name: Verify the map matches the conformance workflow
+        run: scripts/conformance-suites-for.sh --verify
+
+  sync-issue:
+    if: always() && github.event_name == 'push'
+    needs:
+      - check
+    permissions:
+      issues: write
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Sync issue
+        uses: ./.github/actions/workflow/failure-issue
+        with:
+          conclusion: ${{ contains(needs.*.result, 'failure') && 'failure' || job.status }}
+          needs: ${{ toJSON(needs) }}

--- a/scripts/conformance-suites-for.sh
+++ b/scripts/conformance-suites-for.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Print the conformance suites a set of changed files needs, or ALL.
+# Usage: scripts/conformance-suites-for.sh <file>...
+#        git diff --name-only main... | scripts/conformance-suites-for.sh
+#        scripts/conformance-suites-for.sh --verify
+#
+# Reads .github/conformance-suite-map.yaml. A file matching nothing in the map
+# prints ALL, so an incomplete map costs CI time rather than coverage.
+
+# -f matters: the map holds globs, and without it the shell expands them
+# against the working tree instead of matching them as patterns.
+set -ef
+
+MAP=".github/conformance-suite-map.yaml"
+CHAINSAW_DIR="test/conformance/chainsaw"
+WORKFLOW=".github/workflows/tests-conformance.yaml"
+
+if [ ! -f "$MAP" ]; then
+  echo "error: $MAP not found; run from the repository root" >&2
+  exit 1
+fi
+
+# Without this the yq calls return nothing and every check silently passes.
+if ! command -v yq >/dev/null 2>&1; then
+  echo "error: yq is required (.github/actions/tools/yq installs it in CI)" >&2
+  exit 1
+fi
+
+# Bash patterns already let * span /, so ** collapses to * and a leading */
+# is redundant.
+to_pattern() {
+  local p="${1//\*\*/\*}"
+  printf '%s' "${p#\*/}"
+}
+
+runnable_suites() {
+  {
+    grep -o -- 'tests-path:[[:space:]]*[^[:space:]]*' "$WORKFLOW" | sed 's|tests-path:[[:space:]]*||'
+    grep -o -- "$CHAINSAW_DIR/[A-Za-z0-9_.-]*" "$WORKFLOW" | sed "s|^$CHAINSAW_DIR/||"
+  } | cut -d/ -f1 | grep -v '^\.$' | sort -u
+}
+
+# glob<TAB>suite, one pair per line.
+pairs=$(yq -r '.suites | to_entries[] | .key as $k | .value[] | $k + "\t" + .' "$MAP")
+skip_globs=$(yq -r '.skip[]' "$MAP")
+
+if [ "${1:-}" = "--verify" ]; then
+  failed=0
+  runnable=$(runnable_suites)
+  while IFS=$'\t' read -r glob suite; do
+    [ -n "$suite" ] || continue
+    if [ ! -d "$CHAINSAW_DIR/$suite" ]; then
+      echo "error: $MAP maps $glob to '$suite', which is not a directory in $CHAINSAW_DIR" >&2
+      failed=1
+    elif ! printf '%s\n' "$runnable" | grep -qx -- "$suite"; then
+      echo "error: $MAP maps $glob to '$suite', which no job in $WORKFLOW runs" >&2
+      failed=1
+    fi
+  done <<EOF
+$pairs
+EOF
+  while IFS= read -r key; do
+    case "$key" in
+      skip|suites|"") ;;
+      *) echo "error: $MAP has unknown top level key '$key'" >&2; failed=1 ;;
+    esac
+  done <<EOF
+$(yq -r 'keys[]' "$MAP")
+EOF
+  if [ "$failed" -ne 0 ]; then
+    exit 1
+  fi
+  echo "ok: $MAP is consistent with $WORKFLOW"
+  exit 0
+fi
+
+if [ "$#" -gt 0 ]; then
+  changed=$(printf '%s\n' "$@")
+else
+  changed=$(cat)
+fi
+
+selected=""
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+
+  # A change inside a suite needs that suite, no map entry required.
+  case "$file" in
+    "$CHAINSAW_DIR"/*)
+      rest=${file#"$CHAINSAW_DIR"/}
+      selected="$selected ${rest%%/*}"
+      continue
+      ;;
+  esac
+
+  skipped=false
+  while IFS= read -r glob; do
+    [ -n "$glob" ] || continue
+    pat=$(to_pattern "$glob")
+    case "$file" in
+      $pat) skipped=true; break ;;
+    esac
+  done <<EOF
+$skip_globs
+EOF
+  if [ "$skipped" = true ]; then
+    continue
+  fi
+
+  matched=false
+  while IFS=$'\t' read -r glob suite; do
+    [ -n "$suite" ] || continue
+    pat=$(to_pattern "$glob")
+    case "$file" in
+      $pat) matched=true; selected="$selected $suite" ;;
+    esac
+  done <<EOF
+$pairs
+EOF
+
+  # Unmapped path: fall back to the full run.
+  if [ "$matched" = false ]; then
+    echo ALL
+    exit 0
+  fi
+done <<EOF
+$changed
+EOF
+
+printf '%s\n' $selected | sort -u | tr '\n' ' ' | sed 's/ *$//'
+echo


### PR DESCRIPTION
## Explanation

Every merge to `main` runs the full conformance matrix: 290 KinD clusters across 54 jobs. `check-tests.yaml` has no `paths:` filter, so a documentation change costs exactly as much as a change to the engine. #16162 changed `README.md` and nothing else, and ran all 290.

This adds the metadata needed to run a subset instead, plus the lookup that resolves changed files against it. It doesn't change any test trigger yet, so the scoped run can be reviewed on its own once the map is agreed.

## Related issue

Relates to #16665, Phase 0: "tag test packages/conformance suites with the source paths they cover". Doesn't close it, this is the map and the resolver, not the wiring.

## Milestone of this PR

<!-- can set on request -->

## Documentation (required for features)

Not needed, no Kyverno behavior changes.

## What type of PR is this

/kind cleanup

## Proposed Changes

Two files plus a check:

- `.github/conformance-suite-map.yaml`, source globs to the suites they can affect, plus a `skip` list for paths that can't affect conformance at all.
- `scripts/conformance-suites-for.sh`, resolves a list of changed files to a suite list. `--verify` validates the map.
- `.github/workflows/check-conformance-map.yaml`, runs `--verify`.

**The default is the safe one.** A changed file that matches nothing in the map resolves to `ALL`. An incomplete or wrong map costs CI time, never coverage. That's why the map is deliberately small.

**Shared packages are left out on purpose.** I checked this against history rather than guessing: across 519 commits touching conformance suites, `pkg/engine`, `pkg/cel`, `pkg/controllers`, `pkg/webhooks`, `api/` and `config/crds` co-change with most suites. `validating-policies` alone co-changes with `pkg/cel` in 46 of its 54 commits, and also with `pkg/controllers`, `cmd/cli` and `api/policies.kyverno.io`. So those paths are absent and fall through to the full run. Only paths with a genuinely narrow
blast radius are listed: `pkg/tls`, `pkg/cosign`, `pkg/notary`, `pkg/autogen`, `pkg/event`, `pkg/globalcontext`, `pkg/exceptions`, `pkg/leaderelection`, `cmd/cli` and a few controller directories.

A change under `test/conformance/chainsaw/<suite>` resolves to that suite without needing a map entry, since that one is derivable.

`--verify` checks that every suite named in the map is a real directory under `test/conformance/chainsaw` **and** is actually run by a job in `tests-conformance.yaml`, so the map can't drift from the workflow.

**Measured, not asserted.** I ran the resolver over the diff of each of the last 300 commits on `main`:

| Outcome | Commits |
|---|---|
| Full run (`ALL`) | 282 |
| A subset of suites | 8 |
| No conformance needed | 10 |

So 18 of 300 avoid the 290-cluster run today. That's modest and I'd rather state it accurately than dress it up. It's also a floor: the map starts minimal on purpose, and maintainers who know which suites cover which packages can extend it, with the fail-safe meaning a wrong guess only ever costs time.

The 18 all look right:

```
docs: fix README workflow badge and AI policy link   -> (no suites)
chore: update dependency policy                      -> (no suites)
Fix: require --resource for migrate command          -> cli
fix: validate stdin across apply paths               -> cli
fix: prevent GlobalContextEntry informer failure...  -> globalcontext
test: fix webhook registration typo                  -> webhook-configurations
chore: add new gpol samples                          -> generating-policies
ci: Fix http conformance test blocklist              -> cel
```

Sanity checks:

```
$ scripts/conformance-suites-for.sh --verify
ok: .github/conformance-suite-map.yaml is consistent with .github/workflows/tests-conformance.yaml

$ scripts/conformance-suites-for.sh pkg/tls/certs.go
tls-certificates

$ scripts/conformance-suites-for.sh pkg/engine/validation.go     # shared, unmapped
ALL

$ scripts/conformance-suites-for.sh README.md                    # skip list

$ scripts/conformance-suites-for.sh README.md pkg/tls/certs.go   # skip ignored, not fatal
tls-certificates
```

I also checked `--verify` actually fails rather than passing vacuously: a suite that isn't a directory, a real directory that no job runs (`_step-templates`), and an unknown top level key are all rejected. The script also exits non-zero if `yq` is missing, because without that the checks silently pass.

### Proof Manifests

N/A, no user facing behavior added or changed.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The map entries are my read of the codebase, checked against co-change history, but you know which suites cover which packages far better than I do. I'd rather land a small map you trust and grow it than a large one that looks authoritative and isn't. Happy to take corrections directly on the file.

This uses `yq`, which `pr-labelling.yaml` already installs via `.github/actions/tools/yq`, so no new tooling. If you'd prefer this as a Go tool under `hack/` that parses the workflow properly instead of matching on `tests-path:`, I'm happy to redo it.

If #16899 lands, `check-conformance-map.yaml` and `check-conformance-coverage.yaml` are both one-step checks over the same directory and could be folded into a single workflow. I kept them separate so the two PRs don't conflict.

The obvious follow up is teaching `comment-conformance.yaml` to accept `/conformance <suite>` and gating the 54 jobs on the resolver output, keeping bare `/conformance` as the full run. I didn't put that here because it touches every job in the file and deserves its own review.