### PR TITLE
fix(ttl): record deleted objects metric after deletion

### DIFF
--- a/pkg/controllers/ttl/controller.go
+++ b/pkg/controllers/ttl/controller.go
@@ -162,10 +162,10 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, itemKey 
 			return err
 		}
 		logger.V(2).Info("resource has been deleted")
-	} else {
 		if c.metrics != nil {
 			c.metrics.RecordDeletedObject(ctx, c.gvr, metaObj.GetNamespace())
 		}
+	} else {
 		// Calculate the remaining time until deletion
 		timeRemaining := time.Until(deletionTime)
 		// Add the item back to the queue after the remaining time

--- a/pkg/controllers/ttl/controller_test.go
+++ b/pkg/controllers/ttl/controller_test.go
@@ -136,7 +136,8 @@ type mockMetrics struct {
 	failureCount int
 }
 
-func (m *mockMetrics) RecordTTLInfo(ctx context.Context, gvr schema.GroupVersionResource, observer metric.Observer) {}
+func (m *mockMetrics) RecordTTLInfo(ctx context.Context, gvr schema.GroupVersionResource, observer metric.Observer) {
+}
 
 func (m *mockMetrics) RecordDeletedObject(ctx context.Context, gvr schema.GroupVersionResource, namespace string) {
 	m.deletedCount++
@@ -166,15 +167,15 @@ func TestReconcileMetrics(t *testing.T) {
 	logger := logr.Discard()
 
 	tests := []struct {
-		name                 string
-		ttlValue             string
-		creationTime         time.Time
-		deleteErr            error
-		expectDelete         bool
-		expectDeleteCalled   bool
+		name                  string
+		ttlValue              string
+		creationTime          time.Time
+		deleteErr             error
+		expectDelete          bool
+		expectDeleteCalled    bool
 		expectedDeletedMetric int
 		expectedFailureMetric int
-		expectErr            bool
+		expectErr             bool
 	}{
 		{
 			name:                  "TTL not expired",

--- a/pkg/controllers/ttl/controller_test.go
+++ b/pkg/controllers/ttl/controller_test.go
@@ -1,12 +1,22 @@
 package ttl
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/kyverno/kyverno/api/kyverno"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/metric"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 )
 
@@ -71,6 +81,186 @@ func TestDeterminePropagationPolicy(t *testing.T) {
 			policy := determinePropagationPolicy(metaObj, logger)
 			// Assert the result
 			assert.Equal(t, tc.expectedPolicy, policy)
+		})
+	}
+}
+
+type mockResourceInterface struct {
+	metadata.ResourceInterface
+	deleteCalled bool
+	deletedName  string
+	deleteErr    error
+}
+
+func (m *mockResourceInterface) Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error {
+	m.deleteCalled = true
+	m.deletedName = name
+	return m.deleteErr
+}
+
+type mockMetadataGetter struct {
+	metadata.Getter
+	resource *mockResourceInterface
+}
+
+func (m *mockMetadataGetter) Namespace(string) metadata.ResourceInterface {
+	return m.resource
+}
+
+type mockLister struct {
+	cache.GenericLister
+	obj runtime.Object
+	err error
+}
+
+func (m *mockLister) Get(name string) (runtime.Object, error) {
+	return m.obj, m.err
+}
+
+func (m *mockLister) ByNamespace(namespace string) cache.GenericNamespaceLister {
+	return &mockNamespaceLister{obj: m.obj, err: m.err}
+}
+
+type mockNamespaceLister struct {
+	cache.GenericNamespaceLister
+	obj runtime.Object
+	err error
+}
+
+func (m *mockNamespaceLister) Get(name string) (runtime.Object, error) {
+	return m.obj, m.err
+}
+
+type mockMetrics struct {
+	deletedCount int
+	failureCount int
+}
+
+func (m *mockMetrics) RecordTTLInfo(ctx context.Context, gvr schema.GroupVersionResource, observer metric.Observer) {}
+
+func (m *mockMetrics) RecordDeletedObject(ctx context.Context, gvr schema.GroupVersionResource, namespace string) {
+	m.deletedCount++
+}
+
+func (m *mockMetrics) RecordTTLFailure(ctx context.Context, gvr schema.GroupVersionResource, namespace string) {
+	m.failureCount++
+}
+
+func (m *mockMetrics) RegisterCallback(f metric.Callback) (metric.Registration, error) {
+	return nil, nil
+}
+
+type mockQueue struct {
+	workqueue.TypedRateLimitingInterface[any]
+	addAfterCalled bool
+	addAfterItem   any
+}
+
+func (m *mockQueue) AddAfter(item any, duration time.Duration) {
+	m.addAfterCalled = true
+	m.addAfterItem = item
+}
+
+func TestReconcileMetrics(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	logger := logr.Discard()
+
+	tests := []struct {
+		name                 string
+		ttlValue             string
+		creationTime         time.Time
+		deleteErr            error
+		expectDelete         bool
+		expectDeleteCalled   bool
+		expectedDeletedMetric int
+		expectedFailureMetric int
+		expectErr            bool
+	}{
+		{
+			name:                  "TTL not expired",
+			ttlValue:              "2h",
+			creationTime:          time.Now(),
+			expectDelete:          false,
+			expectDeleteCalled:    false,
+			expectedDeletedMetric: 0,
+			expectedFailureMetric: 0,
+			expectErr:             false,
+		},
+		{
+			name:                  "TTL expired - successful deletion",
+			ttlValue:              "1m",
+			creationTime:          time.Now().Add(-2 * time.Minute),
+			expectDelete:          true,
+			expectDeleteCalled:    true,
+			deleteErr:             nil,
+			expectedDeletedMetric: 1,
+			expectedFailureMetric: 0,
+			expectErr:             false,
+		},
+		{
+			name:                  "TTL expired - failed deletion",
+			ttlValue:              "1m",
+			creationTime:          time.Now().Add(-2 * time.Minute),
+			expectDelete:          true,
+			expectDeleteCalled:    true,
+			deleteErr:             apierrors.NewInternalError(fmt.Errorf("some internal error")),
+			expectedDeletedMetric: 0,
+			expectedFailureMetric: 1,
+			expectErr:             true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-resource",
+					Namespace:         "test-namespace",
+					CreationTimestamp: metav1.NewTime(tc.creationTime),
+					Labels: map[string]string{
+						kyverno.LabelCleanupTtl: tc.ttlValue,
+					},
+				},
+			}
+
+			mockRes := &mockResourceInterface{
+				deleteErr: tc.deleteErr,
+			}
+			mockClient := &mockMetadataGetter{
+				resource: mockRes,
+			}
+			mockL := &mockLister{
+				obj: obj,
+			}
+			mockM := &mockMetrics{}
+			queue := &mockQueue{}
+
+			c := &controller{
+				client:  mockClient,
+				lister:  mockL,
+				metrics: mockM,
+				queue:   queue,
+				gvr:     gvr,
+			}
+
+			err := c.reconcile(context.TODO(), logger, "test-namespace/test-resource", "", "")
+
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectDeleteCalled, mockRes.deleteCalled)
+			assert.Equal(t, tc.expectedDeletedMetric, mockM.deletedCount)
+			assert.Equal(t, tc.expectedFailureMetric, mockM.failureCount)
+
+			if !tc.expectDelete {
+				assert.True(t, queue.addAfterCalled, "object should be re-queued")
+				assert.Equal(t, "test-namespace/test-resource", queue.addAfterItem)
+			} else {
+				assert.False(t, queue.addAfterCalled, "object should not be re-queued")
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What

Follow up to issue #17103.Fixes an incorrect metric recording behavior in the TTL controller.

`RecordDeletedObject()` was being called when a resource's TTL had **not yet expired** and the resource was only being re-queued for future processing. As a result, the `kyverno_ttl_controller_deletedobjects` metric could report resources as deleted even though they were still present in the cluster.

The metric is now recorded only after the TTL controller successfully deletes the resource.

## Why

The `kyverno_ttl_controller_deletedobjects` metric is intended to represent resources actually deleted by the TTL controller.

Previously:

- Resources with an unexpired TTL incorrectly incremented the deleted-object metric.
- Reconciliation or re-queuing could cause the metric to be incremented multiple times before deletion.
- Successfully deleted resources were not recorded in the metric.

This change moves `RecordDeletedObject()` to the successful deletion path while leaving the existing TTL scheduling, deletion error handling, and retry behavior unchanged.

## Testing

Added regression coverage for the relevant reconciliation paths:

- TTL not expired: verifies the resource is re-queued and `RecordDeletedObject()` is not called.
- TTL expired with successful deletion: verifies the deletion occurs and `RecordDeletedObject()` is recorded exactly once.
- TTL expired with failed deletion: verifies `RecordTTLFailure()` is recorded and `RecordDeletedObject()` is not recorded.

Tests executed:

```text
go test -count=1 -v ./pkg/controllers/ttl