### PR TITLE
[Bug Fix] Fix data race and goroutine leak in policy_spec fuzzing on get bytes error

### DIFF
--- a/pkg/utils/fuzz/policy_spec.go
+++ b/pkg/utils/fuzz/policy_spec.go
@@ -119,7 +119,7 @@ func createRules(ff *fuzz.ConsumeFuzzer) []kyvernov1.Rule {
 	for i := 0; i < noOfRules%100; i++ {
 		ruleBytes, err := ff.GetBytes()
 		if err != nil {
-			return rules
+			break
 		}
 		wg.Add(1)
 		ff1 := fuzz.NewConsumer(ruleBytes)

--- a/pkg/utils/fuzz/policy_spec_test.go
+++ b/pkg/utils/fuzz/policy_spec_test.go
@@ -1,0 +1,26 @@
+package fuzz
+
+import (
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+)
+
+func TestCreateRules_Break(t *testing.T) {
+	// Provide exactly enough bytes for ff.GetInt() to return a non-zero value,
+	// but not enough bytes for the subsequent ff.GetBytes() to succeed.
+	// This will hit the `break` statement we added.
+	// GetInt() in go-fuzz-headers reads 4 bytes. 
+	// The bytes [0x05, 0x00, 0x00, 0x00] correspond to integer 5, so noOfRules%100 = 5.
+	// Since there are only 4 bytes, ff.GetBytes() will fail immediately, hitting the break.
+	
+	data := []byte{0x05, 0x00, 0x00, 0x00}
+	ff := fuzz.NewConsumer(data)
+	
+	// This should not panic or leak goroutines, and should return immediately.
+	rules := createRules(ff)
+	
+	if len(rules) != 0 {
+		t.Errorf("Expected 0 rules, got %d", len(rules))
+	}
+}


### PR DESCRIPTION
Fixes #16907

This PR replaces the `return rules` with a `break` statement in `pkg/utils/fuzz/policy_spec.go` to ensure that the WaitGroup waits for all spawned background goroutines before returning the slice, avoiding a potential data race or leaked goroutines when a fuzzer runs out of bytes mid-loop.
