### PR TITLE
fix: goroutine leak when reports counter init partially fails

### DIFF
--- a/pkg/breaker/resource_counter.go
+++ b/pkg/breaker/resource_counter.go
@@ -54,6 +54,10 @@ func (c *counter) Count() (int, bool) {
 	return c.entries.Len(), c.retryWatcher.IsRunning()
 }
 
+func (c *counter) Stop() {
+	c.retryWatcher.Stop()
+}
+
 func StartResourceCounter(ctx context.Context, client metadataclient.Interface, gvr schema.GroupVersionResource, tweakListOptions internalinterfaces.TweakListOptionsFunc) (*counter, error) {
 	objs, err := client.Resource(gvr).List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -107,6 +111,8 @@ func StartAdmissionReportsCounter(ctx context.Context, client metadataclient.Int
 	}
 	cephrs, err := StartResourceCounter(ctx, client, reportsv1.SchemeGroupVersion.WithResource("clusterephemeralreports"), tweakListOptions)
 	if err != nil {
+		// stop the first watcher so retried calls don't accumulate goroutines
+		ephrs.Stop()
 		return nil, err
 	}
 	return composite{
@@ -124,6 +130,8 @@ func StartBackgroundReportsCounter(ctx context.Context, client metadataclient.In
 	}
 	cephrs, err := StartResourceCounter(ctx, client, reportsv1.SchemeGroupVersion.WithResource("clusterephemeralreports"), tweakListOptions)
 	if err != nil {
+		// stop the first watcher so retried calls don't accumulate goroutines
+		ephrs.Stop()
 		return nil, err
 	}
 	return composite{

--- a/pkg/breaker/resource_counter_test.go
+++ b/pkg/breaker/resource_counter_test.go
@@ -3,16 +3,25 @@
 package breaker
 
 import (
+	"context"
+	"errors"
+	"runtime"
 	"testing"
+	"time"
 
 	//watchtools "github.com/kyverno/kyverno/cmd/kyverno/watch"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	k8swatch "k8s.io/apimachinery/pkg/watch"
+	metadatafake "k8s.io/client-go/metadata/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 type fakeRetryWatcher struct {
 	running bool
+	stopped bool
 	ch      chan k8swatch.Event
 }
 
@@ -24,7 +33,9 @@ func (f *fakeRetryWatcher) IsRunning() bool {
 	return f.running
 }
 
-func (f *fakeRetryWatcher) Stop() {}
+func (f *fakeRetryWatcher) Stop() {
+	f.stopped = true
+}
 
 // counter tests
 
@@ -91,6 +102,56 @@ func TestCounter_NotRunning(t *testing.T) {
 	}
 	if running {
 		t.Fatalf("expected watcher to NOT be running")
+	}
+}
+
+func TestCounter_Stop(t *testing.T) {
+	fw := &fakeRetryWatcher{
+		running: true,
+		ch:      make(chan k8swatch.Event),
+	}
+
+	c := &counter{
+		entries:      sets.New[types.UID](),
+		retryWatcher: fw,
+	}
+
+	c.Stop()
+	if !fw.stopped {
+		t.Fatalf("expected underlying retry watcher to be stopped")
+	}
+}
+
+func TestStartAdmissionReportsCounter_PartialInitFailure(t *testing.T) {
+	client := metadatafake.NewSimpleMetadataClient(metadatafake.NewTestScheme())
+	// first counter starts fine
+	client.PrependReactor("list", "ephemeralreports", func(action k8stesting.Action) (bool, kruntime.Object, error) {
+		list := &metav1.List{}
+		list.SetResourceVersion("1")
+		return true, list, nil
+	})
+	// second counter fails to start
+	client.PrependReactor("list", "clusterephemeralreports", func(action k8stesting.Action) (bool, kruntime.Object, error) {
+		return true, nil, errors.New("the server is currently unable to handle the request")
+	})
+
+	before := runtime.NumGoroutine()
+	for i := 0; i < 20; i++ {
+		if _, err := StartAdmissionReportsCounter(context.TODO(), client); err == nil {
+			t.Fatal("expected an error")
+		}
+	}
+	// the successfully started ephemeralreports watchers must be stopped,
+	// otherwise each failed call above leaks their goroutines
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if runtime.NumGoroutine() <= before+3 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("goroutines leaked: before=%d now=%d", before, runtime.NumGoroutine())
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
## Explanation

While digging into #17001 I found a goroutine leak in the breaker's resource counters.

`StartAdmissionReportsCounter` and `StartBackgroundReportsCounter` start two watchers, one for `ephemeralreports` and one for `clusterephemeralreports`. If the first one starts fine but the second fails, we return the error and just... forget about the first watcher. It keeps running forever.

On its own that would be a one-off leak, but since #13641 all three controllers retry these functions every 2s until they succeed. So if the reports API is flapping (reports-server rollout, crash loop, outage — exactly the situation the retry was added for), every attempt that gets halfway leaks 3 goroutines. That adds up fast and eventually the pod gets OOMKilled.

## Related issue

Related: #17001

Worth noting: the file the reporter points at (`pkg/breaker/reports_server_watcher.go`) doesn't actually exist upstream — I checked main, release-1.17, the v1.17.2 tag and the whole git history. They're on an N4K build, so that 5s watcher loop is Nirmata code and needs to go to them. But their report made me look at this code path and the leak here is real, it's just triggered a bit differently.

## Milestone of this PR

/milestone TBD

## What type of PR is this

/kind bug

## Proposed Changes

- give `counter` a `Stop()` method that stops the underlying `RetryWatcher`. Stopping it closes the result channel, so the pump goroutine exits too — nothing left behind.
- in both `Start*ReportsCounter` functions, stop the first watcher before returning the second one's error, so the retry loops start each attempt clean.
- tests: a small one for `Stop()`, and a regression test that reproduces the leak with a fake metadata client (first list succeeds, second fails). Without the fix it fails with `goroutines leaked: before=2 now=62` after 20 attempts; with it, everything goes back to baseline.

### Proof Manifests

Not applicable — internal reliability fix, nothing policy-facing. The unit test is the repro.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

Being upfront about scope: this probably isn't the full story for #17001. In the reporter's cluster the reports CRDs are served locally, so upstream init succeeds first try — their 5s loop is fork code. This fixes the upstream half of the problem.