### PR TITLE
fix(make): correct go mod tidy check in unused-package-check target

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,3 +89,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      - Makefile$

--- a/Makefile
+++ b/Makefile
@@ -211,10 +211,9 @@ lint: $(GOLANGCI_LINT)
 
 .PHONY: unused-package-check
 unused-package-check:
-	@tidy=$$(go mod tidy); \
-	if [ -n "$${tidy}" ]; then \
-		echo "go mod tidy checking failed!"; echo "$${tidy}"; echo; \
-	fi
+	@git diff --quiet -- go.mod go.sum && git diff --quiet --cached -- go.mod go.sum || (echo "go.mod or go.sum has uncommitted changes - run 'go mod tidy'" && git --no-pager diff -- go.mod go.sum && git --no-pager diff --cached -- go.mod go.sum && exit 1)
+	@go mod tidy
+	@git diff --quiet -- go.mod go.sum && git diff --quiet --cached -- go.mod go.sum || (echo "go mod tidy checking failed - go.mod or go.sum were modified" && git --no-pager diff -- go.mod go.sum && git --no-pager diff --cached -- go.mod go.sum && exit 1)
 
 $(BACKGROUND_BIN): fmt
 	@echo Build background controller binary... >&2


### PR DESCRIPTION
## Description

Fixes the `unused-package-check` Makefile target which incorrectly passed even when `go mod tidy` modified `go.mod` or `go.sum`.

### Root Cause
The original implementation captured stdout from `go mod tidy`:
\`\`\`make
@tidy=$$(go mod tidy); \
if [ -n "$$tidy" ]; then \
  echo "go mod tidy checking failed!"; echo "$$tidy"; echo; \
fi
\`\`\`

But `go mod tidy` modifies files silently without printing output, so the check always passed.

### Solution
New implementation:
1. First verifies `go.mod`/`go.sum` are clean (both staged and unstaged) before running `go mod tidy`
2. Runs `go mod tidy`
3. Verifies `go.mod`/`go.sum` are still clean after - fails with diff if modified

### Additional Changes
- Added `Makefile` exclusion to `.golangci.yml` formatters to prevent `goimports` from reformatting the Makefile (it's not a Go file)

### Checks
- `make imports-check` ✅
- `make fmt-check` ✅  
- `make unused-package-check` ✅

This is a focused fix (2 files only) split from the larger PR #16884.