### PR TITLE
[Bug] Support generateName in resource filter evaluations during admission

### DIFF
--- a/pkg/engine/internal/match.go
+++ b/pkg/engine/internal/match.go
@@ -42,8 +42,11 @@ func MatchPolicyContext(ctx context.Context, logger logr.Logger, client engineap
 func checkResourceFilters(configuration config.Configuration, gvk schema.GroupVersionKind, subresource string, resources ...unstructured.Unstructured) bool {
 	for _, resource := range resources {
 		if resource.Object != nil {
-			// TODO: account for generate name here ?
-			if configuration.ToFilter(gvk, subresource, resource.GetNamespace(), resource.GetName()) {
+			name := resource.GetName()
+			if name == "" {
+				name = resource.GetGenerateName()
+			}
+			if configuration.ToFilter(gvk, subresource, resource.GetNamespace(), name) {
 				return false
 			}
 		}

--- a/pkg/engine/internal/match_test.go
+++ b/pkg/engine/internal/match_test.go
@@ -1,0 +1,91 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/kyverno/kyverno/pkg/config"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type mockConfig struct {
+	config.Configuration
+	toFilter func(kind schema.GroupVersionKind, subresource, namespace, name string) bool
+}
+
+func (m *mockConfig) ToFilter(kind schema.GroupVersionKind, subresource, namespace, name string) bool {
+	return m.toFilter(kind, subresource, namespace, name)
+}
+
+func Test_checkResourceFilters(t *testing.T) {
+	tests := []struct {
+		name          string
+		resource      unstructured.Unstructured
+		filterName    string // the name we expect ToFilter to be called with
+		shouldFilter  bool
+		expectedMatch bool
+	}{
+		{
+			name: "resource with name",
+			resource: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name":      "test-pod",
+						"namespace": "default",
+					},
+				},
+			},
+			filterName:    "test-pod",
+			shouldFilter:  true,
+			expectedMatch: false, // if it filters, it returns false
+		},
+		{
+			name: "resource with generateName",
+			resource: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"generateName": "test-pod-",
+						"namespace":    "default",
+					},
+				},
+			},
+			filterName:    "test-pod-",
+			shouldFilter:  true,
+			expectedMatch: false,
+		},
+		{
+			name: "resource with neither",
+			resource: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"namespace": "default",
+					},
+				},
+			},
+			filterName:    "",
+			shouldFilter:  false,
+			expectedMatch: true,
+		},
+	}
+
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+	subresource := ""
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &mockConfig{
+				toFilter: func(kind schema.GroupVersionKind, sub, namespace, name string) bool {
+					if name != tt.filterName {
+						t.Errorf("expected ToFilter to be called with name %q, got %q", tt.filterName, name)
+					}
+					return tt.shouldFilter
+				},
+			}
+
+			result := checkResourceFilters(cfg, gvk, subresource, tt.resource)
+			if result != tt.expectedMatch {
+				t.Errorf("expected %v, got %v", tt.expectedMatch, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Explanation

This PR addresses a bug where Kyverno's engine fails to evaluate global `resourceFilters` configurations correctly against resources created using `generateName` (such as Pods spawned by ReplicaSets or Jobs). During `CREATE` admission reviews, `resource.GetName()` is empty, causing wildcard resource filters (e.g. `[Pod, *, custom-pod-*]`) to skip bypassing these resources.

This fix updates `checkResourceFilters` to fall back to `resource.GetGenerateName()` when the `name` field is empty, fulfilling the existing `TODO` in the codebase.

## Related issue

Closes #17167

<!--
Add the milestone label by commenting `/milestone 1.2.3`.
-->


## What type of PR is this

/kind bug

## Proposed Changes

- **`pkg/engine/internal/match.go`**: Updated `checkResourceFilters` to evaluate `resource.GetGenerateName()` if `resource.GetName()` evaluates to `""`.
- **`pkg/engine/internal/match_test.go`**: Added comprehensive unit tests targeting `checkResourceFilters` directly for name, generateName, and missing metadata scenarios.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

