### PR TITLE
chore: trigger code freeze status check (do not merge)

### DIFF
--- a/.github/workflows/code-freeze.yaml
+++ b/.github/workflows/code-freeze.yaml
@@ -3,6 +3,7 @@
 # Configure frozen release branches through the FROZEN_BRANCHES repository
 # variable (comma-separated, for example "release-1.19,release-1.20") and mark
 # the "Code freeze" / "freeze" status check as required in branch protection.
+# Temporary trigger PRs can be opened against release branches so GitHub exposes the check in ruleset configuration.
 
 name: Code freeze
 


### PR DESCRIPTION
This is a temporary draft PR to make the `Code freeze` / `freeze` status check appear in the release-1.19 ruleset picker.

- Do not merge
- Close after the check is added to the ruleset