### PR TITLE
fix(jmespath): correct function names in validation errors

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -812,14 +812,14 @@ func jpRegexMatch(arguments []any) (any, error) {
 }
 
 func jpPatternMatch(arguments []any) (any, error) {
-	pattern, err := validateArg(regexMatch, arguments, 0, reflect.String)
+	pattern, err := validateArg(patternMatch, arguments, 0, reflect.String)
 	if err != nil {
 		return nil, err
 	}
 
 	src, err := ifaceToString(arguments[1])
 	if err != nil {
-		return nil, formatError(invalidArgumentTypeError, regexMatch, 2, "String or Real")
+		return nil, formatError(invalidArgumentTypeError, patternMatch, 2, "String or Real")
 	}
 
 	return wildcard.Match(pattern.String(), src), nil
@@ -952,7 +952,7 @@ func jpRound(arguments []any) (any, error) {
 
 func jpBase64Decode(arguments []any) (any, error) {
 	var err error
-	str, err := validateArg("", arguments, 0, reflect.String)
+	str, err := validateArg(base64Decode, arguments, 0, reflect.String)
 	if err != nil {
 		return nil, err
 	}
@@ -967,7 +967,7 @@ func jpBase64Decode(arguments []any) (any, error) {
 
 func jpBase64Encode(arguments []any) (any, error) {
 	var err error
-	str, err := validateArg("", arguments, 0, reflect.String)
+	str, err := validateArg(base64Encode, arguments, 0, reflect.String)
 	if err != nil {
 		return nil, err
 	}
@@ -1275,7 +1275,7 @@ func jpImageNormalize(configuration config.Configuration) gojmespath.JpFunction 
 
 func jpIsExternalURL(arguments []any) (any, error) {
 	var err error
-	str, err := validateArg(pathCanonicalize, arguments, 0, reflect.String)
+	str, err := validateArg(isExternalURL, arguments, 0, reflect.String)
 	if err != nil {
 		return nil, err
 	}
@@ -1302,7 +1302,7 @@ func jpIsExternalURL(arguments []any) (any, error) {
 
 func jpSha256(arguments []any) (any, error) {
 	var err error
-	str, err := validateArg("", arguments, 0, reflect.String)
+	str, err := validateArg(SHA256, arguments, 0, reflect.String)
 	if err != nil {
 		return nil, err
 	}
@@ -1317,7 +1317,7 @@ func jpSha256(arguments []any) (any, error) {
 
 func jpSha1(arguments []any) (any, error) {
 	var err error
-	str, err := validateArg("", arguments, 0, reflect.String)
+	str, err := validateArg(SHA1, arguments, 0, reflect.String)
 	if err != nil {
 		return nil, err
 	}
@@ -1332,7 +1332,7 @@ func jpSha1(arguments []any) (any, error) {
 
 func jpMd5(arguments []any) (any, error) {
 	var err error
-	str, err := validateArg("", arguments, 0, reflect.String)
+	str, err := validateArg(MD5, arguments, 0, reflect.String)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/jmespath/functions_test.go
+++ b/pkg/engine/jmespath/functions_test.go
@@ -1790,3 +1790,38 @@ func Test_MD5(t *testing.T) {
 	assert.Assert(t, ok)
 	assert.Equal(t, str, "def42e1abd2462df1f9f0a4b3d488221")
 }
+
+func Test_CustomFunctions_ValidationErrors(t *testing.T) {
+	t.Run("is_external_url", func(t *testing.T) {
+		_, err := jpIsExternalURL([]any{123})
+		assert.ErrorContains(t, err, "JMESPath function 'is_external_url': argument #1 is not of type string")
+	})
+	t.Run("pattern_match arg 1", func(t *testing.T) {
+		_, err := jpPatternMatch([]any{123, "foo"})
+		assert.ErrorContains(t, err, "JMESPath function 'pattern_match': argument #1 is not of type string")
+	})
+	t.Run("pattern_match arg 2", func(t *testing.T) {
+		_, err := jpPatternMatch([]any{"foo", []any{}})
+		assert.ErrorContains(t, err, "JMESPath function 'pattern_match': argument #2 is not of type String or Real")
+	})
+	t.Run("base64_decode", func(t *testing.T) {
+		_, err := jpBase64Decode([]any{123})
+		assert.ErrorContains(t, err, "JMESPath function 'base64_decode': argument #1 is not of type string")
+	})
+	t.Run("base64_encode", func(t *testing.T) {
+		_, err := jpBase64Encode([]any{123})
+		assert.ErrorContains(t, err, "JMESPath function 'base64_encode': argument #1 is not of type string")
+	})
+	t.Run("sha256", func(t *testing.T) {
+		_, err := jpSha256([]any{123})
+		assert.ErrorContains(t, err, "JMESPath function 'sha256': argument #1 is not of type string")
+	})
+	t.Run("sha1", func(t *testing.T) {
+		_, err := jpSha1([]any{123})
+		assert.ErrorContains(t, err, "JMESPath function 'sha1': argument #1 is not of type string")
+	})
+	t.Run("md5", func(t *testing.T) {
+		_, err := jpMd5([]any{123})
+		assert.ErrorContains(t, err, "JMESPath function 'md5': argument #1 is not of type string")
+	})
+}


### PR DESCRIPTION
## What


This PR follows up on #17092,several custom JMESPath functions in `pkg/engine/jmespath/functions.go` use incorrect or empty function-name values when reporting argument validation errors.

For example, calling `is_external_url(123)` currently produces an error referring to `path_canonicalize`, even though `path_canonicalize` was not used. Similarly, `pattern_match` reports `regex_match`, while `base64_decode`, `base64_encode`, `sha256`, `sha1`, and `md5` can report an empty function name.

This PR corrects the function-name constants passed to `validateArg()` and `formatError()` so that validation errors consistently identify the function that actually failed. Regression tests have also been added to cover these cases.

## Why

Accurate error messages are important when debugging Kyverno policies. Reporting a different function name, or an empty function name, can make it difficult for users to determine which expression caused the failure.

For example, an invalid argument to:

`is_external_url(123)`

should produce an error identifying `is_external_url`, rather than:

`JMESPath function 'path_canonicalize': argument #1 is not of type string`

The change only affects the error-reporting path for invalid arguments. Valid JMESPath expressions continue to use the same execution logic and produce the same results.

## Testing

- Added regression tests covering the affected custom JMESPath functions and their validation error messages.
- Verified all affected function-name mappings against their corresponding JMESPath function constants.
- Ran the package test suite:

```bash
go test ./pkg/engine/jmespath
