### PR TITLE
fix(jmespath): correct time_add validation errors

### DIFF
--- a/pkg/engine/jmespath/time.go
+++ b/pkg/engine/jmespath/time.go
@@ -100,9 +100,9 @@ func jpTimeToCron(arguments []interface{}) (interface{}, error) {
 }
 
 func jpTimeAdd(arguments []interface{}) (interface{}, error) {
-	if t, err := getTimeArg(timeToCron, arguments, 0); err != nil {
+	if t, err := getTimeArg(timeAdd, arguments, 0); err != nil {
 		return nil, err
-	} else if d, err := getDurationArg(timeToCron, arguments, 1); err != nil {
+	} else if d, err := getDurationArg(timeAdd, arguments, 1); err != nil {
 		return nil, err
 	} else {
 		return t.Add(d).Format(time.RFC3339), nil

--- a/pkg/engine/jmespath/time_test.go
+++ b/pkg/engine/jmespath/time_test.go
@@ -532,3 +532,14 @@ func Test_jpTimeBetween(t *testing.T) {
 		})
 	}
 }
+
+func Test_jpTimeAdd_ValidationErrors(t *testing.T) {
+	t.Run("invalid timestamp", func(t *testing.T) {
+		_, err := jpTimeAdd([]interface{}{123, "3h"})
+		assert.ErrorContains(t, err, "JMESPath function 'time_add': argument #1 is not of type string")
+	})
+	t.Run("invalid duration", func(t *testing.T) {
+		_, err := jpTimeAdd([]interface{}{"2021-01-02T15:04:05-07:00", 123})
+		assert.ErrorContains(t, err, "JMESPath function 'time_add': argument #2 is not of type string")
+	})
+}


### PR DESCRIPTION
### What

Follow up to issue #17112 .Fixes misleading argument validation errors returned by the custom JMESPath `time_add` function.

When `time_add` receives an argument with an invalid type, the validation logic generates an error describing which JMESPath function and argument caused the validation failure. However, `jpTimeAdd()` was passing the `timeToCron` function name to the validation helpers instead of its own `timeAdd` function name.

As a result, errors triggered while evaluating `time_add` incorrectly reported `time_to_cron` as the failing function. This affects both the timestamp argument and the duration argument validation paths.

### Why

The `time_add` function should identify itself correctly in validation errors. Reporting `time_to_cron` is misleading and can make policy debugging more difficult because users may investigate the wrong JMESPath function.

For example, an invalid duration could produce:

**Current:**
`JMESPath function 'time_to_cron': argument #2 is not of type string`

The error should instead be:

**Expected:**
`JMESPath function 'time_add': argument #2 is not of type string`

The fix passes the correct `timeAdd` function name to both `getTimeArg()` and `getDurationArg()`. This only corrects the error reporting and does not change the behavior of valid `time_add` evaluations.

### Testing

- Added regression tests covering invalid timestamp and duration arguments to `time_add`.
- Verified that validation errors correctly reference `time_add` instead of `time_to_cron`.
- Ran `gofmt` successfully on the modified files.
- Ran `gofmt -d` and confirmed there are no remaining formatting changes.
- Ran `git diff --check` successfully with no whitespace errors.
- Ran `go test ./pkg/engine/jmespath/...` successfully.
- Confirmed that existing valid `time_add` behavior remains unchanged.
- Confirmed that only the intended files were modified:
  - `pkg/engine/jmespath/time.go`
  - `pkg/engine/jmespath/time_test.go`