### PR TITLE
fix(event): use dynamic APIVersion and Kind for Event ObjectReferences

### DIFF
--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -170,8 +170,7 @@ func NewResourceGenerationEvent(policy, rule string, source Source, resource kyv
 func NewBackgroundFailedEvent(err error, policy engineapi.GenericPolicy, rule string, source Source, resource kyvernov1.ResourceSpec) []Info {
 	events := make([]Info, 0, 1)
 	regarding := corev1.ObjectReference{
-		// TODO: iirc it's not safe to assume api version is set
-		APIVersion: "kyverno.io/v1",
+		APIVersion: policy.GetAPIVersion(),
 		Kind:       policy.GetKind(),
 		Name:       policy.GetName(),
 		Namespace:  policy.GetNamespace(),
@@ -210,8 +209,7 @@ func NewBackgroundSuccessEvent(source Source, policy engineapi.GenericPolicy, re
 		action = ResourceMutated
 	}
 	regarding := corev1.ObjectReference{
-		// TODO: iirc it's not safe to assume api version is set
-		APIVersion: "kyverno.io/v1",
+		APIVersion: policy.GetAPIVersion(),
 		Kind:       policy.GetKind(),
 		Name:       policy.GetName(),
 		Namespace:  policy.GetNamespace(),
@@ -260,9 +258,8 @@ func NewPolicyExceptionEvents(engineResponse engineapi.EngineResponse, ruleResp 
 
 			exceptionEvent := Info{
 				Regarding: corev1.ObjectReference{
-					// TODO: iirc it's not safe to assume api version is set
-					APIVersion: "kyverno.io/v2",
-					Kind:       "PolicyException",
+					APIVersion: exception.GetAPIVersion(),
+					Kind:       exception.GetKind(),
 					Name:       name,
 					Namespace:  ns,
 					UID:        exception.GetUID(),
@@ -285,12 +282,11 @@ func NewPolicyExceptionEvents(engineResponse engineapi.EngineResponse, ruleResp 
 		// build the policy events
 		policyMessage := fmt.Sprintf("resource %s was skipped from rule %s due to policy exceptions %s", resourceKey(engineResponse.PatchedResource), ruleResp.Name(), strings.Join(exceptionNames, ", "))
 		regarding := corev1.ObjectReference{
-			// TODO: iirc it's not safe to assume api version is set
-			APIVersion: "kyverno.io/v1",
-			Kind:       pol.GetKind(),
-			Name:       pol.GetName(),
-			Namespace:  pol.GetNamespace(),
-			UID:        pol.GetUID(),
+			APIVersion: policy.GetAPIVersion(),
+			Kind:       policy.GetKind(),
+			Name:       policy.GetName(),
+			Namespace:  policy.GetNamespace(),
+			UID:        policy.GetUID(),
 		}
 		policyEvent := Info{
 			Regarding: regarding,
@@ -313,8 +309,7 @@ func NewPolicyExceptionEvents(engineResponse engineapi.EngineResponse, ruleResp 
 
 func NewCleanupPolicyEvent(policy kyvernov2.CleanupPolicyInterface, resource unstructured.Unstructured, err error) Info {
 	regarding := corev1.ObjectReference{
-		// TODO: iirc it's not safe to assume api version is set
-		APIVersion: "kyverno.io/v2",
+		APIVersion: policy.GetAPIVersion(),
 		Kind:       policy.GetKind(),
 		Name:       policy.GetName(),
 		Namespace:  policy.GetNamespace(),

--- a/pkg/event/events_test.go
+++ b/pkg/event/events_test.go
@@ -199,6 +199,10 @@ func Test_NewFailedEvent_no_rule(t *testing.T) {
 
 func Test_NewCleanupPolicyEvent_success(t *testing.T) {
 	pol := &kyvernov2.ClusterCleanupPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kyverno.io/v2",
+			Kind:       "ClusterCleanupPolicy",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "remove-stale-pods",
 			UID:  "pol-uid-1",
@@ -213,6 +217,8 @@ func Test_NewCleanupPolicyEvent_success(t *testing.T) {
 	ev := NewCleanupPolicyEvent(pol, res, nil)
 
 	assert.Equal(t, "remove-stale-pods", ev.Regarding.Name)
+	assert.Equal(t, "kyverno.io/v2", ev.Regarding.APIVersion)
+	assert.Equal(t, "ClusterCleanupPolicy", ev.Regarding.Kind)
 	assert.Equal(t, PolicyApplied, ev.Reason)
 	assert.Equal(t, ResourceCleanedUp, ev.Action)
 	assert.Equal(t, CleanupController, ev.Source)
@@ -222,6 +228,10 @@ func Test_NewCleanupPolicyEvent_success(t *testing.T) {
 
 func Test_NewCleanupPolicyEvent_failure(t *testing.T) {
 	pol := &kyvernov2.ClusterCleanupPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kyverno.io/v2",
+			Kind:       "ClusterCleanupPolicy",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cleanup-cm",
 		},
@@ -242,6 +252,10 @@ func Test_NewCleanupPolicyEvent_failure(t *testing.T) {
 
 func Test_NewCleanupPolicyEvent_namespaced(t *testing.T) {
 	pol := &kyvernov2.CleanupPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kyverno.io/v2",
+			Kind:       "CleanupPolicy",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "secret-cleaner",
 			Namespace: "team-a",
@@ -257,6 +271,8 @@ func Test_NewCleanupPolicyEvent_namespaced(t *testing.T) {
 
 	assert.Equal(t, "secret-cleaner", ev.Regarding.Name)
 	assert.Equal(t, "team-a", ev.Regarding.Namespace)
+	assert.Equal(t, "kyverno.io/v2", ev.Regarding.APIVersion)
+	assert.Equal(t, "CleanupPolicy", ev.Regarding.Kind)
 	assert.Equal(t, ResourceCleanedUp, ev.Action)
 }
 
@@ -369,3 +385,109 @@ func Test_NewPolicyAppliedEvent_NamespacedMutatingPolicy(t *testing.T) {
 	assert.Contains(t, ev.Message, "Secret team-a/credentials is successfully mutated")
 	assert.Equal(t, "team-a", ev.Regarding.Namespace)
 }
+
+func Test_NewBackgroundFailedEvent(t *testing.T) {
+	pol := &kyvernov1.ClusterPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kyverno.io/v1",
+			Kind:       "ClusterPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-policy",
+		},
+	}
+	enginePol := engineapi.NewKyvernoPolicy(pol)
+
+	res := kyvernov1.ResourceSpec{
+		APIVersion: "v1",
+		Kind:       "Pod",
+		Namespace:  "default",
+		Name:       "test-pod",
+	}
+
+	err := errors.New("test error")
+	events := NewBackgroundFailedEvent(err, enginePol, "test-rule", GeneratePolicyController, res)
+
+	assert.Len(t, events, 1)
+	assert.Equal(t, "kyverno.io/v1", events[0].Regarding.APIVersion)
+	assert.Equal(t, "ClusterPolicy", events[0].Regarding.Kind)
+	assert.Equal(t, "test-policy", events[0].Regarding.Name)
+	assert.Equal(t, "v1", events[0].Related.APIVersion)
+	assert.Equal(t, "Pod", events[0].Related.Kind)
+}
+
+func Test_NewBackgroundSuccessEvent(t *testing.T) {
+	pol := &kyvernov1.ClusterPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kyverno.io/v1",
+			Kind:       "ClusterPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-policy",
+		},
+	}
+	enginePol := engineapi.NewKyvernoPolicy(pol)
+
+	res := kyvernov1.ResourceSpec{
+		APIVersion: "v1",
+		Kind:       "Pod",
+		Namespace:  "default",
+		Name:       "test-pod",
+	}
+
+	events := NewBackgroundSuccessEvent(GeneratePolicyController, enginePol, []kyvernov1.ResourceSpec{res})
+
+	assert.Len(t, events, 1)
+	assert.Equal(t, "kyverno.io/v1", events[0].Regarding.APIVersion)
+	assert.Equal(t, "ClusterPolicy", events[0].Regarding.Kind)
+	assert.Equal(t, "test-policy", events[0].Regarding.Name)
+}
+
+func Test_NewPolicyExceptionEvents(t *testing.T) {
+	pol := &kyvernov1.ClusterPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kyverno.io/v1",
+			Kind:       "ClusterPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-policy",
+		},
+	}
+	enginePol := engineapi.NewKyvernoPolicy(pol)
+
+	exception := &kyvernov2.PolicyException{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kyverno.io/v2",
+			Kind:       "PolicyException",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-exception",
+			Namespace: "default",
+		},
+	}
+
+	ruleResp := engineapi.NewRuleResponse("test-rule", engineapi.Validation, "msg", engineapi.RuleStatusSkip, nil).WithExceptions([]engineapi.GenericException{engineapi.NewPolicyException(exception)})
+
+	resource := unstructured.Unstructured{}
+	resource.SetKind("Pod")
+	resource.SetNamespace("default")
+	resource.SetName("test-pod")
+
+	engineResp := engineapi.EngineResponse{
+		Resource:        resource,
+		PatchedResource: resource,
+	}
+	engineResp = engineResp.WithPolicy(enginePol)
+
+	events := NewPolicyExceptionEvents(engineResp, *ruleResp, AdmissionController)
+
+	assert.Len(t, events, 2)
+	assert.Equal(t, "kyverno.io/v2", events[0].Regarding.APIVersion)
+	assert.Equal(t, "PolicyException", events[0].Regarding.Kind)
+	assert.Equal(t, "test-exception", events[0].Regarding.Name)
+
+	assert.Equal(t, "kyverno.io/v1", events[1].Regarding.APIVersion)
+	assert.Equal(t, "ClusterPolicy", events[1].Regarding.Kind)
+	assert.Equal(t, "test-policy", events[1].Regarding.Name)
+}
+


### PR DESCRIPTION

### Explanation

This PR fixes an issue where Kubernetes Events generated for Kyverno policies and exceptions had hardcoded `APIVersion` (`"kyverno.io/v1"` or `"kyverno.io/v2"`) and `Kind` fields in their `ObjectReference`. While this worked for traditional `ClusterPolicy` and `Policy` resources, it resulted in invalid object references for newer grouped policies like `ValidatingAdmissionPolicy`, `ValidatingPolicy`, and `PolicyException` (which resides in `policies.kyverno.io`). 

This PR dynamically fetches the `APIVersion` and `Kind` using the respective `GetAPIVersion()` and `GetKind()` methods of `GenericPolicy`, `GenericException`, and `CleanupPolicyInterface` to ensure events are always accurately associated with their underlying resources.

### Related issue

Closes #17050

### What type of PR is this

/kind bug

### Proposed Changes

- Replaced hardcoded `"kyverno.io/v1"` and `"kyverno.io/v2"` with `policy.GetAPIVersion()` and `exception.GetAPIVersion()` across background and exception event generating functions in `pkg/event/events.go`.
- Replaced hardcoded `Kind: "PolicyException"` with `exception.GetKind()`.
- This ensures that when tooling like `kubectl describe` looks up these events, they map to the correct GVK, fixing event monitoring.

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
