### PR TITLE
fix(validation): reject non-string values in request.operation conditions

### DIFF
--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -1283,7 +1283,10 @@ func validateConditionValuesKeyRequestOperation(c kyvernov1.Condition) (string, 
 	case reflect.Slice:
 		values := reflect.ValueOf(v)
 		for i := 0; i < values.Len(); i++ {
-			value := values.Index(i).Interface().(string)
+			value, ok := values.Index(i).Interface().(string)
+			if !ok {
+				return fmt.Sprintf("value[%d]", i), fmt.Errorf("'value[%d]' found to be of the type %T. The provided values are expected to be strings", i, values.Index(i).Interface())
+			}
 			if !valuesAllowed[value] {
 				return fmt.Sprintf("value[%d]", i), fmt.Errorf("unknown value '%s' found under the 'value' field. Only the following values are allowed: [CREATE, UPDATE, DELETE, CONNECT]", value)
 			}

--- a/pkg/validation/policy/validate_test.go
+++ b/pkg/validation/policy/validate_test.go
@@ -271,6 +271,33 @@ func Test_Validate_DenyConditionsValuesList_KeyRequestOperation_ExpectedItem(t *
 	assert.Nil(t, err)
 }
 
+// A `{{request.operation}}` condition whose `value` list contains non-strings
+// used to panic on an unchecked type assertion rather than being rejected.
+// https://github.com/kyverno/kyverno/issues/16969
+func Test_Validate_DenyConditionsValuesList_KeyRequestOperation_NonStringItem(t *testing.T) {
+	denyConditions := []byte(`
+	[
+		{
+			"key":"{{request.operation}}",
+			"operator":"Equals",
+			"value": [
+				1,
+				2
+			]
+		}
+	]
+	`)
+
+	var dcs []kyverno.Condition
+	err := json.Unmarshal(denyConditions, &dcs)
+	assert.Nil(t, err)
+
+	path, err := validateConditions(dcs, "conditions")
+	assert.NotNil(t, err)
+	assert.Contains(t, path, "value[0]")
+	assert.Contains(t, err.Error(), "expected to be strings")
+}
+
 func Test_Validate_PreconditionsValuesList_KeyRequestOperation_UnknownItem(t *testing.T) {
 	preConditions := []byte(`
 	[


### PR DESCRIPTION
## Explanation

Fixes #16969.

`validateConditionValuesKeyRequestOperation` handles the `reflect.Slice` case by asserting each element is a string, with no comma-ok:

https://github.com/kyverno/kyverno/blob/main/pkg/validation/policy/validate.go#L1286

So a policy whose `{{request.operation}}` condition carries a list of non-strings panics instead of being rejected:

```yaml
conditions:
  - key: "{{request.operation}}"
    operator: Equals
    value: [1, 2]
```

```
panic: interface conversion: interface {} is int64, not string
        pkg/validation/policy/validate.go:1286
```

The container type is already checked, and the function's own `default:` branch returns a clean error for anything that is neither a string nor a list. The gap is only the element types inside the list, so this change makes the slice branch behave the way the rest of the function already does.

The new error names the offending index and the type found, mirroring the wording of that `default:` branch.

I could not find a `recover()` anywhere in the policy validation path, so this surfaces as a panic rather than a rejection. I have not measured the blast radius on a live webhook and would rather not overstate it: the verified fact is that malformed user input panics where it should produce a validation error.

## Related issue

Fixes #16969

## Milestone of this PR

N/A

## Proposed Changes

- `pkg/validation/policy/validate.go`: use the comma-ok form when reading list elements and return a descriptive error instead of panicking.
- `pkg/validation/policy/validate_test.go`: regression test. It panics on `main` and passes with this change, so it is not merely agreeing with the diff.

## Proof Manifest

Reproduced before, verified after, on `upstream/main` @ `7ae1887bd`.

Before (test on `main`, fix stashed):
```
--- FAIL: Test_Validate_DenyConditionsValuesList_KeyRequestOperation_NonStringItem
panic: interface conversion: interface {} is int64, not string
```

After:
```
ok  	github.com/kyverno/kyverno/pkg/validation/policy	0.033s
```

`gofmt` clean.

## Checklist

<!--
Please mark any checkboxes that do not apply to this PR as [N/A].
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/PULL_REQUEST_TEMPLATE.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [N/A] This is a feature and I have added documentation.
- [x] My PR needs to be cherry picked to a specific release branch: no.
- [x] I have added or changed the tests and they pass locally.
- [x] I used AI assistance on this contribution and have disclosed it with an `Assisted-by:` trailer on the commit, per the [AI usage policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md).
