### PR TITLE
fix: close layer readers per-iteration to avoid FD/memory leak

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/oci/pull/options.go
+++ b/cmd/cli/kubectl-kyverno/commands/oci/pull/options.go
@@ -11,6 +11,7 @@ import (
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/oci/internal"
 	policyutils "github.com/kyverno/kyverno/pkg/utils/policy"
@@ -76,33 +77,43 @@ func (o options) execute(ctx context.Context, dir string, keychain authn.Keychai
 			return fmt.Errorf("getting layer media type: %v", err)
 		}
 		if lmt == internal.PolicyLayerMediaType {
-			blob, err := layer.Compressed()
-			if err != nil {
-				return fmt.Errorf("getting layer blob: %v", err)
-			}
-			defer blob.Close()
-
-			layerBytes, err := io.ReadAll(blob)
-			if err != nil {
-				return fmt.Errorf("reading layer blob: %v", err)
-			}
-			policies, _, _, _, _, _, _, err := yamlutils.GetPolicy(layerBytes)
-			if err != nil {
-				return fmt.Errorf("unmarshaling layer blob: %v", err)
-			}
-			for _, policy := range policies {
-				policyBytes, err := policyutils.ToYaml(policy)
-				if err != nil {
-					return fmt.Errorf("converting policy to yaml: %v", err)
-				}
-				pp := filepath.Join(dir, policy.GetName()+".yaml")
-				fmt.Fprintf(os.Stderr, "Saving policy into disk [%s]...\n", pp)
-				if err := os.WriteFile(pp, policyBytes, 0o600); err != nil {
-					return fmt.Errorf("creating file: %v", err)
-				}
+			if err := extractAndSavePolicies(layer, dir); err != nil {
+				return err
 			}
 		}
 	}
 	fmt.Fprintf(os.Stderr, "Done.")
+	return nil
+}
+
+// extractAndSavePolicies reads the policies out of a single layer's blob and writes them to
+// disk. It is factored out of execute so the layer's ReadCloser is closed at the end of each
+// iteration rather than accumulating open readers until execute returns.
+func extractAndSavePolicies(layer v1.Layer, dir string) error {
+	blob, err := layer.Compressed()
+	if err != nil {
+		return fmt.Errorf("getting layer blob: %v", err)
+	}
+	defer blob.Close()
+
+	layerBytes, err := io.ReadAll(blob)
+	if err != nil {
+		return fmt.Errorf("reading layer blob: %v", err)
+	}
+	policies, _, _, _, _, _, _, err := yamlutils.GetPolicy(layerBytes)
+	if err != nil {
+		return fmt.Errorf("unmarshaling layer blob: %v", err)
+	}
+	for _, policy := range policies {
+		policyBytes, err := policyutils.ToYaml(policy)
+		if err != nil {
+			return fmt.Errorf("converting policy to yaml: %v", err)
+		}
+		pp := filepath.Join(dir, policy.GetName()+".yaml")
+		fmt.Fprintf(os.Stderr, "Saving policy into disk [%s]...\n", pp)
+		if err := os.WriteFile(pp, policyBytes, 0o600); err != nil {
+			return fmt.Errorf("creating file: %v", err)
+		}
+	}
 	return nil
 }

--- a/cmd/cli/kubectl-kyverno/commands/oci/pull/options.go
+++ b/cmd/cli/kubectl-kyverno/commands/oci/pull/options.go
@@ -100,7 +100,7 @@ func extractAndSavePolicies(layer v1.Layer, dir string) error {
 	if err != nil {
 		return fmt.Errorf("reading layer blob: %v", err)
 	}
-	policies, _, _, _, _, _, _, err := yamlutils.GetPolicy(layerBytes)
+	policies, _, _, _, _, _, _, err := yamlutils.GetPolicy(layerBytes) //nolint:dogsled // GetPolicy returns 7 policy-kind slices; only ClusterPolicy/Policy results are relevant here
 	if err != nil {
 		return fmt.Errorf("unmarshaling layer blob: %v", err)
 	}

--- a/cmd/cli/kubectl-kyverno/commands/oci/pull/options_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/oci/pull/options_test.go
@@ -1,0 +1,87 @@
+package pull
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/stretchr/testify/assert"
+)
+
+const testClusterPolicyYAML = `
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-labels
+spec:
+  rules:
+  - name: check-team
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "label 'team' is required"
+      pattern:
+        metadata:
+          labels:
+            team: "?*"
+`
+
+// trackedReadCloser records whether Close was called, so tests can assert
+// that a layer's reader is actually released rather than only checking
+// the returned error.
+type trackedReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (t *trackedReadCloser) Close() error {
+	t.closed = true
+	return nil
+}
+
+// trackedLayer wraps a static layer, returning a trackedReadCloser from
+// Compressed so tests can observe whether it was closed.
+type trackedLayer struct {
+	v1.Layer
+	rc *trackedReadCloser
+}
+
+func newTrackedLayer(t *testing.T, data []byte) *trackedLayer {
+	t.Helper()
+	base := static.NewLayer(data, types.MediaType("test"))
+	blob, err := base.Compressed()
+	assert.NoError(t, err)
+	return &trackedLayer{Layer: base, rc: &trackedReadCloser{Reader: blob}}
+}
+
+func (l *trackedLayer) Compressed() (io.ReadCloser, error) {
+	return l.rc, nil
+}
+
+func TestExtractAndSavePolicies(t *testing.T) {
+	dir := t.TempDir()
+	layer := newTrackedLayer(t, []byte(testClusterPolicyYAML))
+
+	err := extractAndSavePolicies(layer, dir)
+	assert.NoError(t, err)
+	assert.True(t, layer.rc.closed, "layer reader should be closed after extraction")
+
+	out, err := os.ReadFile(filepath.Join(dir, "require-labels.yaml"))
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "require-labels")
+}
+
+func TestExtractAndSavePoliciesClosesReaderOnUnmarshalError(t *testing.T) {
+	dir := t.TempDir()
+	layer := newTrackedLayer(t, []byte("not: [valid, policy"))
+
+	err := extractAndSavePolicies(layer, dir)
+	assert.Error(t, err)
+	assert.True(t, layer.rc.closed, "layer reader should be closed even when extraction fails")
+}


### PR DESCRIPTION
## Summary
- `defer` inside a `for` loop only runs when the *surrounding function* returns, not at the end of each iteration. `execute` in `cmd/cli/kubectl-kyverno/commands/oci/pull/options.go` opened a layer's `io.ReadCloser` via `defer` on every loop iteration.
- For images with many layers, this accumulates open readers (FDs/memory) for the lifetime of the call instead of releasing each one as it's consumed.
- Fix: factor the loop body into its own function (`extractAndSavePolicies`) so the deferred `Close()` fires at the end of every iteration. Behavior and error messages are unchanged.

Note: the sibling leak in `pkg/image/verifiers/cpol/cosign/sigstore.go` (also reported in #16959) was already fixed by #17039, so this PR is now scoped to just the CLI `oci pull` command. Rebased onto current `main` accordingly.

Fixes #16959

## Test plan
- [x] `go build ./cmd/cli/kubectl-kyverno/commands/oci/pull/...`
- [x] `go vet ./cmd/cli/kubectl-kyverno/commands/oci/pull/...`
- [x] `go test ./cmd/cli/kubectl-kyverno/commands/oci/pull/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined policy extraction during OCI pulls for supported policy layers.
  * Policy files continue to be generated in the target directory from supported OCI policy layers.

* **Bug Fixes**
  * Improved handling of errors while reading or processing policy content.
  * Ensured policy-layer resources are properly closed when extraction succeeds or fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->