### PR TITLE
ci: migrate cherry-pick workflows to GitHub App auth

### DIFF
--- a/.github/actions/git/cherry-pick/action.yaml
+++ b/.github/actions/git/cherry-pick/action.yaml
@@ -39,7 +39,12 @@ runs:
         sudo apt install gh -y
     - name: Authenticate gh
       shell: bash
-      run: gh auth setup-git
+      run: |
+        if [ -z "$GH_TOKEN" ]; then
+          echo "::error::github-token input is empty, check the workflow secrets configuration"
+          exit 1
+        fi
+        gh auth setup-git
       env:
         GH_TOKEN: ${{ inputs.github-token }}
     - name: Create cherry-pick PRs

--- a/.github/workflows/cherry-pick-on-merge.yaml
+++ b/.github/workflows/cherry-pick-on-merge.yaml
@@ -72,7 +72,10 @@ jobs:
             exit 1
           fi
 
-          echo "::add-mask::$key"
+          # ::add-mask:: is line-based, mask each line of the key individually.
+          while IFS= read -r line; do
+            [ -n "$line" ] && echo "::add-mask::$line"
+          done <<< "$key"
           {
             echo "private_key<<EOF"
             printf '%s\n' "$key"

--- a/.github/workflows/cherry-pick-on-merge.yaml
+++ b/.github/workflows/cherry-pick-on-merge.yaml
@@ -45,11 +45,56 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+      - name: Normalize GitHub App private key
+        if: steps.cherry.outputs.result != '[]'
+        id: normalize-key
+        shell: bash
+        env:
+          RAW_APP_PRIVATE_KEY: ${{ secrets.PR_UPDATER_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          key="$RAW_APP_PRIVATE_KEY"
+          # Support secrets saved with escaped newlines.
+          key="${key//\\n/$'\n'}"
+
+          if ! printf '%s' "$key" | grep -Eq 'BEGIN (RSA |EC |)PRIVATE KEY'; then
+            # Support secrets saved as base64-encoded PEM.
+            decoded="$(printf '%s' "$RAW_APP_PRIVATE_KEY" | tr -d '[:space:]' | base64 --decode 2>/dev/null || true)"
+            decoded="${decoded//\\n/$'\n'}"
+            if printf '%s' "$decoded" | grep -Eq 'BEGIN (RSA |EC |)PRIVATE KEY'; then
+              key="$decoded"
+            fi
+          fi
+
+          if ! printf '%s' "$key" | grep -Eq 'BEGIN (RSA |EC |)PRIVATE KEY'; then
+            echo "PR_UPDATER_APP_PRIVATE_KEY does not look like a valid PEM private key." >&2
+            exit 1
+          fi
+
+          echo "::add-mask::$key"
+          {
+            echo "private_key<<EOF"
+            printf '%s\n' "$key"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Create GitHub App token
+        if: steps.cherry.outputs.result != '[]'
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.PR_UPDATER_APP_CLIENT_ID }}
+          private-key: ${{ steps.normalize-key.outputs.private_key }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
       - name: Cherry-pick to each branch
         if: steps.cherry.outputs.result != '[]'
         uses: ./.github/actions/git/cherry-pick
         with:
-          github-token: ${{ secrets.PR_UPDATE_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           source-pr: ${{ github.event.pull_request.number }}
           source-pr-title: ${{ github.event.pull_request.title }}
           target-branches: ${{ fromJSON(steps.cherry.outputs.result)[0] }}

--- a/.github/workflows/comment-cherry-pick.yaml
+++ b/.github/workflows/comment-cherry-pick.yaml
@@ -43,6 +43,51 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           reaction: "+1"
 
+      - name: Normalize GitHub App private key
+        id: normalize-key
+        shell: bash
+        env:
+          RAW_APP_PRIVATE_KEY: ${{ secrets.PR_UPDATER_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          key="$RAW_APP_PRIVATE_KEY"
+          # Support secrets saved with escaped newlines.
+          key="${key//\\n/$'\n'}"
+
+          if ! printf '%s' "$key" | grep -Eq 'BEGIN (RSA |EC |)PRIVATE KEY'; then
+            # Support secrets saved as base64-encoded PEM.
+            decoded="$(printf '%s' "$RAW_APP_PRIVATE_KEY" | tr -d '[:space:]' | base64 --decode 2>/dev/null || true)"
+            decoded="${decoded//\\n/$'\n'}"
+            if printf '%s' "$decoded" | grep -Eq 'BEGIN (RSA |EC |)PRIVATE KEY'; then
+              key="$decoded"
+            fi
+          fi
+
+          if ! printf '%s' "$key" | grep -Eq 'BEGIN (RSA |EC |)PRIVATE KEY'; then
+            echo "PR_UPDATER_APP_PRIVATE_KEY does not look like a valid PEM private key." >&2
+            exit 1
+          fi
+
+          echo "::add-mask::$key"
+          {
+            echo "private_key<<EOF"
+            printf '%s\n' "$key"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.PR_UPDATER_APP_CLIENT_ID }}
+          private-key: ${{ steps.normalize-key.outputs.private_key }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+
       - name: Check if PR is merged
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: check-merged
@@ -88,7 +133,7 @@ jobs:
         if: ${{ fromJSON(steps.check-merged.outputs.result).merged == false && fromJSON(steps.check-merged.outputs.result).state != 'closed' }}
         uses: ben-z/actions-comment-on-issue@402eb412a8f396be0d4ac52a823ec7121206cc26 # v1.0.3
         with:
-          GITHUB_TOKEN: ${{ secrets.PR_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           message: |
             Commits from this PR will automatically be cherry-picked once this PR gets merged.
 
@@ -104,7 +149,7 @@ jobs:
         continue-on-error: true # Send failure comment to PR
         id: cherry-pick
         with:
-          github-token: ${{ secrets.PR_UPDATE_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           source-pr: ${{ github.event.issue.number }}
           source-pr-title: ${{ github.event.issue.title }}
           target-branches: ${{ steps.extract-branch.outputs.branch }}
@@ -114,7 +159,7 @@ jobs:
         if: ${{ steps.cherry-pick.outputs.success == false && fromJSON(steps.check-merged.outputs.result).merged == true }}
         uses: ben-z/actions-comment-on-issue@402eb412a8f396be0d4ac52a823ec7121206cc26 # v1.0.3
         with:
-          GITHUB_TOKEN: ${{ secrets.PR_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           message: |
             :no_entry_sign: Cherry picking merge commit `${{ fromJSON(steps.check-merged.outputs.result).mergeCommit}}` failed. 
 

--- a/.github/workflows/comment-cherry-pick.yaml
+++ b/.github/workflows/comment-cherry-pick.yaml
@@ -69,7 +69,10 @@ jobs:
             exit 1
           fi
 
-          echo "::add-mask::$key"
+          # ::add-mask:: is line-based, mask each line of the key individually.
+          while IFS= read -r line; do
+            [ -n "$line" ] && echo "::add-mask::$line"
+          done <<< "$key"
           {
             echo "private_key<<EOF"
             printf '%s\n' "$key"


### PR DESCRIPTION
## Problem

The cherry-pick bot stopped working (first observed on #16929, `/cherry-pick release-1.19`). The failed run shows `GH_TOKEN` was **empty** and `gh auth setup-git` failed with:

```
You are not logged into any GitHub hosts. Run gh auth login to authenticate.
```

## Root cause

#16662 migrated `pr-branch-updater` from the `PR_UPDATE_TOKEN` PAT to GitHub App auth, and the `PR_UPDATE_TOKEN` org secret was removed as part of that cleanup (last successful bot cherry-pick was #16634 on Jul 18, right before #16662 merged on Jul 20).

However, `comment-cherry-pick.yaml` and `cherry-pick-on-merge.yaml` were missed in that migration and still reference `secrets.PR_UPDATE_TOKEN`, which now silently resolves to an empty string.

## Fix

- Mint a short-lived GitHub App installation token via `actions/create-github-app-token` (SHA-pinned, v3.2.0) using the existing `PR_UPDATER_APP_CLIENT_ID` / `PR_UPDATER_APP_PRIVATE_KEY` org secrets, following the same pattern (including private-key normalization) as [kyverno/.github pr-branch-updater](https://github.com/kyverno/.github/blob/main/.github/workflows/pr-branch-updater.yml).
- Pass the app token to the cherry-pick composite action and the PR comment steps.
- Add a fail-fast guard in the composite action so an empty token produces a clear error instead of a confusing downstream `gh` auth failure.

## Notes for reviewers

- The app installation needs **Contents: write**, **Pull requests: write**, and **Issues: write** on this repo (the token request will fail loudly if not granted).
- The `PR_UPDATER_APP_*` org secrets must be shared with this repo (they already are, per `pr-branch-updater.yml`).
- Pre-existing limitation (unchanged by this PR): the `pull_request: closed`-triggered workflow gets no secrets when the head branch is on a fork, so the comment-triggered path remains the reliable one for fork PRs.

## Testing

- YAML validated locally.
- Once merged, can be verified by re-commenting `/cherry-pick release-1.19` on #16929.