### PR TITLE
Fix context leak in TTL controller reconcile loop

### DIFF
--- a/pkg/controllers/ttl/controller.go
+++ b/pkg/controllers/ttl/controller.go
@@ -153,18 +153,18 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, itemKey 
 		deleteOptions := metav1.DeleteOptions{
 			PropagationPolicy: determinePropagationPolicy(metaObj, logger),
 		}
-		err = c.client.Namespace(namespace).Delete(context.Background(), metaObj.GetName(), deleteOptions)
+		err = c.client.Namespace(namespace).Delete(ctx, metaObj.GetName(), deleteOptions)
 		if err != nil {
 			logger.Error(err, "failed to delete resource")
 			if c.metrics != nil {
-				c.metrics.RecordTTLFailure(context.Background(), c.gvr, metaObj.GetNamespace())
+				c.metrics.RecordTTLFailure(ctx, c.gvr, metaObj.GetNamespace())
 			}
 			return err
 		}
 		logger.V(2).Info("resource has been deleted")
 	} else {
 		if c.metrics != nil {
-			c.metrics.RecordDeletedObject(context.Background(), c.gvr, metaObj.GetNamespace())
+			c.metrics.RecordDeletedObject(ctx, c.gvr, metaObj.GetNamespace())
 		}
 		// Calculate the remaining time until deletion
 		timeRemaining := time.Until(deletionTime)


### PR DESCRIPTION
## Explanation

While reviewing the TTL controller, I noticed that `context.Background()` is being used in the `reconcile` loop for API deletion calls and metric recording, instead of the provided `ctx context.Context`.

This is a classic Kubernetes controller anti-pattern that prevents the API calls from being cancelled if the controller context shuts down or restarts. If the API server is unresponsive during a shutdown, these calls can hang and delay the graceful shutdown of the controller. This PR replaces `context.Background()` with `ctx`.

## Related issue

Fixes #17031

## Milestone of this PR

/milestone TBD

## What type of PR is this

/kind bug

## Proposed Changes

- Replaced `context.Background()` with the provided `ctx` parameter in `pkg/controllers/ttl/controller.go` during resource deletion and metric recording.

### Proof Manifests

Not applicable — internal reliability fix, nothing policy-facing. 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This small fix ensures the TTL controller respects graceful shutdown signals.
