### PR TITLE
fix(ivpol): reject ImageValidatingPolicy with empty matchConstraints

### DIFF
--- a/pkg/image/verification/evaluator/validate.go
+++ b/pkg/image/verification/evaluator/validate.go
@@ -41,6 +41,11 @@ func Validate(ivpol policiesv1beta1.ImageValidatingPolicyLike, lister corev1list
 		errs = errList
 	}
 
+	spec := ivpol.GetSpec()
+	if spec.MatchConstraints == nil || len(spec.MatchConstraints.ResourceRules) == 0 {
+		errs = append(errs, field.Required(field.NewPath("spec").Child("matchConstraints"), "a matchConstraints with at least one resource rule is required"))
+	}
+
 	if ivpol.GetNamespace() != "" && !toggle.AllowHTTPInNamespacedPolicies.Enabled() {
 		if engine.ExpressionsUseHTTP(ivpolExpressions(ivpol)...) {
 			errs = append(errs, field.Forbidden(field.NewPath("spec"), "http.* is not allowed in namespaced policies; set --allowHTTPInNamespacedPolicies to enable"))

--- a/pkg/image/verification/evaluator/validate_test.go
+++ b/pkg/image/verification/evaluator/validate_test.go
@@ -1,0 +1,105 @@
+package evaluator
+
+import (
+	"testing"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidate_MatchConstraints(t *testing.T) {
+	tests := []struct {
+		name      string
+		ivpol     *policiesv1beta1.ImageValidatingPolicy
+		wantErr   bool
+		wantField string
+		wantMsg   string
+	}{
+		{
+			name: "nil matchConstraints is rejected",
+			ivpol: &policiesv1beta1.ImageValidatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "nil-constraints"},
+				Spec: policiesv1beta1.ImageValidatingPolicySpec{
+					MatchImageReferences: []policiesv1beta1.MatchImageReference{
+						{Glob: "ghcr.io/*"},
+					},
+					Validations: []admissionregistrationv1.Validation{
+						{Expression: "true"},
+					},
+				},
+			},
+			wantErr:   true,
+			wantField: "spec.matchConstraints",
+			wantMsg:   "a matchConstraints with at least one resource rule is required",
+		},
+		{
+			name: "empty resourceRules is rejected",
+			ivpol: &policiesv1beta1.ImageValidatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "empty-rules"},
+				Spec: policiesv1beta1.ImageValidatingPolicySpec{
+					MatchConstraints: &admissionregistrationv1.MatchResources{
+						ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{},
+					},
+					MatchImageReferences: []policiesv1beta1.MatchImageReference{
+						{Glob: "ghcr.io/*"},
+					},
+					Validations: []admissionregistrationv1.Validation{
+						{Expression: "true"},
+					},
+				},
+			},
+			wantErr:   true,
+			wantField: "spec.matchConstraints",
+			wantMsg:   "a matchConstraints with at least one resource rule is required",
+		},
+		{
+			name: "valid matchConstraints is accepted",
+			ivpol: &policiesv1beta1.ImageValidatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid-constraints"},
+				Spec: policiesv1beta1.ImageValidatingPolicySpec{
+					MatchConstraints: &admissionregistrationv1.MatchResources{
+						ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+							{
+								RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+									Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+									Rule: admissionregistrationv1.Rule{
+										APIGroups:   []string{""},
+										APIVersions: []string{"v1"},
+										Resources:   []string{"pods"},
+									},
+								},
+							},
+						},
+					},
+					MatchImageReferences: []policiesv1beta1.MatchImageReference{
+						{Glob: "ghcr.io/*"},
+					},
+					Validations: []admissionregistrationv1.Validation{
+						{Expression: "true"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Validate(tt.ivpol, nil)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantField)
+				assert.Contains(t, err.Error(), tt.wantMsg)
+			} else {
+				// The matchConstraints check should not produce an error.
+				// Other compile errors may still be present, so we only
+				// verify the matchConstraints error is absent.
+				if err != nil {
+					assert.NotContains(t, err.Error(), "matchConstraints")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Explanation

This PR fixes a validation gap where `ImageValidatingPolicy` accepted `spec.matchConstraints` when it was missing or when `resourceRules` was empty.

The other CEL-based policy types (`ValidatingPolicy`, `MutatingPolicy`, `GeneratingPolicy`, and `DeletingPolicy`) already enforce this validation during policy admission. This change brings `ImageValidatingPolicy` into consistency with those policy types and prevents invalid policies from being silently accepted.

## Related issue

Closes #17161

## What type of PR is this

/kind bug

## Proposed Changes

* `pkg/image/verification/evaluator/validate.go`

  * Added validation in `Validate()` requiring `spec.matchConstraints` to contain at least one `resourceRules` entry.
  * Aligns `ImageValidatingPolicy` validation with `ValidatingPolicy`, `MutatingPolicy`, `GeneratingPolicy`, and `DeletingPolicy`.

* `pkg/image/verification/evaluator/validate_test.go`

  * Added table-driven tests covering:

    * Missing `matchConstraints`
    * Empty `resourceRules`
    * Valid `matchConstraints`

### Proof Manifests

#### Invalid Policy

The following policy is rejected after the fix:

```yaml
apiVersion: policies.kyverno.io/v1beta1
kind: ImageValidatingPolicy
metadata:
  name: ivpol-empty-constraints
spec:
  matchConstraints: {}
  matchImageReferences:
    - glob: "ghcr.io/*"
  validationActions: [Deny]
  validations:
    - expression: "true"
      message: "should never match all resources"
```

Expected result:

```text
Error from server: error when creating "policy-invalid.yaml": admission webhook "validate-policy.kyverno.svc" denied the request:
spec.matchConstraints: Required value: a matchConstraints with at least one resource rule is required
```

#### Valid Policy

A policy containing valid resource rules continues to be accepted:

```yaml
apiVersion: policies.kyverno.io/v1beta1
kind: ImageValidatingPolicy
metadata:
  name: ivpol-valid-constraints
spec:
  matchConstraints:
    resourceRules:
      - apiGroups: [""]
        apiVersions: ["v1"]
        resources: ["pods"]
        operations: ["CREATE", "UPDATE"]
  matchImageReferences:
    - glob: "ghcr.io/*"
  validationActions: [Deny]
  validations:
    - expression: "true"
      message: "valid policy"
```

Expected result:

```text
imagevalidatingpolicy.policies.kyverno.io/ivpol-valid-constraints created
```

### Verification

The following checks pass locally:

* `TestValidate_MatchConstraints` — all 3 test cases pass.
* Full `pkg/image/verification/evaluator` test suite — pass.
* `go build ./pkg/image/verification/evaluator/...` — pass.
* `go build ./pkg/webhooks/policy/...` — pass.
* `go build ./cmd/kyverno/...` — pass.
* `go vet` — pass.
* `gofmt` — clean.
* `git diff --check` — clean.

## Checklist

* [x] I have read the [[contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md)](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
* [x] I have read the [[AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md)](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md) and disclosed AI assistance as required.
* [x] I have read the [[PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md)](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the applicable process.
* [x] This is a bug fix and I have added unit tests that prove my fix is effective.
* [ ] This is a feature and I have added CLI tests that are applicable.
* [ ] My PR needs to be cherry picked to a specific release branch.
* [ ] My PR contains new or altered behavior to Kyverno and CLI support should be added.

## Further Comments

No API or CRD changes are required. The change only adds validation to the existing `ImageValidatingPolicy` admission validation path and adds regression coverage.