### PR TITLE
fix: handle semver parsing errors

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -1018,7 +1018,10 @@ func jpSemverCompare(arguments []any) (any, error) {
 		return nil, err
 	}
 
-	version, _ := semver.Parse(v.String())
+	version, err := semver.Parse(v.String())
+	if err != nil {
+		return nil, err
+	}
 	expectedRange, err := semver.ParseRange(r.String())
 	if err != nil {
 		return nil, err

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -867,6 +867,22 @@ func Test_SemverCompare(t *testing.T) {
 	}
 }
 
+func Test_SemverCompare_Invalid(t *testing.T) {
+	errorCases := []string{
+		"semver_compare('invalid-version', '>=0.0.0')",
+		"semver_compare('invalid-version', '==0.0.0')",
+	}
+	for _, tc := range errorCases {
+		t.Run(tc, func(t *testing.T) {
+			jp, err := jmespathInterface.Query(tc)
+			assert.NilError(t, err)
+
+			_, err = jp.Search("")
+			assert.ErrorContains(t, err, "No Major.Minor.Patch elements found")
+		})
+	}
+}
+
 func Test_Lookup(t *testing.T) {
 	testCases := []struct {
 		collection     string


### PR DESCRIPTION
## What

Fix error handling in the `semver_compare` JMESPath function.
The function previously ignored the error returned by `semver.Parse()` when parsing the supplied version. This change propagates the parsing error instead of continuing with the zero-value `semver.Version`.
A regression test has also been added to cover invalid semantic version inputs.

## Why

When an invalid or malformed version was provided, `semver.Parse()` returned both a zero-value version (`0.0.0`) and an error. The error was previously discarded, allowing the zero-value version to be used in the comparison.
This could produce incorrect policy evaluation results. For example, an invalid version could incorrectly satisfy a range such as `>=0.0.0` instead of returning an error.
With this change, invalid versions now return the parsing error, while valid semantic version comparisons continue to work as before.

## Testing

Added regression coverage for invalid version inputs:
- `semver_compare('invalid-version', '>=0.0.0')`
- `semver_compare('invalid-version', '==0.0.0')`

The tests verify that the expected parsing error is returned and that existing valid `semver_compare` behavior remains unchanged.

## Follow-up
Fixes #17089