### PR TITLE
Fix memory leak and loop hang in CLI executeTasks

### DIFF
--- a/pkg/cli/loader/resource_loader.go
+++ b/pkg/cli/loader/resource_loader.go
@@ -171,17 +171,21 @@ func (cl *ClusterLoader) executeTasks(ctx context.Context, tasks []LoadTask) ([]
 	var results []LoadTaskResult
 	expectedResults := len(tasks)
 
+	timer := time.NewTimer(cl.resourceOptions.Timeout)
+	defer timer.Stop()
+
+loopLabel:
 	for i := 0; i < expectedResults; i++ {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case result := <-cl.workerPool.GetResults():
 			results = append(results, result)
-		case <-time.After(cl.resourceOptions.Timeout):
+		case <-timer.C:
 			if !cl.resourceOptions.ContinueOnError {
 				return nil, fmt.Errorf("timeout waiting for task results")
 			}
-			break
+			break loopLabel
 		}
 	}
 


### PR DESCRIPTION
### Context
Fixes #17049

In `pkg/cli/loader/resource_loader.go`, the `executeTasks` loop was using an inline `time.After` in a `select` statement. This caused two significant issues when loading a large number of resources:
1. **Memory Leak**: `time.After` allocated a new `Timer` on every iteration, which wasn't collected until expiration, consuming excessive memory.
2. **Loop Hang**: When `ContinueOnError` was set to `true`, a timeout would trigger a `break` that only exited the `select` statement, not the `for` loop. This caused the loop to endlessly cycle through remaining tasks, hanging the CLI repeatedly.

### Changes
- Moved `time.Timer` instantiation outside of the `for` loop, acting as a unified overall timeout instead of a per-result timeout.
- Added `defer timer.Stop()` to properly clean up the timer.
- Added a `loopLabel:` to the `for` loop and updated the `break` statement to `break loopLabel`, ensuring we correctly exit the waiting process entirely on a timeout.

### Verification
- Checked that tests in `pkg/cli/loader/...` still pass successfully.
- Code conforms to Kyverno linting rules.

### PR Checklist
- [x] I have read and followed the documentation AND the [troubleshooting guide](https://kyverno.io/docs/troubleshooting/).
- [x] I have searched other issues in this repository and mine is not recorded.
- [x] I have checked if there is an existing PR that addresses this issue.
- [x] I have provided a description of the bug or feature request.
- [x] My changes do not break any existing functionality.
- [x] I have added a sign-off trailer to my commit.
