### PR TITLE
Fix ignored context in notary registry resolution

### DIFF
--- a/pkg/image/verifiers/cpol/notary/registry.go
+++ b/pkg/image/verifiers/cpol/notary/registry.go
@@ -44,7 +44,7 @@ func parseReferenceCrane(ctx context.Context, ref string, registryClient verifie
 	}
 
 	repository := newRepository(remoteOpts, nameRef)
-	err = resolveDigestCrane(repository, remoteOpts, nameRef)
+	err = resolveDigestCrane(ctx, repository, remoteOpts, nameRef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to resolve digest")
 	}
@@ -67,8 +67,8 @@ func isDigestReference(reference string) bool {
 	return index != -1
 }
 
-func resolveDigestCrane(repo notationregistry.Repository, remoteOpts []gcrremote.Option, ref name.Reference) error {
-	_, err := repo.Resolve(context.Background(), ref.Identifier())
+func resolveDigestCrane(ctx context.Context, repo notationregistry.Repository, remoteOpts []gcrremote.Option, ref name.Reference) error {
+	_, err := repo.Resolve(ctx, ref.Identifier())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Explanation

While reviewing the Notary image verification logic in `pkg/image/verifiers/cpol/notary/registry.go`, I noticed a subtle but dangerous context leak during OCI registry resolution.

The function `parseReferenceCrane` correctly accepts a cancellable `ctx context.Context` from the webhook/evaluator and passes it down for fetching registry options. However, when it calls the helper `resolveDigestCrane(repository, remoteOpts, nameRef)` to actually resolve the digest against the registry, the helper completely ignores the provided context and hardcodes `context.Background()`:

```go
func resolveDigestCrane(repo notationregistry.Repository, remoteOpts []gcrremote.Option, ref name.Reference) error {
	_, err := repo.Resolve(context.Background(), ref.Identifier())
// ...
```

This causes the OCI network request to become entirely un-cancellable. If the registry hangs or is slow, the webhook context timeout will be ignored, leading to resource exhaustion, hanging admission webhooks, and potentially blocking API server requests.

This PR fixes the issue by passing the `ctx` from `parseReferenceCrane` directly into `resolveDigestCrane` so that the `repo.Resolve` call correctly respects the admission webhook timeouts and cancellations.

## Related issue

Fixes #17077 

## Milestone of this PR

/milestone TBD

## What type of PR is this

/kind bug

## Proposed Changes

- Pass `ctx context.Context` to `resolveDigestCrane`.
- Use `ctx` instead of `context.Background()` when calling `repo.Resolve()`.

### Proof Manifests

Not applicable.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This is an XS fix that ensures image verification correctly handles context cancellations and timeouts when communicating with external OCI registries.
