### PR TITLE
fix: handle nil input in CopyMap and add unit tests

### DIFF
--- a/pkg/utils/data/data.go
+++ b/pkg/utils/data/data.go
@@ -8,6 +8,9 @@ import (
 
 // CopyMap creates a full copy of the target map
 func CopyMap(m map[string]interface{}) map[string]interface{} {
+	if m == nil {
+		return nil
+	}
 	mapCopy := make(map[string]interface{})
 	for k, v := range m {
 		mapCopy[k] = v

--- a/pkg/utils/data/data_test.go
+++ b/pkg/utils/data/data_test.go
@@ -20,6 +20,43 @@ func TestOriginalMapMustNotBeChanged(t *testing.T) {
 	assert.Equal(t, originalMap["r"], 2138)
 }
 
+func TestCopyMap(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]interface{}
+		want map[string]interface{}
+	}{
+		{
+			name: "nil map",
+			m:    nil,
+			want: nil,
+		},
+		{
+			name: "empty map",
+			m:    map[string]interface{}{},
+			want: map[string]interface{}{},
+		},
+		{
+			name: "populated map",
+			m: map[string]interface{}{
+				"key": "value",
+			},
+			want: map[string]interface{}{
+				"key": "value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CopyMap(tt.m)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CopyMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSliceContains(t *testing.T) {
 	type args struct {
 		slice  []string


### PR DESCRIPTION
## Explanation
In `pkg/utils/data/data.go`, `CopySliceOfMaps(nil)` returns `nil`, whereas `CopyMap(nil)` returned an empty non-nil map (`map[string]interface{}{}`). This PR updates `CopyMap` to return `nil` when passed a `nil` map input, ensuring consistent `nil` semantics across slice and map copying utilities.

## Proposed Changes
- Added a `nil` check to `CopyMap()` in `pkg/utils/data/data.go`.
- Added unit tests `TestCopyMap` in `pkg/utils/data/data_test.go` testing `nil`, `empty`, and `populated` map scenarios.

## Proof Manifests
- Ran `go test -v ./pkg/utils/data/...` (Passed: 100%)
- Ran `make imports fmt` and `make imports-check fmt-check` (Passed)

## Checklist
- [x] Unit tests added/updated and passing.