### PR TITLE
fix(cli): prevent silent failures when loading invalid cluster resources

### DIFF
--- a/pkg/cli/loader/resource_loader.go
+++ b/pkg/cli/loader/resource_loader.go
@@ -78,7 +78,10 @@ func (cl *ClusterLoader) LoadResources(ctx context.Context) (*ResourceResult, er
 		return nil, fmt.Errorf("invalid options: %w", err)
 	}
 
-	tasks := cl.createLoadingTasks()
+	tasks, err := cl.createLoadingTasks()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create loading tasks: %w", err)
+	}
 
 	results, err := cl.executeTasks(ctx, tasks)
 	if err != nil {
@@ -114,18 +117,24 @@ func (cl *ClusterLoader) validateOptions(options ResourceOptions) error {
 	return nil
 }
 
-func (cl *ClusterLoader) createLoadingTasks() []LoadTask {
+func (cl *ClusterLoader) createLoadingTasks() ([]LoadTask, error) {
 	var tasks []LoadTask
 	taskID := 0
 	gvks := cl.resourceOptions.ResourceTypes
 	restMapper, err := utils.GetRESTMapper(cl.client)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("failed to get REST mapper: %w", err)
 	}
 	for _, gvk := range gvks {
 		mapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
-			return nil
+			if cl.resourceOptions.ContinueOnError {
+				if cl.logger != nil {
+					cl.logger.Warnf("failed to map GVK %v: %v", gvk, err)
+				}
+				continue
+			}
+			return nil, fmt.Errorf("failed to map GVK %v: %w", gvk, err)
 		}
 		gvr := mapping.Resource
 		client := cl.client.GetDynamicInterface().Resource(gvr)
@@ -156,7 +165,7 @@ func (cl *ClusterLoader) createLoadingTasks() []LoadTask {
 		taskID++
 	}
 
-	return tasks
+	return tasks, nil
 }
 
 func (cl *ClusterLoader) executeTasks(ctx context.Context, tasks []LoadTask) ([]LoadTaskResult, error) {

--- a/pkg/cli/loader/resource_loader_test.go
+++ b/pkg/cli/loader/resource_loader_test.go
@@ -119,9 +119,42 @@ func TestClusterLoader_Tasks(t *testing.T) {
 			client: client,
 		}
 
-		tasks := loader.createLoadingTasks()
+		tasks, err := loader.createLoadingTasks()
+		assert.NoError(t, err)
 		assert.Len(t, tasks, 1)
 		assert.Equal(t, "test", tasks[0].Namespace)
+	})
+
+	t.Run("mapping failure without continue on error", func(t *testing.T) {
+		client, _ := dclient.NewFakeClient(runtime.NewScheme(), nil)
+		loader := &ClusterLoader{
+			resourceOptions: ResourceOptions{
+				ResourceTypes: []schema.GroupVersionKind{{Kind: "InvalidKind"}},
+				Namespace:     "test",
+			},
+			client: client,
+		}
+
+		tasks, err := loader.createLoadingTasks()
+		assert.Error(t, err)
+		assert.Nil(t, tasks)
+		assert.Contains(t, err.Error(), "failed to map GVK")
+	})
+
+	t.Run("mapping failure with continue on error", func(t *testing.T) {
+		client, _ := dclient.NewFakeClient(runtime.NewScheme(), nil)
+		loader := &ClusterLoader{
+			resourceOptions: ResourceOptions{
+				ResourceTypes:   []schema.GroupVersionKind{{Kind: "InvalidKind"}},
+				Namespace:       "test",
+				ContinueOnError: true,
+			},
+			client: client,
+		}
+
+		tasks, err := loader.createLoadingTasks()
+		assert.NoError(t, err)
+		assert.Empty(t, tasks)
 	})
 }
 


### PR DESCRIPTION
### Context
Fixes #17165. 

Previously, when the `ClusterLoader` encountered an invalid or unknown `GroupVersionKind` inside `createLoadingTasks()`, it swallowed the REST mapping error and silently returned a `nil` task slice. This caused `LoadResources()` to skip processing and exit with a `0` success code, silently dropping the requested resources.

### Changes Made
- Modified `createLoadingTasks()` to return an explicit error `([]LoadTask, error)`.
- Re-wired error handling during GVK-to-GVR REST mapping:
  - If `ContinueOnError` is disabled (default), the mapper error correctly bubbles up.
  - If `ContinueOnError` is enabled, the error is logged as a warning, and we gracefully skip the invalid resource type without breaking the batch.
- Updated `LoadResources()` to capture the propagated error and fail fast.
- Updated `resource_loader_test.go` with two new sub-tests to explicitly validate mapping failures with and without the `ContinueOnError` flag.


### PR Checklist
- [x] I have read and followed the [troubleshooting guide](https://kyverno.io/docs/troubleshooting/).
- [x] I have added necessary unit tests to cover the new execution paths.
- [x] I have run `make imports fmt` (or `go fmt`) locally to ensure the code is styled correctly.
- [x] I have run the relevant `go test` targets locally to ensure everything passes before pushing.
