### PR TITLE
chore: cut release v1.19.0-rc.3

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: kyverno-policies
-version: 3.9.0-rc.2  # VERSION
-appVersion: v1.19.0-rc.2
+version: 3.9.0-rc.3  # VERSION
+appVersion: v1.19.0-rc.3
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policies/README.md
+++ b/charts/kyverno-policies/README.md
@@ -2,7 +2,7 @@
 
 Kubernetes Pod Security Standards implemented as Kyverno policies
 
-![Version: 3.9.0-rc.2](https://img.shields.io/badge/Version-3.9.0--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.0-rc.2](https://img.shields.io/badge/AppVersion-v1.19.0--rc.2-informational?style=flat-square)
+![Version: 3.9.0-rc.3](https://img.shields.io/badge/Version-3.9.0--rc.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.0-rc.3](https://img.shields.io/badge/AppVersion-v1.19.0--rc.3-informational?style=flat-square)
 
 ## About
 

--- a/charts/kyverno/Chart.lock
+++ b/charts/kyverno/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: grafana
   repository: ""
-  version: 3.9.0-rc.2
+  version: 3.9.0-rc.3
 - name: crds
   repository: ""
-  version: 3.9.0-rc.2
+  version: 3.9.0-rc.3
 - name: kyverno-api
   repository: https://kyverno.github.io/api
   version: 0.0.1-alpha.4
@@ -14,5 +14,5 @@ dependencies:
 - name: reports-server
   repository: https://kyverno.github.io/reports-server/
   version: 0.1.6
-digest: sha256:b2c9d2411ded512e9cb3bc72feafb506912519357aedad1a996c141d3e7277b2
-generated: "2026-08-11T16:11:14.6596+08:00"
+digest: sha256:3cf177dc7a7a1fa3d6fdcd468ad876f4f56cd4c471b7545ec66f4a61e13b67b4
+generated: "2026-08-12T14:09:32.812924+08:00"

--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: kyverno
-version: 3.9.0-rc.2  # VERSION
-appVersion: v1.19.0-rc.2
+version: 3.9.0-rc.3  # VERSION
+appVersion: v1.19.0-rc.3
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
 keywords:
@@ -42,10 +42,10 @@ annotations:
       description: Add support for configuring container lifecycle hooks (e.g. a preStop sleep) on the admission, background, cleanup and reports controllers.
 dependencies:
   - name: grafana
-    version: 3.9.0-rc.2  # VERSION
+    version: 3.9.0-rc.3  # VERSION
     condition: grafana.enabled
   - name: crds
-    version: 3.9.0-rc.2  # VERSION
+    version: 3.9.0-rc.3  # VERSION
     condition: crds.install
   - name: kyverno-api
     version: 0.0.1-alpha.4

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -2,7 +2,7 @@
 
 Kubernetes Native Policy Management
 
-![Version: 3.9.0-rc.2](https://img.shields.io/badge/Version-3.9.0--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.0-rc.2](https://img.shields.io/badge/AppVersion-v1.19.0--rc.2-informational?style=flat-square)
+![Version: 3.9.0-rc.3](https://img.shields.io/badge/Version-3.9.0--rc.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.0-rc.3](https://img.shields.io/badge/AppVersion-v1.19.0--rc.3-informational?style=flat-square)
 
 ## About
 
@@ -987,8 +987,8 @@ Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | crds | 3.9.0-rc.2 |
-|  | grafana | 3.9.0-rc.2 |
+|  | crds | 3.9.0-rc.3 |
+|  | grafana | 3.9.0-rc.3 |
 | https://kyverno.github.io/api | kyverno-api | 0.0.1-alpha.4 |
 | https://kyverno.github.io/reports-server/ | reports-server | 0.1.6 |
 | https://openreports.github.io/reports-api | openreports | 0.1.0 |

--- a/charts/kyverno/charts/crds/Chart.yaml
+++ b/charts/kyverno/charts/crds/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: crds
-version: 3.9.0-rc.2  # VERSION
+version: 3.9.0-rc.3  # VERSION

--- a/charts/kyverno/charts/crds/README.md
+++ b/charts/kyverno/charts/crds/README.md
@@ -1,6 +1,6 @@
 # crds
 
-![Version: 3.9.0-rc.2](https://img.shields.io/badge/Version-3.9.0--rc.2-informational?style=flat-square)
+![Version: 3.9.0-rc.3](https://img.shields.io/badge/Version-3.9.0--rc.3-informational?style=flat-square)
 
 ## Values
 

--- a/charts/kyverno/charts/grafana/Chart.yaml
+++ b/charts/kyverno/charts/grafana/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: grafana
-version: 3.9.0-rc.2  # VERSION
+version: 3.9.0-rc.3  # VERSION

--- a/charts/kyverno/charts/grafana/README.md
+++ b/charts/kyverno/charts/grafana/README.md
@@ -1,6 +1,6 @@
 # grafana
 
-![Version: 3.9.0-rc.2](https://img.shields.io/badge/Version-3.9.0--rc.2-informational?style=flat-square)
+![Version: 3.9.0-rc.3](https://img.shields.io/badge/Version-3.9.0--rc.3-informational?style=flat-square)
 
 ## Values
 


### PR DESCRIPTION
## Description

Cut release `v1.19.0-rc.3`:

- Bump Helm chart versions (`kyverno`, `kyverno-policies`, `crds`, `grafana`) to `3.9.0-rc.3`
- Bump chart `appVersion` to `v1.19.0-rc.3`
- Regenerate Helm chart docs
- Update `Chart.lock`

Once merged, the merged commit will be tagged `v1.19.0-rc.3` to trigger the release workflow.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.