### PR TITLE
Fix goroutine and ticker leak in metrics initialization

### DIFF
--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -124,8 +124,11 @@ func InitMetrics(
 	if otelProvider == "prometheus" && metricsConfiguration.GetMetricsRefreshInterval() > 0 {
 		ticker := time.NewTicker(metricsConfiguration.GetMetricsRefreshInterval())
 		go func() {
+			defer ticker.Stop()
 			for {
 				select {
+				case <-ctx.Done():
+					return
 				case <-ticker.C:
 					if p, ok := otel.GetMeterProvider().(*sdkmetric.MeterProvider); ok {
 						if err := p.Shutdown(ctx); err != nil {


### PR DESCRIPTION
## Explanation

While reviewing the metrics initialization in `pkg/metrics/init.go`, I found a goroutine and ticker leak in the Prometheus `MeterProvider` refresh logic.

When `otelProvider == "prometheus"` and `MetricsRefreshInterval > 0`, a background goroutine is spawned to re-create the `MeterProvider`. However, its `select` loop does not check `ctx.Done()`, meaning it will loop forever even if the context is cancelled. Additionally, `ticker.Stop()` is never called.

## Related issue

Fixes #17021

## Milestone of this PR

/milestone TBD

## What type of PR is this

/kind bug

## Proposed Changes

- Added `defer ticker.Stop()` to ensure the ticker is cleaned up.
- Added a `case <-ctx.Done(): return` block in the `select` to exit the goroutine upon context cancellation.

### Proof Manifests

Not applicable — internal reliability fix, nothing policy-facing. 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This is a straightforward fix for a resource leak on hot-reload or graceful shutdown.
