### PR TITLE
fix(cli): show syntax highlight for JMESPath compile errors in jp query

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/jp/query/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/jp/query/command.go
@@ -152,6 +152,9 @@ func evaluate(input interface{}, query string) (interface{}, error) {
 	jp := jmespath.New(config.NewDefaultConfiguration(false))
 	q, err := jp.Query(query)
 	if err != nil {
+		if syntaxError, ok := err.(gojmespath.SyntaxError); ok {
+			return nil, fmt.Errorf("%s\n%s", syntaxError, syntaxError.HighlightLocation())
+		}
 		return nil, fmt.Errorf("failed to compile JMESPath: %s, error: %v", query, err)
 	}
 	result, err := q.Search(input)


### PR DESCRIPTION
## What this PR does
`evaluate()` in `cmd/cli/kubectl-kyverno/commands/jp/query/command.go` only
applied `gojmespath.SyntaxError`'s `HighlightLocation()` formatting to errors
from `Search()` (runtime evaluation). Compile errors from `Query()`, which is
where the large majority of JMESPath syntax mistakes are actually caught,
fell through to a plain `fmt.Errorf` with no indication of where in the
expression the error occurred.

This applies the same `SyntaxError` handling to the compile-time path so
both error paths produce a helpful, located error message instead of a
cryptic one.

Fixes #16488

## Verification
- `gofmt -l` clean
- `go build ./...` passes
- `go test ./cmd/cli/kubectl-kyverno/commands/jp/...` passes
- Manually confirmed: `kyverno jp query -q "foo[" -i input.yaml` now shows
  the caret-pointing highlighted error instead of the generic wrapped message