### PR TITLE
Refactor/generate validation offline mode

### DIFF
--- a/pkg/policy/generate/config.go
+++ b/pkg/policy/generate/config.go
@@ -1,0 +1,87 @@
+package generate
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	"github.com/kyverno/kyverno/pkg/policy/auth/fake"
+)
+
+// GenerateConfig holds all configuration required to build a Generate validator.
+// Callers should always set Logger; all other fields are optional depending on mode.
+type GenerateConfig struct {
+	Rule *kyvernov1.Rule
+	Client dclient.Interface
+	Mock bool
+	Logger logr.Logger
+	BackgroundSA string
+	AdmissionSA string
+	ReportsSA string
+}
+
+// generateStep pairs a Generate validator with the verbs it should use when calling Validate.
+type generateStep struct {
+	g     *Generate
+	verbs []string
+}
+
+
+type configuredGenerate struct {
+	steps []generateStep
+}
+
+// NewGenerateValidator builds the correct Generate validator based on cfg.
+//
+// Offline (Mock=true): returns a single step backed by fake auth checkers that
+// always permit, so no Kubernetes API access is needed. Structural errors in the
+// generate rule are still reported.
+//
+// Online (Mock=false): returns one or two steps backed by real SubjectAccessReview
+// calls:
+//   - If the rule is synchronize, an admission-controller step with ["list","get"]
+//     verbs runs first.
+//   - A background-controller step (verbs determined by the rule) always runs.
+func NewGenerateValidator(cfg GenerateConfig) *configuredGenerate {
+	if cfg.Mock {
+		g := &Generate{
+			rule:               cfg.Rule,
+			authChecker:        fake.NewFakeAuth(),
+			authCheckerReports: fake.NewFakeAuth(),
+			log:                cfg.Logger,
+		}
+		return &configuredGenerate{
+			steps: []generateStep{{g: g, verbs: nil}},
+		}
+	}
+
+	var steps []generateStep
+
+	// For synchronize rules the admission controller also needs list/get access.
+	if cfg.Rule.Generation.Synchronize && cfg.AdmissionSA != "" {
+		steps = append(steps, generateStep{
+			g:     NewGenerateFactory(cfg.Client, cfg.Rule, cfg.AdmissionSA, cfg.ReportsSA, cfg.Logger),
+			verbs: []string{"list", "get"},
+		})
+	}
+
+	steps = append(steps, generateStep{
+		g:     NewGenerateFactory(cfg.Client, cfg.Rule, cfg.BackgroundSA, cfg.ReportsSA, cfg.Logger),
+		verbs: nil,
+	})
+
+	return &configuredGenerate{steps: steps}
+}
+
+
+func (c *configuredGenerate) Validate(ctx context.Context, _ []string) (warnings []string, path string, err error) {
+	for _, step := range c.steps {
+		w, p, e := step.g.Validate(ctx, step.verbs)
+		if e != nil {
+			return nil, p, e
+		}
+		warnings = append(warnings, w...)
+	}
+	return warnings, "", nil
+}

--- a/pkg/policy/generate/validate_test.go
+++ b/pkg/policy/generate/validate_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 
 	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/logging"
+	"github.com/kyverno/kyverno/pkg/policy/auth/fake"
 	"gotest.tools/v3/assert"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 )
 
 func Test_Validate_Generate_HasAnchors(t *testing.T) {
@@ -56,4 +59,173 @@ func Test_Validate_Generate_HasAnchors(t *testing.T) {
 	if _, _, err := checker.Validate(context.TODO(), nil); err != nil {
 		assert.Assert(t, err != nil)
 	}
+}
+
+
+// Test_NewGenerateValidator_OfflineMode verifies that offline (mock) mode succeeds
+// for a valid generate rule without any cluster access, and that it uses fake auth.
+func Test_NewGenerateValidator_OfflineMode(t *testing.T) {
+	rule := &kyverno.Rule{
+		Name: "test-offline",
+		Generation: &kyverno.Generation{
+			GeneratePattern: kyverno.GeneratePattern{
+				ResourceSpec: kyverno.ResourceSpec{
+					Kind: "ConfigMap",
+					Name: "test-cm",
+				},
+			},
+		},
+	}
+
+	v := NewGenerateValidator(GenerateConfig{
+		Rule:         rule,
+		Client:       nil,
+		Mock:         true,
+		Logger:       logging.GlobalLogger(),
+		BackgroundSA: "system:serviceaccount:kyverno:kyverno-background-controller",
+		AdmissionSA:  "system:serviceaccount:kyverno:kyverno",
+		ReportsSA:    "",
+	})
+
+	assert.Equal(t, 1, len(v.steps))
+	_, isFake := v.steps[0].g.authChecker.(*fake.FakeAuth)
+	assert.Assert(t, isFake, "offline mode must use fake auth checker")
+
+	warnings, _, err := v.Validate(context.TODO(), nil)
+	assert.NilError(t, err)
+	assert.Equal(t, 0, len(warnings))
+}
+
+// Test_NewGenerateValidator_OfflineStructuralError verifies that offline mode still
+// surfaces structural errors (e.g. CELPreconditions on a generate rule).
+func Test_NewGenerateValidator_OfflineStructuralError(t *testing.T) {
+	rule := &kyverno.Rule{
+		Name: "test-offline-structural",
+		CELPreconditions: []admissionregistrationv1.MatchCondition{
+			{Name: "check", Expression: "true"},
+		},
+		Generation: &kyverno.Generation{
+			GeneratePattern: kyverno.GeneratePattern{
+				ResourceSpec: kyverno.ResourceSpec{Kind: "ConfigMap"},
+			},
+		},
+	}
+
+	v := NewGenerateValidator(GenerateConfig{
+		Rule:   rule,
+		Mock:   true,
+		Logger: logging.GlobalLogger(),
+	})
+
+	_, _, err := v.Validate(context.TODO(), nil)
+	assert.ErrorContains(t, err, "celPrecondition can only be used with validate.cel")
+}
+
+// Test_NewGenerateValidator_OnlineSynchronize_StepCount verifies that an online
+// synchronize rule produces two steps: admission-SA first, then background-SA.
+func Test_NewGenerateValidator_OnlineSynchronize_StepCount(t *testing.T) {
+	rule := &kyverno.Rule{
+		Name: "test-sync",
+		Generation: &kyverno.Generation{
+			GeneratePattern: kyverno.GeneratePattern{
+				ResourceSpec: kyverno.ResourceSpec{Kind: "ConfigMap"},
+			},
+			Synchronize: true,
+		},
+	}
+
+	v := NewGenerateValidator(GenerateConfig{
+		Rule:         rule,
+		Client:       nil, // not called at construction time
+		Mock:         false,
+		Logger:       logging.GlobalLogger(),
+		BackgroundSA: "system:serviceaccount:kyverno:kyverno-background-controller",
+		AdmissionSA:  "system:serviceaccount:kyverno:kyverno",
+		ReportsSA:    "",
+	})
+
+	assert.Equal(t, 2, len(v.steps))
+	assert.DeepEqual(t, []string{"list", "get"}, v.steps[0].verbs)
+	assert.Assert(t, v.steps[1].verbs == nil, "background step should have nil verbs")
+}
+
+// Test_NewGenerateValidator_OnlineNonSynchronize_StepCount verifies that a non-synchronize
+// online rule produces exactly one background-SA step.
+func Test_NewGenerateValidator_OnlineNonSynchronize_StepCount(t *testing.T) {
+	rule := &kyverno.Rule{
+		Name: "test-nosync",
+		Generation: &kyverno.Generation{
+			GeneratePattern: kyverno.GeneratePattern{
+				ResourceSpec: kyverno.ResourceSpec{Kind: "ConfigMap"},
+			},
+			Synchronize: false,
+		},
+	}
+
+	v := NewGenerateValidator(GenerateConfig{
+		Rule:         rule,
+		Client:       nil,
+		Mock:         false,
+		Logger:       logging.GlobalLogger(),
+		BackgroundSA: "system:serviceaccount:kyverno:kyverno-background-controller",
+		AdmissionSA:  "system:serviceaccount:kyverno:kyverno",
+		ReportsSA:    "",
+	})
+
+	assert.Equal(t, 1, len(v.steps))
+	assert.Assert(t, v.steps[0].verbs == nil)
+}
+
+// Test_NewGenerateValidator_ReportsAuthPresent verifies that when ReportsSA is set in
+// online mode, the background step includes a non-nil reports auth checker.
+func Test_NewGenerateValidator_ReportsAuthPresent(t *testing.T) {
+	rule := &kyverno.Rule{
+		Name: "test-reports-present",
+		Generation: &kyverno.Generation{
+			GeneratePattern: kyverno.GeneratePattern{
+				ResourceSpec: kyverno.ResourceSpec{Kind: "ConfigMap"},
+			},
+		},
+	}
+
+	v := NewGenerateValidator(GenerateConfig{
+		Rule:         rule,
+		Client:       nil,
+		Mock:         false,
+		Logger:       logging.GlobalLogger(),
+		BackgroundSA: "system:serviceaccount:kyverno:kyverno-background-controller",
+		AdmissionSA:  "",
+		ReportsSA:    "system:serviceaccount:kyverno:kyverno-reports-controller",
+	})
+
+	assert.Equal(t, 1, len(v.steps))
+	assert.Assert(t, v.steps[0].g.authCheckerReports != nil,
+		"reports auth checker must be non-nil when ReportsSA is provided")
+}
+
+// Test_NewGenerateValidator_ReportsAuthAbsent verifies that when ReportsSA is empty in
+// online mode, the background step has a nil reports auth checker so no reports checks run.
+func Test_NewGenerateValidator_ReportsAuthAbsent(t *testing.T) {
+	rule := &kyverno.Rule{
+		Name: "test-reports-absent",
+		Generation: &kyverno.Generation{
+			GeneratePattern: kyverno.GeneratePattern{
+				ResourceSpec: kyverno.ResourceSpec{Kind: "ConfigMap"},
+			},
+		},
+	}
+
+	v := NewGenerateValidator(GenerateConfig{
+		Rule:         rule,
+		Client:       nil,
+		Mock:         false,
+		Logger:       logging.GlobalLogger(),
+		BackgroundSA: "system:serviceaccount:kyverno:kyverno-background-controller",
+		AdmissionSA:  "",
+		ReportsSA:    "",
+	})
+
+	assert.Equal(t, 1, len(v.steps))
+	assert.Assert(t, v.steps[0].g.authCheckerReports == nil,
+		"reports auth checker must be nil when ReportsSA is empty")
 }

--- a/pkg/validation/policy/actions.go
+++ b/pkg/validation/policy/actions.go
@@ -68,32 +68,20 @@ func validateActions(idx int, rule *kyvernov1.Rule, client dclient.Interface, mo
 
 	// Generate
 	if rule.HasGenerate() {
-		// TODO: this check is there to support offline validations
-		// generate uses selfSubjectReviews to verify actions
-		// this need to modified to use different implementation for online and offline mode
-		if mock {
-			checker = generate.NewFakeGenerate(*rule.Generation)
-			if w, path, err := checker.Validate(context.TODO(), nil); err != nil {
-				return nil, fmt.Errorf("path: spec.rules[%d].generate.%s.: %v", idx, path, err)
-			} else if w != nil {
-				warnings = append(warnings, w...)
-			}
-		} else {
-			if rule.Generation.Synchronize {
-				admissionSA := fmt.Sprintf("system:serviceaccount:%s:%s", config.KyvernoNamespace(), config.KyvernoServiceAccountName())
-				checker = generate.NewGenerateFactory(client, rule, admissionSA, reportsSA, logging.GlobalLogger())
-				if w, path, err := checker.Validate(context.TODO(), []string{"list", "get"}); err != nil {
-					return nil, fmt.Errorf("path: spec.rules[%d].generate.%s.: %v", idx, path, err)
-				} else if w != nil {
-					warnings = append(warnings, w...)
-				}
-			}
-			checker = generate.NewGenerateFactory(client, rule, backgroundSA, reportsSA, logging.GlobalLogger())
-			if w, path, err := checker.Validate(context.TODO(), nil); err != nil {
-				return nil, fmt.Errorf("path: spec.rules[%d].generate.%s.: %v", idx, path, err)
-			} else if w != nil {
-				warnings = append(warnings, w...)
-			}
+		admissionSA := fmt.Sprintf("system:serviceaccount:%s:%s", config.KyvernoNamespace(), config.KyvernoServiceAccountName())
+		checker = generate.NewGenerateValidator(generate.GenerateConfig{
+			Rule:         rule,
+			Client:       client,
+			Mock:         mock,
+			Logger:       logging.GlobalLogger(),
+			BackgroundSA: backgroundSA,
+			AdmissionSA:  admissionSA,
+			ReportsSA:    reportsSA,
+		})
+		if w, path, err := checker.Validate(context.TODO(), nil); err != nil {
+			return nil, fmt.Errorf("path: spec.rules[%d].generate.%s.: %v", idx, path, err)
+		} else if w != nil {
+			warnings = append(warnings, w...)
 		}
 
 		if slices.Contains(rule.MatchResources.Kinds, rule.Generation.Kind) {

--- a/pkg/validation/policy/actions_test.go
+++ b/pkg/validation/policy/actions_test.go
@@ -5,6 +5,7 @@ import (
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/stretchr/testify/assert"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 )
 
 func Test_validateActions_NilRule(t *testing.T) {
@@ -57,4 +58,49 @@ func Test_validateActions_GenerateMockSuccess(t *testing.T) {
 	warnings, err := validateActions(0, rule, nil, true, "", "")
 	assert.NoError(t, err)
 	assert.Empty(t, warnings)
+}
+
+// Test_validateActions_GenerateOfflineSynchronize verifies that offline (mock) mode
+// succeeds for a synchronize generate rule without any Kubernetes cluster access.
+func Test_validateActions_GenerateOfflineSynchronize(t *testing.T) {
+	rule := &kyvernov1.Rule{
+		Name: "test-rule",
+		Generation: &kyvernov1.Generation{
+			GeneratePattern: kyvernov1.GeneratePattern{
+				ResourceSpec: kyvernov1.ResourceSpec{
+					Kind: "NetworkPolicy",
+					Name: "default-netpol",
+				},
+			},
+			Synchronize: true,
+		},
+	}
+
+	warnings, err := validateActions(0, rule, nil, true, "", "")
+	assert.NoError(t, err)
+	assert.Empty(t, warnings)
+}
+
+// Test_validateActions_GenerateOfflineStructuralError verifies that offline mode still
+// rejects structurally invalid generate rules (e.g. CELPreconditions mixed with generate).
+func Test_validateActions_GenerateOfflineStructuralError(t *testing.T) {
+	rule := &kyvernov1.Rule{
+		Name: "test-rule",
+		CELPreconditions: []admissionregistrationv1.MatchCondition{
+			{Name: "check", Expression: "true"},
+		},
+		Generation: &kyvernov1.Generation{
+			GeneratePattern: kyvernov1.GeneratePattern{
+				ResourceSpec: kyvernov1.ResourceSpec{
+					Kind: "ConfigMap",
+					Name: "test-cm",
+				},
+			},
+		},
+	}
+
+	warnings, err := validateActions(0, rule, nil, true, "", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "celPrecondition can only be used with validate.cel")
+	assert.Nil(t, warnings)
 }


### PR DESCRIPTION
## Explanation

The Generate-rule validation in `pkg/validation/policy/actions.go` had an inline `if mock { ... } else { ... }` branch to paper over the fact that the offline CLI path cannot call `SelfSubjectAccessReview` to verify permissions. The workaround was kept in `actions.go` rather than inside the Generate validation package where it belongs.

## Related issue

## Milestone of this PR

## Documentation (required for features)

## What type of PR is this

> /kind cleanup

## Proposed Changes

The refactor now pulls all of that out into a new type in the `generate` package. You now create a `GenerateConfig` struct (rule, client, mock flag, service account names, logger) and pass it to `NewGenerateValidator`, which returns a `configuredGenerate` — a list of ordered steps, each pairing a Generate validator with the verbs it should check. Calling `.Validate()` on it runs those steps in sequence.

actions.go replaces the  `if mock { ... } else { ... }` block call. The same-kind loop check is unchanged.

The test files `pkg/policy/generate/validate_test.go`, `pkg/validation/policy/actions_test.go` pin down the contract of this new constructor: that offline mode uses fake auth and never touches the API, that structural rule errors (like celPreconditions on a generate rule) are still caught in offline mode.

### Proof Manifests

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments
