### PR TITLE
ci: add configurable code freeze check

### DIFF
--- a/.github/workflows/code-freeze.yaml
+++ b/.github/workflows/code-freeze.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Code freeze
+
+on:
+  pull_request:
+    branches:
+      - release-*
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions: {}
+
+jobs:
+  freeze:
+    name: Code freeze
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check whether target branch is frozen
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          FROZEN_BRANCHES: ${{ vars.FROZEN_BRANCHES }}
+        run: |
+          set -euo pipefail
+
+          normalized_branches="$(printf '%s' "${FROZEN_BRANCHES:-}" | tr -d '[:space:]')"
+
+          if [[ -z "$normalized_branches" ]]; then
+            echo "No frozen branches are configured."
+            exit 0
+          fi
+
+          if printf ',%s,' "$normalized_branches" | grep -Fq ",${BASE_REF},"; then
+            echo "Code freeze is active for ${BASE_REF}. PR merges are blocked."
+            exit 1
+          fi
+
+          echo "No code freeze is configured for ${BASE_REF}."

--- a/.github/workflows/code-freeze.yaml
+++ b/.github/workflows/code-freeze.yaml
@@ -7,7 +7,7 @@
 name: Code freeze
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - release-*
     types:
@@ -15,6 +15,7 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+      - edited
 
 permissions: {}
 
@@ -30,14 +31,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          normalized_branches="$(printf '%s' "${FROZEN_BRANCHES:-}" | tr -d '[:space:]')"
+          normalized_branches="$(
+            printf '%s' "${FROZEN_BRANCHES:-}" \
+              | tr ',[:space:]' '\n' \
+              | sed '/^$/d'
+          )"
 
           if [[ -z "$normalized_branches" ]]; then
             echo "No frozen branches are configured."
             exit 0
           fi
 
-          if printf ',%s,' "$normalized_branches" | grep -Fq ",${BASE_REF},"; then
+          if printf '%s\n' "$normalized_branches" | grep -Fxq "$BASE_REF"; then
             echo "Code freeze is active for ${BASE_REF}. PR merges are blocked."
             exit 1
           fi

--- a/.github/workflows/code-freeze.yaml
+++ b/.github/workflows/code-freeze.yaml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
+# Configure frozen release branches through the FROZEN_BRANCHES repository
+# variable (comma-separated, for example "release-1.19,release-1.20") and mark
+# the "Code freeze" / "freeze" status check as required in branch protection.
+
 name: Code freeze
 
 on:


### PR DESCRIPTION
## Explanation
Add a configurable GitHub Actions check that blocks PR merges to frozen release branches based on the `FROZEN_BRANCHES` repository variable. This lets maintainers enable or disable a code freeze without editing workflows for each release branch.

## Related issue
N/A

## Proposed Changes
- add a `Code freeze` workflow for PRs targeting `release-*` branches
- fail the `freeze` job when the PR base branch appears in `FROZEN_BRANCHES`
- allow the check to pass when no branches are configured or the target branch is not frozen

## Checklist
- [x] I have read the contributing guidelines
- [x] I have read the AI Usage Policy. I used AI assistance and disclosed it in the commit trailer.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.