### PR TITLE
fix: support NamespacedValidatingPolicy in admissionpolicy-generator controller

### DIFF
--- a/pkg/admissionpolicy/builder.go
+++ b/pkg/admissionpolicy/builder.go
@@ -101,12 +101,13 @@ func BuildValidatingAdmissionPolicy(
 		validations = rule.Validation.CEL.Expressions
 		auditAnnotations = rule.Validation.CEL.AuditAnnotations
 		variables = rule.Validation.CEL.Variables
-	} else if vpol := policy.AsValidatingPolicy(); vpol != nil {
-		matchResources = *vpol.Spec.MatchConstraints
-		matchConditions = vpol.Spec.MatchConditions
-		validations = vpol.Spec.Validations
-		auditAnnotations = vpol.Spec.AuditAnnotations
-		variables = vpol.Spec.Variables
+	} else if vpol := policy.AsValidatingPolicyLike(); vpol != nil {
+		spec := vpol.GetSpec()
+		matchResources = *spec.MatchConstraints
+		matchConditions = spec.MatchConditions
+		validations = spec.Validations
+		auditAnnotations = spec.AuditAnnotations
+		variables = spec.Variables
 
 		// convert celexceptions if exist
 		for _, exception := range exceptions {
@@ -214,9 +215,13 @@ func BuildValidatingAdmissionPolicyBinding(
 		}
 		paramRef = rule.Validation.CEL.ParamRef
 		policyName = "cpol-" + cpol.GetName()
-	} else if vpol := policy.AsValidatingPolicy(); vpol != nil {
-		validationActions = vpol.Spec.ValidationActions()
-		policyName = "vpol-" + vpol.GetName()
+	} else if vpol := policy.AsValidatingPolicyLike(); vpol != nil {
+		validationActions = vpol.GetSpec().ValidationActions()
+		if vpol.GetNamespace() != "" {
+			policyName = "nvpol-" + vpol.GetNamespace() + "-" + vpol.GetName()
+		} else {
+			policyName = "vpol-" + vpol.GetName()
+		}
 	}
 
 	// set owner reference

--- a/pkg/controllers/admissionpolicygenerator/controller.go
+++ b/pkg/controllers/admissionpolicygenerator/controller.go
@@ -119,8 +119,17 @@ func NewController(
 	}
 
 	// Set up an event handler for when validating policies change
-	if _, err := controllerutils.AddEventHandlersT(vpolInformer.Informer(), c.addVP, c.updateVP, c.deleteVP); err != nil {
-		logger.Error(err, "failed to register event handlers")
+	if vpolInformer != nil {
+		if _, err := controllerutils.AddEventHandlersT(vpolInformer.Informer(), c.addVP, c.updateVP, c.deleteVP); err != nil {
+			logger.Error(err, "failed to register event handlers")
+		}
+	}
+
+	// Set up an event handler for when namespaced validating policies change
+	if nvpolInformer != nil {
+		if _, err := controllerutils.AddEventHandlersT(nvpolInformer.Informer(), c.addVP, c.updateVP, c.deleteVP); err != nil {
+			logger.Error(err, "failed to register event handlers")
+		}
 	}
 
 	// Set up an event handler for when mutating policies change
@@ -242,6 +251,24 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 		if err != nil {
 			return err
 		}
+	} else if polType == "NamespacedValidatingPolicy" {
+		generateValidatingAdmissionPolicy := toggle.FromContext(context.TODO()).GenerateValidatingAdmissionPolicy()
+		if !generateValidatingAdmissionPolicy {
+			return nil
+		}
+		nvpol, err := c.getNamespacedValidatingPolicy(namespace, name)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			logger.Error(err, "unable to get the policy from policy informer")
+			return err
+		}
+		policy = engineapi.NewNamespacedValidatingPolicy(nvpol)
+		err = c.handleVAPGeneration(ctx, polType, policy)
+		if err != nil {
+			return err
+		}
 	} else if polType == "MutatingPolicy" {
 		mpol, err := c.getMutatingPolicy(name)
 		if err != nil {
@@ -291,6 +318,18 @@ func (c *controller) updatePolicyStatus(ctx context.Context, policy engineapi.Ge
 		}
 
 		logging.V(3).Info("updated validating policy status", "name", vpol.GetName(), "status", new.Status)
+	} else if nvpol := policy.AsNamespacedValidatingPolicy(); nvpol != nil {
+		latest := nvpol.DeepCopy()
+		latest.Status.Generated = generated
+		latest.Status.GetConditionStatus().Message = msg
+
+		new, err := c.kyvernoClient.PoliciesV1beta1().NamespacedValidatingPolicies(nvpol.GetNamespace()).UpdateStatus(ctx, latest, metav1.UpdateOptions{})
+		if err != nil {
+			logging.Error(err, "failed to update namespaced validating policy status", "name", nvpol.GetName(), "namespace", nvpol.GetNamespace(), "status", latest.Status)
+			return
+		}
+
+		logging.V(3).Info("updated namespaced validating policy status", "name", nvpol.GetName(), "namespace", nvpol.GetNamespace(), "status", new.Status)
 	} else if mpol := policy.AsMutatingPolicy(); mpol != nil {
 		latest := mpol.DeepCopy()
 		latest.Status.Generated = generated

--- a/pkg/controllers/admissionpolicygenerator/generate-vap.go
+++ b/pkg/controllers/admissionpolicygenerator/generate-vap.go
@@ -30,6 +30,8 @@ func (c *controller) handleVAPGeneration(ctx context.Context, polType string, po
 	var vapName string
 	if polType == "ClusterPolicy" {
 		vapName = "cpol-" + policy.GetName()
+	} else if polType == "NamespacedValidatingPolicy" {
+		vapName = "nvpol-" + policy.GetNamespace() + "-" + policy.GetName()
 	} else {
 		vapName = "vpol-" + policy.GetName()
 	}
@@ -73,13 +75,18 @@ func (c *controller) handleVAPGeneration(ctx context.Context, polType string, po
 			genericExceptions = append(genericExceptions, engineapi.NewPolicyException(&exception))
 		}
 	} else {
-		pol := policy.AsValidatingPolicy()
+		pol := policy.AsValidatingPolicyLike()
 		wantVap := pol.GetSpec().GenerateValidatingAdmissionPolicyEnabled()
 		shouldDelete := !wantVap
 
 		var reason string
 		if wantVap {
-			isAutogen := len(pol.GetStatus().Autogen.Configs) > 0
+			var isAutogen bool
+			if vpol := policy.AsValidatingPolicy(); vpol != nil {
+				isAutogen = len(vpol.GetStatus().Autogen.Configs) > 0
+			} else if nvpol := policy.AsNamespacedValidatingPolicy(); nvpol != nil {
+				isAutogen = len(nvpol.GetStatus().Autogen.Configs) > 0
+			}
 			if isAutogen {
 				shouldDelete = true
 				reason = "skip generating ValidatingAdmissionPolicy: pod controllers autogen is enabled."

--- a/pkg/controllers/admissionpolicygenerator/utils.go
+++ b/pkg/controllers/admissionpolicygenerator/utils.go
@@ -30,6 +30,18 @@ func (c *controller) getValidatingPolicy(name string) (*policiesv1beta1.Validati
 	return vpol, nil
 }
 
+// getNamespacedValidatingPolicy gets the Kyverno NamespacedValidatingPolicy
+func (c *controller) getNamespacedValidatingPolicy(namespace, name string) (*policiesv1beta1.NamespacedValidatingPolicy, error) {
+	if c.nvpolLister == nil {
+		return nil, fmt.Errorf("NamespacedValidatingPolicy lister is nil")
+	}
+	nvpol, err := c.nvpolLister.NamespacedValidatingPolicies(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+	return nvpol, nil
+}
+
 // getMutatingPolicy gets the Kyverno MutatingPolicy
 func (c *controller) getMutatingPolicy(name string) (*policiesv1beta1.MutatingPolicy, error) {
 	mpol, err := c.mpolLister.Get(name)

--- a/pkg/controllers/admissionpolicygenerator/vpol.go
+++ b/pkg/controllers/admissionpolicygenerator/vpol.go
@@ -7,13 +7,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// this file contains the handler functions for ValidatingPolicy resources.
-func (c *controller) addVP(obj *policiesv1beta1.ValidatingPolicy) {
+// this file contains the handler functions for ValidatingPolicy and NamespacedValidatingPolicy resources.
+func (c *controller) addVP(obj policiesv1beta1.ValidatingPolicyLike) {
 	logger.V(2).Info("validating policy created", "uid", obj.GetUID(), "kind", obj.GetKind(), "name", obj.GetName())
 	c.enqueueVP(obj)
 }
 
-func (c *controller) updateVP(old, obj *policiesv1beta1.ValidatingPolicy) {
+func (c *controller) updateVP(old, obj policiesv1beta1.ValidatingPolicyLike) {
 	if datautils.DeepEqual(old.GetSpec(), obj.GetSpec()) {
 		return
 	}
@@ -21,18 +21,22 @@ func (c *controller) updateVP(old, obj *policiesv1beta1.ValidatingPolicy) {
 	c.enqueueVP(obj)
 }
 
-func (c *controller) deleteVP(obj *policiesv1beta1.ValidatingPolicy) {
-	vpol := kubeutils.GetObjectWithTombstone(obj).(*policiesv1beta1.ValidatingPolicy)
+func (c *controller) deleteVP(obj policiesv1beta1.ValidatingPolicyLike) {
+	vpol := kubeutils.GetObjectWithTombstone(obj).(policiesv1beta1.ValidatingPolicyLike)
 
 	logger.V(2).Info("validating policy deleted", "uid", vpol.GetUID(), "kind", vpol.GetKind(), "name", vpol.GetName())
 	c.enqueueVP(obj)
 }
 
-func (c *controller) enqueueVP(obj *policiesv1beta1.ValidatingPolicy) {
+func (c *controller) enqueueVP(obj policiesv1beta1.ValidatingPolicyLike) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
 		logger.Error(err, "failed to extract policy name")
 		return
 	}
-	c.queue.Add("ValidatingPolicy/" + key)
+	if obj.GetNamespace() != "" {
+		c.queue.Add("NamespacedValidatingPolicy/" + key)
+	} else {
+		c.queue.Add("ValidatingPolicy/" + key)
+	}
 }

--- a/pkg/controllers/admissionpolicygenerator/vpol_test.go
+++ b/pkg/controllers/admissionpolicygenerator/vpol_test.go
@@ -1,0 +1,111 @@
+package admissionpolicygenerator
+
+import (
+	"testing"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+)
+
+func TestEnqueueVP_ClusterValidatingPolicy(t *testing.T) {
+	t.Parallel()
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.DefaultTypedControllerRateLimiter[any](),
+		workqueue.TypedRateLimitingQueueConfig[any]{Name: "test"},
+	)
+	defer queue.ShutDown()
+
+	c := &controller{queue: queue}
+
+	vpol := &policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-vpol",
+		},
+	}
+
+	c.enqueueVP(vpol)
+
+	assert.Equal(t, 1, queue.Len(), "ValidatingPolicy must be enqueued")
+	item, _ := queue.Get()
+	defer queue.Done(item)
+	assert.Equal(t, "ValidatingPolicy/test-vpol", item, "queue key must have ValidatingPolicy/ prefix")
+}
+
+func TestEnqueueVP_NamespacedValidatingPolicy(t *testing.T) {
+	t.Parallel()
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.DefaultTypedControllerRateLimiter[any](),
+		workqueue.TypedRateLimitingQueueConfig[any]{Name: "test"},
+	)
+	defer queue.ShutDown()
+
+	c := &controller{queue: queue}
+
+	nvpol := &policiesv1beta1.NamespacedValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-nvpol",
+			Namespace: "test-namespace",
+		},
+	}
+
+	c.enqueueVP(nvpol)
+
+	assert.Equal(t, 1, queue.Len(), "NamespacedValidatingPolicy must be enqueued")
+	item, _ := queue.Get()
+	defer queue.Done(item)
+	assert.Equal(t, "NamespacedValidatingPolicy/test-namespace/test-nvpol", item, "queue key must have NamespacedValidatingPolicy/ prefix and namespace/name")
+}
+
+func TestHandlersVP_NamespacedValidatingPolicy(t *testing.T) {
+	t.Parallel()
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.DefaultTypedControllerRateLimiter[any](),
+		workqueue.TypedRateLimitingQueueConfig[any]{Name: "test"},
+	)
+	defer queue.ShutDown()
+
+	c := &controller{queue: queue}
+
+	nvpolOld := &policiesv1beta1.NamespacedValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-nvpol",
+			Namespace: "default",
+		},
+		Spec: policiesv1beta1.ValidatingPolicySpec{
+			Validations: []policiesv1beta1.Validation{
+				{Message: "msg1"},
+			},
+		},
+	}
+	nvpolNew := &policiesv1beta1.NamespacedValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-nvpol",
+			Namespace: "default",
+		},
+		Spec: policiesv1beta1.ValidatingPolicySpec{
+			Validations: []policiesv1beta1.Validation{
+				{Message: "msg2"},
+			},
+		},
+	}
+
+	c.addVP(nvpolOld)
+	assert.Equal(t, 1, queue.Len())
+	item, _ := queue.Get()
+	queue.Done(item)
+	assert.Equal(t, "NamespacedValidatingPolicy/default/test-nvpol", item)
+
+	c.updateVP(nvpolOld, nvpolNew)
+	assert.Equal(t, 1, queue.Len())
+	item, _ = queue.Get()
+	queue.Done(item)
+	assert.Equal(t, "NamespacedValidatingPolicy/default/test-nvpol", item)
+
+	c.deleteVP(nvpolNew)
+	assert.Equal(t, 1, queue.Len())
+	item, _ = queue.Get()
+	queue.Done(item)
+	assert.Equal(t, "NamespacedValidatingPolicy/default/test-nvpol", item)
+}


### PR DESCRIPTION
## Description

This PR resolves #17158 by adding full support for `NamespacedValidatingPolicy` (`nvpol`) resources in the `admissionpolicy-generator` controller (`pkg/controllers/admissionpolicygenerator`).

### Root Cause
When `NamespacedValidatingPolicy` (`nvpol`) was added under `policies.kyverno.io/v1beta1`, `nvpolInformer` was passed to `NewController` and stored in `c.nvpolLister`, but informer event handler registration (`controllerutils.AddEventHandlersT`), reconcile key dispatching, and status updates for `NamespacedValidatingPolicy` were omitted in `admissionpolicygenerator`.

### Key Changes
1. **Informer Event Handler Registration (`controller.go`):** Added `AddEventHandlersT` for `nvpolInformer` in `NewController` to enqueue `NamespacedValidatingPolicy` events.
2. **Event Handling & Enqueuing (`vpol.go`):** Updated `addVP`, `updateVP`, `deleteVP`, and `enqueueVP` to accept `policiesv1beta1.ValidatingPolicyLike`. Enqueues keys with prefix `"NamespacedValidatingPolicy/"` when `GetNamespace()` is non-empty.
3. **Reconciler Dispatch & Status Updates (`controller.go`, `utils.go`, `generate-vap.go`):**
   - Added `getNamespacedValidatingPolicy` lister helper in `utils.go`.
   - Added `NamespacedValidatingPolicy` branch in `reconcile()` to fetch the resource, wrap it with `engineapi.NewNamespacedValidatingPolicy`, and invoke `handleVAPGeneration`.
   - Added `NamespacedValidatingPolicy` status update branch in `updatePolicyStatus()`.
   - Updated VAP name construction for namespaced validating policies (`nvpol-<namespace>-<name>`).
4. **VAP Builder (`pkg/admissionpolicy/builder.go`):** Updated `BuildValidatingAdmissionPolicy` and `BuildValidatingAdmissionPolicyBinding` to use `policy.AsValidatingPolicyLike()` so spec constraints, validations, and binding actions are extracted for both cluster-scoped and namespaced validating policies.
5. **Unit Tests (`vpol_test.go`):** Added unit tests covering event handler functions and key enqueuing logic for `NamespacedValidatingPolicy`.

## Related Issue
Fixes #17158

## Checklist
- [x] Title follows [conventional commit guidelines](https://www.conventionalcommits.org/).
- [x] Code changes are covered by unit tests.
- [x] Commits are signed off (`git commit -s`).
- [x] Generated code and imports verified.
