### PR TITLE
fix: implement bounded worker pools for webhook async tasks 

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alitto/pond/v2"
 	"github.com/go-logr/logr"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/cmd/internal"
@@ -692,6 +693,7 @@ func main() {
 			setup.KyvernoClient,
 			kyvernoInformer.Kyverno().V2().UpdateRequests(),
 			urGenerator,
+			pond.NewPool(maxAuditWorkers, pond.WithQueueSize(maxAuditCapacity)),
 		)
 		policyHandlers := webhookspolicy.NewHandlers(
 			setup.KyvernoDynamicClient,

--- a/pkg/webhooks/resource/fake.go
+++ b/pkg/webhooks/resource/fake.go
@@ -57,6 +57,7 @@ func NewFakeHandlers(ctx context.Context, policyCache policycache.Cache) *resour
 		eventGen:      event.NewFake(),
 		pcBuilder:     webhookutils.NewPolicyContextBuilder(configuration, jp),
 		auditPool:     pond.NewPool(8, pond.WithQueueSize(1000)),
+		reportsPool:   pond.NewPool(8, pond.WithQueueSize(1000)),
 		engine: engine.NewEngine(
 			configuration,
 			jp,

--- a/pkg/webhooks/resource/handlers.go
+++ b/pkg/webhooks/resource/handlers.go
@@ -65,6 +65,7 @@ type resourceHandlers struct {
 	backgroundServiceAccountName string
 	reportsServiceAccountName    string
 	auditPool                    pond.Pool
+	reportsPool                  pond.Pool
 	breaker.Breaker
 }
 
@@ -112,6 +113,7 @@ func NewHandlers(
 		backgroundServiceAccountName: backgroundServiceAccountName,
 		reportsServiceAccountName:    reportsServiceAccountName,
 		auditPool:                    pond.NewPool(maxAuditWorkers, pond.WithQueueSize(maxAuditCapacity)),
+		reportsPool:                  pond.NewPool(maxAuditWorkers, pond.WithQueueSize(maxAuditCapacity)),
 	}
 }
 
@@ -141,6 +143,7 @@ func (h *resourceHandlers) Validate(ctx context.Context, logger logr.Logger, req
 		h.admissionReports,
 		h.metricsConfig,
 		h.nsLister,
+		h.reportsPool,
 	)
 	var wg wait.Group
 	var ok bool
@@ -202,7 +205,7 @@ func (h *resourceHandlers) Mutate(ctx context.Context, logger logr.Logger, reque
 		logger.Error(err, "failed to build policy context")
 		return admissionutils.Response(request.UID, err)
 	}
-	mh := mutation.NewMutationHandler(logger, h.kyvernoClient, h.engine, h.eventGen, h.nsLister, h.metricsConfig, h.admissionReports)
+	mh := mutation.NewMutationHandler(logger, h.kyvernoClient, h.engine, h.eventGen, h.nsLister, h.metricsConfig, h.admissionReports, h.reportsPool)
 	patches, warnings, err := mh.HandleMutation(ctx, request, mutatePolicies, policyContext, startTime, h.configuration)
 	if err != nil {
 		logger.Error(err, "mutation failed")

--- a/pkg/webhooks/resource/handlers_test.go
+++ b/pkg/webhooks/resource/handlers_test.go
@@ -10,6 +10,8 @@ import (
 
 	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	fakekyvernov1 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/fake"
+	kyvernoinformers "github.com/kyverno/kyverno/pkg/client/informers/externalversions"
 	"github.com/kyverno/kyverno/pkg/config"
 	"github.com/kyverno/kyverno/pkg/engine"
 	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
@@ -928,4 +930,40 @@ func (b *mockPolicyContextBuilder) Build(request admissionv1.AdmissionRequest, r
 	}
 	b.contexts = append(b.contexts, pc)
 	return pc, err
+}
+
+func Test_NewHandlers(t *testing.T) {
+	ctx := context.Background()
+	policyCache := policycache.NewCache()
+	h := NewFakeHandlers(ctx, policyCache)
+	assert.Assert(t, h != nil)
+	assert.Assert(t, h.auditPool != nil)
+	assert.Assert(t, h.reportsPool != nil)
+
+	kyvernoclient := fakekyvernov1.NewSimpleClientset()
+	kyvernoInformers := kyvernoinformers.NewSharedInformerFactory(kyvernoclient, 0)
+
+	realH := NewHandlers(
+		h.engine,
+		h.client,
+		h.kyvernoClient,
+		h.configuration,
+		h.metricsConfig,
+		h.pCache,
+		h.nsLister,
+		h.urLister,
+		kyvernoInformers.Kyverno().V1().ClusterPolicies(),
+		kyvernoInformers.Kyverno().V1().Policies(),
+		h.urGenerator,
+		h.eventGen,
+		h.admissionReports,
+		h.backgroundServiceAccountName,
+		h.reportsServiceAccountName,
+		nil,
+		0,
+		0,
+	)
+	assert.Assert(t, realH != nil)
+	assert.Assert(t, realH.auditPool != nil)
+	assert.Assert(t, realH.reportsPool != nil)
 }

--- a/pkg/webhooks/resource/mutation/mutation.go
+++ b/pkg/webhooks/resource/mutation/mutation.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/alitto/pond/v2"
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/breaker"
@@ -45,6 +46,7 @@ func NewMutationHandler(
 	nsLister corev1listers.NamespaceLister,
 	metrics metrics.MetricsConfigManager,
 	admissionReports bool,
+	reportsPool pond.Pool,
 ) MutationHandler {
 	return &mutationHandler{
 		log:              log,
@@ -54,6 +56,7 @@ func NewMutationHandler(
 		nsLister:         nsLister,
 		metrics:          metrics,
 		admissionReports: admissionReports,
+		reportsPool:      reportsPool,
 	}
 }
 
@@ -65,6 +68,7 @@ type mutationHandler struct {
 	nsLister         corev1listers.NamespaceLister
 	metrics          metrics.MetricsConfigManager
 	admissionReports bool
+	reportsPool      pond.Pool
 }
 
 func (h *mutationHandler) HandleMutation(
@@ -157,11 +161,11 @@ func (v *mutationHandler) applyMutations(
 	v.eventGen.Add(events...)
 
 	if v.needsReports(request, v.admissionReports) && reportutils.IsPolicyReportable(policyContext.Policy()) {
-		go func() { //nolint:gosec // background context is intentional: the goroutine outlives the request
+		v.reportsPool.Submit(func() {
 			if err := v.createReports(context.TODO(), policyContext.NewResource(), request, engineResponses...); err != nil {
 				v.log.Error(err, "failed to create report")
 			}
-		}()
+		})
 	}
 
 	logMutationResponse(patches, engineResponses, v.log)

--- a/pkg/webhooks/resource/validation/validation.go
+++ b/pkg/webhooks/resource/validation/validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/alitto/pond/v2"
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/breaker"
@@ -43,8 +44,9 @@ func NewValidationHandler(
 	pcBuilder webhookutils.PolicyContextBuilder,
 	eventGen event.Interface,
 	admissionReports bool,
-	metrics metrics.MetricsConfigManager,
+	metricsConfig metrics.MetricsConfigManager,
 	nsLister corev1listers.NamespaceLister,
+	reportsPool pond.Pool,
 ) ValidationHandler {
 	return &validationHandler{
 		log:              log,
@@ -54,8 +56,9 @@ func NewValidationHandler(
 		pcBuilder:        pcBuilder,
 		eventGen:         eventGen,
 		admissionReports: admissionReports,
-		metrics:          metrics,
+		metricsConfig:    metricsConfig,
 		nsLister:         nsLister,
+		reportsPool:      reportsPool,
 	}
 }
 
@@ -67,8 +70,9 @@ type validationHandler struct {
 	pcBuilder        webhookutils.PolicyContextBuilder
 	eventGen         event.Interface
 	admissionReports bool
-	metrics          metrics.MetricsConfigManager
+	metricsConfig    metrics.MetricsConfigManager
 	nsLister         corev1listers.NamespaceLister
+	reportsPool      pond.Pool
 }
 
 func (v *validationHandler) HandleValidationEnforce(
@@ -154,7 +158,7 @@ func (v *validationHandler) HandleValidationEnforce(
 
 	// create the admission report if any of the policies involved doesn't have the report exclusion label
 	if NeedsReports(request, policyContext.NewResource(), v.admissionReports) && hasReportablePolicy(policies) {
-		go func() { //nolint:gosec // background context is intentional: the goroutine outlives the request
+		v.reportsPool.Submit(func() {
 			if err := v.createReports(context.TODO(), policyContext.NewResource(), request, engineResponses...); err != nil {
 				if reportutils.IsNamespaceTerminationError(err) {
 					// Log namespace termination errors at debug level as they are expected
@@ -163,7 +167,7 @@ func (v *validationHandler) HandleValidationEnforce(
 					v.log.Error(err, "failed to create report")
 				}
 			}
-		}()
+		})
 	}
 
 	engineResponses = append(engineResponses, auditWarnEngineResponses...)

--- a/pkg/webhooks/updaterequest/generator.go
+++ b/pkg/webhooks/updaterequest/generator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/alitto/pond/v2"
 	backoff "github.com/cenkalti/backoff/v7"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
 	"github.com/kyverno/kyverno/pkg/background/common"
@@ -30,14 +31,16 @@ type generator struct {
 	urLister kyvernov2listers.UpdateRequestNamespaceLister
 
 	urGenerator generatorutils.UpdateRequestGenerator
+	workerPool  pond.Pool
 }
 
 // NewGenerator returns a new instance of UpdateRequest resource generator
-func NewGenerator(client versioned.Interface, urInformer kyvernov2informers.UpdateRequestInformer, urGenerator generatorutils.UpdateRequestGenerator) Generator {
+func NewGenerator(client versioned.Interface, urInformer kyvernov2informers.UpdateRequestInformer, urGenerator generatorutils.UpdateRequestGenerator, workerPool pond.Pool) Generator {
 	return &generator{
 		client:      client,
 		urLister:    urInformer.Lister().UpdateRequests(config.KyvernoNamespace()),
 		urGenerator: urGenerator,
+		workerPool:  workerPool,
 	}
 }
 
@@ -47,7 +50,7 @@ func (g *generator) Apply(ctx context.Context, ur kyvernov2.UpdateRequestSpec) e
 		return nil
 	}
 	logger.V(4).Info("apply Update Request", "request", ur)
-	go g.applyResource(context.TODO(), ur) //nolint:gosec // background context is intentional: the goroutine outlives the request
+	g.workerPool.Submit(func() { g.applyResource(context.TODO(), ur) })
 	return nil
 }
 

--- a/pkg/webhooks/updaterequest/generator_test.go
+++ b/pkg/webhooks/updaterequest/generator_test.go
@@ -1,0 +1,51 @@
+package updaterequest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alitto/pond/v2"
+	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	fakekyvernov2 "github.com/kyverno/kyverno/pkg/client/clientset/versioned/fake"
+	kyvernoinformers "github.com/kyverno/kyverno/pkg/client/informers/externalversions"
+	generatorutils "github.com/kyverno/kyverno/pkg/utils/generator"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewGenerator(t *testing.T) {
+	client := fakekyvernov2.NewSimpleClientset()
+	informers := kyvernoinformers.NewSharedInformerFactory(client, 0)
+	urInformer := informers.Kyverno().V2().UpdateRequests()
+	pool := pond.NewPool(2, pond.WithQueueSize(10))
+
+	gen := NewGenerator(client, urInformer, nil, pool)
+	assert.NotNil(t, gen)
+}
+
+func Test_Generator_Apply(t *testing.T) {
+	client := fakekyvernov2.NewSimpleClientset()
+	informers := kyvernoinformers.NewSharedInformerFactory(client, 0)
+	urInformer := informers.Kyverno().V2().UpdateRequests()
+	pool := pond.NewPool(2, pond.WithQueueSize(10))
+
+	urGenerator := generatorutils.NewUpdateRequestGenerator(nil, nil)
+	gen := NewGenerator(client, urInformer, urGenerator, pool)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Empty Generate UR should return nil directly without submitting to pool
+	emptyUR := kyvernov2.UpdateRequestSpec{
+		Type: kyvernov2.Generate,
+	}
+	err := gen.Apply(ctx, emptyUR)
+	assert.NoError(t, err)
+
+	// Valid Mutate UR should be submitted to pool
+	mutateUR := kyvernov2.UpdateRequestSpec{
+		Type: kyvernov2.Mutate,
+	}
+	err = gen.Apply(ctx, mutateUR)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
### Context
Fixes #17126

Currently, Kyverno webhook handlers spawn unbounded goroutines via `createReports` in validation/mutation and `applyResource` in UpdateRequest generation. Under heavy cluster load (e.g., massive deployments or crashlooping pods), these goroutines wait indefinitely on slow Kubernetes API server responses without concurrency limits. This directly leads to severe memory/CPU exhaustion (OOM), triggering Denial of Service (DoS) scenarios and potentially cascading cluster degradation.

### Changes Made
- Initialized bounded worker pools using `github.com/alitto/pond/v2` for webhook reports and update requests (similar to how `auditPool` safely handles audit events).
- To keep the fix minimal and avoid breaking backwards compatibility or requiring Helm chart updates, we reused the `maxAuditWorkers` and `maxAuditCapacity` configuration as a generalized background task limit.
- Introduced `reportsPool` in `pkg/webhooks/resource/handlers.go` and injected it into `validationHandler` and `mutationHandler`.
- Substituted unbounded `go func() { ... }()` calls with bounded submissions: `v.reportsPool.Submit(...)`.
- Added `workerPool` in `pkg/webhooks/updaterequest/generator.go` (injected from `cmd/kyverno/main.go`).
- Replaced `go g.applyResource(...)` with `g.workerPool.Submit(...)`.

### Verification Steps
- [x] Ran `go fmt ./...` and `goimports -w .` locally.
- [x] Ran `go test ./pkg/webhooks/updaterequest/... ./pkg/webhooks/resource/...` locally; all tests compiled and passed.
- [x] Ensured no new linter violations were introduced in the changed packages.
- [x] Reviewed code path for potential nil-pointer dereferences.
