### PR TITLE
feat: allow imageRegistry context errors to be caught

### DIFF
--- a/api/kyverno/v1/common_types.go
+++ b/api/kyverno/v1/common_types.go
@@ -172,6 +172,11 @@ type ImageRegistry struct {
 	// ImageRegistryCredentials provides credentials that will be used for authentication with registry
 	// +kubebuilder:validation:Optional
 	ImageRegistryCredentials *ImageRegistryCredentials `json:"imageRegistryCredentials,omitempty"`
+
+	// CatchError controls whether image registry errors are returned as context data.
+	// When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+	// +optional
+	CatchError bool `json:"catchError,omitempty"`
 }
 
 // ConfigMapReference refers to a ConfigMap

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_cleanuppolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_cleanuppolicies.yaml
@@ -293,6 +293,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry
@@ -1587,6 +1592,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clustercleanuppolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clustercleanuppolicies.yaml
@@ -293,6 +293,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry
@@ -1587,6 +1592,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clusterpolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clusterpolicies.yaml
@@ -329,6 +329,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -1369,6 +1374,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -2455,6 +2465,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -2839,6 +2854,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -3598,6 +3618,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -5419,6 +5444,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -6471,6 +6501,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -7569,6 +7604,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -7962,6 +8002,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -8733,6 +8778,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -10632,6 +10682,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -11466,6 +11521,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -12346,6 +12406,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -12730,6 +12795,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -13660,6 +13730,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -15450,6 +15525,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -16502,6 +16582,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -17600,6 +17685,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -17993,6 +18083,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -18764,6 +18859,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policies.yaml
@@ -330,6 +330,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -1370,6 +1375,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -2456,6 +2466,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -2840,6 +2855,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -3599,6 +3619,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -5421,6 +5446,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -6473,6 +6503,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -7571,6 +7606,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -7964,6 +8004,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -8735,6 +8780,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -10635,6 +10685,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -11469,6 +11524,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -12349,6 +12409,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -12733,6 +12798,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -13663,6 +13733,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -15453,6 +15528,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -16505,6 +16585,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -17603,6 +17688,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -17996,6 +18086,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -18767,6 +18862,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_cleanuppolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_cleanuppolicies.yaml
@@ -287,6 +287,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry
@@ -1581,6 +1586,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clustercleanuppolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clustercleanuppolicies.yaml
@@ -287,6 +287,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry
@@ -1581,6 +1586,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
@@ -323,6 +323,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -1363,6 +1368,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -2449,6 +2459,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -2833,6 +2848,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -3592,6 +3612,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -5413,6 +5438,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -6465,6 +6495,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -7563,6 +7598,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -7956,6 +7996,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -8727,6 +8772,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -10626,6 +10676,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -11460,6 +11515,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -12340,6 +12400,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -12724,6 +12789,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -13654,6 +13724,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -15444,6 +15519,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -16496,6 +16576,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -17594,6 +17679,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -17987,6 +18077,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -18758,6 +18853,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policies.yaml
@@ -324,6 +324,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -1364,6 +1369,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -2450,6 +2460,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -2834,6 +2849,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -3593,6 +3613,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -5415,6 +5440,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -6467,6 +6497,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -7565,6 +7600,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -7958,6 +7998,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -8729,6 +8774,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -10629,6 +10679,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -11463,6 +11518,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -12343,6 +12403,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -12727,6 +12792,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -13657,6 +13727,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -15447,6 +15522,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -16499,6 +16579,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -17597,6 +17682,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -17990,6 +18080,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -18761,6 +18856,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be

--- a/config/crds/kyverno/kyverno.io_cleanuppolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_cleanuppolicies.yaml
@@ -287,6 +287,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry
@@ -1581,6 +1586,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry

--- a/config/crds/kyverno/kyverno.io_clustercleanuppolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_clustercleanuppolicies.yaml
@@ -287,6 +287,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry
@@ -1581,6 +1586,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry

--- a/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
@@ -323,6 +323,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -1363,6 +1368,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -2449,6 +2459,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -2833,6 +2848,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -3592,6 +3612,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -5413,6 +5438,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -6465,6 +6495,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -7563,6 +7598,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -7956,6 +7996,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -8727,6 +8772,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -10626,6 +10676,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -11460,6 +11515,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -12340,6 +12400,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -12724,6 +12789,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -13654,6 +13724,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -15444,6 +15519,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -16496,6 +16576,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -17594,6 +17679,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -17987,6 +18077,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -18758,6 +18853,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be

--- a/config/crds/kyverno/kyverno.io_policies.yaml
+++ b/config/crds/kyverno/kyverno.io_policies.yaml
@@ -324,6 +324,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -1364,6 +1369,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -2450,6 +2460,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -2834,6 +2849,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -3593,6 +3613,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -5415,6 +5440,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -6467,6 +6497,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -7565,6 +7600,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -7958,6 +7998,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -8729,6 +8774,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -10629,6 +10679,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -11463,6 +11518,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -12343,6 +12403,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -12727,6 +12792,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -13657,6 +13727,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -15447,6 +15522,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -16499,6 +16579,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -17597,6 +17682,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -17990,6 +18080,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -18761,6 +18856,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -494,6 +494,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry
@@ -1788,6 +1793,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry
@@ -3106,6 +3116,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry
@@ -4400,6 +4415,11 @@ spec:
                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                         details.
                       properties:
+                        catchError:
+                          description: |-
+                            CatchError controls whether image registry errors are returned as context data.
+                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                          type: boolean
                         imageRegistryCredentials:
                           description: ImageRegistryCredentials provides credentials
                             that will be used for authentication with registry
@@ -5754,6 +5774,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -6794,6 +6819,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -7880,6 +7910,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -8264,6 +8299,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -9023,6 +9063,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -10844,6 +10889,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -11896,6 +11946,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -12994,6 +13049,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -13387,6 +13447,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -14158,6 +14223,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -16057,6 +16127,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -16891,6 +16966,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -17771,6 +17851,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -18155,6 +18240,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -19085,6 +19175,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -20875,6 +20970,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -21927,6 +22027,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -23025,6 +23130,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -23418,6 +23528,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -24189,6 +24304,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -26896,6 +27016,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -27936,6 +28061,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -29022,6 +29152,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -29406,6 +29541,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -30165,6 +30305,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -31987,6 +32132,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -33039,6 +33189,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -34137,6 +34292,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -34530,6 +34690,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -35301,6 +35466,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -37201,6 +37371,11 @@ spec:
                               ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                               details.
                             properties:
+                              catchError:
+                                description: |-
+                                  CatchError controls whether image registry errors are returned as context data.
+                                  When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                type: boolean
                               imageRegistryCredentials:
                                 description: ImageRegistryCredentials provides credentials
                                   that will be used for authentication with registry
@@ -38035,6 +38210,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -38915,6 +39095,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -39299,6 +39484,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -40229,6 +40419,11 @@ spec:
                                         ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                         details.
                                       properties:
+                                        catchError:
+                                          description: |-
+                                            CatchError controls whether image registry errors are returned as context data.
+                                            When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                          type: boolean
                                         imageRegistryCredentials:
                                           description: ImageRegistryCredentials provides
                                             credentials that will be used for authentication
@@ -42019,6 +42214,11 @@ spec:
                                   ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                   details.
                                 properties:
+                                  catchError:
+                                    description: |-
+                                      CatchError controls whether image registry errors are returned as context data.
+                                      When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                    type: boolean
                                   imageRegistryCredentials:
                                     description: ImageRegistryCredentials provides
                                       credentials that will be used for authentication
@@ -43071,6 +43271,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -44169,6 +44374,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -44562,6 +44772,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be
@@ -45333,6 +45548,11 @@ spec:
                                             ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image
                                             details.
                                           properties:
+                                            catchError:
+                                              description: |-
+                                                CatchError controls whether image registry errors are returned as context data.
+                                                When enabled, errors set failed to true and populate errorMessage instead of failing the rule.
+                                              type: boolean
                                             imageRegistryCredentials:
                                               description: ImageRegistryCredentials
                                                 provides credentials that will be

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -2580,6 +2580,19 @@ ImageRegistryCredentials
 <p>ImageRegistryCredentials provides credentials that will be used for authentication with registry</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>catchError</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CatchError controls whether image registry errors are returned as context data.
+When enabled, errors set failed to true and populate errorMessage instead of failing the rule.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr />

--- a/docs/user/crd/kyverno.v1.html
+++ b/docs/user/crd/kyverno.v1.html
@@ -5095,6 +5095,34 @@ the image reference.</p>
       </tr>
     
   
+    
+    
+      <tr>
+        <td><code>catchError</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>CatchError controls whether image registry errors are returned as context data.
+When enabled, errors set failed to true and populate errorMessage instead of failing the rule.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
 
 
       </tbody>

--- a/pkg/engine/context/loaders/imagedata.go
+++ b/pkg/engine/context/loaders/imagedata.go
@@ -91,11 +91,17 @@ func (idl *imageDataLoader) fetchImageData() (interface{}, error) {
 	// They must be specified explicitly in ImageRegistryCredentials
 	client, err := idl.rclientFactory.GetClient(idl.ctx, entry.ImageRegistry.ImageRegistryCredentials, resourceNamespace, nil)
 	if err != nil {
+		if entry.ImageRegistry.CatchError {
+			return imageDataError(err), nil
+		}
 		return nil, fmt.Errorf("failed to get registry client %s: %v", entry.Name, err)
 	}
 
 	imageData, err := idl.fetchImageDataMap(client, refString)
 	if err != nil {
+		if entry.ImageRegistry.CatchError {
+			return imageDataError(err), nil
+		}
 		return nil, err
 	}
 
@@ -107,6 +113,13 @@ func (idl *imageDataLoader) fetchImageData() (interface{}, error) {
 	}
 
 	return imageData, nil
+}
+
+func imageDataError(err error) map[string]interface{} {
+	return map[string]interface{}{
+		"failed":       true,
+		"errorMessage": err.Error(),
+	}
 }
 
 func getNamespaceFromContext(ctx enginecontext.Interface) string {
@@ -156,6 +169,8 @@ func (idl *imageDataLoader) fetchImageDataMap(client engineapi.ImageDataClient, 
 		"manifestList":  manifestList,
 		"manifest":      manifest,
 		"configData":    configData,
+		"failed":        false,
+		"errorMessage":  "",
 	}
 
 	// we need to do the conversion from struct types to an interface type so that jmespath

--- a/pkg/engine/context/loaders/imagedata_test.go
+++ b/pkg/engine/context/loaders/imagedata_test.go
@@ -1,0 +1,129 @@
+package loaders
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	gcrremote "github.com/google/go-containerregistry/pkg/v1/remote"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/config"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
+	"github.com/kyverno/kyverno/pkg/engine/jmespath"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockImageDataClient struct {
+	data *engineapi.ImageData
+	err  error
+}
+
+func (m *mockImageDataClient) ForRef(context.Context, string) (*engineapi.ImageData, error) {
+	return m.data, m.err
+}
+
+func (m *mockImageDataClient) FetchImageDescriptor(context.Context, string) (*gcrremote.Descriptor, error) {
+	return nil, nil
+}
+
+func (m *mockImageDataClient) Keychain() authn.Keychain {
+	return nil
+}
+
+func (m *mockImageDataClient) Options(context.Context) ([]gcrremote.Option, []name.Option, error) {
+	return nil, nil, nil
+}
+
+func (m *mockImageDataClient) NameOptions() []name.Option {
+	return nil
+}
+
+type mockRegistryClientFactory struct {
+	client engineapi.RegistryClient
+	err    error
+}
+
+func (m *mockRegistryClientFactory) GetClient(context.Context, *kyvernov1.ImageRegistryCredentials, string, []string) (engineapi.RegistryClient, error) {
+	return m.client, m.err
+}
+
+func TestImageDataLoaderCatchError(t *testing.T) {
+	jp := jmespath.New(config.NewDefaultConfiguration(false))
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	newLoader := func(catchError bool, factory engineapi.RegistryClientFactory) (enginecontext.Interface, enginecontext.Loader) {
+		engineCtx := enginecontext.NewContext(jp)
+		entry := kyvernov1.ContextEntry{
+			Name: "imageData",
+			ImageRegistry: &kyvernov1.ImageRegistry{
+				Reference:  "example.com/team/does-not-exist:latest",
+				CatchError: catchError,
+			},
+		}
+		return engineCtx, NewImageDataLoader(ctx, logger, entry, engineCtx, jp, factory)
+	}
+
+	t.Run("successful lookup exposes failure fields", func(t *testing.T) {
+		client := &mockImageDataClient{data: &engineapi.ImageData{
+			Image:         "nginx:latest",
+			ResolvedImage: "nginx@sha256:12345",
+			Manifest:      []byte(`{"foo":"bar"}`),
+			Config:        []byte(`{"baz":"qux"}`),
+		}}
+		engineCtx, loader := newLoader(true, &mockRegistryClientFactory{client: client})
+
+		require.NoError(t, loader.LoadData())
+		failed, err := engineCtx.Query("imageData.failed")
+		require.NoError(t, err)
+		assert.Equal(t, false, failed)
+		errorMessage, err := engineCtx.Query("imageData.errorMessage")
+		require.NoError(t, err)
+		assert.Equal(t, "", errorMessage)
+		resolvedImage, err := engineCtx.Query("imageData.resolvedImage")
+		require.NoError(t, err)
+		assert.Equal(t, "nginx@sha256:12345", resolvedImage)
+	})
+
+	t.Run("manifest unknown becomes context data", func(t *testing.T) {
+		client := &mockImageDataClient{err: errors.New("MANIFEST_UNKNOWN: requested image not found")}
+		engineCtx, loader := newLoader(true, &mockRegistryClientFactory{client: client})
+
+		require.NoError(t, loader.LoadData())
+		failed, err := engineCtx.Query("imageData.failed")
+		require.NoError(t, err)
+		assert.Equal(t, true, failed)
+		errorMessage, err := engineCtx.Query("imageData.errorMessage")
+		require.NoError(t, err)
+		assert.Contains(t, errorMessage, "MANIFEST_UNKNOWN")
+		resolvedImage, err := engineCtx.Query("imageData.resolvedImage || ''")
+		require.NoError(t, err)
+		assert.Equal(t, "", resolvedImage)
+	})
+
+	t.Run("manifest unknown remains an error by default", func(t *testing.T) {
+		client := &mockImageDataClient{err: errors.New("MANIFEST_UNKNOWN: requested image not found")}
+		_, loader := newLoader(false, &mockRegistryClientFactory{client: client})
+
+		err := loader.LoadData()
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "MANIFEST_UNKNOWN")
+	})
+
+	t.Run("registry client error becomes context data", func(t *testing.T) {
+		engineCtx, loader := newLoader(true, &mockRegistryClientFactory{err: errors.New("credentials unavailable")})
+
+		require.NoError(t, loader.LoadData())
+		failed, err := engineCtx.Query("imageData.failed")
+		require.NoError(t, err)
+		assert.Equal(t, true, failed)
+		errorMessage, err := engineCtx.Query("imageData.errorMessage")
+		require.NoError(t, err)
+		assert.Contains(t, errorMessage, "credentials unavailable")
+	})
+}


### PR DESCRIPTION
## Explanation

An `imageRegistry` context lookup currently fails the rule before preconditions are evaluated when the registry returns an error such as `MANIFEST_UNKNOWN`. Expressions such as `{{ imageData.resolvedImage || '' }}` therefore never get an opportunity to supply their fallback value.

This adds an opt-in `catchError` field. When enabled, registry lookup failures become context data instead of rule-loading errors, allowing preconditions to skip verification for images which no longer exist.

## Related issue

Related to #14302.

This is a clean current-`main` successor to #15760, preserving its accepted design while resolving its merge conflicts and generated-code drift. Credit to @jakharmonika364 for the original implementation.

## Milestone of this PR

Maintainers can assign the appropriate milestone.

## Documentation (required for features)

Generated CRD and API reference documentation is included. A website documentation PR can follow maintainer feedback on the API shape.

## What type of PR is this

/kind api-change

## Proposed Changes

Before this PR, any registry-client or image-metadata error aborts context loading before preconditions run.

This PR:

- adds `imageRegistry.catchError`, defaulting to `false` for backward compatibility;
- returns `failed: true` and `errorMessage` when an image lookup fails and catching is enabled;
- returns `failed: false` and an empty `errorMessage` after a successful lookup;
- regenerates source, CLI, Helm, install-manifest, and API-reference schemas from current `main`;
- adds focused tests for success, client errors, default behavior, and an exact `MANIFEST_UNKNOWN` failure;
- proves `imageData.resolvedImage || ''` evaluates to an empty string after the error is caught.

After this PR, policies can test `imageData.failed` in preconditions and skip a rule without emitting a failure for an expected missing image. The registry lookup still occurs because image existence cannot be known without querying the registry.

### Proof Manifests

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: skip-missing-images
spec:
  validationFailureAction: Audit
  rules:
    - name: evaluate-existing-images
      match:
        any:
          - resources:
              kinds:
                - Pod
      context:
        - name: imageData
          imageRegistry:
            reference: "{{ request.object.spec.containers[0].image }}"
            catchError: true
      preconditions:
        all:
          - key: "{{ imageData.failed }}"
            operator: Equals
            value: false
      validate:
        message: image exists and can be evaluated
        pattern:
          metadata:
            labels:
              checked-image: "true"
---
apiVersion: v1
kind: Pod
metadata:
  name: missing-image
spec:
  containers:
    - name: app
      image: example.com/team/does-not-exist:latest
```

The registry error is stored in `imageData`; the precondition evaluates to false and the rule is skipped instead of failing during context loading.

## Testing

- `go test -race ./pkg/engine/context/loaders ./pkg/engine/context`
- `go vet ./pkg/engine/context/loaders ./pkg/engine/context`
- `make imports-check fmt-check verify-codegen`
- Current CRDs, embedded CLI CRDs, Helm CRDs, install manifest, and API reference docs regenerated.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the AI Usage Policy and disclosed assistance with an `Assisted-by` commit trailer.
- [x] I have read the PR documentation guide and included proof manifests and generated API documentation.
- [x] This change includes unit tests which prove the fix is effective.
- [ ] I have sent a separate website documentation PR.
- [ ] This feature includes a Kyverno CLI integration test.
- [ ] This PR needs to be cherry picked to a specific release branch.

## Further Comments

The current diff contains no real registry host, cloud account identifier, personal email address, internal domain, or local filesystem path. Tests use `example.com`, and the commit uses GitHub's noreply address.
