### PR TITLE
fix(cli): use CRD-declared plural when indexing CR instances in fake DClient

### DIFF
--- a/ext/cluster/fake.go
+++ b/ext/cluster/fake.go
@@ -115,7 +115,7 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 	// GVR for CR instances using the CRD-declared plural rather than the heuristic
 	// meta.UnsafeGuessKindToResource, which produces the wrong plural for resources
 	// like TeleportRoleV8 (CRD plural "teleportrolesv8", guessed "teleportrolev8s").
-	var crdAPIGroups []*restmapper.APIGroupResources
+	crdAPIGroups := make([]*restmapper.APIGroupResources, 0, len(collectedCRDs))
 	for _, crd := range collectedCRDs {
 		crdAPIGroups = append(crdAPIGroups, convertCRDToAPIGroupResources(crd))
 	}

--- a/ext/cluster/fake.go
+++ b/ext/cluster/fake.go
@@ -72,61 +72,128 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 	list := []schema.GroupVersionResource{}
 	gvrToGVK := make(map[schema.GroupVersionResource]schema.GroupVersionKind)
 
+	// Pass 1: register every CRD and collect them so we can build a REST mapper
+	// before processing CR instances. This is needed because the object list may
+	// contain instances before their CRD, and the order must not matter.
+	var collectedCRDs []*apiextensionsv1.CustomResourceDefinition
 	for _, o := range objects {
-		if crd, ok := o.(*apiextensionsv1.CustomResourceDefinition); ok {
-			for _, version := range crd.Spec.Versions {
-				if version.Storage {
-					crdGVR := schema.GroupVersionResource{
-						Group:    crd.Spec.Group,
-						Version:  version.Name,
-						Resource: crd.Spec.Names.Plural,
+		crd, ok := o.(*apiextensionsv1.CustomResourceDefinition)
+		if !ok {
+			continue
+		}
+		collectedCRDs = append(collectedCRDs, crd)
+		for _, version := range crd.Spec.Versions {
+			if version.Storage {
+				crdGVR := schema.GroupVersionResource{
+					Group:    crd.Spec.Group,
+					Version:  version.Name,
+					Resource: crd.Spec.Names.Plural,
+				}
+				if _, exists := gvr[crdGVR]; !exists {
+					list = append(list, crdGVR)
+					crdGVK := schema.GroupVersionKind{
+						Group:   crd.Spec.Group,
+						Version: version.Name,
+						Kind:    crd.Spec.Names.Kind,
 					}
-					if _, exists := gvr[crdGVR]; !exists {
-						list = append(list, crdGVR)
-						crdGVK := schema.GroupVersionKind{
-							Group:   crd.Spec.Group,
-							Version: version.Name,
-							Kind:    crd.Spec.Names.Kind,
-						}
-						gvr[crdGVR] = crdGVK.Kind + "List"
-						gvrToGVK[crdGVR] = crdGVK
+					gvr[crdGVR] = crdGVK.Kind + "List"
+					gvrToGVK[crdGVR] = crdGVK
 
-						crdGVKList := crdGVK
-						crdGVKList.Kind += "List"
-						if !s.Recognizes(crdGVKList) {
-							s.AddKnownTypeWithName(crdGVKList, &unstructured.UnstructuredList{})
-						}
+					crdGVKList := crdGVK
+					crdGVKList.Kind += "List"
+					if !s.Recognizes(crdGVKList) {
+						s.AddKnownTypeWithName(crdGVKList, &unstructured.UnstructuredList{})
 					}
 				}
 			}
-
-			s.AddKnownTypeWithName(o.GetObjectKind().GroupVersionKind(), o)
-			continue
 		}
 
+		s.AddKnownTypeWithName(o.GetObjectKind().GroupVersionKind(), o)
+	}
+
+	// Build a REST mapper from the collected CRDs. This lets pass 2 resolve the
+	// GVR for CR instances using the CRD-declared plural rather than the heuristic
+	// meta.UnsafeGuessKindToResource, which produces the wrong plural for resources
+	// like TeleportRoleV8 (CRD plural "teleportrolesv8", guessed "teleportrolev8s").
+	var crdAPIGroups []*restmapper.APIGroupResources
+	for _, crd := range collectedCRDs {
+		crdAPIGroups = append(crdAPIGroups, convertCRDToAPIGroupResources(crd))
+	}
+	crdMapper := restmapper.NewDiscoveryRESTMapper(crdAPIGroups)
+
+	// Pass 2: register non-CRD object types in the scheme and GVR maps.
+	// Objects are NOT added to allFakeObjects here; they are inserted into the
+	// tracker via Create below so that the explicit CRD-declared GVR is used as
+	// the storage key rather than the UnsafeGuessKindToResource result.
+	for _, o := range objects {
+		if _, ok := o.(*apiextensionsv1.CustomResourceDefinition); ok {
+			continue
+		}
 		gvk := o.GetObjectKind().GroupVersionKind()
-		plural, _ := meta.UnsafeGuessKindToResource(gvk)
-		if _, ok := gvr[plural]; ok {
-			continue
+
+		// Determine the correct GVR: prefer the CRD-declared plural over the guess.
+		var gvrKey schema.GroupVersionResource
+		if mapping, err := crdMapper.RESTMapping(gvk.GroupKind(), gvk.Version); err == nil {
+			gvrKey = mapping.Resource
+		} else {
+			gvrKey, _ = meta.UnsafeGuessKindToResource(gvk)
 		}
 
-		s.AddKnownTypeWithName(gvk, o)
+		// Always register the GVK in the scheme; the tracker needs it for List.
+		if !s.Recognizes(gvk) {
+			s.AddKnownTypeWithName(gvk, o)
+		}
 		gvkList := gvk
 		gvkList.Kind += "List"
 		if !s.Recognizes(gvkList) {
 			s.AddKnownTypeWithName(gvkList, &unstructured.UnstructuredList{})
 		}
 
-		gvr[plural] = gvkList.Kind
-		gvrToGVK[plural] = gvk
-
-		list = append(list, plural)
+		// Only add a new GVR entry if the CRD pass hasn't registered it already.
+		if _, ok := gvr[gvrKey]; !ok {
+			gvr[gvrKey] = gvkList.Kind
+			gvrToGVK[gvrKey] = gvk
+			list = append(list, gvrKey)
+		}
 	}
 
-	allFakeObjects := make([]runtime.Object, 0, len(objects))
-	allFakeObjects = append(allFakeObjects, objects...)
+	// Create the fake dynamic client with the scheme and GVR map but without
+	// pre-loading objects. Objects are added via Create below so they are stored
+	// in the tracker under the correct GVR (the one from the CRD or the fallback
+	// guess) rather than the UnsafeGuessKindToResource result that tracker.Add
+	// would use internally.
+	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(s, gvr)
 
-	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(s, gvr, allFakeObjects...)
+	// Insert each non-CRD object into the tracker under the correct GVR using
+	// Create, which routes through ObjectReaction → tracker.Create(gvr, obj, ns)
+	// and stores the object under the explicit GVR from dyn.Resource(gvrKey).
+	for _, o := range objects {
+		if _, ok := o.(*apiextensionsv1.CustomResourceDefinition); ok {
+			continue
+		}
+		obj, ok := o.(*unstructured.Unstructured)
+		if !ok {
+			continue
+		}
+		gvk := obj.GroupVersionKind()
+		var objGVR schema.GroupVersionResource
+		if mapping, err := crdMapper.RESTMapping(gvk.GroupKind(), gvk.Version); err == nil {
+			objGVR = mapping.Resource
+		} else {
+			objGVR, _ = meta.UnsafeGuessKindToResource(gvk)
+		}
+		ns := obj.GetNamespace()
+		ri := dyn.Resource(objGVR)
+		if ns != "" {
+			if _, err := ri.Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+				return nil, err
+			}
+		} else {
+			if _, err := ri.Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	// Filter out CRDs from objects before converting for kube client
 	// CRDs are not regular Kubernetes resources and can't be converted

--- a/ext/cluster/fake.go
+++ b/ext/cluster/fake.go
@@ -75,9 +75,12 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 
 	// Build a remap table from CRDs whose declared plural differs from the
 	// UnsafeGuessKindToResource heuristic (e.g. TeleportRoleV8: CRD plural
-	// "teleportrolesv8", heuristic gives "teleportrolev8s"). tracker.Add always
-	// uses the heuristic, so resource.List on the correct CRD plural would return
-	// empty without the remappingDynamic wrapper below.
+	// "teleportrolesv8", heuristic gives "teleportrolev8s").
+	//
+	// tracker.Add always derives the storage key via UnsafeGuessKindToResource —
+	// it explicitly notes this is a heuristic and that tests with non-standard
+	// plurals must use tracker.Create instead:
+	// https://github.com/kubernetes/client-go/blob/v0.36.3/testing/fixture.go#L512-L517
 	gvrRemap := make(map[schema.GroupVersionResource]schema.GroupVersionResource)
 	for _, o := range objects {
 		crd, ok := o.(*apiextensionsv1.CustomResourceDefinition)
@@ -85,6 +88,9 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 			continue
 		}
 		for _, version := range crd.Spec.Versions {
+			if !version.Storage {
+				continue
+			}
 			gvk := schema.GroupVersionKind{Group: crd.Spec.Group, Version: version.Name, Kind: crd.Spec.Names.Kind}
 			guessed, _ := meta.UnsafeGuessKindToResource(gvk)
 			if crd.Spec.Names.Plural != guessed.Resource {

--- a/ext/cluster/fake.go
+++ b/ext/cluster/fake.go
@@ -72,6 +72,14 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 	list := []schema.GroupVersionResource{}
 	gvrToGVK := make(map[schema.GroupVersionResource]schema.GroupVersionKind)
 
+	// objWithGVR pairs an unstructured instance with the GVR it should be stored
+	// under in the fake tracker — resolved once and reused for the Create call.
+	type objWithGVR struct {
+		obj *unstructured.Unstructured
+		gvr schema.GroupVersionResource
+	}
+	var toCreate []objWithGVR
+
 	// Collect CRDs first so the REST mapper below can resolve CR instance plurals
 	// before the main loop processes them. Without this, meta.UnsafeGuessKindToResource
 	// produces wrong plurals for CRDs with non-standard plural names (e.g. kind
@@ -127,6 +135,15 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 		if mapping, err := crdMapper.RESTMapping(gvk.GroupKind(), gvk.Version); err == nil {
 			plural = mapping.Resource
 		}
+
+		// Always collect unstructured instances with their resolved GVR so we can
+		// insert them into the tracker after the client is created. We do this before
+		// the duplicate-GVR check below because a CRD may have already registered the
+		// same GVR in the scheme/gvr maps — we still need to populate the tracker.
+		if obj, ok := o.(*unstructured.Unstructured); ok {
+			toCreate = append(toCreate, objWithGVR{obj: obj, gvr: plural})
+		}
+
 		if _, ok := gvr[plural]; ok {
 			continue
 		}
@@ -144,33 +161,21 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 		list = append(list, plural)
 	}
 
-	// Create the fake client without pre-loading objects. Each non-CRD object is
-	// inserted below via Create so the tracker stores it under the GVR resolved
-	// above (CRD-declared plural) rather than the one tracker.Add would derive
-	// internally via UnsafeGuessKindToResource.
+	// Create the fake client without pre-loading objects. Each collected instance
+	// is inserted via Create so the tracker stores it under the GVR resolved above
+	// (CRD-declared plural) rather than what tracker.Add derives internally via
+	// UnsafeGuessKindToResource.
 	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(s, gvr)
 
-	for _, o := range objects {
-		if _, ok := o.(*apiextensionsv1.CustomResourceDefinition); ok {
-			continue
-		}
-		obj, ok := o.(*unstructured.Unstructured)
-		if !ok {
-			continue
-		}
-		gvk := obj.GroupVersionKind()
-		plural, _ := meta.UnsafeGuessKindToResource(gvk)
-		if mapping, err := crdMapper.RESTMapping(gvk.GroupKind(), gvk.Version); err == nil {
-			plural = mapping.Resource
-		}
-		ns := obj.GetNamespace()
-		ri := dyn.Resource(plural)
+	for _, item := range toCreate {
+		ns := item.obj.GetNamespace()
+		ri := dyn.Resource(item.gvr)
 		if ns != "" {
-			if _, err := ri.Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+			if _, err := ri.Namespace(ns).Create(context.Background(), item.obj, metav1.CreateOptions{}); err != nil {
 				return nil, err
 			}
 		} else {
-			if _, err := ri.Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+			if _, err := ri.Create(context.Background(), item.obj, metav1.CreateOptions{}); err != nil {
 				return nil, err
 			}
 		}

--- a/ext/cluster/fake.go
+++ b/ext/cluster/fake.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/fake"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/openapi"
@@ -141,16 +142,12 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 		list = append(list, plural)
 	}
 
-	allFakeObjects := make([]runtime.Object, 0, len(objects))
-	allFakeObjects = append(allFakeObjects, objects...)
-
-	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(s, gvr, allFakeObjects...)
-
-	// tracker.Add (called by the constructor above) always uses
-	// UnsafeGuessKindToResource to pick the storage key, so CR instances with
-	// non-standard plural names land under the wrong GVR. Re-insert them via
-	// Create, which routes through ObjectReaction → tracker.Create(gvr, obj, ns)
-	// and stores them under the explicit CRD-declared GVR instead.
+	// Build a remap table: CRD-declared GVR → guessed GVR (where tracker.Add
+	// actually stores objects). tracker.Add uses UnsafeGuessKindToResource, so
+	// for CRDs with non-standard plural names the two diverge. We wrap the
+	// dynamic interface below so that callers using the correct CRD plural are
+	// transparently redirected to the GVR the tracker knows about.
+	gvrRemap := make(map[schema.GroupVersionResource]schema.GroupVersionResource)
 	for _, o := range objects {
 		obj, ok := o.(*unstructured.Unstructured)
 		if !ok {
@@ -160,20 +157,18 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 		guessed, _ := meta.UnsafeGuessKindToResource(gvk)
 		mapping, err := crdMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil || mapping.Resource == guessed {
-			continue // GVR is already correct; tracker.Add handled it fine
+			continue
 		}
-		ns := obj.GetNamespace()
-		ri := dyn.Resource(mapping.Resource)
-		if ns != "" {
-			if _, err := ri.Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
-				return nil, err
-			}
-		} else {
-			if _, err := ri.Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
-				return nil, err
-			}
-		}
+		gvrRemap[mapping.Resource] = guessed // teleportrolesv8 → teleportrolev8s
 	}
+
+	allFakeObjects := make([]runtime.Object, 0, len(objects))
+	allFakeObjects = append(allFakeObjects, objects...)
+
+	dyn := newRemappingDynamic(
+		fake.NewSimpleDynamicClientWithCustomListKinds(s, gvr, allFakeObjects...),
+		gvrRemap,
+	)
 
 	// Filter out CRDs from objects before converting for kube client
 	// CRDs are not regular Kubernetes resources and can't be converted
@@ -205,6 +200,29 @@ func (c fakeCluster) RESTMapper(crds []*apiextensionsv1.CustomResourceDefinition
 
 func (c fakeCluster) IsFake() bool {
 	return true
+}
+
+// remappingDynamic wraps a dynamic.Interface and redirects Resource() calls for
+// CRD-declared GVRs to the guessed GVR that tracker.Add actually used as the
+// storage key. This makes retrieval consistent with storage without requiring a
+// separate Create pass or any changes to how objects are loaded.
+type remappingDynamic struct {
+	dynamic.Interface
+	remap map[schema.GroupVersionResource]schema.GroupVersionResource
+}
+
+func newRemappingDynamic(dyn dynamic.Interface, remap map[schema.GroupVersionResource]schema.GroupVersionResource) dynamic.Interface {
+	if len(remap) == 0 {
+		return dyn
+	}
+	return &remappingDynamic{Interface: dyn, remap: remap}
+}
+
+func (d *remappingDynamic) Resource(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	if mapped, ok := d.remap[gvr]; ok {
+		gvr = mapped
+	}
+	return d.Interface.Resource(gvr)
 }
 
 func convertCRDToAPIGroupResources(crd *apiextensionsv1.CustomResourceDefinition) *restmapper.APIGroupResources {

--- a/ext/cluster/fake.go
+++ b/ext/cluster/fake.go
@@ -72,19 +72,12 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 	list := []schema.GroupVersionResource{}
 	gvrToGVK := make(map[schema.GroupVersionResource]schema.GroupVersionKind)
 
-	// objWithGVR pairs an unstructured instance with the GVR it should be stored
-	// under in the fake tracker — resolved once and reused for the Create call.
-	type objWithGVR struct {
-		obj *unstructured.Unstructured
-		gvr schema.GroupVersionResource
-	}
-	var toCreate []objWithGVR
-
-	// Collect CRDs first so the REST mapper below can resolve CR instance plurals
-	// before the main loop processes them. Without this, meta.UnsafeGuessKindToResource
-	// produces wrong plurals for CRDs with non-standard plural names (e.g. kind
-	// TeleportRoleV8 has CRD plural "teleportrolesv8" but the heuristic gives
-	// "teleportrolev8s"), causing resource.List to return empty results at test time.
+	// Collect CRDs in a first pass so we can build a REST mapper before the main
+	// loop. The mapper lets us detect CRDs whose plural name does not match the
+	// lowercase-kind + "s" heuristic (e.g. TeleportRoleV8: CRD plural
+	// "teleportrolesv8", UnsafeGuessKindToResource gives "teleportrolev8s").
+	// Without this, resource.List on the correct plural returns empty because
+	// tracker.Add stores instances under the wrong key.
 	var collectedCRDs []*apiextensionsv1.CustomResourceDefinition
 	for _, o := range objects {
 		if crd, ok := o.(*apiextensionsv1.CustomResourceDefinition); ok {
@@ -130,20 +123,7 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 		}
 
 		gvk := o.GetObjectKind().GroupVersionKind()
-		// Prefer the CRD-declared plural; fall back to the heuristic for built-in types.
 		plural, _ := meta.UnsafeGuessKindToResource(gvk)
-		if mapping, err := crdMapper.RESTMapping(gvk.GroupKind(), gvk.Version); err == nil {
-			plural = mapping.Resource
-		}
-
-		// Always collect unstructured instances with their resolved GVR so we can
-		// insert them into the tracker after the client is created. We do this before
-		// the duplicate-GVR check below because a CRD may have already registered the
-		// same GVR in the scheme/gvr maps — we still need to populate the tracker.
-		if obj, ok := o.(*unstructured.Unstructured); ok {
-			toCreate = append(toCreate, objWithGVR{obj: obj, gvr: plural})
-		}
-
 		if _, ok := gvr[plural]; ok {
 			continue
 		}
@@ -161,21 +141,35 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 		list = append(list, plural)
 	}
 
-	// Create the fake client without pre-loading objects. Each collected instance
-	// is inserted via Create so the tracker stores it under the GVR resolved above
-	// (CRD-declared plural) rather than what tracker.Add derives internally via
-	// UnsafeGuessKindToResource.
-	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(s, gvr)
+	allFakeObjects := make([]runtime.Object, 0, len(objects))
+	allFakeObjects = append(allFakeObjects, objects...)
 
-	for _, item := range toCreate {
-		ns := item.obj.GetNamespace()
-		ri := dyn.Resource(item.gvr)
+	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(s, gvr, allFakeObjects...)
+
+	// tracker.Add (called by the constructor above) always uses
+	// UnsafeGuessKindToResource to pick the storage key, so CR instances with
+	// non-standard plural names land under the wrong GVR. Re-insert them via
+	// Create, which routes through ObjectReaction → tracker.Create(gvr, obj, ns)
+	// and stores them under the explicit CRD-declared GVR instead.
+	for _, o := range objects {
+		obj, ok := o.(*unstructured.Unstructured)
+		if !ok {
+			continue
+		}
+		gvk := obj.GroupVersionKind()
+		guessed, _ := meta.UnsafeGuessKindToResource(gvk)
+		mapping, err := crdMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil || mapping.Resource == guessed {
+			continue // GVR is already correct; tracker.Add handled it fine
+		}
+		ns := obj.GetNamespace()
+		ri := dyn.Resource(mapping.Resource)
 		if ns != "" {
-			if _, err := ri.Namespace(ns).Create(context.Background(), item.obj, metav1.CreateOptions{}); err != nil {
+			if _, err := ri.Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
 				return nil, err
 			}
 		} else {
-			if _, err := ri.Create(context.Background(), item.obj, metav1.CreateOptions{}); err != nil {
+			if _, err := ri.Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
 				return nil, err
 			}
 		}

--- a/ext/cluster/fake.go
+++ b/ext/cluster/fake.go
@@ -72,101 +72,84 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 	list := []schema.GroupVersionResource{}
 	gvrToGVK := make(map[schema.GroupVersionResource]schema.GroupVersionKind)
 
-	// Pass 1: register every CRD and collect them so we can build a REST mapper
-	// before processing CR instances. This is needed because the object list may
-	// contain instances before their CRD, and the order must not matter.
+	// Collect CRDs first so the REST mapper below can resolve CR instance plurals
+	// before the main loop processes them. Without this, meta.UnsafeGuessKindToResource
+	// produces wrong plurals for CRDs with non-standard plural names (e.g. kind
+	// TeleportRoleV8 has CRD plural "teleportrolesv8" but the heuristic gives
+	// "teleportrolev8s"), causing resource.List to return empty results at test time.
 	var collectedCRDs []*apiextensionsv1.CustomResourceDefinition
 	for _, o := range objects {
-		crd, ok := o.(*apiextensionsv1.CustomResourceDefinition)
-		if !ok {
-			continue
+		if crd, ok := o.(*apiextensionsv1.CustomResourceDefinition); ok {
+			collectedCRDs = append(collectedCRDs, crd)
 		}
-		collectedCRDs = append(collectedCRDs, crd)
-		for _, version := range crd.Spec.Versions {
-			if version.Storage {
-				crdGVR := schema.GroupVersionResource{
-					Group:    crd.Spec.Group,
-					Version:  version.Name,
-					Resource: crd.Spec.Names.Plural,
-				}
-				if _, exists := gvr[crdGVR]; !exists {
-					list = append(list, crdGVR)
-					crdGVK := schema.GroupVersionKind{
-						Group:   crd.Spec.Group,
-						Version: version.Name,
-						Kind:    crd.Spec.Names.Kind,
-					}
-					gvr[crdGVR] = crdGVK.Kind + "List"
-					gvrToGVK[crdGVR] = crdGVK
-
-					crdGVKList := crdGVK
-					crdGVKList.Kind += "List"
-					if !s.Recognizes(crdGVKList) {
-						s.AddKnownTypeWithName(crdGVKList, &unstructured.UnstructuredList{})
-					}
-				}
-			}
-		}
-
-		s.AddKnownTypeWithName(o.GetObjectKind().GroupVersionKind(), o)
 	}
-
-	// Build a REST mapper from the collected CRDs. This lets pass 2 resolve the
-	// GVR for CR instances using the CRD-declared plural rather than the heuristic
-	// meta.UnsafeGuessKindToResource, which produces the wrong plural for resources
-	// like TeleportRoleV8 (CRD plural "teleportrolesv8", guessed "teleportrolev8s").
 	crdAPIGroups := make([]*restmapper.APIGroupResources, 0, len(collectedCRDs))
 	for _, crd := range collectedCRDs {
 		crdAPIGroups = append(crdAPIGroups, convertCRDToAPIGroupResources(crd))
 	}
 	crdMapper := restmapper.NewDiscoveryRESTMapper(crdAPIGroups)
 
-	// Pass 2: register non-CRD object types in the scheme and GVR maps.
-	// Objects are NOT added to allFakeObjects here; they are inserted into the
-	// tracker via Create below so that the explicit CRD-declared GVR is used as
-	// the storage key rather than the UnsafeGuessKindToResource result.
 	for _, o := range objects {
-		if _, ok := o.(*apiextensionsv1.CustomResourceDefinition); ok {
+		if crd, ok := o.(*apiextensionsv1.CustomResourceDefinition); ok {
+			for _, version := range crd.Spec.Versions {
+				if version.Storage {
+					crdGVR := schema.GroupVersionResource{
+						Group:    crd.Spec.Group,
+						Version:  version.Name,
+						Resource: crd.Spec.Names.Plural,
+					}
+					if _, exists := gvr[crdGVR]; !exists {
+						list = append(list, crdGVR)
+						crdGVK := schema.GroupVersionKind{
+							Group:   crd.Spec.Group,
+							Version: version.Name,
+							Kind:    crd.Spec.Names.Kind,
+						}
+						gvr[crdGVR] = crdGVK.Kind + "List"
+						gvrToGVK[crdGVR] = crdGVK
+
+						crdGVKList := crdGVK
+						crdGVKList.Kind += "List"
+						if !s.Recognizes(crdGVKList) {
+							s.AddKnownTypeWithName(crdGVKList, &unstructured.UnstructuredList{})
+						}
+					}
+				}
+			}
+
+			s.AddKnownTypeWithName(o.GetObjectKind().GroupVersionKind(), o)
 			continue
 		}
+
 		gvk := o.GetObjectKind().GroupVersionKind()
-
-		// Determine the correct GVR: prefer the CRD-declared plural over the guess.
-		var gvrKey schema.GroupVersionResource
+		// Prefer the CRD-declared plural; fall back to the heuristic for built-in types.
+		plural, _ := meta.UnsafeGuessKindToResource(gvk)
 		if mapping, err := crdMapper.RESTMapping(gvk.GroupKind(), gvk.Version); err == nil {
-			gvrKey = mapping.Resource
-		} else {
-			gvrKey, _ = meta.UnsafeGuessKindToResource(gvk)
+			plural = mapping.Resource
+		}
+		if _, ok := gvr[plural]; ok {
+			continue
 		}
 
-		// Always register the GVK in the scheme; the tracker needs it for List.
-		if !s.Recognizes(gvk) {
-			s.AddKnownTypeWithName(gvk, o)
-		}
+		s.AddKnownTypeWithName(gvk, o)
 		gvkList := gvk
 		gvkList.Kind += "List"
 		if !s.Recognizes(gvkList) {
 			s.AddKnownTypeWithName(gvkList, &unstructured.UnstructuredList{})
 		}
 
-		// Only add a new GVR entry if the CRD pass hasn't registered it already.
-		if _, ok := gvr[gvrKey]; !ok {
-			gvr[gvrKey] = gvkList.Kind
-			gvrToGVK[gvrKey] = gvk
-			list = append(list, gvrKey)
-		}
+		gvr[plural] = gvkList.Kind
+		gvrToGVK[plural] = gvk
+
+		list = append(list, plural)
 	}
 
-	// Create the fake dynamic client with the scheme and GVR map but without
-	// pre-loading objects. Objects are added via Create below so they are stored
-	// in the tracker under the correct GVR (the one from the CRD or the fallback
-	// guess) rather than the UnsafeGuessKindToResource result that tracker.Add
-	// would use internally.
+	// Create the fake client without pre-loading objects. Each non-CRD object is
+	// inserted below via Create so the tracker stores it under the GVR resolved
+	// above (CRD-declared plural) rather than the one tracker.Add would derive
+	// internally via UnsafeGuessKindToResource.
 	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(s, gvr)
 
-	// Insert each non-CRD object into the tracker under the correct GVR using
-	// Create, which routes through ObjectReaction → tracker.Create(gvr, obj, ns)
-	// and stores the object under the explicit GVR from dyn.Resource(gvrKey).
 	for _, o := range objects {
 		if _, ok := o.(*apiextensionsv1.CustomResourceDefinition); ok {
 			continue
@@ -176,14 +159,12 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 			continue
 		}
 		gvk := obj.GroupVersionKind()
-		var objGVR schema.GroupVersionResource
+		plural, _ := meta.UnsafeGuessKindToResource(gvk)
 		if mapping, err := crdMapper.RESTMapping(gvk.GroupKind(), gvk.Version); err == nil {
-			objGVR = mapping.Resource
-		} else {
-			objGVR, _ = meta.UnsafeGuessKindToResource(gvk)
+			plural = mapping.Resource
 		}
 		ns := obj.GetNamespace()
-		ri := dyn.Resource(objGVR)
+		ri := dyn.Resource(plural)
 		if ns != "" {
 			if _, err := ri.Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
 				return nil, err

--- a/ext/cluster/fake.go
+++ b/ext/cluster/fake.go
@@ -73,23 +73,26 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 	list := []schema.GroupVersionResource{}
 	gvrToGVK := make(map[schema.GroupVersionResource]schema.GroupVersionKind)
 
-	// Collect CRDs in a first pass so we can build a REST mapper before the main
-	// loop. The mapper lets us detect CRDs whose plural name does not match the
-	// lowercase-kind + "s" heuristic (e.g. TeleportRoleV8: CRD plural
-	// "teleportrolesv8", UnsafeGuessKindToResource gives "teleportrolev8s").
-	// Without this, resource.List on the correct plural returns empty because
-	// tracker.Add stores instances under the wrong key.
-	var collectedCRDs []*apiextensionsv1.CustomResourceDefinition
+	// Build a remap table from CRDs whose declared plural differs from the
+	// UnsafeGuessKindToResource heuristic (e.g. TeleportRoleV8: CRD plural
+	// "teleportrolesv8", heuristic gives "teleportrolev8s"). tracker.Add always
+	// uses the heuristic, so resource.List on the correct CRD plural would return
+	// empty without the remappingDynamic wrapper below.
+	gvrRemap := make(map[schema.GroupVersionResource]schema.GroupVersionResource)
 	for _, o := range objects {
-		if crd, ok := o.(*apiextensionsv1.CustomResourceDefinition); ok {
-			collectedCRDs = append(collectedCRDs, crd)
+		crd, ok := o.(*apiextensionsv1.CustomResourceDefinition)
+		if !ok {
+			continue
+		}
+		for _, version := range crd.Spec.Versions {
+			gvk := schema.GroupVersionKind{Group: crd.Spec.Group, Version: version.Name, Kind: crd.Spec.Names.Kind}
+			guessed, _ := meta.UnsafeGuessKindToResource(gvk)
+			if crd.Spec.Names.Plural != guessed.Resource {
+				actual := schema.GroupVersionResource{Group: crd.Spec.Group, Version: version.Name, Resource: crd.Spec.Names.Plural}
+				gvrRemap[actual] = guessed
+			}
 		}
 	}
-	crdAPIGroups := make([]*restmapper.APIGroupResources, 0, len(collectedCRDs))
-	for _, crd := range collectedCRDs {
-		crdAPIGroups = append(crdAPIGroups, convertCRDToAPIGroupResources(crd))
-	}
-	crdMapper := restmapper.NewDiscoveryRESTMapper(crdAPIGroups)
 
 	for _, o := range objects {
 		if crd, ok := o.(*apiextensionsv1.CustomResourceDefinition); ok {
@@ -140,26 +143,6 @@ func (c fakeCluster) DClient(objects []runtime.Object) (dclient.Interface, error
 		gvrToGVK[plural] = gvk
 
 		list = append(list, plural)
-	}
-
-	// Build a remap table: CRD-declared GVR → guessed GVR (where tracker.Add
-	// actually stores objects). tracker.Add uses UnsafeGuessKindToResource, so
-	// for CRDs with non-standard plural names the two diverge. We wrap the
-	// dynamic interface below so that callers using the correct CRD plural are
-	// transparently redirected to the GVR the tracker knows about.
-	gvrRemap := make(map[schema.GroupVersionResource]schema.GroupVersionResource)
-	for _, o := range objects {
-		obj, ok := o.(*unstructured.Unstructured)
-		if !ok {
-			continue
-		}
-		gvk := obj.GroupVersionKind()
-		guessed, _ := meta.UnsafeGuessKindToResource(gvk)
-		mapping, err := crdMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-		if err != nil || mapping.Resource == guessed {
-			continue
-		}
-		gvrRemap[mapping.Resource] = guessed // teleportrolesv8 → teleportrolev8s
 	}
 
 	allFakeObjects := make([]runtime.Object, 0, len(objects))

--- a/ext/cluster/fake_test.go
+++ b/ext/cluster/fake_test.go
@@ -23,7 +23,7 @@ func TestDClient_ConstructionDoesNotPanicWithWildcardMutateExisting(t *testing.T
 	cluster := fakeCluster{}
 
 	// DClient must not panic when building the client.
-	var client interface{}
+	var client any
 	require.NotPanics(t, func() {
 		var err error
 		client, err = cluster.DClient([]runtime.Object{ns})
@@ -176,6 +176,56 @@ func TestDClient_CustomResourceNonStandardPluralListSucceeds(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, list.Items, 1,
 		"resource.List should find the instance under the CRD-declared plural, not the heuristic guess")
+}
+
+// TestDClient_CustomResourceNonStandardPluralGetSucceeds verifies that a CR instance
+// is findable via resource.Get when the CRD declares a plural name that differs from
+// what meta.UnsafeGuessKindToResource would produce.
+func TestDClient_CustomResourceNonStandardPluralGetSucceeds(t *testing.T) {
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "teleportrolesv8.resources.teleport.dev",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "resources.teleport.dev",
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "teleportrolesv8",
+				Singular: "teleportrolev8",
+				Kind:     "TeleportRoleV8",
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{Name: "v1", Served: true, Storage: true},
+			},
+		},
+	}
+
+	role := &unstructured.Unstructured{}
+	role.SetAPIVersion("resources.teleport.dev/v1")
+	role.SetKind("TeleportRoleV8")
+	role.SetName("my-team-dev-role")
+	role.SetNamespace("teleport")
+
+	cluster := fakeCluster{}
+	client, err := cluster.DClient([]runtime.Object{crd, role})
+	require.NoError(t, err)
+
+	got, err := client.GetDynamicInterface().
+		Resource(schema.GroupVersionResource{
+			Group:    "resources.teleport.dev",
+			Version:  "v1",
+			Resource: "teleportrolesv8",
+		}).
+		Namespace("teleport").
+		Get(context.Background(), "my-team-dev-role", metav1.GetOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "my-team-dev-role", got.GetName(),
+		"resource.Get should find the instance under the CRD-declared plural, not the heuristic guess")
 }
 
 // TestDClient_CRDListDoesNotPanic verifies the list behavior works for custom resources.

--- a/ext/cluster/fake_test.go
+++ b/ext/cluster/fake_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestDClient_ConstructionDoesNotPanicWithWildcardMutateExisting(t *testing.T) {
@@ -118,6 +119,62 @@ func TestDClient_ConfigMapListDoesNotPanic(t *testing.T) {
 	}, "ListResource on ConfigMap must not panic")
 
 	assert.NoError(t, err)
+}
+
+// TestDClient_CustomResourceNonStandardPluralListSucceeds verifies that a CR instance
+// is findable via resource.List when the CRD declares a plural name that differs from
+// what meta.UnsafeGuessKindToResource would produce.
+//
+// Concretely: kind "TeleportRoleV8" has CRD plural "teleportrolesv8", but the heuristic
+// produces "teleportrolev8s". Before the fix, resource.List with the correct CRD plural
+// returned an empty list because instances were stored under the wrong GVR key.
+func TestDClient_CustomResourceNonStandardPluralListSucceeds(t *testing.T) {
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "teleportrolesv8.resources.teleport.dev",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "resources.teleport.dev",
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "teleportrolesv8",
+				Singular: "teleportrolev8",
+				Kind:     "TeleportRoleV8",
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{Name: "v1", Served: true, Storage: true},
+			},
+		},
+	}
+
+	role := &unstructured.Unstructured{}
+	role.SetAPIVersion("resources.teleport.dev/v1")
+	role.SetKind("TeleportRoleV8")
+	role.SetName("my-team-dev-role")
+	role.SetNamespace("teleport")
+
+	cluster := fakeCluster{}
+	client, err := cluster.DClient([]runtime.Object{crd, role})
+	require.NoError(t, err)
+
+	// Query using the CRD-declared plural — this is exactly the GVR that CEL
+	// resource.List("resources.teleport.dev/v1", "teleportrolesv8", "teleport") uses.
+	list, err := client.GetDynamicInterface().
+		Resource(schema.GroupVersionResource{
+			Group:    "resources.teleport.dev",
+			Version:  "v1",
+			Resource: "teleportrolesv8",
+		}).
+		Namespace("teleport").
+		List(context.Background(), metav1.ListOptions{})
+
+	require.NoError(t, err)
+	assert.Len(t, list.Items, 1,
+		"resource.List should find the instance under the CRD-declared plural, not the heuristic guess")
 }
 
 // TestDClient_CRDListDoesNotPanic verifies the list behavior works for custom resources.

--- a/ext/cluster/fake_test.go
+++ b/ext/cluster/fake_test.go
@@ -126,8 +126,9 @@ func TestDClient_ConfigMapListDoesNotPanic(t *testing.T) {
 // what meta.UnsafeGuessKindToResource would produce.
 //
 // Concretely: kind "TeleportRoleV8" has CRD plural "teleportrolesv8", but the heuristic
-// produces "teleportrolev8s". Before the fix, resource.List with the correct CRD plural
-// returned an empty list because instances were stored under the wrong GVR key.
+// produces "teleportrolev8s". tracker.Add stores instances under the heuristic key;
+// DClient wraps the dynamic interface so that callers using the correct CRD plural
+// ("teleportrolesv8") are transparently redirected to where the tracker stored them.
 func TestDClient_CustomResourceNonStandardPluralListSucceeds(t *testing.T) {
 	crd := &apiextensionsv1.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{

--- a/test/cli/test-crd-nonstandard-plural/cluster-resources.yaml
+++ b/test/cli/test-crd-nonstandard-plural/cluster-resources.yaml
@@ -1,0 +1,25 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: ClusterResource
+metadata:
+  name: cluster-resources
+spec:
+  crds:
+    - crds/teleportrolesv8.yaml
+    - crds/widgets.yaml
+  resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: default
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: teleport
+    # One TeleportRoleV8 instance. resource.List("resources.teleport.dev/v1","teleportrolesv8","teleport")
+    # must return this — before the fix it returned [] because tracker.Add stored it under the
+    # heuristic plural "teleportrolev8s" instead of the CRD-declared plural "teleportrolesv8".
+    - apiVersion: resources.teleport.dev/v1
+      kind: TeleportRoleV8
+      metadata:
+        name: my-team-dev-role
+        namespace: teleport

--- a/test/cli/test-crd-nonstandard-plural/crds/teleportrolesv8.yaml
+++ b/test/cli/test-crd-nonstandard-plural/crds/teleportrolesv8.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: teleportrolesv8.resources.teleport.dev
+spec:
+  group: resources.teleport.dev
+  scope: Namespaced
+  names:
+    kind: TeleportRoleV8
+    plural: teleportrolesv8   # does NOT match UnsafeGuessKindToResource("TeleportRoleV8") = "teleportrolev8s"
+    singular: teleportrolev8
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/test/cli/test-crd-nonstandard-plural/crds/widgets.yaml
+++ b/test/cli/test-crd-nonstandard-plural/crds/widgets.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  scope: Namespaced
+  names:
+    kind: Widget
+    plural: widgets
+    singular: widget
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/test/cli/test-crd-nonstandard-plural/kyverno-test.yaml
+++ b/test/cli/test-crd-nonstandard-plural/kyverno-test.yaml
@@ -1,17 +1,18 @@
 apiVersion: cli.kyverno.io/v1alpha1
+clusterResources:
+- cluster-resources.yaml
 kind: Test
 metadata:
   name: test-crd-nonstandard-plural
-clusterResources:
-  - cluster-resources.yaml
 policies:
-  - policy.yaml
+- policy.yaml
 resources:
-  - widget.yaml
+- widget.yaml
 results:
-  - isMutatingPolicy: true
-    policy: stamp-role-count
-    kind: Widget
-    resources: ["default/my-widget"]
-    patchedResources: patched/widget.yaml
-    result: pass
+- isMutatingPolicy: true
+  kind: Widget
+  patchedResources: patched/widget.yaml
+  policy: stamp-role-count
+  resources:
+  - default/my-widget
+  result: pass

--- a/test/cli/test-crd-nonstandard-plural/kyverno-test.yaml
+++ b/test/cli/test-crd-nonstandard-plural/kyverno-test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: test-crd-nonstandard-plural
+clusterResources:
+  - cluster-resources.yaml
+policies:
+  - policy.yaml
+resources:
+  - widget.yaml
+results:
+  - isMutatingPolicy: true
+    policy: stamp-role-count
+    kind: Widget
+    resources: ["default/my-widget"]
+    patchedResources: patched/widget.yaml
+    result: pass

--- a/test/cli/test-crd-nonstandard-plural/patched/widget.yaml
+++ b/test/cli/test-crd-nonstandard-plural/patched/widget.yaml
@@ -5,5 +5,6 @@ metadata:
   namespace: default
   annotations:
     role-count: "1"   # proves resource.List found the TeleportRoleV8 instance
+    role-name: my-team-dev-role   # proves resource.Get resolved the CRD-declared plural correctly
   labels:
     app.kubernetes.io/managed-by: kyverno

--- a/test/cli/test-crd-nonstandard-plural/patched/widget.yaml
+++ b/test/cli/test-crd-nonstandard-plural/patched/widget.yaml
@@ -1,0 +1,9 @@
+apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: my-widget
+  namespace: default
+  annotations:
+    role-count: "1"   # proves resource.List found the TeleportRoleV8 instance
+  labels:
+    app.kubernetes.io/managed-by: kyverno

--- a/test/cli/test-crd-nonstandard-plural/policy.yaml
+++ b/test/cli/test-crd-nonstandard-plural/policy.yaml
@@ -1,0 +1,29 @@
+apiVersion: policies.kyverno.io/v1
+kind: MutatingPolicy
+metadata:
+  name: stamp-role-count
+  annotations:
+    policies.kyverno.io/description: >-
+      Stamps the number of TeleportRoleV8 resources found via resource.List onto
+      an annotation. The annotation must be "1" (not "0") for the test to pass,
+      proving that resource.List resolves the CRD-declared plural correctly.
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["example.com"]
+        apiVersions: ["v1"]
+        resources: ["widgets"]
+        operations: ["CREATE"]
+  variables:
+    - name: roles
+      expression: |
+        dyn(resource.List("resources.teleport.dev/v1", "teleportrolesv8", "teleport").items)
+  mutations:
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: |
+          [JSONPatch{
+            op: "add",
+            path: "/metadata/annotations/role-count",
+            value: string(size(variables.roles))
+          }]

--- a/test/cli/test-crd-nonstandard-plural/policy.yaml
+++ b/test/cli/test-crd-nonstandard-plural/policy.yaml
@@ -18,6 +18,9 @@ spec:
     - name: roles
       expression: |
         dyn(resource.List("resources.teleport.dev/v1", "teleportrolesv8", "teleport").items)
+    - name: role
+      expression: |
+        resource.Get("resources.teleport.dev/v1", "teleportrolesv8", "teleport", "my-team-dev-role")
   mutations:
     - patchType: JSONPatch
       jsonPatch:
@@ -26,4 +29,9 @@ spec:
             op: "add",
             path: "/metadata/annotations/role-count",
             value: string(size(variables.roles))
+          },
+          JSONPatch{
+            op: "add",
+            path: "/metadata/annotations/role-name",
+            value: dyn(variables.role).metadata.name
           }]

--- a/test/cli/test-crd-nonstandard-plural/widget.yaml
+++ b/test/cli/test-crd-nonstandard-plural/widget.yaml
@@ -1,0 +1,6 @@
+apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: my-widget
+  namespace: default
+  annotations: {}


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

`kyverno test` with `clusterResources:` builds a fake dynamic client to serve `resource.Get()` and `resource.List()` calls made by CEL policies at test time. The fake client used `meta.UnsafeGuessKindToResource` to determine the GVR under which CR instances are stored in its object tracker. For any CRD whose plural name does not match the lowercase-kind + "s" heuristic — for example `TeleportRoleV8` where the CRD declares plural `teleportrolesv8` but the heuristic produces `teleportrolev8s` — instances were stored under the wrong key. A subsequent `resource.List("...", "teleportrolesv8", ...)` call returned an empty list, silently breaking CEL policies that aggregate cluster state via `resource.List`.

This is a bug fix. After this PR, `resource.List` calls using the CRD-declared plural are transparently redirected to the GVR the tracker actually used, so instances are found correctly.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR

<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

N/A — bug fix with no user-visible behaviour change other than making the CLI test framework work correctly for CRDs with non-standard plural names.

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

/kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

The fix adds a small pre-loop in `DClient` (`ext/cluster/fake.go`) that scans the CRDs in the object list and builds a remap table for any CRD whose declared plural differs from `UnsafeGuessKindToResource(Kind)`. The main loop and how objects are loaded into the tracker are unchanged.

The dynamic interface returned by `DClient` is then wrapped in a thin `remappingDynamic` shim that overrides `Resource()`: when a caller asks for the CRD-declared GVR (e.g. `teleportrolesv8`), it is silently redirected to the heuristic GVR (e.g. `teleportrolev8s`) where `tracker.Add` actually stored the objects. Standard k8s types whose plural already matches the heuristic pass through unchanged.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

CRD with non-standard plural + a MutatingPolicy that aggregates instances via `resource.List`:

```yaml
# crd.yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: teleportrolesv8.resources.teleport.dev
spec:
  group: resources.teleport.dev
  scope: Namespaced
  names:
    kind: TeleportRoleV8
    plural: teleportrolesv8   # does NOT match UnsafeGuess "teleportrolev8s"
    singular: teleportrolev8
  versions:
    - name: v1
      served: true
      storage: true
      schema:
        openAPIV3Schema:
          type: object
```

```yaml
# policy.yaml
apiVersion: policies.kyverno.io/v1
kind: MutatingPolicy
metadata:
  name: stamp-role-count
spec:
  matchConstraints:
    resourceRules:
      - apiGroups: ["example.com"]
        apiVersions: ["v1"]
        resources: ["widgets"]
        operations: ["CREATE"]
  variables:
    - name: roles
      expression: |
        dyn(resource.List("resources.teleport.dev/v1", "teleportrolesv8", "teleport").items)
  mutations:
    - patchType: JSONPatch
      jsonPatch:
        expression: |
          [JSONPatch{op: "add", path: "/metadata/annotations/role-count",
            value: string(size(variables.roles))}]
```

```yaml
# kyverno-test.yaml
apiVersion: cli.kyverno.io/v1alpha1
kind: Test
metadata:
  name: stamp-role-count
clusterResources:
  - cluster-resources.yaml   # contains the CRD + one TeleportRoleV8 instance
policies:
  - policy.yaml
resources:
  - widget.yaml
results:
  - isMutatingPolicy: true
    policy: stamp-role-count
    kind: Widget
    resources: ["default/my-widget"]
    patchedResources: patched/widget.yaml
    result: pass
```

```yaml
# patched/widget.yaml — role-count must be "1", not "0"
apiVersion: example.com/v1
kind: Widget
metadata:
  name: my-widget
  namespace: default
  annotations:
    role-count: "1"
```

Before this fix the annotation would be `"0"` (empty list); after the fix it is `"1"`.

Output:
```
make build-cli && ./cmd/cli/kubectl-kyverno/kubectl-kyverno test test/cli/test-crd-nonstandard-plural --detailed-results && kyverno test /Users/afarbos/Repos/github/kyverno/test/cli/test-crd-nonstandard-plural --detailed-results ; echo $?
Go fmt...
Build cli binary...
Loading test  ( test/cli/test-crd-nonstandard-plural/kyverno-test.yaml ) ...
  Loading values/variables ...
  Loading policies ...
  Loading resources ...
Loading Kubernetes resources ...
  Loading exceptions ...
  Applying 1 policy to 1 resource with 0 exceptions ...
  Checking results ...

│────│──────────────────│──────│─────────────────────────────────────────│────────│────────│─────────│
│ ID │ POLICY           │ RULE │ RESOURCE                                │ RESULT │ REASON │ MESSAGE │
│────│──────────────────│──────│─────────────────────────────────────────│────────│────────│─────────│
│ 1  │ stamp-role-count │      │ example.com/v1/Widget/default/my-widget │ Pass   │ Ok     │ success │
│────│──────────────────│──────│─────────────────────────────────────────│────────│────────│─────────│


Test Summary: 1 tests passed and 0 tests failed

Loading test  ( /Users/afarbos/Repos/github/kyverno/test/cli/test-crd-nonstandard-plural/kyverno-test.yaml ) ...
  Loading values/variables ...
  Loading policies ...
  Loading resources ...
Loading Kubernetes resources ...
  Loading exceptions ...
  Applying 1 policy to 1 resource with 0 exceptions ...
panic: unimplemented

goroutine 1 [running]:
k8s.io/client-go/discovery/fake.(*FakeDiscovery).OpenAPIV3(0x10f0f7900?)
	k8s.io/client-go@v0.35.4/discovery/fake/discovery.go:169 +0x2c
github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/processor.(*PolicyProcessor).openAPI(0x10f9ccbc0?)
	github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/processor/policy_processor.go:972 +0x2c4
github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/processor.(*PolicyProcessor).ApplyPoliciesOnResource(0x15ea47474278)
	github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/processor/policy_processor.go:319 +0x2164
github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/test.runTest({0x10f9cb8b8, 0x15ea46bf8068}, {{0x15ea46c79140, 0x5a}, {0x0, 0x0}, 0x15ea47813908, {0x0, 0x0}}, 0x0)
	github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/test/test.go:382 +0x2fbc
github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/test.testCommandExecute({0x10f9cb8b8, 0x15ea46bf8068}, {0x15ea471ccf60, 0x1, 0x2}, {0x103d847d0, 0x11}, {0x0, 0x0}, {0x103db3a0a, ...}, ...)
	github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/test/command.go:156 +0xa30
github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/test.Command.func1(0x15ea4785fb08, {0x15ea471ccf60, 0x1, 0x2})
	github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/test/command.go:41 +0x10c
github.com/spf13/cobra.(*Command).execute(0x15ea4785fb08, {0x15ea471ccf20, 0x2, 0x2})
	github.com/spf13/cobra@v1.10.2/command.go:1015 +0x814
github.com/spf13/cobra.(*Command).ExecuteC(0x15ea473aa008)
	github.com/spf13/cobra@v1.10.2/command.go:1148 +0x350
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.10.2/command.go:1071
main.main()
	github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/main.go:21 +0x80
2
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). AI assistance was used in authoring this fix; disclosed via `Co-authored-by` trailer in the commit.
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

The bug only manifests for CRDs where `strings.ToLower(kind) + "s" != plural` (i.e. non-standard plural names). All standard k8s built-in resource types are unaffected because their plurals match the heuristic and the remap table will be empty for them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic resource access for custom resources whose declared plural differs from Kubernetes’ inferred resource name.
  * `List` and `Get` operations now correctly resolve these custom resources using their declared resource names.

* **Tests**
  * Added coverage for nonstandard custom-resource plurals in list and get operations.
  * Added end-to-end validation through a Kyverno policy test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->