### PR TITLE
fix(imageverify): coalesce concurrent verification requests

### DIFF
--- a/pkg/engine/internal/imageverifier.go
+++ b/pkg/engine/internal/imageverifier.go
@@ -37,6 +37,14 @@ type imageVerifier struct {
 	ivm           *engineapi.ImageVerificationMetadata
 }
 
+type sharedImageVerification struct {
+	ruleResponse engineapi.RuleResponse
+	digest       string
+	hasResponse  bool
+}
+
+var imageVerificationFlights verificationGroup[sharedImageVerification]
+
 func NewImageVerifier(
 	logger logr.Logger,
 	rclient engineapi.RegistryClient,
@@ -98,19 +106,7 @@ func (iv *imageVerifier) Verify(
 			digest = imageInfo.Digest
 		} else {
 			iv.logger.V(2).Info("cache entry not found", "namespace", iv.policyContext.Policy().GetNamespace(), "policy", iv.policyContext.Policy().GetName(), "ruleName", iv.rule.Name, "imageRef", image)
-			ruleResp, digest = iv.verifyImage(ctx, imageVerify, imageInfo, cfg)
-			if ruleResp != nil && ruleResp.Status() == engineapi.RuleStatusPass {
-				if iv.ivCache != nil {
-					setted, err := iv.ivCache.Set(ctx, iv.policyContext.Policy(), iv.rule.Name, image, imageVerify.UseCache)
-					if err != nil {
-						iv.logger.Error(err, "error occurred during cache set", "image", image)
-					} else {
-						if setted {
-							iv.logger.V(4).Info("successfully set cache", "namespace", iv.policyContext.Policy().GetNamespace(), "policy", iv.policyContext.Policy().GetName(), "ruleName", iv.rule.Name, "imageRef", image)
-						}
-					}
-				}
-			}
+			ruleResp, digest = iv.verifyImageOnCacheMiss(ctx, imageVerify, imageInfo, cfg)
 		}
 
 		if imageVerify.MutateDigest {
@@ -135,6 +131,52 @@ func (iv *imageVerifier) Verify(
 		}
 	}
 	return patches, responses
+}
+
+func (iv *imageVerifier) verifyImageOnCacheMiss(
+	ctx context.Context,
+	imageVerify kyvernov1.ImageVerification,
+	imageInfo apiutils.ImageInfo,
+	cfg config.Configuration,
+) (*engineapi.RuleResponse, string) {
+	image := imageInfo.String()
+	key := imageverifycache.Key(iv.policyContext.Policy(), iv.rule.Name, image)
+	result, err := imageVerificationFlights.Do(ctx, key, func() sharedImageVerification {
+		if iv.ivCache != nil && imageVerify.UseCache {
+			found, cacheErr := iv.ivCache.Get(ctx, iv.policyContext.Policy(), iv.rule.Name, image, true)
+			if cacheErr != nil {
+				iv.logger.Error(cacheErr, "error occurred during cache recheck", "image", image)
+			} else if found {
+				return sharedImageVerification{
+					ruleResponse: *engineapi.RulePass(iv.rule.Name, engineapi.ImageVerify, "verified from cache", iv.rule.ReportProperties),
+					digest:       imageInfo.Digest,
+					hasResponse:  true,
+				}
+			}
+		}
+
+		response, digest := iv.verifyImage(ctx, imageVerify, imageInfo, cfg)
+		if response == nil {
+			return sharedImageVerification{digest: digest}
+		}
+		if response.Status() == engineapi.RuleStatusPass && iv.ivCache != nil && imageVerify.UseCache {
+			stored, cacheErr := iv.ivCache.Set(ctx, iv.policyContext.Policy(), iv.rule.Name, image, true)
+			if cacheErr != nil {
+				iv.logger.Error(cacheErr, "error occurred during cache set", "image", image)
+			} else if stored {
+				iv.logger.V(4).Info("successfully set cache", "namespace", iv.policyContext.Policy().GetNamespace(), "policy", iv.policyContext.Policy().GetName(), "ruleName", iv.rule.Name, "imageRef", image)
+			}
+		}
+		return sharedImageVerification{ruleResponse: *response, digest: digest, hasResponse: true}
+	})
+	if err != nil {
+		return engineapi.RuleError(iv.rule.Name, engineapi.ImageVerify, "image verification canceled", err, iv.rule.ReportProperties), ""
+	}
+	if result.hasResponse {
+		response := result.ruleResponse
+		return &response, result.digest
+	}
+	return nil, result.digest
 }
 
 func (iv *imageVerifier) isPreviouslyVerified(image string) bool {

--- a/pkg/engine/internal/verification_group.go
+++ b/pkg/engine/internal/verification_group.go
@@ -1,0 +1,28 @@
+package internal
+
+import (
+	"context"
+
+	"golang.org/x/sync/singleflight"
+)
+
+type verificationGroup[T any] struct {
+	group singleflight.Group
+}
+
+func (g *verificationGroup[T]) Do(ctx context.Context, key string, fn func() T) (T, error) {
+	result := g.group.DoChan(key, func() (any, error) {
+		return fn(), nil
+	})
+	select {
+	case <-ctx.Done():
+		var zero T
+		return zero, ctx.Err()
+	case value := <-result:
+		if value.Err != nil {
+			var zero T
+			return zero, value.Err
+		}
+		return value.Val.(T), nil
+	}
+}

--- a/pkg/engine/internal/verification_group_test.go
+++ b/pkg/engine/internal/verification_group_test.go
@@ -1,0 +1,97 @@
+package internal
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerificationGroupCoalescesConcurrentCalls(t *testing.T) {
+	var group verificationGroup[int]
+	var calls atomic.Int64
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+
+	const workers = 50
+	results := make(chan int, workers)
+	for range workers {
+		go func() {
+			value, err := group.Do(context.Background(), "same-image", func() int {
+				calls.Add(1)
+				once.Do(func() { close(started) })
+				<-release
+				return 42
+			})
+			require.NoError(t, err)
+			results <- value
+		}()
+	}
+
+	<-started
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+	for range workers {
+		assert.Equal(t, 42, <-results)
+	}
+	assert.Equal(t, int64(1), calls.Load())
+}
+
+func TestVerificationGroupKeepsDifferentKeysIndependent(t *testing.T) {
+	var group verificationGroup[string]
+	var calls atomic.Int64
+
+	first, err := group.Do(context.Background(), "first", func() string {
+		calls.Add(1)
+		return "one"
+	})
+	require.NoError(t, err)
+	second, err := group.Do(context.Background(), "second", func() string {
+		calls.Add(1)
+		return "two"
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "one", first)
+	assert.Equal(t, "two", second)
+	assert.Equal(t, int64(2), calls.Load())
+}
+
+func TestVerificationGroupAllowsWaiterCancellation(t *testing.T) {
+	var group verificationGroup[int]
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := group.Do(context.Background(), "image", func() int {
+			close(started)
+			<-release
+			return 7
+		})
+		leaderDone <- err
+	}()
+	<-started
+
+	ctx, cancel := context.WithCancel(context.Background())
+	waiterDone := make(chan error, 1)
+	var waiterCalled atomic.Bool
+	go func() {
+		_, err := group.Do(ctx, "image", func() int {
+			waiterCalled.Store(true)
+			return 0
+		})
+		waiterDone <- err
+	}()
+	cancel()
+	assert.ErrorIs(t, <-waiterDone, context.Canceled)
+
+	close(release)
+	require.NoError(t, <-leaderDone)
+	assert.False(t, waiterCalled.Load())
+}

--- a/pkg/image/verification/cache/client.go
+++ b/pkg/image/verification/cache/client.go
@@ -87,7 +87,8 @@ func WithTTLDuration(t time.Duration) Option {
 	}
 }
 
-func generateKey(policy metav1.Object, ruleName string, imageRef string) string {
+// Key returns the process-local cache and coalescing key for an image verification.
+func Key(policy metav1.Object, ruleName string, imageRef string) string {
 	return string(policy.GetUID()) + ";" + policy.GetResourceVersion() + ";" + ruleName + ";" + imageRef
 }
 
@@ -99,7 +100,7 @@ func (c *cache) Set(ctx context.Context, policy metav1.Object, ruleName string, 
 		// Else If enabled globally then return if locally disabled
 		return false, nil
 	}
-	key := generateKey(policy, ruleName, imageRef)
+	key := Key(policy, ruleName, imageRef)
 
 	stored := c.cache.SetWithTTL(key, nil, 1, c.ttl)
 	c.cache.Wait()
@@ -117,7 +118,7 @@ func (c *cache) Get(ctx context.Context, policy metav1.Object, ruleName string, 
 		// Else If enabled globally then return if locally disabled
 		return false, nil
 	}
-	key := generateKey(policy, ruleName, imageRef)
+	key := Key(policy, ruleName, imageRef)
 	_, found := c.cache.Get(key)
 	if found {
 		return true, nil


### PR DESCRIPTION
## Explanation

Concurrent admission requests which verify the same image can all observe a verification-cache miss and independently perform the same remote registry and signature work. This amplifies registry load and long-tail admission latency before the first successful request can populate the cache.

This bug fix coalesces identical in-flight verification requests so one operation serves all concurrent waiters.

## Related issue

Closes #16997

Related SDK issue and credential-cache fix: kyverno/sdk#131, kyverno/sdk#132

## Milestone of this PR

Maintainers can assign the appropriate milestone.

## Documentation (required for features)

Not required. This is an internal concurrency fix with no API, policy syntax, or user-facing configuration change.

## What type of PR is this

/kind bug

## Proposed Changes

- Coordinate image verification with a process-local `singleflight` group keyed by the existing policy UID/resource version, rule name, and image reference identity.
- Recheck the persistent verification cache inside the flight to close the race between the initial miss and leader election.
- Coalesce in-flight work even when `useCache: false`; persistent cache reads and writes remain conditional on that setting.
- Preserve independent waiter cancellation and avoid persisting failed verification results.
- Return value copies of shared rule responses so callers do not share mutable response pointers.

### Proof Manifests

Not applicable. The externally visible policy behavior is unchanged; deterministic race-tested unit tests exercise the concurrency property directly.

## Testing

- `go test -race ./pkg/engine/internal ./pkg/image/verification/cache`
- `go vet ./pkg/engine/internal ./pkg/image/verification/cache`
- `make imports-check fmt-check verify-codegen`
- `git diff --check`

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the AI Usage Policy and disclosed assistance with an `Assisted-by` commit trailer.
- [x] I have read the PR documentation guide; this internal bug fix is exempt from proof manifests and documentation changes.
- [x] This is a bug fix and I have added unit tests that prove the fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch.
- [ ] My PR contains new or altered user-facing behavior requiring CLI support.

## Further Comments

This PR addresses duplicate image/signature verification work. The companion SDK change addresses repeated private ECR credential/client construction; the fixes are independent and can be reviewed or merged separately.
