### PR TITLE
feat(jmespath): cache compiled queries on shared interface

### DIFF
--- a/pkg/engine/jmespath/interface.go
+++ b/pkg/engine/jmespath/interface.go
@@ -1,6 +1,7 @@
 package jmespath
 
 import (
+	"github.com/dgraph-io/ristretto/v2"
 	gojmespath "github.com/kyverno/go-jmespath"
 	"github.com/kyverno/kyverno/pkg/config"
 )
@@ -16,16 +17,21 @@ type Interface interface {
 
 type implementation struct {
 	functionCaller *gojmespath.FunctionCaller
+	cache          *ristretto.Cache[string, *QueryProxy]
 }
 
 func New(configuration config.Configuration) Interface {
 	return newImplementation(configuration)
 }
 
-func (i implementation) Query(query string) (Query, error) {
-	return newJMESPath(query, i.functionCaller)
+func (i *implementation) Query(query string) (Query, error) {
+	return i.getQuery(query)
 }
 
-func (i implementation) Search(query string, data interface{}) (interface{}, error) {
-	return newExecution(i.functionCaller, query, data)
+func (i *implementation) Search(query string, data interface{}) (interface{}, error) {
+	proxy, err := i.getQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	return proxy.Search(data)
 }

--- a/pkg/engine/jmespath/interface_test.go
+++ b/pkg/engine/jmespath/interface_test.go
@@ -1,0 +1,201 @@
+package jmespath
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/kyverno/kyverno/pkg/config"
+	"gotest.tools/v3/assert"
+)
+
+func TestQueryCacheReuse(t *testing.T) {
+	jp := New(config.NewDefaultConfiguration(false))
+
+	query := "object.something"
+
+	first, err := jp.Query(query)
+	assert.NilError(t, err)
+	second, err := jp.Query(query)
+	assert.NilError(t, err)
+	assert.Assert(t, first == second)
+}
+
+func TestQueryCacheDistinct(t *testing.T) {
+	jp := New(config.NewDefaultConfiguration(false))
+
+	data := map[string]interface{}{
+		"a": map[string]interface{}{"value": 1},
+		"b": map[string]interface{}{"value": 2},
+	}
+
+	first, err := jp.Query("a.value")
+	assert.NilError(t, err)
+	second, err := jp.Query("b.value")
+	assert.NilError(t, err)
+
+	firstResult, err := first.Search(data)
+	assert.NilError(t, err)
+	secondResult, err := second.Search(data)
+	assert.NilError(t, err)
+
+	assert.Equal(t, firstResult, 1)
+	assert.Equal(t, secondResult, 2)
+}
+
+func TestSearch(t *testing.T) {
+	jp := New(config.NewDefaultConfiguration(false))
+
+	data := map[string]interface{}{
+		"object": map[string]interface{}{"value": 3},
+	}
+
+	proxy, err := jp.Query("object.value")
+	assert.NilError(t, err)
+	queryResult, err := proxy.Search(data)
+	assert.NilError(t, err)
+
+	searchResult, err := jp.Search("object.value", data)
+	assert.NilError(t, err)
+
+	assert.Equal(t, searchResult, queryResult)
+	assert.Equal(t, searchResult, 3)
+}
+
+func TestQueryCacheInvalid(t *testing.T) {
+	jp := New(config.NewDefaultConfiguration(false))
+
+	if _, err := jp.Query("object."); err == nil {
+		t.Fatal("expected error for invalid query")
+	}
+}
+
+func TestQueryCacheSameKeyDifferentData(t *testing.T) {
+	jp := New(config.NewDefaultConfiguration(false))
+
+	data1 := map[string]interface{}{
+		"object": map[string]interface{}{"value": 1},
+	}
+	data2 := map[string]interface{}{
+		"object": map[string]interface{}{"value": 2},
+	}
+
+	result1, err := jp.Search("object.value", data1)
+	assert.NilError(t, err)
+	result2, err := jp.Search("object.value", data2)
+	assert.NilError(t, err)
+
+	assert.Equal(t, result1, 1)
+	assert.Equal(t, result2, 2)
+}
+
+func TestQueryCacheFunctionCall(t *testing.T) {
+	jp := New(config.NewDefaultConfiguration(false))
+
+	data := map[string]interface{}{
+		"object": map[string]interface{}{"value": "a,b,c"},
+	}
+	query := "split(object.value, ',')"
+
+	first, err := jp.Query(query)
+	assert.NilError(t, err)
+	second, err := jp.Query(query)
+	assert.NilError(t, err)
+	assert.Assert(t, first == second)
+
+	firstResult, err := first.Search(data)
+	assert.NilError(t, err)
+	secondResult, err := second.Search(data)
+	assert.NilError(t, err)
+
+	firstSplit, ok := firstResult.([]any)
+	assert.Assert(t, ok)
+	secondSplit, ok := secondResult.([]any)
+	assert.Assert(t, ok)
+	assert.Equal(t, firstSplit[0], "a")
+	assert.Equal(t, firstSplit[1], "b")
+	assert.Equal(t, firstSplit[2], "c")
+	assert.Equal(t, secondSplit[0], "a")
+	assert.Equal(t, secondSplit[1], "b")
+	assert.Equal(t, secondSplit[2], "c")
+}
+
+func BenchmarkQueryRepeated(b *testing.B) {
+	jp := New(config.NewDefaultConfiguration(false))
+	query := "object.value"
+	if _, err := jp.Query(query); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := jp.Query(query); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSearchRepeated(b *testing.B) {
+	jp := New(config.NewDefaultConfiguration(false))
+	data := map[string]interface{}{
+		"object": map[string]interface{}{"value": 1},
+	}
+	if _, err := jp.Search("object.value", data); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := jp.Search("object.value", data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkQueryDistinct(b *testing.B) {
+	jp := New(config.NewDefaultConfiguration(false))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := jp.Query(fmt.Sprintf("object.key_%d", i)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestQueryCacheConcurrent(t *testing.T) {
+	jp := New(config.NewDefaultConfiguration(false))
+
+	data := map[string]interface{}{
+		"object": map[string]interface{}{"value": 1},
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 10)
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				proxy, err := jp.Query("object.value")
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if _, err := proxy.Search(data); err != nil {
+					errCh <- err
+					return
+				}
+				if _, err := jp.Search("object.value", data); err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}

--- a/pkg/engine/jmespath/new.go
+++ b/pkg/engine/jmespath/new.go
@@ -1,9 +1,12 @@
 package jmespath
 
 import (
+	"github.com/dgraph-io/ristretto/v2"
 	gojmespath "github.com/kyverno/go-jmespath"
 	"github.com/kyverno/kyverno/pkg/config"
 )
+
+const defaultQueryCacheSize = 1024
 
 type QueryProxy struct {
 	jmesPath       *gojmespath.JMESPath
@@ -25,6 +28,23 @@ func newJMESPath(query string, functionCaller *gojmespath.FunctionCaller) (*Quer
 	}, nil
 }
 
+func (i *implementation) getQuery(query string) (*QueryProxy, error) {
+	if i.cache != nil {
+		if proxy, ok := i.cache.Get(query); ok {
+			return proxy, nil
+		}
+	}
+	proxy, err := newJMESPath(query, i.functionCaller)
+	if err != nil {
+		return nil, err
+	}
+	if i.cache != nil {
+		i.cache.Set(query, proxy, 1)
+		i.cache.Wait()
+	}
+	return proxy, nil
+}
+
 func newImplementation(configuration config.Configuration) Interface {
 	functionCaller := gojmespath.NewFunctionCaller()
 	functions := GetFunctions(configuration)
@@ -32,11 +52,13 @@ func newImplementation(configuration config.Configuration) Interface {
 		functionCaller.Register(f.FunctionEntry)
 	}
 
-	return implementation{
-		functionCaller,
+	cache, err := ristretto.NewCache(&ristretto.Config[string, *QueryProxy]{
+		MaxCost:     defaultQueryCacheSize,
+		NumCounters: 10 * defaultQueryCacheSize,
+		BufferItems: 64,
+	})
+	if err != nil {
+		return &implementation{functionCaller: functionCaller}
 	}
-}
-
-func newExecution(fCall *gojmespath.FunctionCaller, query string, data interface{}) (interface{}, error) {
-	return gojmespath.Search(query, data, gojmespath.WithFunctionCaller(fCall))
+	return &implementation{functionCaller: functionCaller, cache: cache}
 }


### PR DESCRIPTION
**Explanation**

This PR fixes #16911 by caching compiled gojmespath query trees on the shared `jmespath.Interface`. The interface is created once and shared by every admission request, but each `Query`/`Search` call previously recompiled the same policy expression. This is a performance fix with no user-facing behavior changes.

**Related issue**
https://github.com/kyverno/kyverno/issues/16911

**What type of PR is this**

/kind bug

**Proposed Changes**

- `pkg/engine/jmespath/interface.go` — added a bounded ristretto cache to `implementation`; `Query`/`Search` now route through it.
- `pkg/engine/jmespath/new.go` — added `getQuery` (cached compile), a 1024-entry bounded cache, and removed `newExecution`.
- `pkg/engine/jmespath/interface_test.go` — added tests (cache reuse, distinct keys, same-key-different-data, function calls, invalid query, concurrency) and benchmarks.

**Proof Manifests**

- `go test -race ./pkg/engine/jmespath/` — all tests pass.
- `go test ./pkg/engine/context/ ./pkg/engine/variables/ ./pkg/utils/conditions/` — all pass.
- Benchmark (i5-8265U): repeated query 13,886 ns/op → 184 ns/op, 19 → 0 allocs; full cached cycle 439 ns/op.

**Checklist**

- [x] I have read the contributing guidelines.
- [x] I have read the AI Usage Policy. If I used AI assistance, I have disclosed it in my commit(s) (e.g., via Co-authored-by or Assisted-by trailer).
- [x] I have read the PR documentation guide and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is .
- [ ] My PR contains new or altered behavior to Kyverno and
- [ ] CLI support should be added and my PR doesn't contain that functionality.