### PR TITLE
fix(cli): aggregate test case selector errors

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"fmt"
+	"go.uber.org/multierr"
 	"io"
 	"path/filepath"
 	"regexp"
@@ -91,11 +92,11 @@ func testCommandExecute(
 	// fetch resource filters
 	resourceFilters := filter.ExtractResourceFilters(testCase)
 	// parse filter
-	filter, errors := filter.ParseFilter(testCase)
-	if len(errors) > 0 {
+	parsedFilter, parseErrs := filter.ParseFilter(testCase)
+	if len(parseErrs) > 0 {
 		fmt.Fprintln(out)
 		fmt.Fprintln(out, "Filter errors:")
-		for _, e := range errors {
+		for _, e := range parseErrs {
 			fmt.Fprintln(out, "  Error:", e)
 		}
 	}
@@ -110,26 +111,25 @@ func testCommandExecute(
 		fmt.Fprintln(out)
 		fmt.Fprintln(out, "No test yamls available")
 	}
-	if errs := tests.Errors(); len(errs) > 0 {
+	if parseErrs := tests.Errors(); len(parseErrs) > 0 {
 		fmt.Fprintln(out)
 		fmt.Fprintln(out, "Test errors:")
-		for _, e := range errs {
+		for _, e := range parseErrs {
 			fmt.Fprintln(out, "  Path:", e.Path)
 			fmt.Fprintln(out, "    Error:", e.Err)
 		}
-		return fmt.Errorf("found %d errors after loading tests", len(errs))
+		return fmt.Errorf("found %d errors after loading tests", len(parseErrs))
 	}
 	if len(tests) == 0 {
 		if requireTests {
 			return fmt.Errorf("no tests found")
 		}
 
-		if len(errors) == 0 {
+		if len(parseErrs) == 0 {
 			return nil
-		} else {
-			// TODO aggregate errors
-			return errors[0]
 		}
+
+		return multierr.Combine(parseErrs...)
 	}
 	rc := &resultCounts{}
 	var fullTable table.Table
@@ -142,7 +142,7 @@ func testCommandExecute(
 			// filter results
 			var filteredResults []v1alpha1.TestResult
 			for _, res := range test.Test.Results {
-				if filter.Apply(res) {
+				if parsedFilter.Apply(res) {
 					if len(resourceFilters) > 0 {
 						res.Resources = resourceFilters
 					}

--- a/cmd/cli/kubectl-kyverno/commands/test/command_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command_test.go
@@ -773,3 +773,31 @@ spec:
 		})
 	}
 }
+
+func TestCommandAggregatesFilterErrors(t *testing.T) {
+	out := bytes.NewBufferString("")
+
+	err := testCommandExecute(
+		out,
+		[]string{"."},
+		"kyverno-test.yaml",
+		"",
+		"invalid-filter-1,invalid-filter-2",
+		"",
+		false,
+		false,
+		false,
+		false,
+		false,
+	)
+
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "invalid-filter-1")
+	assert.Contains(t, err.Error(), "invalid-filter-2")
+
+	output := out.String()
+	assert.Contains(t, output, "Filter errors:")
+	assert.Contains(t, output, "invalid-filter-1")
+	assert.Contains(t, output, "invalid-filter-2")
+}


### PR DESCRIPTION
## Explanation

When multiple invalid values are provided through the `--test-case-selector` flag, Kyverno CLI was only returning the first parsing error even though all invalid selectors were detected.

This PR updates the error handling to aggregate all `test-case-selector` parsing errors and return them together. This helps users identify and fix all invalid selectors in a single execution.

## Related issue

Fixes #16980

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
 /kind bug


## Proposed Changes

- Aggregate multiple `test-case-selector` parsing errors using `multierr.Combine`.
- Return all invalid selector errors instead of only the first error.
- Updated filter parsing logic to use the parsed filter only when parsing succeeds.
- Added unit tests to verify multiple invalid selectors are reported correctly.

### Proof Manifests



## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The added test case verifies that when multiple invalid selectors are provided:

```bash
kubectl-kyverno test test/cli/test-validating-policy/json-check-dockerfile \
  --test-case-selector "invalid-filter-1,invalid-filter-2"
```

The CLI returns an aggregated error containing both invalid selectors instead of failing on the first parsing error.