### PR TITLE
ci: bind cherry-pick composite inputs via env before shell

### DIFF
--- a/.github/actions/git/cherry-pick/action.yaml
+++ b/.github/actions/git/cherry-pick/action.yaml
@@ -46,42 +46,46 @@ runs:
       id: cherry-pick
       shell: bash
       continue-on-error: true
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        TARGET_BRANCHES: ${{ inputs.target-branches }}
+        SOURCE_PR: ${{ inputs.source-pr }}
+        SOURCE_PR_TITLE: ${{ inputs.source-pr-title }}
+        MERGE_COMMIT: ${{ inputs.merge-commit }}
       run: |
-        IFS=',' read -ra BRANCHES <<< "${{ inputs.target-branches }}"
+        IFS=',' read -ra BRANCHES <<< "$TARGET_BRANCHES"
         success=true
         git_logs=""
         
         for target_branch in "${BRANCHES[@]}"; do
           echo "🔄 Cherry-picking to $target_branch..."
         
-          pr_branch_name=cherry-pick-${{ inputs.source-pr }}-${target_branch}
+          pr_branch_name="cherry-pick-${SOURCE_PR}-${target_branch}"
         
-          git fetch --prune origin $target_branch
-          git checkout -B ${pr_branch_name} origin/$target_branch
+          git fetch --prune origin "$target_branch"
+          git checkout -B "${pr_branch_name}" "origin/${target_branch}"
         
 
-          if git cherry-pick -s -m 1 ${{ inputs.merge-commit }}; then
-            git push --force-with-lease origin ${pr_branch_name}
+          if git cherry-pick -s -m 1 "$MERGE_COMMIT"; then
+            git push --force-with-lease origin "${pr_branch_name}"
         
             if gh pr list --base "$target_branch" --head "$pr_branch_name" --state open --json number --jq '.[0].number' | grep -q .; then
               echo "PR from '$pr_branch_name' to '$target_branch' already exists. Skipping creation"
             else
               gh pr create \
-                --title "${{ inputs.source-pr-title }} (Cherry-pick #${{ inputs.source-pr }})" \
-                --body "Cherry-pick #${{ inputs.source-pr }}" \
-                --base ${target_branch} \
-                --head cherry-pick-${{ inputs.source-pr }}-${target_branch}
+                --title "${SOURCE_PR_TITLE} (Cherry-pick #${SOURCE_PR})" \
+                --body "Cherry-pick #${SOURCE_PR}" \
+                --base "${target_branch}" \
+                --head "${pr_branch_name}"
             fi
           else
             echo "❌ Error while cherry picking into ${target_branch}"
-            git_logs+=$(git cherry-pick -s -m 1 ${{ inputs.merge-commit }} 2>&1)
+            git_logs+=$(git cherry-pick -s -m 1 "$MERGE_COMMIT" 2>&1)
             git cherry-pick --abort
             success=false
             continue
           fi
         done
         
-        echo "success=${success}" >> $GITHUB_OUTPUT
-        echo "git-logs=${git_logs}" >> $GITHUB_OUTPUT
-      env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        echo "success=${success}" >> "$GITHUB_OUTPUT"
+        echo "git-logs=${git_logs}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Bind `target-branches`, `source-pr`, `source-pr-title`, and `merge-commit` through `env:` before use in the cherry-pick composite shell script.
- Same class as GitHub’s documented script-injection guidance for composite actions that interpolate caller-controlled inputs into `run:` scripts (including force-push / `gh pr create` paths).

## Test plan
- [ ] Cherry-pick workflow with trusted bot inputs still creates PRs as before
- [ ] No functional change for normal maintainer-driven cherry-picks


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when automated cherry-pick pull requests use branch names or paths containing special characters.
  - Improved handling of workflow inputs passed to the cherry-pick process.

- **Chores**
  - Updated the automation workflow to process inputs more safely while preserving existing duplicate detection, cherry-pick outcomes, and pull request creation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->