### PR TITLE
fix(webhook): do not offload namespaceObject match conditions to the API server

### DIFF
--- a/pkg/controllers/webhook/match_conditions.go
+++ b/pkg/controllers/webhook/match_conditions.go
@@ -1,0 +1,77 @@
+package webhook
+
+import (
+	"sync"
+
+	"github.com/google/cel-go/cel"
+	celast "github.com/google/cel-go/common/ast"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+)
+
+// namespaceObjectVarName is declared by the API server CEL environment used to
+// compile webhook match conditions, but it is only populated for
+// ValidatingAdmissionPolicy/MutatingAdmissionPolicy. For webhook match
+// conditions the API server always binds it to null (see
+// k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions), so any field
+// access on it fails at evaluation time (e.g. "no such key: metadata").
+const namespaceObjectVarName = "namespaceObject"
+
+// webhookMatchConditions filters out match conditions that cannot be offloaded
+// to the API server because they reference variables the API server never
+// populates for webhook match conditions (namespaceObject). Offloaded match
+// conditions are only a pre-filter: the Kyverno engine always re-evaluates the
+// full set of match conditions with the resolved namespace, so dropping a
+// condition here only means the corresponding requests are forwarded to Kyverno
+// instead of being filtered by the API server.
+func webhookMatchConditions(conditions []admissionregistrationv1.MatchCondition) []admissionregistrationv1.MatchCondition {
+	var result []admissionregistrationv1.MatchCondition
+	for _, condition := range conditions {
+		if referencesNamespaceObject(condition.Expression) {
+			continue
+		}
+		result = append(result, condition)
+	}
+	return result
+}
+
+// matchConditionParseEnv is a parse-only CEL environment: expressions are not
+// type-checked, so no variable declarations are needed, but parsing must
+// support the syntax accepted for match conditions (e.g. optional field
+// selection).
+var (
+	matchConditionParseEnv     *cel.Env
+	errMatchConditionParseEnv  error
+	matchConditionParseEnvOnce sync.Once
+)
+
+func getMatchConditionParseEnv() (*cel.Env, error) {
+	matchConditionParseEnvOnce.Do(func() {
+		matchConditionParseEnv, errMatchConditionParseEnv = cel.NewEnv(cel.OptionalTypes())
+	})
+	return matchConditionParseEnv, errMatchConditionParseEnv
+}
+
+// referencesNamespaceObject reports whether the given CEL expression references
+// the namespaceObject variable. If the expression cannot be parsed, it is
+// conservatively treated as referencing it so evaluation stays on the Kyverno
+// side.
+func referencesNamespaceObject(expression string) bool {
+	env, err := getMatchConditionParseEnv()
+	if err != nil {
+		return true
+	}
+	parsed, iss := env.Parse(expression)
+	if iss != nil && iss.Err() != nil {
+		return true
+	}
+	found := false
+	celast.PreOrderVisit(parsed.NativeRep().Expr(), celast.NewExprVisitor(func(node celast.Expr) {
+		if found || node == nil {
+			return
+		}
+		if node.Kind() == celast.IdentKind && node.AsIdent() == namespaceObjectVarName {
+			found = true
+		}
+	}))
+	return found
+}

--- a/pkg/controllers/webhook/match_conditions_test.go
+++ b/pkg/controllers/webhook/match_conditions_test.go
@@ -1,0 +1,159 @@
+package webhook
+
+import (
+	"testing"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/kyverno/kyverno/pkg/config"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/stretchr/testify/assert"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestReferencesNamespaceObject(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		expression string
+		want       bool
+	}{
+		{
+			name:       "field access",
+			expression: "'some-label' in namespaceObject.metadata.labels",
+			want:       true,
+		},
+		{
+			name:       "has macro",
+			expression: "has(namespaceObject.metadata.annotations)",
+			want:       true,
+		},
+		{
+			name:       "nested in logical expression",
+			expression: "request.operation == 'CREATE' && namespaceObject.metadata.name != 'default'",
+			want:       true,
+		},
+		{
+			name:       "no reference",
+			expression: "!(request.resource.group == 'coordination.k8s.io' && request.resource.resource == 'leases')",
+			want:       false,
+		},
+		{
+			name:       "similar identifier is not a match",
+			expression: "object.metadata.name != 'namespaceObject'",
+			want:       false,
+		},
+		{
+			name:       "optional field selection syntax without reference",
+			expression: `object.metadata.?labels["opt-in"].orValue("") == "true"`,
+			want:       false,
+		},
+		{
+			name:       "optional field selection syntax with reference",
+			expression: `namespaceObject.metadata.?labels["opt-in"].orValue("") == "true"`,
+			want:       true,
+		},
+		{
+			name:       "unparsable expression is conservatively kept on the Kyverno side",
+			expression: "namespaceObject.metadata.",
+			want:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, referencesNamespaceObject(tt.expression))
+		})
+	}
+}
+
+func TestWebhookMatchConditions(t *testing.T) {
+	t.Parallel()
+	conditions := []admissionregistrationv1.MatchCondition{
+		{Name: "safe", Expression: "request.operation == 'CREATE'"},
+		{Name: "ns-label", Expression: "'some-label' in namespaceObject.metadata.labels"},
+		{Name: "also-safe", Expression: "object.metadata.name != 'skip-me'"},
+	}
+	filtered := webhookMatchConditions(conditions)
+	assert.Equal(t, []admissionregistrationv1.MatchCondition{
+		{Name: "safe", Expression: "request.operation == 'CREATE'"},
+		{Name: "also-safe", Expression: "object.metadata.name != 'skip-me'"},
+	}, filtered)
+
+	assert.Nil(t, webhookMatchConditions(nil))
+	assert.Nil(t, webhookMatchConditions([]admissionregistrationv1.MatchCondition{
+		{Name: "ns-label", Expression: "namespaceObject.metadata.name == 'prod'"},
+	}))
+}
+
+func TestBuildWebhookRules_NamespaceObjectMatchConditionsNotOffloaded(t *testing.T) {
+	matchConstraints := &admissionregistrationv1.MatchResources{
+		ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+			{
+				RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{"apps"},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"deployments"},
+					},
+				},
+			},
+		},
+	}
+	tests := []struct {
+		name                    string
+		matchConditions         []admissionregistrationv1.MatchCondition
+		expectedMatchConditions []admissionregistrationv1.MatchCondition
+	}{
+		{
+			name: "namespaceObject condition is kept out of the webhook configuration",
+			matchConditions: []admissionregistrationv1.MatchCondition{
+				{Name: "ns-has-label", Expression: "'some-label' in namespaceObject.metadata.labels"},
+			},
+			expectedMatchConditions: nil,
+		},
+		{
+			name: "only webhook-safe conditions are offloaded",
+			matchConditions: []admissionregistrationv1.MatchCondition{
+				{Name: "ns-has-label", Expression: "'some-label' in namespaceObject.metadata.labels"},
+				{Name: "exclude-leases", Expression: "!(request.resource.group == 'coordination.k8s.io' && request.resource.resource == 'leases')"},
+			},
+			expectedMatchConditions: []admissionregistrationv1.MatchCondition{
+				{Name: "exclude-leases", Expression: "!(request.resource.group == 'coordination.k8s.io' && request.resource.resource == 'leases')"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vpol := &policiesv1beta1.ValidatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "check-ns-label",
+				},
+				Spec: policiesv1beta1.ValidatingPolicySpec{
+					FailurePolicy:    ptr.To(admissionregistrationv1.Fail),
+					MatchConstraints: matchConstraints,
+					MatchConditions:  tt.matchConditions,
+				},
+			}
+			expressionCache := NewExpressionCache()
+			expressionCache.AddPolicyExpressions(vpol.GetMatchConditions())
+			webhooks := buildWebhookRules(
+				config.NewDefaultConfiguration(false),
+				"",
+				config.ValidatingPolicyWebhookName,
+				"/vpol",
+				0,
+				nil,
+				[]engineapi.GenericPolicy{engineapi.NewValidatingPolicy(vpol)},
+				expressionCache,
+			)
+			// the policy must stay fine-grained: it keeps its own webhook, only the
+			// namespaceObject match conditions are left to the Kyverno engine
+			assert.Len(t, webhooks, 1)
+			assert.Equal(t, config.ValidatingPolicyWebhookName+"-fail-finegrained-check-ns-label", webhooks[0].Name)
+			assert.Equal(t, tt.expectedMatchConditions, webhooks[0].MatchConditions)
+		})
+	}
+}

--- a/pkg/controllers/webhook/validating.go
+++ b/pkg/controllers/webhook/validating.go
@@ -54,7 +54,7 @@ func buildWebhookRules(cfg config.Configuration, server, name, queryPath string,
 				SideEffects:             &noneOnDryRun,
 				AdmissionReviewVersions: []string{"v1"},
 			}
-			matchConditions := validConditions(expressionCache, p.GetMatchConditions())
+			matchConditions := webhookMatchConditions(validConditions(expressionCache, p.GetMatchConditions()))
 			if spec := generatingPolicySpec(policy); spec != nil && spec.SynchronizationEnabled() {
 				// For synchronize-enabled generating policies, match conditions must only
 				// filter CREATE requests at the API server. UPDATE and DELETE requests
@@ -106,7 +106,7 @@ func buildWebhookRules(cfg config.Configuration, server, name, queryPath string,
 					policy := policies[config]
 					webhook.MatchConditions = append(
 						webhook.MatchConditions,
-						autogen.CreateMatchConditions(config, policy.Targets, validConditions(expressionCache, policy.Spec.MatchConditions))...,
+						autogen.CreateMatchConditions(config, policy.Targets, webhookMatchConditions(validConditions(expressionCache, policy.Spec.MatchConditions)))...,
 					)
 					for _, match := range policy.Spec.MatchConstraints.ResourceRules {
 						webhook.Rules = append(webhook.Rules, match.RuleWithOperations)
@@ -122,7 +122,7 @@ func buildWebhookRules(cfg config.Configuration, server, name, queryPath string,
 					policy := policies[config]
 					webhook.MatchConditions = append(
 						webhook.MatchConditions,
-						autogen.CreateMatchConditions(config, policy.Targets, validConditions(expressionCache, policy.Spec.MatchConditions))...,
+						autogen.CreateMatchConditions(config, policy.Targets, webhookMatchConditions(validConditions(expressionCache, policy.Spec.MatchConditions)))...,
 					)
 					for _, match := range policy.Spec.MatchConstraints.ResourceRules {
 						webhook.Rules = append(webhook.Rules, match.RuleWithOperations)
@@ -140,7 +140,7 @@ func buildWebhookRules(cfg config.Configuration, server, name, queryPath string,
 					autogenPolicy := policies[config]
 					webhook.MatchConditions = append(
 						webhook.MatchConditions,
-						autogen.CreateMatchConditions(config, autogenPolicy.Targets, validConditions(expressionCache, autogenPolicy.Spec.MatchConditions))...,
+						autogen.CreateMatchConditions(config, autogenPolicy.Targets, webhookMatchConditions(validConditions(expressionCache, autogenPolicy.Spec.MatchConditions)))...,
 					)
 					for _, match := range autogenPolicy.Spec.MatchConstraints.ResourceRules {
 						webhook.Rules = append(webhook.Rules, match.RuleWithOperations)


### PR DESCRIPTION
## Explanation

Fixes #17018

CEL policies (ValidatingPolicy, ImageValidatingPolicy, MutatingPolicy, GeneratingPolicy) with `matchConditions` are classified as *fine-grained* and their match conditions are copied verbatim into the generated webhook configuration, where the **API server** evaluates them before calling Kyverno.

The API server *declares* `namespaceObject` in the CEL environment used to compile webhook match conditions (shared with ValidatingAdmissionPolicy), so such expressions compile cleanly on both sides. However, it **never populates** the variable for webhooks — the webhook match conditions matcher hardcodes `namespace = nil` ([apiserver `webhook/matchconditions/matcher.go`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions/matcher.go)); it is only bound for ValidatingAdmissionPolicy/MutatingAdmissionPolicy. `namespaceObject` is therefore always CEL `null` and any field access fails at evaluation time:

```
error: failed to create deployment: deployments.apps "nginx" is forbidden:
expression ''some-label' in namespaceObject.metadata.labels' resulted in error: no such key: metadata
```

With `failurePolicy: Fail` (the default) this rejects **every** matching request — even when the condition would be true — before it ever reaches Kyverno (hence no Kyverno logs). Background scans work because the Kyverno engine resolves the namespace itself, which is why the issue only manifests at admission time.

## Fix

When building fine-grained webhooks, keep match conditions that reference `namespaceObject` out of the webhook configuration and let the Kyverno engine evaluate them:

- Detection parses the expression with a parse-only CEL environment (optional types syntax enabled) and walks the AST for `namespaceObject` identifier references. Unparsable expressions are conservatively kept Kyverno-side.
- This is **safe**: offloaded match conditions are only a pre-filter — the engine always re-evaluates the full set of match conditions with the resolved namespace, so policy outcomes are unchanged; those requests are simply forwarded to Kyverno instead of being filtered by the API server.
- Policies **stay fine-grained**: they keep their per-policy webhook (rules, `timeoutSeconds`, `matchPolicy`, failure-policy grouping), and any remaining webhook-safe conditions are still offloaded.

## Proof

Reproduced the issue on `release-1.19`/`main` in KinD with the policy from #17018, then verified with this fix (same cluster, patched image):

```console
$ kubectl get validatingwebhookconfiguration -o json | jq '.items[].webhooks[] | select(.name | contains("finegrained")) | {name, matchConditions}'
{
  "name": "vpol.validate.kyverno.svc-fail-finegrained-check-ns-label",
  "matchConditions": null
}

# labeled namespace, compliant deployment
$ kubectl create deployment nginx --image=nginx -n labeled
deployment.apps/nginx created

# labeled namespace, violating deployment
$ kubectl create deployment forbidden --image=nginx -n labeled
error: failed to create deployment: admission webhook "vpol.validate.kyverno.svc-fail-finegrained-check-ns-label" denied the request: Policy check-ns-label failed: denied by policy

# unlabeled namespace, match condition evaluates to false -> policy skipped
$ kubectl create deployment forbidden --image=nginx -n unlabeled
deployment.apps/forbidden created
```

## Related issue

Closes #17018

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR needs to be cherry-picked to a stable release branch (release-1.19).
- [ ] My PR contains new or altered behavior to Kyverno and I have documented these changes in the [website repo](https://github.com/kyverno/website).