### PR TITLE
[Draft/POC] :TraceEntry structure for CEL decision explainability (#16692)

### DIFF
--- a/pkg/cel/compiler/trace.go
+++ b/pkg/cel/compiler/trace.go
@@ -1,0 +1,67 @@
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+)
+
+// TraceEntry is a single captured expression evaluation. One flat type is
+// reused across all layers (match, variable, verdict, exception).
+type TraceEntry struct {
+	Layer      string
+	Name       string
+	Expression string
+	Value      string
+	Error      string
+	Evaluated  bool
+}
+
+// CaptureTrace turns tracked eval state into TraceEntry values. Returns nil
+// unless the program was compiled with cel.OptTrackState.
+func CaptureTrace(layer, name string, ast *cel.Ast, details *cel.EvalDetails) []TraceEntry {
+	if details == nil {
+		return nil
+	}
+	state := details.State()
+	if state == nil {
+		return nil
+	}
+
+	ids := state.IDs()
+	entries := make([]TraceEntry, 0, len(ids))
+	for _, id := range ids {
+		val, found := state.Value(id)
+		if !found {
+			continue
+		}
+
+		expr, err := cel.AstToString(ast)
+		if err != nil {
+			expr = ""
+		}
+
+		entry := TraceEntry{
+			Layer:      layer,
+			Name:       name,
+			Expression: expr,
+			Evaluated:  true,
+		}
+		if val != nil {
+			entry.Value = fmt.Sprintf("%v", val.Value())
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// NotEvaluated marks an expression that was skipped, e.g. an unreferenced
+// variable or a short-circuited match condition.
+func NotEvaluated(layer, name, expression string) TraceEntry {
+	return TraceEntry{
+		Layer:      layer,
+		Name:       name,
+		Expression: expression,
+		Evaluated:  false,
+	}
+}

--- a/pkg/cel/compiler/trace_test.go
+++ b/pkg/cel/compiler/trace_test.go
@@ -1,0 +1,69 @@
+package compiler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/assert"
+)
+
+// Real compile + eval with OptTrackState, not a mock.
+func TestCaptureTrace_RealEvaluation(t *testing.T) {
+	env, err := cel.NewEnv(cel.Variable("ns", cel.StringType))
+	assert.NoError(t, err)
+
+	ast, issues := env.Compile(`ns == "prod"`)
+	assert.NoError(t, issues.Err())
+
+	prog, err := env.Program(ast, cel.EvalOptions(cel.OptTrackState))
+	assert.NoError(t, err)
+
+	_, details, err := prog.ContextEval(context.Background(), map[string]any{
+		"ns": "default",
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, details)
+
+	entries := CaptureTrace("match", "only-prod", ast, details)
+	assert.NotEmpty(t, entries)
+
+	found := false
+	for _, e := range entries {
+		if e.Value == "false" {
+			found = true
+		}
+		assert.Equal(t, "match", e.Layer)
+		assert.Equal(t, "only-prod", e.Name)
+		assert.True(t, e.Evaluated)
+	}
+	assert.True(t, found)
+}
+
+func TestCaptureTrace_NilDetails(t *testing.T) {
+	env, err := cel.NewEnv(cel.Variable("ns", cel.StringType))
+	assert.NoError(t, err)
+
+	ast, issues := env.Compile(`ns == "prod"`)
+	assert.NoError(t, issues.Err())
+
+	prog, err := env.Program(ast)
+	assert.NoError(t, err)
+
+	_, details, err := prog.ContextEval(context.Background(), map[string]any{
+		"ns": "default",
+	})
+	assert.NoError(t, err)
+	assert.Nil(t, details)
+
+	entries := CaptureTrace("match", "only-prod", ast, details)
+	assert.Nil(t, entries)
+}
+
+func TestNotEvaluated(t *testing.T) {
+	entry := NotEvaluated("match", "only-staging", `ns == "staging"`)
+	assert.Equal(t, "match", entry.Layer)
+	assert.Equal(t, "only-staging", entry.Name)
+	assert.False(t, entry.Evaluated)
+	assert.Empty(t, entry.Value)
+}


### PR DESCRIPTION
## PR Description

Early proof of concept for #16692 / KDP #91.

This adds a small **TraceEntry** type and a **CaptureTrace** helper in **pkg/cel/compiler** that turns cel-go's **EvalDetails** (populated when a program is compiled with **cel.OptTrackState**) into per-expression trace records: expression text, resolved value and whether it was actually evaluated.
The goal here is just to prove the core mechanism works end to end before wiring it into the real match/variable/validation call sites in vpol. T**raceEntry** is intentionally flat and reused across layers rather than typed per layer since cel-go's own E**valState** is flat and scoped per compiled program, not globally.

Also includes **NotEvaluated**, used for expressions that get skipped, either a match condition after an earlier one short-circuits, or a variable that's never referenced. Both are cases I found while reading the vpol compiler where the current code has nothing to show for them today.

**What this is not :** not wired into any real policy evaluation yet, no CLI surface, no tests beyond the capture mechanism itself. Opening as draft to get early feedback on the approach before building further.

```go
go test ./pkg/cel/compiler/... -run "TestCaptureTrace|TestNotEvaluated" -v
```
All passing locally.