### PR TITLE
Fix resource leak in sigstore fetchReferrers loop

### DIFF
--- a/pkg/image/verifiers/cpol/cosign/sigstore.go
+++ b/pkg/image/verifiers/cpol/cosign/sigstore.go
@@ -127,14 +127,16 @@ func fetchBundles(ref name.Reference, limit int, predicateType string, remoteOpt
 		if layerSize > maxLayerSize {
 			return nil, nil, fmt.Errorf("layer size %d exceeds %d", layerSize, maxLayerSize)
 		}
-		layerBytes, err := layer.Uncompressed()
+		bundleBytes, err := func() ([]byte, error) {
+			layerBytes, err := layer.Uncompressed()
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch referrer layer: %w", err)
+			}
+			defer layerBytes.Close()
+			return io.ReadAll(layerBytes)
+		}()
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch referrer layer: %w", err)
-		}
-		defer layerBytes.Close()
-		bundleBytes, err := io.ReadAll(layerBytes)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch referrer layer: %w", err)
+			return nil, nil, err
 		}
 		b := &bundle.Bundle{}
 		err = b.UnmarshalJSON(bundleBytes)


### PR DESCRIPTION
## Explanation

While reviewing the image verification code, I noticed a "defer in loop" resource leak in `pkg/image/verifiers/cpol/cosign/sigstore.go`.

In `fetchReferrers`, the reader for each uncompressed image layer is closed using `defer layerBytes.Close()` inside a `for` loop. Since `defer` is scoped to the function and not the loop block, the file descriptors and memory for all referrers remain held until the entire `fetchReferrers` function returns. If an image has many referrers, this can unnecessarily spike memory usage.

This PR fixes the issue by wrapping the read operation in an anonymous function, ensuring the layer bytes reader is closed immediately after the layer is read in each loop iteration.

## Related issue

Fixes #17037

## Milestone of this PR

/milestone TBD

## What type of PR is this

/kind bug

## Proposed Changes

- Scoped `defer layerBytes.Close()` inside an anonymous function in `fetchReferrers` loop.

### Proof Manifests

Not applicable.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This follows standard Go best practices for loop resources.
