### PR TITLE
fix(jmespath): guard random() argument type

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5" // #nosec G501
-	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1" // #nosec G505
 	"crypto/sha256"
@@ -1168,18 +1167,15 @@ func ifaceToString(iface any) (string, error) {
 }
 
 func jpRandom(arguments []any) (any, error) {
-	pattern := arguments[0].(string)
-	if pattern == "" {
-		return "", errors.New("no pattern provided")
-	}
-
-	b := make([]byte, 8)
-	_, err := rand.Read(b)
+	pattern, err := validateArg(random, arguments, 0, reflect.String)
 	if err != nil {
 		return nil, err
 	}
+	if pattern.String() == "" {
+		return "", errors.New("no pattern provided")
+	}
 
-	ans, err := regen.Generate(pattern)
+	ans, err := regen.Generate(pattern.String())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -1790,3 +1790,67 @@ func Test_MD5(t *testing.T) {
 	assert.Assert(t, ok)
 	assert.Equal(t, str, "def42e1abd2462df1f9f0a4b3d488221")
 }
+
+func Test_Random(t *testing.T) {
+	type args struct {
+		arguments []any
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{{
+		name: "valid pattern",
+		args: args{
+			arguments: []any{"[0-9a-z]{8}"},
+		},
+	}, {
+		name: "nil argument",
+		args: args{
+			arguments: []any{nil},
+		},
+		wantErr: true,
+	}, {
+		name: "float64 argument",
+		args: args{
+			arguments: []any{float64(10)},
+		},
+		wantErr: true,
+	}, {
+		name: "bool argument",
+		args: args{
+			arguments: []any{true},
+		},
+		wantErr: true,
+	}, {
+		name: "no arguments",
+		args: args{
+			arguments: []any{},
+		},
+		wantErr: true,
+	}, {
+		name: "empty pattern",
+		args: args{
+			arguments: []any{""},
+		},
+		wantErr: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := jpRandom(tt.args.arguments)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("jpRandom() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				res, ok := got.(string)
+				if !ok {
+					t.Errorf("jpRandom() returned non-string result: %T", got)
+				}
+				if res == "" {
+					t.Errorf("jpRandom() returned empty string for valid pattern")
+				}
+			}
+		})
+	}
+}

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -1825,3 +1825,67 @@ func Test_CustomFunctions_ValidationErrors(t *testing.T) {
 		assert.ErrorContains(t, err, "JMESPath function 'md5': argument #1 is not of type string")
 	})
 }
+
+func Test_Random(t *testing.T) {
+	type args struct {
+		arguments []any
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{{
+		name: "valid pattern",
+		args: args{
+			arguments: []any{"[0-9a-z]{8}"},
+		},
+	}, {
+		name: "nil argument",
+		args: args{
+			arguments: []any{nil},
+		},
+		wantErr: true,
+	}, {
+		name: "float64 argument",
+		args: args{
+			arguments: []any{float64(10)},
+		},
+		wantErr: true,
+	}, {
+		name: "bool argument",
+		args: args{
+			arguments: []any{true},
+		},
+		wantErr: true,
+	}, {
+		name: "no arguments",
+		args: args{
+			arguments: []any{},
+		},
+		wantErr: true,
+	}, {
+		name: "empty pattern",
+		args: args{
+			arguments: []any{""},
+		},
+		wantErr: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := jpRandom(tt.args.arguments)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("jpRandom() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				res, ok := got.(string)
+				if !ok {
+					t.Errorf("jpRandom() returned non-string result: %T", got)
+				}
+				if res == "" {
+					t.Errorf("jpRandom() returned empty string for valid pattern")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Explanation

The `random()` JMESPath function crashed Kyverno instead of returning an error when it was given anything other than a string.

`jpRandom` did a bare type assertion on its first argument, with no `ok` guard. So a policy like `{{ random(request.object.spec.replicas) }}`, or one referencing a field that does not exist, panicked the engine at runtime rather than surfacing a normal policy error.

This is a fix of existing behavior. After the change, invalid arguments produce the same "invalid argument type" error every other custom JMESPath function in the package already returns.

## Related issue

Closes #16822

## Milestone of this PR

<!-- happy to add a milestone if maintainers want this cherry-picked -->

## Documentation (required for features)

Not applicable. No new or altered user-facing behavior beyond replacing a panic with a normal error.

- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

`pkg/engine/jmespath/functions.go`

- `jpRandom` now uses `validateArg(random, arguments, 0, reflect.String)` instead of `arguments[0].(string)`. `validateArg` already covers the three failure modes that panicked before: index out of bounds, `nil` argument, and wrong type. This is the same helper every other custom function in the file uses, so `random` is no longer the odd one out.
- Removed the `crypto/rand` block that allocated 8 bytes, read into them, and never used them. `regen.Generate` seeds itself, so the read was dead code. The `crypto/rand` import goes with it.

`pkg/engine/jmespath/functions_test.go`

- Added `Test_Random`, the first test coverage for this function. Table-driven, covering the valid pattern, `nil`, `float64`, `bool`, missing argument, and empty pattern cases.

Verified the test actually reproduces the bug: with the test in place and the fix reverted, `Test_Random/nil_argument` panics at `functions.go:1171`. With the fix applied the full `pkg/engine/jmespath` package passes.

### Proof Manifests

Not applicable, this is an internal panic fix with unit test coverage rather than a policy behavior change.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

Issue #16822 is still labelled `triage`, so this has not been accepted yet. I went with `validateArg` because it keeps `random` consistent with the rest of the package rather than adding a bespoke guard.

Reproduction: revert the guard to `arguments[0].(string)` and `Test_Random/nil_argument` panics with `interface conversion: interface {} is nil, not string`. With the guard in place it returns an error instead. The removed `crypto/rand.Read` block was dead, its buffer was never read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for random-value patterns, returning errors when inputs are missing, empty, or not text.
  * Preserved existing behavior for valid patterns.

* **Tests**
  * Added coverage for valid patterns and invalid input types, including empty and missing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->