### PR TITLE
fix(webhook): prevent nil scope panic when sorting rules

### DIFF
--- a/pkg/controllers/webhook/utils.go
+++ b/pkg/controllers/webhook/utils.go
@@ -246,7 +246,18 @@ func sortedRules(rules []admissionregistrationv1.RuleWithOperations) []admission
 		if x := less(a.Operations, b.Operations); x != 0 {
 			return x
 		}
-		if x := strings.Compare(string(*a.Scope), string(*b.Scope)); x != 0 {
+		var scopeA, scopeB string
+		if a.Scope != nil {
+			scopeA = string(*a.Scope)
+		} else {
+			scopeA = string(admissionregistrationv1.AllScopes)
+		}
+		if b.Scope != nil {
+			scopeB = string(*b.Scope)
+		} else {
+			scopeB = string(admissionregistrationv1.AllScopes)
+		}
+		if x := strings.Compare(scopeA, scopeB); x != 0 {
 			return x
 		}
 		return 0

--- a/pkg/controllers/webhook/utils_test.go
+++ b/pkg/controllers/webhook/utils_test.go
@@ -881,6 +881,45 @@ func TestSortedRules(t *testing.T) {
 			input:         []admissionregistrationv1.RuleWithOperations{rule_apps_pods, rule_apps_pods_cluster},
 			expectedRules: []admissionregistrationv1.RuleWithOperations{rule_apps_pods_cluster, rule_apps_pods},
 		},
+		{
+			name: "Nil scope",
+			input: []admissionregistrationv1.RuleWithOperations{
+				{
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{"apps"},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+						Scope:       nil,
+					},
+				},
+				{
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{"apps"},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+						Scope:       ptr.To(admissionregistrationv1.NamespacedScope),
+					},
+				},
+			},
+			expectedRules: []admissionregistrationv1.RuleWithOperations{
+				{
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{"apps"},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+						Scope:       nil,
+					},
+				},
+				{
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{"apps"},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+						Scope:       ptr.To(admissionregistrationv1.NamespacedScope),
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What

This is follow up to issue #17132 .This PR fixes a nil pointer dereference in the webhook rule sorting logic.

The `sortedRules()` comparator in `pkg/controllers/webhook/utils.go` previously dereferenced `*a.Scope` and `*b.Scope` without checking whether either value was `nil`.

This PR adds a safe nil check and normalizes omitted scopes to `admissionregistrationv1.AllScopes`, which matches Kubernetes' default behavior for an unspecified `Scope`.

---

## Why

`admissionregistrationv1.Rule.Scope` is an optional field represented as `*ScopeType`.

Rules generated through Kyverno's webhook generation path can contain a `nil` scope. When such rules reach `sortedRules()`, the comparator dereferences a nil pointer and causes the webhook controller to panic while sorting rules.

Normalizing omitted scopes to `admissionregistrationv1.AllScopes` preserves Kubernetes semantics because an unspecified scope is treated as matching all resources.

This change:

- Prevents a nil pointer dereference.
- Preserves the existing ordering of explicit scopes.
- Keeps the comparator deterministic.
- Aligns sorting behavior with Kubernetes defaulting semantics.

---

## Testing

Added a new `Nil scope` test case to `TestSortedRules()` in `pkg/controllers/webhook/utils_test.go`.

The new test verifies that rules containing both `nil` and non-nil scopes can be sorted successfully without triggering a panic.

Executed:

```bash
gofmt -w pkg/controllers/webhook/utils.go pkg/controllers/webhook/utils_test.go

git diff --check

go test -count=1 ./pkg/controllers/webhook/...