### PR TITLE
Fix context propagation in MatchPolicyContext

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -72,7 +72,7 @@ func (e *engine) Validate(
 	startTime := time.Now()
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext)
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.validate"), policyContext)
-	if internal.MatchPolicyContext(logger, e.client, policyContext, e.configuration) {
+	if internal.MatchPolicyContext(ctx, logger, e.client, policyContext, e.configuration) {
 		policyResponse := e.validate(ctx, logger, policyContext)
 		response = response.WithPolicyResponse(policyResponse)
 	}
@@ -91,7 +91,7 @@ func (e *engine) Mutate(
 	startTime := time.Now()
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext)
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.mutate"), policyContext)
-	if internal.MatchPolicyContext(logger, e.client, policyContext, e.configuration) {
+	if internal.MatchPolicyContext(ctx, logger, e.client, policyContext, e.configuration) {
 		policyResponse, patchedResource := e.mutate(ctx, logger, policyContext)
 		response = response.
 			WithPatchedResource(patchedResource).
@@ -111,7 +111,7 @@ func (e *engine) Generate(
 	startTime := time.Now()
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext)
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.generate"), policyContext)
-	if internal.MatchPolicyContext(logger, e.client, policyContext, e.configuration) {
+	if internal.MatchPolicyContext(ctx, logger, e.client, policyContext, e.configuration) {
 		policyResponse := e.generateResponse(ctx, logger, policyContext)
 		response = response.WithPolicyResponse(policyResponse)
 	}
@@ -130,7 +130,7 @@ func (e *engine) VerifyAndPatchImages(
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext)
 	ivm := engineapi.ImageVerificationMetadata{}
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.verify"), policyContext)
-	if internal.MatchPolicyContext(logger, e.client, policyContext, e.configuration) {
+	if internal.MatchPolicyContext(ctx, logger, e.client, policyContext, e.configuration) {
 		policyResponse, patchedResource, innerIvm := e.verifyAndPatchImages(ctx, logger, policyContext)
 		response, ivm = response.
 			WithPolicyResponse(policyResponse).
@@ -150,7 +150,7 @@ func (e *engine) ApplyBackgroundChecks(
 	startTime := time.Now()
 	response := engineapi.NewEngineResponseFromPolicyContext(policyContext)
 	logger := internal.LoggerWithPolicyContext(logging.WithName("engine.background"), policyContext)
-	if internal.MatchPolicyContext(logger, e.client, policyContext, e.configuration) {
+	if internal.MatchPolicyContext(ctx, logger, e.client, policyContext, e.configuration) {
 		policyResponse := e.applyBackgroundChecks(ctx, logger, policyContext)
 		response = response.WithPolicyResponse(policyResponse)
 	}

--- a/pkg/engine/internal/match.go
+++ b/pkg/engine/internal/match.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions"
 )
 
-func MatchPolicyContext(logger logr.Logger, client engineapi.Client, policyContext engineapi.PolicyContext, configuration config.Configuration) bool {
+func MatchPolicyContext(ctx context.Context, logger logr.Logger, client engineapi.Client, policyContext engineapi.PolicyContext, configuration config.Configuration) bool {
 	policy := policyContext.Policy()
 	old := policyContext.OldResource()
 	new := policyContext.NewResource()
@@ -31,7 +31,7 @@ func MatchPolicyContext(logger logr.Logger, client engineapi.Client, policyConte
 	}
 
 	if policy.GetSpec().GetMatchConditions() != nil {
-		if !checkMatchConditions(logger, policyContext, gvk, subresource) {
+		if !checkMatchConditions(ctx, logger, policyContext, gvk, subresource) {
 			logger.V(4).Info("webhookConfiguration.matchConditions doesn't match request")
 			return false
 		}
@@ -69,7 +69,7 @@ func checkNamespacedPolicy(policy kyvernov1.PolicyInterface, resources ...unstru
 	return true
 }
 
-func checkMatchConditions(logger logr.Logger, policyContext engineapi.PolicyContext, gvk schema.GroupVersionKind, subresource string) bool {
+func checkMatchConditions(ctx context.Context, logger logr.Logger, policyContext engineapi.PolicyContext, gvk schema.GroupVersionKind, subresource string) bool {
 	policy := policyContext.Policy()
 	old := policyContext.OldResource()
 	new := policyContext.NewResource()
@@ -95,6 +95,6 @@ func checkMatchConditions(logger logr.Logger, policyContext engineapi.PolicyCont
 	}
 	matchConditionFilter := compiler.CompileMatchConditions(optionalVars)
 	matcher := matchconditions.NewMatcher(matchConditionFilter, nil, policy.GetKind(), "", policy.GetName())
-	result := matcher.Match(context.TODO(), versionedAttr, nil, nil)
+	result := matcher.Match(ctx, versionedAttr, nil, nil)
 	return result.Matches
 }


### PR DESCRIPTION
## Explanation

This PR fixes a critical architectural gap where request-scoped contexts were being discarded during policy matching. While the engine's main handlers (`Validate`, `Mutate`, `Generate`, etc.) correctly received a `context.Context` from the admission webhooks, they were dropping it when calling `internal.MatchPolicyContext()`. 

Inside the matcher, `checkMatchConditions` passed a raw `context.TODO()` to the CEL `matcher.Match()` function. If the CEL execution hung or if the upstream webhook was cancelled (e.g., due to a 30s timeout), the evaluation could not be interrupted.

This change plumbs the live context from the engine down through `MatchPolicyContext` and into the CEL match condition evaluation, preventing un-cancellable goroutines and potential memory exhaustion.

## Related issue

Closes #16909

## What type of PR is this

/kind bug

## Proposed Changes

* Added `ctx context.Context` parameter to `MatchPolicyContext` and `checkMatchConditions` in `pkg/engine/internal/match.go`
* Replaced `context.TODO()` with the live `ctx` in the CEL `matcher.Match(ctx, ...)` call.
* Plumbed the live context from all callers in `pkg/engine/engine.go` (`Validate`, `Mutate`, `Generate`, `VerifyAndPatchImages`, `ApplyBackgroundChecks`).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This addresses an identical class of context-propagation bugs as seen previously in the generation/background controllers, ensuring the entire engine evaluates policies in a safe, deadline-respecting manner.
