### PR TITLE
fix(gpol): mark UpdateRequest as Failed when engine evaluation returns an error result

### DIFF
--- a/pkg/background/gpol/generate_controller.go
+++ b/pkg/background/gpol/generate_controller.go
@@ -164,6 +164,13 @@ func (c *CELGenerateController) ProcessUR(ur *kyvernov2.UpdateRequest) error {
 			engineResponse = engineResponse.WithPolicy(engineapi.NewGeneratingPolicyFromLike(res.Policy))
 			if res.Result.Status() == engineapi.RuleStatusSkip {
 				c.eventGen.Add(event.NewPolicyExceptionEvents(engineResponse, *res.Result, event.GeneratePolicyController)...)
+			} else if res.Result.Status() == engineapi.RuleStatusError || res.Result.Status() == engineapi.RuleStatusFail {
+				// surface evaluation/generation errors instead of silently
+				// reporting the UR as Completed, so users can diagnose why no
+				// resources were generated (https://github.com/kyverno/kyverno/issues/16983)
+				err := fmt.Errorf("gpol %s failed for trigger %s: %s", ur.Spec.GetPolicyKey(), ur.Spec.RuleContext[i].Trigger.String(), res.Result.Message())
+				logger.Error(err, "failed to generate resources for gpol", "gpol", ur.Spec.GetPolicyKey())
+				failures = append(failures, err)
 			} else {
 				resourcesToSync := res.Result.GeneratedResources()
 				for _, resource := range resourcesToSync {

--- a/pkg/background/gpol/generate_controller.go
+++ b/pkg/background/gpol/generate_controller.go
@@ -168,8 +168,8 @@ func (c *CELGenerateController) ProcessUR(ur *kyvernov2.UpdateRequest) error {
 				// surface evaluation/generation errors instead of silently
 				// reporting the UR as Completed, so users can diagnose why no
 				// resources were generated (https://github.com/kyverno/kyverno/issues/16983)
-				err := fmt.Errorf("gpol %s failed for trigger %s: %s", ur.Spec.GetPolicyKey(), ur.Spec.RuleContext[i].Trigger.String(), res.Result.Message())
-				logger.Error(err, "failed to generate resources for gpol", "gpol", ur.Spec.GetPolicyKey())
+				err := fmt.Errorf("gpol %s rule %s %s for trigger %s: %s", ur.Spec.GetPolicyKey(), res.Result.Name(), res.Result.Status(), ur.Spec.RuleContext[i].Trigger.String(), res.Result.Message())
+				logger.Error(err, "failed to generate resources for gpol", "gpol", ur.Spec.GetPolicyKey(), "rule", res.Result.Name(), "status", res.Result.Status())
 				failures = append(failures, err)
 			} else {
 				resourcesToSync := res.Result.GeneratedResources()

--- a/pkg/background/gpol/generate_controller_test.go
+++ b/pkg/background/gpol/generate_controller_test.go
@@ -16,6 +16,7 @@ import (
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/event"
 	"github.com/kyverno/kyverno/pkg/logging"
+	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -84,6 +85,39 @@ func (testStatusControl) Skip(string, []kyvernov1.ResourceSpec) (*kyvernov2.Upda
 type testEventGen struct{}
 
 func (testEventGen) Add(...event.Info) {}
+
+type errorEngine struct{}
+
+func (e *errorEngine) Handle(_ celengine.EngineRequest, p gpolengine.Policy, _ bool) (gpolengine.EngineResponse, error) {
+	return gpolengine.EngineResponse{
+		Trigger: &unstructured.Unstructured{},
+		Policies: []gpolengine.GeneratingPolicyResponse{{
+			Policy: p.Policy,
+			Result: engineapi.RuleError("rule", engineapi.Generation, "failed to evaluate policy", assert.AnError, nil),
+		}},
+	}, nil
+}
+
+type recordingStatusControl struct {
+	failed  bool
+	success bool
+	message string
+}
+
+func (r *recordingStatusControl) Failed(_ string, message string, _ []kyvernov1.ResourceSpec) (*kyvernov2.UpdateRequest, error) {
+	r.failed = true
+	r.message = message
+	return nil, nil
+}
+
+func (r *recordingStatusControl) Success(string, []kyvernov1.ResourceSpec) (*kyvernov2.UpdateRequest, error) {
+	r.success = true
+	return nil, nil
+}
+
+func (r *recordingStatusControl) Skip(string, []kyvernov1.ResourceSpec) (*kyvernov2.UpdateRequest, error) {
+	return nil, nil
+}
 
 type triggerClient struct {
 	*MockClient
@@ -256,4 +290,55 @@ func TestProcessUR_ConcurrentCacheRestoreAndGenerateExistingDoesNotDeleteDownstr
 	defer wm.lock.Unlock()
 	assert.Len(t, client.deleted, 0)
 	assert.Contains(t, wm.dynamicWatchers[configMapGVR].metadataCache, downstream.GetUID())
+}
+
+// Regression test for kyverno/kyverno#16983: when the engine evaluation
+// returns an error result (e.g. a CEL evaluation error or a failure while
+// creating the downstream resource), ProcessUR must mark the UpdateRequest
+// as Failed with the error message instead of silently reporting it as
+// Completed with nothing generated.
+func TestProcessUR_ErrorResultMarksURFailed(t *testing.T) {
+	policyName := "test-gpol"
+	trigger := makeUnstructured("", "", "v1", "ConfigMap", "trigger-cm", "tenant-a", "trigger-uid", nil)
+	// needsReports dereferences the global reporting configuration
+	reportutils.NewReportingConfig(nil)
+	statusControl := &recordingStatusControl{}
+	controller := &CELGenerateController{
+		client: &triggerClient{
+			MockClient: &MockClient{},
+			trigger:    trigger,
+		},
+		restMapper: &mockRESTMapper{fn: func(gk schema.GroupKind, version string) (*meta.RESTMapping, error) {
+			return &meta.RESTMapping{Resource: schema.GroupVersionResource{Group: gk.Group, Version: version, Resource: "configmaps"}}, nil
+		}},
+		context:       libs.NewFakeContextProvider(),
+		engine:        &errorEngine{},
+		provider:      &testProvider{policy: gpolengine.Policy{Policy: &policiesv1beta1.GeneratingPolicy{ObjectMeta: metav1.ObjectMeta{Name: policyName}}}},
+		watchManager:  &WatchManager{},
+		statusControl: statusControl,
+		eventGen:      testEventGen{},
+		log:           logging.WithName("test-gpol-controller"),
+	}
+
+	ur := &kyvernov2.UpdateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "ur-error-result"},
+		Spec: kyvernov2.UpdateRequestSpec{
+			Type:   kyvernov2.CELGenerate,
+			Policy: policyName,
+			RuleContext: []kyvernov2.RuleContext{{
+				Rule: "rule",
+				Trigger: kyvernov1.ResourceSpec{
+					APIVersion: trigger.GetAPIVersion(),
+					Kind:       trigger.GetKind(),
+					Namespace:  trigger.GetNamespace(),
+					Name:       trigger.GetName(),
+				},
+			}},
+		},
+	}
+
+	require.NoError(t, controller.ProcessUR(ur))
+	assert.True(t, statusControl.failed, "UR should be marked as Failed")
+	assert.False(t, statusControl.success, "UR should not be marked as Completed")
+	assert.Contains(t, statusControl.message, "failed to evaluate policy")
 }

--- a/pkg/background/gpol/generate_controller_test.go
+++ b/pkg/background/gpol/generate_controller_test.go
@@ -300,8 +300,12 @@ func TestProcessUR_ConcurrentCacheRestoreAndGenerateExistingDoesNotDeleteDownstr
 func TestProcessUR_ErrorResultMarksURFailed(t *testing.T) {
 	policyName := "test-gpol"
 	trigger := makeUnstructured("", "", "v1", "ConfigMap", "trigger-cm", "tenant-a", "trigger-uid", nil)
-	// needsReports dereferences the global reporting configuration
-	reportutils.NewReportingConfig(nil)
+	// needsReports dereferences the global reporting configuration; set it
+	// explicitly for this test and restore the previous value afterwards to
+	// avoid order-dependent behavior across tests in this package.
+	prevReportingCfg := reportutils.ReportingCfg
+	reportutils.ReportingCfg = reportutils.NewReportingConfig(nil)
+	t.Cleanup(func() { reportutils.ReportingCfg = prevReportingCfg })
 	statusControl := &recordingStatusControl{}
 	controller := &CELGenerateController{
 		client: &triggerClient{


### PR DESCRIPTION
## Explanation

Related to #16983.

While verifying #16983 on `release-1.19` (and `v1.19.0-rc.1`), the reported scenario itself — `generateExisting` for pre-existing matched namespaces — worked correctly in a clean KinD cluster: URs were created and the downstream RoleBindings were generated in all matched namespaces, including after a background-controller restart.

However, the investigation surfaced a real defect that exactly matches the reporter's symptom (`UR state: Completed`, all triggers listed, nothing generated, nothing in the logs):

`ProcessUR` only treats errors returned by `engine.Handle` itself as failures. When the evaluation fails **inside** the engine — a CEL evaluation error, or a failure creating/updating the downstream resource (e.g. RBAC denial, admission rejection) — the error is wrapped into a `RuleStatusError` rule response by `engineImpl.generate`, which `ProcessUR` silently ignores: nothing is logged, the error is not appended to `failures`, and `updateURStatus` reports the UR as **Completed** with no resources generated. Users are left with no way to diagnose why generation did not happen.

Reproduced by making the generated resource invalid (empty `roleRef.name`): nothing is generated, the UR completes successfully, and no error is logged.

## Changes

- Treat `RuleStatusError` (and `RuleStatusFail`) rule results in `ProcessUR` as failures: log the rule message and propagate it to the UpdateRequest status so the UR is marked `Failed` with the underlying error.
- Add `TestProcessUR_ErrorResultMarksURFailed` regression test (fails on `main` without the fix: the UR is marked Completed and the error message is empty).

## Proof

Without the fix:
```
--- FAIL: TestProcessUR_ErrorResultMarksURFailed
    Error: "" does not contain "failed to evaluate policy"
    (UR marked Completed, statusControl.failed == false)
```

With the fix:
```
=== RUN   TestProcessUR_ErrorResultMarksURFailed
--- PASS: TestProcessUR_ErrorResultMarksURFailed
ok  github.com/kyverno/kyverno/pkg/background/gpol
```

`go test -race ./pkg/background/gpol/...` passes; `golangci-lint run ./pkg/background/gpol/...` reports 0 issues.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective.
- [ ] My PR needs to be cherry-picked to release-1.19.