### PR TITLE
feat(cel): enable two-variable comprehensions

### DIFF
--- a/pkg/cel/compiler/env.go
+++ b/pkg/cel/compiler/env.go
@@ -69,6 +69,7 @@ func defaultEnvOptionsWithHomogeneousAggregateEnforcement(enforce bool) []cel.En
 		ext.Sets(),
 		ext.Strings(ext.StringsVersion(2)),
 		ext.Regex(ext.RegexVersion(1)),
+		ext.TwoVarComprehensions(),
 		// register kubernetes libs
 		library.CIDR(),
 		library.Format(),

--- a/pkg/cel/compiler/env_test.go
+++ b/pkg/cel/compiler/env_test.go
@@ -85,3 +85,99 @@ func TestEnvOptionsForVersion(t *testing.T) {
 		require.NoError(t, issues.Err())
 	}
 }
+
+func TestTwoVarComprehensions_TransformList(t *testing.T) {
+	env, err := NewBaseEnv()
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`[10, 20, 30].transformList(i, v, v + i)`)
+	if issues != nil {
+		require.NoError(t, issues.Err())
+	}
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	out, _, err := prg.Eval(map[string]any{})
+	require.NoError(t, err)
+
+	list, ok := out.(traits.Lister)
+	require.True(t, ok)
+	assert.Equal(t, 3, int(list.Size().(types.Int)))
+	assert.Equal(t, int64(10), list.Get(types.Int(0)).Value())
+	assert.Equal(t, int64(21), list.Get(types.Int(1)).Value())
+	assert.Equal(t, int64(32), list.Get(types.Int(2)).Value())
+}
+
+func TestTwoVarComprehensions_TransformMap(t *testing.T) {
+	env, err := cel.NewEnv(DynamicResourceEnvOptions()...)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`{"a": 1, "b": 2}.transformMap(k, v, v * 10)`)
+	if issues != nil {
+		require.NoError(t, issues.Err())
+	}
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	out, _, err := prg.Eval(map[string]any{})
+	require.NoError(t, err)
+
+	m, ok := out.(traits.Mapper)
+	require.True(t, ok)
+	aVal := m.Get(types.String("a"))
+	bVal := m.Get(types.String("b"))
+	assert.Equal(t, int64(10), aVal.Value())
+	assert.Equal(t, int64(20), bVal.Value())
+}
+
+func TestTwoVarComprehensions_TransformMapEntry(t *testing.T) {
+	env, err := cel.NewEnv(DynamicResourceEnvOptions()...)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`{"greeting": "hello"}.transformMapEntry(k, v, {v: k})`)
+	if issues != nil {
+		require.NoError(t, issues.Err())
+	}
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	out, _, err := prg.Eval(map[string]any{})
+	require.NoError(t, err)
+
+	m, ok := out.(traits.Mapper)
+	require.True(t, ok)
+	val := m.Get(types.String("hello"))
+	assert.Equal(t, "greeting", val.Value())
+}
+
+func TestTwoVarComprehensions_AllWithTwoVars(t *testing.T) {
+	env, err := NewBaseEnv()
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`[10, 20, 30].all(i, v, v > i)`)
+	if issues != nil {
+		require.NoError(t, issues.Err())
+	}
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	out, _, err := prg.Eval(map[string]any{})
+	require.NoError(t, err)
+	assert.Equal(t, true, out.Value())
+}
+
+func TestTwoVarComprehensions_ExistsWithTwoVars(t *testing.T) {
+	env, err := cel.NewEnv(DynamicResourceEnvOptions()...)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`{"x": 1, "y": 2}.exists(k, v, k == "x" && v == 1)`)
+	if issues != nil {
+		require.NoError(t, issues.Err())
+	}
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	out, _, err := prg.Eval(map[string]any{})
+	require.NoError(t, err)
+	assert.Equal(t, true, out.Value())
+}


### PR DESCRIPTION
## Explanation

Kyverno's default CEL environment doesn't register the `TwoVarComprehensions` extension, so expressions using `transformList`, `transformMap`, `transformMapEntry`, or the two-variable forms of `all`/`exists` fail to compile with undeclared reference errors. This PR registers `ext.TwoVarComprehensions()` so those macros are available wherever the default environment is used.

## Related issue

Closes #16877

## Milestone of this PR

<!-- Maintainers can assign the milestone, or comment `/milestone <version>` if requested. -->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.

* [ ] I have sent the draft PR to add or update the documentation and the link is:

## What type of PR is this

/kind feature

## Proposed Changes

* Register `ext.TwoVarComprehensions()` in the default CEL environment.
* Add tests for `transformList`, `transformMap`, `transformMapEntry`, and two-variable `all`/`exists`.
* Ran `go test ./pkg/cel/compiler/...` and `go test ./pkg/cel/...` with no regressions.

### Proof Manifests

Not applicable — this change registers a CEL language extension and is covered by unit tests.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the AI Usage Policy. If I used AI assistance, I have disclosed it in my commit(s) as required by the policy.
- [ ] I have read the PR documentation guide and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch.
- [x] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

While investigating the issue, I also checked whether `flatten()` and string formatting were actually missing. `flatten()` is already available through the existing `ext.Lists` registration, and the current environment already supports `.format()`. The missing piece was `TwoVarComprehensions` not being registered.

Before this change, expressions using `transformList`, `transformMap`, `transformMapEntry`, and the two-variable variants of `all` and `exists` failed to compile with undeclared reference errors. After registering the extension, the new unit tests pass, along with the existing `pkg/cel/compiler/...` and `pkg/cel/...` test suites.
