### PR TITLE
feat(cel): add time extension library for CEL policies

### DIFF
--- a/pkg/cel/compiler/env.go
+++ b/pkg/cel/compiler/env.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kyverno/sdk/extensions/cel/libs/image"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/cel/library"
+	celtime "github.com/kyverno/kyverno/pkg/cel/libs/time"
 )
 
 // breaking change history is stored inside the library structure. each policy compiler can pass a kyverno
@@ -75,6 +76,7 @@ func defaultEnvOptionsWithHomogeneousAggregateEnforcement(enforce bool) []cel.En
 		library.IP(),
 		library.Lists(),
 		library.Regex(),
+		celtime.Lib(),
 		library.URLs(),
 		library.Quantity(),
 		library.SemverLib(library.SemverVersion(1)),

--- a/pkg/cel/libs/time/impl.go
+++ b/pkg/cel/libs/time/impl.go
@@ -1,0 +1,94 @@
+package time
+
+import (
+	"fmt"
+	gotime "time"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+func time_now() ref.Val {
+	return types.String(gotime.Now().Format(gotime.RFC3339))
+}
+
+func time_now_utc() ref.Val {
+	return types.String(gotime.Now().UTC().Format(gotime.RFC3339))
+}
+
+func time_parse(layout ref.Val, value ref.Val) ref.Val {
+	l, ok := layout.(types.String)
+	if !ok {
+		return types.NewErr("time_parse: layout must be a string")
+	}
+	v, ok := value.(types.String)
+	if !ok {
+		return types.NewErr("time_parse: value must be a string")
+	}
+	t, err := gotime.Parse(string(l), string(v))
+	if err != nil {
+		return types.WrapErr(err)
+	}
+	return types.String(t.Format(gotime.RFC3339))
+}
+
+func time_add(ts ref.Val, duration ref.Val) ref.Val {
+	t, err := parseRFC3339(ts)
+	if err != nil {
+		return types.WrapErr(err)
+	}
+	d, ok := duration.(types.String)
+	if !ok {
+		return types.NewErr("time_add: duration must be a string")
+	}
+	dur, err := gotime.ParseDuration(string(d))
+	if err != nil {
+		return types.WrapErr(err)
+	}
+	return types.String(t.Add(dur).Format(gotime.RFC3339))
+}
+
+func time_diff(t1 ref.Val, t2 ref.Val) ref.Val {
+	t1t, err := parseRFC3339(t1)
+	if err != nil {
+		return types.WrapErr(err)
+	}
+	t2t, err := parseRFC3339(t2)
+	if err != nil {
+		return types.WrapErr(err)
+	}
+	return types.String(t2t.Sub(t1t).String())
+}
+
+func time_before(t1 ref.Val, t2 ref.Val) ref.Val {
+	t1t, err := parseRFC3339(t1)
+	if err != nil {
+		return types.WrapErr(err)
+	}
+	t2t, err := parseRFC3339(t2)
+	if err != nil {
+		return types.WrapErr(err)
+	}
+	return types.Bool(t1t.Before(t2t))
+}
+
+func time_after(t1 ref.Val, t2 ref.Val) ref.Val {
+	t1t, err := parseRFC3339(t1)
+	if err != nil {
+		return types.WrapErr(err)
+	}
+	t2t, err := parseRFC3339(t2)
+	if err != nil {
+		return types.WrapErr(err)
+	}
+	return types.Bool(t1t.After(t2t))
+}
+
+// parseRFC3339 is a shared helper used by all functions that accept timestamp arguments
+func parseRFC3339(val ref.Val) (gotime.Time, error) {
+	s, ok := val.(types.String)
+	if !ok {
+		return gotime.Time{}, fmt.Errorf("expected string, got %T", val)
+	}
+	return gotime.Parse(gotime.RFC3339, string(s))
+}

--- a/pkg/cel/libs/time/impl_test.go
+++ b/pkg/cel/libs/time/impl_test.go
@@ -1,0 +1,118 @@
+package time
+
+import (
+	gotime "time"
+	"testing"
+
+	"github.com/google/cel-go/common/types"
+)
+
+func TestTimeNow(t *testing.T) {
+	result := time_now()
+	if _, ok := result.(types.String); !ok {
+		t.Fatalf("expected types.String, got %T", result)
+	}
+	// result should be a valid RFC3339 string
+	s := string(result.(types.String))
+	if _, err := gotime.Parse(gotime.RFC3339, s); err != nil {
+		t.Fatalf("time_now returned invalid RFC3339: %v", err)
+	}
+}
+
+func TestTimeNowUtc(t *testing.T) {
+	result := time_now_utc()
+	if _, ok := result.(types.String); !ok {
+		t.Fatalf("expected types.String, got %T", result)
+	}
+	s := string(result.(types.String))
+	parsed, err := gotime.Parse(gotime.RFC3339, s)
+	if err != nil {
+		t.Fatalf("time_now_utc returned invalid RFC3339: %v", err)
+	}
+	if parsed.Location() != gotime.UTC {
+		t.Fatalf("expected UTC, got %v", parsed.Location())
+	}
+}
+
+func TestTimeParse(t *testing.T) {
+	result := time_parse(
+		types.String(gotime.RFC3339),
+		types.String("2024-01-15T10:00:00Z"),
+	)
+	if _, ok := result.(types.String); !ok {
+		t.Fatalf("expected types.String, got %T", result)
+	}
+}
+
+func TestTimeParseInvalid(t *testing.T) {
+	result := time_parse(
+		types.String(gotime.RFC3339),
+		types.String("not-a-timestamp"),
+	)
+	if _, ok := result.(*types.Err); !ok {
+		t.Fatalf("expected error for invalid timestamp, got %T", result)
+	}
+}
+
+func TestTimeAdd(t *testing.T) {
+	result := time_add(
+		types.String("2024-01-15T10:00:00Z"),
+		types.String("24h"),
+	)
+	if _, ok := result.(types.String); !ok {
+		t.Fatalf("expected types.String, got %T", result)
+	}
+	expected := "2024-01-16T10:00:00Z"
+	if string(result.(types.String)) != expected {
+		t.Fatalf("expected %s, got %s", expected, result)
+	}
+}
+
+func TestTimeDiff(t *testing.T) {
+	result := time_diff(
+		types.String("2024-01-15T10:00:00Z"),
+		types.String("2024-01-16T10:00:00Z"),
+	)
+	if _, ok := result.(types.String); !ok {
+		t.Fatalf("expected types.String, got %T", result)
+	}
+	if string(result.(types.String)) != "24h0m0s" {
+		t.Fatalf("expected 24h0m0s, got %s", result)
+	}
+}
+
+func TestTimeBefore(t *testing.T) {
+	result := time_before(
+		types.String("2024-01-15T10:00:00Z"),
+		types.String("2024-01-16T10:00:00Z"),
+	)
+	if result != types.True {
+		t.Fatalf("expected true, got %v", result)
+	}
+
+	result = time_before(
+		types.String("2024-01-16T10:00:00Z"),
+		types.String("2024-01-15T10:00:00Z"),
+	)
+	if result != types.False {
+		t.Fatalf("expected false, got %v", result)
+	}
+}
+
+func TestTimeAfter(t *testing.T) {
+	result := time_after(
+		types.String("2024-01-16T10:00:00Z"),
+		types.String("2024-01-15T10:00:00Z"),
+	)
+	if result != types.True {
+		t.Fatalf("expected true, got %v", result)
+	}
+
+	result = time_after(
+		types.String("2024-01-15T10:00:00Z"),
+		types.String("2024-01-16T10:00:00Z"),
+	)
+	if result != types.False {
+		t.Fatalf("expected false, got %v", result)
+	}
+}

--- a/pkg/cel/libs/time/lib.go
+++ b/pkg/cel/libs/time/lib.go
@@ -1,0 +1,80 @@
+package time
+
+import (
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+const libraryName = "kyverno.time"
+
+type lib struct{}
+
+func Lib() cel.EnvOption {
+	return cel.Lib(&lib{})
+}
+
+func (*lib) LibraryName() string {
+	return libraryName
+}
+
+func (*lib) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Function("time_now",
+			cel.Overload("time_now",
+				[]*cel.Type{},
+				cel.StringType,
+				cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+					return time_now()
+				}),
+			),
+		),
+		cel.Function("time_now_utc",
+			cel.Overload("time_now_utc",
+				[]*cel.Type{},
+				cel.StringType,
+				cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+					return time_now_utc()
+				}),
+			),
+		),
+		cel.Function("time_parse",
+			cel.Overload("time_parse_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.StringType,
+				cel.BinaryBinding(time_parse),
+			),
+		),
+		cel.Function("time_add",
+			cel.Overload("time_add_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.StringType,
+				cel.BinaryBinding(time_add),
+			),
+		),
+		cel.Function("time_diff",
+			cel.Overload("time_diff_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.StringType,
+				cel.BinaryBinding(time_diff),
+			),
+		),
+		cel.Function("time_before",
+			cel.Overload("time_before_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.BoolType,
+				cel.BinaryBinding(time_before),
+			),
+		),
+		cel.Function("time_after",
+			cel.Overload("time_after_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.BoolType,
+				cel.BinaryBinding(time_after),
+			),
+		),
+	}
+}
+
+func (*lib) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}

--- a/test/conformance/chainsaw/cel/time/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/cel/time/chainsaw-test.yaml
@@ -1,0 +1,32 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cel-time
+spec:
+  concurrent: false
+  steps:
+  - name: create-policy
+    use:
+      template: ../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait-validating-policy-ready
+    use:
+      template: ../../_step-templates/validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: check-expiry
+  - name: create-expired-configmap
+    try:
+    - create:
+        file: expired-configmap.yaml
+        expect:
+        - check:
+            ($error != null): true
+  - name: create-valid-configmap
+    try:
+    - create:
+        file: valid-configmap.yaml

--- a/test/conformance/chainsaw/cel/time/expired-configmap.yaml
+++ b/test/conformance/chainsaw/cel/time/expired-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: expired-cm
+  annotations:
+    expires-at: "2020-01-01T00:00:00Z"
+data:
+  key: value

--- a/test/conformance/chainsaw/cel/time/policy.yaml
+++ b/test/conformance/chainsaw/cel/time/policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: check-expiry
+spec:
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: [v1]
+      operations: [CREATE]
+      resources: [configmaps]
+  validations:
+    - expression: >-
+        !has(object.metadata.annotations) ||
+        !('expires-at' in object.metadata.annotations) ||
+        time_after(object.metadata.annotations['expires-at'], time_now())
+      message: >-
+        ConfigMap has expired

--- a/test/conformance/chainsaw/cel/time/valid-configmap.yaml
+++ b/test/conformance/chainsaw/cel/time/valid-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: valid-cm
+  annotations:
+    expires-at: "2099-01-01T00:00:00Z"
+data:
+  key: value


### PR DESCRIPTION
Introduces pkg/cel/libs/time with seven time manipulation functions:
- time_now() / time_now_utc()
- time_parse(layout, value)
- time_add(timestamp, duration)
- time_diff(t1, t2)
- time_before(t1, t2)
- time_after(t1, t2)

Ports equivalent JMESPath functions from pkg/engine/jmespath/time.go to enable time-based policies in CEL-native policy types (ValidatingPolicy, MutatingPolicy).

Includes unit tests and a chainsaw conformance test.

## Explanation

This PR adds a CEL time extension library to Kyverno, introducing seven time 
manipulation functions (time_now, time_now_utc, time_parse, time_add, time_diff, 
time_before, time_after) for use in CEL-based policy types (ValidatingPolicy, 
MutatingPolicy). This is an addition of new functionality that ports the existing 
JMESPath time functions to CEL, enabling use cases like certificate expiry checks, 
maintenance window enforcement, and time-based access control in modern Kyverno policies.

## Related issue

closes #16924 

## Milestone of this PR

/milestone 1.19.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind feature

## Proposed Changes

add time extension library for CEL policies

Introduces pkg/cel/libs/time with seven time manipulation functions:
- time_now() / time_now_utc()
- time_parse(layout, value)
- time_add(timestamp, duration)
- time_diff(t1, t2)
- time_before(t1, t2)
- time_after(t1, t2)

Ports equivalent JMESPath functions from pkg/engine/jmespath/time.go
to enable time-based policies in CEL-native policy types
(ValidatingPolicy, MutatingPolicy).

Includes unit tests and a chainsaw conformance test.

### Proof Manifests

# ValidatingPolicy using time_after to deny expired ConfigMaps
apiVersion: policies.kyverno.io/v1beta1
kind: ValidatingPolicy
metadata:
  name: check-expiry
spec:
  validationActions:
    - Deny
  matchConstraints:
    resourceRules:
    - apiGroups: [""]
      apiVersions: [v1]
      operations: [CREATE]
      resources: [configmaps]
  validations:
    - expression: >-
        !has(object.metadata.annotations) ||
        !('expires-at' in object.metadata.annotations) ||
        time_after(object.metadata.annotations['expires-at'], time_now())
      message: ConfigMap has expired

# Denied (timestamp in the past)
apiVersion: v1
kind: ConfigMap
metadata:
  name: expired-cm
  annotations:
    expires-at: "2020-01-01T00:00:00Z"
data:
  key: value

# Allowed (timestamp in the future)
apiVersion: v1
kind: ConfigMap
metadata:
  name: valid-cm
  annotations:
    expires-at: "2099-01-01T00:00:00Z"
data:
  key: value

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
