### PR TITLE
fix(mpol): fail UpdateRequest when background rules Error/Fail

### DIFF
--- a/pkg/background/mpol/processor.go
+++ b/pkg/background/mpol/processor.go
@@ -232,6 +232,24 @@ func (p *processor) Process(ur *kyvernov2.UpdateRequest) error {
 			failures = append(failures, fmt.Errorf("failed to evaluate mpol %s: %v", ur.Spec.GetPolicyKey(), err))
 			continue
 		}
+		// Surface evaluation Error/Fail the same way GeneratingPolicy background does
+		// (https://github.com/kyverno/kyverno/issues/16983 / #17061). Without this, a
+		// mutateExisting UR can report Completed when no patch was applied.
+		for _, pol := range response.Policies {
+			for _, rule := range pol.Rules {
+				if rule.Status() == engineapi.RuleStatusError || rule.Status() == engineapi.RuleStatusFail {
+					err := fmt.Errorf(
+						"mpol %s rule %s %s: %s",
+						ur.Spec.GetPolicyKey(),
+						rule.Name(),
+						rule.Status(),
+						rule.Message(),
+					)
+					logger.Error(err, "failed to evaluate mpol rule", "mpol", ur.Spec.GetPolicyKey(), "rule", rule.Name(), "status", rule.Status())
+					failures = append(failures, err)
+				}
+			}
+		}
 		if response.PatchedResource != nil {
 			// Skip no-op updates: policy events and periodic background scans re-evaluate
 			// targets that may already be in the desired state. Reports/events are still

--- a/pkg/background/mpol/processor_test.go
+++ b/pkg/background/mpol/processor_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned/fake"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/config"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/event"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
 	"github.com/stretchr/testify/assert"
@@ -170,6 +171,80 @@ func TestProcess_EngineEvaluateError(t *testing.T) {
 	err := p.Process(ur)
 
 	assert.NoError(t, err)
+}
+
+func TestProcess_RuleErrorStatusMarksURFailed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMapList"}, &unstructured.UnstructuredList{})
+	cm := &unstructured.Unstructured{}
+	cm.SetAPIVersion("v1")
+	cm.SetKind("ConfigMap")
+	cm.SetNamespace("default")
+	cm.SetName("target-cm")
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "configmaps"}: "ConfigMapList",
+	}
+	fakeClient, err := dclient.NewFakeClient(scheme, gvrToListKind, cm)
+	assert.NoError(t, err)
+	fakeClient.SetDiscovery(dclient.NewFakeDiscoveryClient(nil))
+
+	policy := &policiesv1beta1.MutatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "bgpol"},
+		Spec: policiesv1beta1.MutatingPolicySpec{
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+					RuleWithOperations: admissionregistrationv1alpha1.RuleWithOperations{
+						Rule: admissionregistrationv1alpha1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"configmaps"},
+						},
+					},
+				}},
+			},
+		},
+	}
+	kyvernoClient := fake.NewSimpleClientset(policy)
+
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "", Version: "v1"}})
+	restMapper.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}, meta.RESTScopeNamespace)
+
+	eng := &fakeEngine{}
+	eng.On("Evaluate").Return(mpolengine.EngineResponse{
+		Policies: []mpolengine.MutatingPolicyResponse{{
+			Policy: policy,
+			Rules: []engineapi.RuleResponse{
+				*engineapi.RuleError("evaluation", engineapi.Mutation, "failed to evaluate policy", errors.New("cel boom"), nil),
+			},
+		}},
+	}, nil)
+
+	sc := &fakeStatusControl{}
+	p := NewProcessor(
+		fakeClient,
+		kyvernoClient,
+		eng,
+		restMapper,
+		&libs.FakeContextProvider{},
+		sc,
+		event.NewFake(),
+		nil,
+	)
+
+	ur := &kyvernov2.UpdateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "ur-rule-error", Namespace: "default"},
+		Spec: kyvernov2.UpdateRequestSpec{
+			Policy: "bgpol",
+			Context: kyvernov2.UpdateRequestSpecContext{
+				AdmissionRequestInfo: kyvernov2.AdmissionRequestInfoObject{},
+			},
+		},
+	}
+
+	assert.NoError(t, p.Process(ur))
+	assert.True(t, sc.failedCalled, "UR should be marked Failed when rule status is Error")
+	assert.False(t, sc.successCalled, "UR should not be marked Completed when rule status is Error")
 }
 
 func TestProcess_FilteredTargetSkipsEngine(t *testing.T) {


### PR DESCRIPTION
## Explanation

Fixes #17062.

Sibling of #17061 for MutatingPolicy background processing.

`pkg/background/mpol/processor.go` only treated a top-level `Evaluate` error or a missing `PatchedResource` as failure. When CEL/match evaluation returned `RuleStatusError` or `RuleStatusFail` with no patch, the UpdateRequest was still marked Completed.

That is silent fail-open for mutateExisting: nothing is applied, but the UR reports success.

## Related issue

Closes #17062. Same class as #16983 / #17061 for GeneratingPolicy.

## Tip of what kind of change this is

🐛 Bug fix (non-breaking change which fixes an issue)

## Proposed Changes

After a successful `Evaluate` call, scan `response.Policies[].Rules` for Error/Fail status and append those to `failures` before `updateURStatus`, matching `pkg/background/gpol/generate_controller.go`.

### Proof Manifests

Unit test: `TestProcess_RuleErrorStatusMarksURFailed` (engine returns RuleError, no PatchedResource; status control must Failed, not Success).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/community/blob/main/CONTRIBUTING.md#submitting-pull-requests) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

Threat model: a mutateExisting policy meant to enforce a security shape can fail evaluation and still report Completed. This does not invent new admission behavior; it makes background status honest about Error/Fail the way gpol already does.


Made with [Cursor](https://cursor.com)