### PR TITLE
fix(apicall): apply httpBlocklist/allowlist to ServiceCall path

### DIFF
--- a/pkg/engine/apicall/executor.go
+++ b/pkg/engine/apicall/executor.go
@@ -73,6 +73,10 @@ func (a *executor) executeServiceCall(ctx context.Context, apiCall *kyvernov1.AP
 		return nil, fmt.Errorf("missing service for APICall %s", a.name)
 	}
 
+	if err := validateServiceCallURL(apiCall.Service.URL); err != nil {
+		return nil, fmt.Errorf("failed to validate service URL for APICall %s: %w", a.name, err)
+	}
+
 	client, err := a.buildHTTPClient(apiCall.Service)
 	if err != nil {
 		return nil, err
@@ -163,8 +167,17 @@ func (a *executor) addHTTPHeaders(req *http.Request, headers []kyvernov1.HTTPHea
 func (a *executor) buildHTTPClient(service *kyvernov1.ServiceCall) (*http.Client, error) {
 	timeout := a.config.GetTimeout()
 	if service == nil || service.CABundle == "" {
+		baseTransport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok || baseTransport == nil {
+			baseTransport = &http.Transport{}
+		}
+		transport := baseTransport.Clone()
+		if err := applySSRFDialContext(transport); err != nil {
+			return nil, err
+		}
 		return &http.Client{
-			Timeout: timeout,
+			Transport: tracing.Transport(transport, otelhttp.WithFilter(tracing.RequestFilterIsInSpan)),
+			Timeout:   timeout,
 		}, nil
 	}
 	caCertPool := x509.NewCertPool()
@@ -176,6 +189,9 @@ func (a *executor) buildHTTPClient(service *kyvernov1.ServiceCall) (*http.Client
 			RootCAs:    caCertPool,
 			MinVersion: tls.VersionTLS12,
 		},
+	}
+	if err := applySSRFDialContext(transport); err != nil {
+		return nil, err
 	}
 	return &http.Client{
 		Transport: tracing.Transport(transport, otelhttp.WithFilter(tracing.RequestFilterIsInSpan)),

--- a/pkg/engine/apicall/httpclient.go
+++ b/pkg/engine/apicall/httpclient.go
@@ -82,5 +82,5 @@ func (c *scopedTokenClient) Do(req *http.Request) (*http.Response, error) {
 			req.Header.Set("Authorization", "Bearer "+token)
 		}
 	}
-	return c.inner.Do(req) //nolint:gosec // SSRF is mitigated by the SDK HTTP library's blocklist/allowlist filter before requests reach this client
+	return c.inner.Do(req) //nolint:gosec // CEL http.* applies SDK blocklist/allowlist before Do; legacy ServiceCall applies the same filters in executeServiceCall/buildHTTPClient
 }

--- a/pkg/engine/apicall/ssrf.go
+++ b/pkg/engine/apicall/ssrf.go
@@ -1,0 +1,195 @@
+package apicall
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/kyverno/kyverno/pkg/toggle"
+	celhttp "github.com/kyverno/sdk/extensions/cel/libs/http"
+)
+
+// validateServiceCallURL enforces the same --httpBlocklist/--httpAllowlist rules used by
+// CEL http.Get/Post before a legacy context.apiCall.service request is dialed.
+// Hostname and allowlist checks run here; CIDR blocking is enforced in the HTTP client's
+// DialContext (see buildHTTPClient).
+func validateServiceCallURL(rawURL string) error {
+	// Ensure flag values parse the same way as the CEL path.
+	if _, err := celhttp.NewHTTPWithBlocklist(toggle.HTTPBlocklist.Values(), toggle.HTTPAllowlist.Values()); err != nil {
+		return fmt.Errorf("invalid HTTP filter configuration: %w", err)
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid service URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("invalid service URL %q: must include scheme and host", rawURL)
+	}
+
+	blocklist := toggle.HTTPBlocklist.Values()
+	allowlist := toggle.HTTPAllowlist.Values()
+
+	allowedURLPrefixes, err := parseAllowlist(allowlist)
+	if err != nil {
+		return err
+	}
+	if len(allowedURLPrefixes) > 0 && !matchesAllowlist(u, allowedURLPrefixes) {
+		return fmt.Errorf("URL %q is not permitted: no matching allowlist entry", rawURL)
+	}
+
+	blockedHosts := make(map[string]struct{})
+	for _, entry := range blocklist {
+		entry = strings.TrimSpace(entry)
+		if entry == "" || strings.Contains(entry, "/") {
+			continue
+		}
+		blockedHosts[normalizeHost(entry)] = struct{}{}
+	}
+	host := u.Hostname()
+	if _, blocked := blockedHosts[normalizeHost(host)]; blocked {
+		return fmt.Errorf("URL %q is blocked: hostname %q is on the blocklist", rawURL, host)
+	}
+	return nil
+}
+
+func parseAllowlist(allowlist []string) ([]*url.URL, error) {
+	var allowed []*url.URL
+	for _, entry := range allowlist {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		u, err := url.Parse(entry)
+		if err != nil {
+			return nil, fmt.Errorf("invalid allowlist URL %q: %w", entry, err)
+		}
+		if u.Scheme == "" || u.Host == "" {
+			return nil, fmt.Errorf("allowlist entry %q must include scheme and host", entry)
+		}
+		allowed = append(allowed, u)
+	}
+	return allowed, nil
+}
+
+func parseBlockedCIDRs(blocklist []string) ([]*net.IPNet, error) {
+	var blocked []*net.IPNet
+	for _, entry := range blocklist {
+		entry = strings.TrimSpace(entry)
+		if entry == "" || !strings.Contains(entry, "/") {
+			continue
+		}
+		_, ipNet, err := net.ParseCIDR(entry)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR %q in blocklist: %w", entry, err)
+		}
+		blocked = append(blocked, ipNet)
+	}
+	return blocked, nil
+}
+
+func normalizeHost(h string) string {
+	return strings.ToLower(strings.TrimRight(h, "."))
+}
+
+func effectivePort(u *url.URL) string {
+	if p := u.Port(); p != "" {
+		return p
+	}
+	switch u.Scheme {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	}
+	return ""
+}
+
+func matchesAllowlist(reqURL *url.URL, allowedURLPrefixes []*url.URL) bool {
+	reqHost := normalizeHost(reqURL.Hostname())
+	reqPort := effectivePort(reqURL)
+	for _, entry := range allowedURLPrefixes {
+		if reqURL.Scheme != entry.Scheme {
+			continue
+		}
+		if normalizeHost(entry.Hostname()) != reqHost || effectivePort(entry) != reqPort {
+			continue
+		}
+		entryPath := entry.Path
+		if entryPath == "" || entryPath == "/" {
+			return true
+		}
+		if reqURL.Path == entryPath {
+			return true
+		}
+		if strings.HasPrefix(reqURL.Path, entryPath) {
+			if entryPath[len(entryPath)-1] == '/' {
+				return true
+			}
+			if len(reqURL.Path) > len(entryPath) && reqURL.Path[len(entryPath)] == '/' {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// secureDialContext mirrors github.com/kyverno/sdk/.../http.secureDialContext so
+// ServiceCall clients enforce CIDR blocklists at dial time (including DNS-rebinding).
+func secureDialContext(blockedCIDRs []*net.IPNet) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	base := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		if ip := net.ParseIP(host); ip != nil {
+			for _, cidr := range blockedCIDRs {
+				if cidr.Contains(ip) {
+					return nil, fmt.Errorf("connection to %s blocked: IP %s falls in blocked range %s", addr, ip, cidr)
+				}
+			}
+			return base.DialContext(ctx, network, addr)
+		}
+		ips, err := net.DefaultResolver.LookupHost(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve %s: %w", host, err)
+		}
+		for _, ipStr := range ips {
+			ip := net.ParseIP(ipStr)
+			if ip == nil {
+				continue
+			}
+			for _, cidr := range blockedCIDRs {
+				if cidr.Contains(ip) {
+					return nil, fmt.Errorf("connection to %s blocked: resolved IP %s falls in blocked range %s", addr, ip, cidr)
+				}
+			}
+		}
+		for _, ipStr := range ips {
+			if net.ParseIP(ipStr) == nil {
+				continue
+			}
+			return base.DialContext(ctx, network, net.JoinHostPort(ipStr, port))
+		}
+		return nil, fmt.Errorf("no usable addresses resolved for %s", addr)
+	}
+}
+
+func applySSRFDialContext(transport *http.Transport) error {
+	blockedCIDRs, err := parseBlockedCIDRs(toggle.HTTPBlocklist.Values())
+	if err != nil {
+		return err
+	}
+	if len(blockedCIDRs) > 0 {
+		transport.DialContext = secureDialContext(blockedCIDRs)
+	}
+	return nil
+}

--- a/pkg/engine/apicall/ssrf_test.go
+++ b/pkg/engine/apicall/ssrf_test.go
@@ -1,0 +1,115 @@
+package apicall
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
+	"github.com/kyverno/kyverno/pkg/toggle"
+	"gotest.tools/v3/assert"
+)
+
+func TestMain(m *testing.M) {
+	// Package tests use httptest on loopback. Keep metadata host blocks, drop loopback CIDRs
+	// so functional ServiceCall tests still dial localhost. Security tests that need the
+	// full default blocklist call toggle.HTTPBlocklist.Reset() explicitly.
+	_ = toggle.HTTPBlocklist.Parse("169.254.169.254,169.254.169.253,metadata.google.internal")
+	os.Exit(m.Run())
+}
+
+func Test_ServiceCall_BlocksMetadataHostname(t *testing.T) {
+	toggle.HTTPBlocklist.Reset()
+	t.Cleanup(func() {
+		_ = toggle.HTTPBlocklist.Parse("169.254.169.254,169.254.169.253,metadata.google.internal")
+	})
+
+	ctx := enginecontext.NewContext(jp)
+	entry := kyvernov1.ContextEntry{
+		Name: "svc",
+		APICall: &kyvernov1.ContextAPICall{
+			APICall: kyvernov1.APICall{
+				Method: "GET",
+				Service: &kyvernov1.ServiceCall{
+					URL: "http://169.254.169.254/latest/meta-data/",
+				},
+			},
+		},
+	}
+	call, err := New(logr.Discard(), jp, entry, ctx, nil, NewAPICallConfiguration(0, 0), "")
+	assert.NilError(t, err)
+	_, err = call.Fetch(context.Background())
+	assert.ErrorContains(t, err, "blocked")
+}
+
+func Test_ServiceCall_BlocksLoopbackCIDR(t *testing.T) {
+	toggle.HTTPBlocklist.Reset()
+	t.Cleanup(func() {
+		_ = toggle.HTTPBlocklist.Parse("169.254.169.254,169.254.169.253,metadata.google.internal")
+	})
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer s.Close()
+
+	ctx := enginecontext.NewContext(jp)
+	entry := kyvernov1.ContextEntry{
+		Name: "svc",
+		APICall: &kyvernov1.ContextAPICall{
+			APICall: kyvernov1.APICall{
+				Method: "GET",
+				Service: &kyvernov1.ServiceCall{
+					URL: s.URL + "/resource",
+				},
+			},
+		},
+	}
+	call, err := New(logr.Discard(), jp, entry, ctx, nil, NewAPICallConfiguration(0, 0), "")
+	assert.NilError(t, err)
+	_, err = call.Fetch(context.Background())
+	assert.ErrorContains(t, err, "blocked")
+}
+
+func Test_ServiceCall_StillInjectsScopedTokenWhenAllowed(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	assert.NilError(t, os.WriteFile(tokenPath, []byte("scoped-sa-token\n"), 0o600))
+	old := scopedTokenPath
+	scopedTokenPath = tokenPath
+	t.Cleanup(func() { scopedTokenPath = old })
+
+	var gotAuth, gotPath string
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer s.Close()
+
+	ctx := enginecontext.NewContext(jp)
+	entry := kyvernov1.ContextEntry{
+		Name: "svc",
+		APICall: &kyvernov1.ContextAPICall{
+			APICall: kyvernov1.APICall{
+				Method: "GET",
+				Service: &kyvernov1.ServiceCall{
+					URL: s.URL + "/latest/meta-data/",
+				},
+			},
+		},
+	}
+	call, err := New(logr.Discard(), jp, entry, ctx, nil, NewAPICallConfiguration(0, 0), "")
+	assert.NilError(t, err)
+	data, err := call.Fetch(context.Background())
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), `{"ok":true}`)
+	assert.Equal(t, gotPath, "/latest/meta-data/")
+	assert.Equal(t, gotAuth, "Bearer scoped-sa-token")
+}

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -57,10 +57,10 @@ const (
 	defaultAllowHTTPInNamespacedPolicies     = false
 	// http blocklist / allowlist flag names
 	HTTPBlocklistFlagName    = "httpBlocklist"
-	HTTPBlocklistDescription = "Comma-separated list of CIDR ranges or hostnames blocked from CEL http.Get/Post calls. Overrides the built-in defaults when set. Example: '169.254.169.254,metadata.google.internal'."
+	HTTPBlocklistDescription = "Comma-separated list of CIDR ranges or hostnames blocked from CEL http.Get/Post and legacy context.apiCall.service calls. Overrides the built-in defaults when set. Example: '169.254.169.254,metadata.google.internal'."
 	httpBlocklistEnvVar      = "FLAG_HTTP_BLOCKLIST"
 	HTTPAllowlistFlagName    = "httpAllowlist"
-	HTTPAllowlistDescription = "Comma-separated list of URL prefixes (scheme+host[+path]) permitted in CEL http.Get/Post calls. When set, only matching URLs are allowed. Example: 'https://api.example.com,https://webhook.corp/v1/'."
+	HTTPAllowlistDescription = "Comma-separated list of URL prefixes (scheme+host[+path]) permitted in CEL http.Get/Post and legacy context.apiCall.service calls. When set, only matching URLs are allowed. Example: 'https://api.example.com,https://webhook.corp/v1/'."
 	httpAllowlistEnvVar      = "FLAG_HTTP_ALLOWLIST"
 )
 


### PR DESCRIPTION
## Summary
- CEL `http.Get`/`http.Post` already honor `--httpBlocklist` / `--httpAllowlist` (and inject the scoped SA token via `NewScopedTokenClient`).
- Legacy `context.apiCall.service` still built a plain `http.Client` with no filter, while auto-adding `Authorization: Bearer <scoped SA token>`.
- Validate ServiceCall URLs against the same allowlist/hostname blocklist rules and install CIDR-aware `DialContext` on the ServiceCall client for parity.
- Docs: flag descriptions now mention ServiceCall as well as CEL http.

## Test plan
- [x] `go test ./pkg/engine/apicall/ -count=1`
- [x] Blocks `http://169.254.169.254/...` under default blocklist
- [x] Blocks loopback httptest under default `127.0.0.0/8`
- [x] Existing ServiceCall functional tests still pass (suite uses metadata-only blocklist via TestMain)

## Notes
Hardening / residual SSRF control parity after the CEL http work. Happy to adjust framing if maintainers prefer a private report path for the residual.

Signed-off-by: Sasha Mitchell <sash.t.mitchell@gmail.com>


Made with [Cursor](https://cursor.com)