### PR TITLE
fix(validation): guard wildcard deny condition key type assertion

### DIFF
--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -1569,8 +1569,11 @@ func validateWildcard(kinds []string, background bool, rule kyvernov1.Rule) erro
 				switch typedConditions := rule.Validation.Deny.GetAnyAllConditions().(type) {
 				case []kyvernov1.Condition: // backwards compatibility
 					for _, condition := range typedConditions {
-						key := condition.GetKey()
-						if !strings.Contains(key.(string), "request.object.metadata.") && (!wildCardAllowedVariables.MatchString(key.(string)) || strings.Contains(key.(string), "request.object.spec")) {
+						key, ok := condition.GetKey().(string)
+						if !ok {
+							return fmt.Errorf("condition key must be a string. Found type %T", condition.GetKey())
+						}
+						if !strings.Contains(key, "request.object.metadata.") && (!wildCardAllowedVariables.MatchString(key) || strings.Contains(key, "request.object.spec")) {
 							return fmt.Errorf("policy can only deal with the metadata field of the resource if" +
 								" the rule does not match any kind")
 						}

--- a/pkg/validation/policy/validate_test.go
+++ b/pkg/validation/policy/validate_test.go
@@ -2179,6 +2179,34 @@ func Test_Any_wildcard_policy(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func Test_Validate_WildcardDenyConditionsNonStringKey(t *testing.T) {
+	ruleJSON := []byte(`
+	{
+		"name": "test-rule",
+		"validate": {
+			"message": "test",
+			"deny": {
+				"conditions": [
+					{
+						"key": 123,
+						"operator": "Equals",
+						"value": "x"
+					}
+				]
+			}
+		}
+	}
+	`)
+
+	var rule kyverno.Rule
+	err := json.Unmarshal(ruleJSON, &rule)
+	assert.Nil(t, err)
+
+	err = validateWildcard([]string{"*"}, false, rule)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "condition key must be a string")
+}
+
 func Test_Validate_RuleImageExtractorsJMESPath(t *testing.T) {
 	rawPolicy := []byte(`{
 		"apiVersion": "kyverno.io/v1",


### PR DESCRIPTION
## Explanation

A wildcard `ClusterPolicy` whose `validate.deny.conditions` contains a condition with a non-string `key` (e.g. an integer) triggers a panic in the policy validation webhook on an unchecked type assertion. Go's net/http recovers the panic per-request so the controller does not crash, but the submitter gets an opaque `InternalError`/EOF instead of a clean rejection message and the policy cannot be applied.

This change guards the type assertion so the policy is rejected with a clear validation error instead of panicking, consistent with the sibling fix for `request.operation` condition values in #16977.

## Related issue

Closes #16984

## What type of PR is this

/kind bug

## Proposed Changes

In `validateWildcard`, the backwards-compatibility flat-list form of `validate.deny.conditions` asserted every condition key to be a string without the comma-ok form. `Condition.RawKey` is `apiextensions.JSON` with no schema restriction to string, so a non-string key (e.g. `key: 123`) panicked with `interface conversion: apiextensions.JSON is int64, not string`.

The assertion is now guarded with the comma-ok form; a non-string key returns a clear validation error instead of panicking, and the subsequent metadata/spec checks use the string value directly.

### Proof Manifests

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: test-wildcard-deny-panic
spec:
  background: false
  rules:
  - name: test-rule
    match:
      any:
      - resources:
          kinds:
          - "*"
    validate:
      message: "test"
      deny:
        conditions:
        - key: 123
          operator: Equals
          value: "x"
```

Before this change the policy triggers a panic in the validation webhook and is rejected with an opaque error; after this change it is rejected with a clean validation error.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

The PR description was generated with the help of an AI tool.
