### PR TITLE
ci: drop issues permission from cherry-pick app token request

### DIFF
--- a/.github/workflows/cherry-pick-on-merge.yaml
+++ b/.github/workflows/cherry-pick-on-merge.yaml
@@ -92,7 +92,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-contents: write
           permission-pull-requests: write
-          permission-issues: write
       - name: Cherry-pick to each branch
         if: steps.cherry.outputs.result != '[]'
         uses: ./.github/actions/git/cherry-pick

--- a/.github/workflows/comment-cherry-pick.yaml
+++ b/.github/workflows/comment-cherry-pick.yaml
@@ -89,7 +89,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-contents: write
           permission-pull-requests: write
-          permission-issues: write
 
       - name: Check if PR is merged
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## Problem

Follow-up to #16967. The first real run ([31169700475](https://github.com/kyverno/kyverno/actions/runs/31169700475), triggered by `/cherry-pick release-1.19` on #16929) failed at the token mint step:

```
Failed to create token for "kyverno/kyverno": The permissions requested are not granted to this installation.
```

The PR-updater GitHub App installation does not grant **Issues** permission, and #16967 requested `permission-issues: write`.

## Fix

Drop `permission-issues: write` from both workflows. It isn't needed: these workflows only comment on pull requests (the job is guarded by `github.event.issue.pull_request`), and commenting on PRs via the issues API is covered by `pull-requests: write` for GitHub App installation tokens.

## Testing

After merge, re-comment `/cherry-pick release-1.19` on #16929 to verify end to end.