### PR TITLE
fix(gpol): preserve DELETE trigger metadata

### DIFF
--- a/pkg/cel/policies/gpol/engine/engine.go
+++ b/pkg/cel/policies/gpol/engine/engine.go
@@ -53,10 +53,11 @@ func (e *engineImpl) Handle(request engine.EngineRequest, policy Policy, cacheRe
 	if err != nil {
 		return response, err
 	}
-	response.Trigger = &object
-	if response.Trigger.Object == nil {
-		response.Trigger = &oldObject
+	trigger := object
+	if trigger.Object == nil {
+		trigger = oldObject
 	}
+	response.Trigger = &trigger
 	// default dry run
 	dryRun := false
 	if request.Request.DryRun != nil {
@@ -67,7 +68,7 @@ func (e *engineImpl) Handle(request engine.EngineRequest, policy Policy, cacheRe
 		&object,
 		&oldObject,
 		schema.GroupVersionKind(request.Request.Kind),
-		object.GetNamespace(),
+		request.Request.Namespace,
 		request.Request.Name,
 		schema.GroupVersionResource(request.Request.Resource),
 		request.Request.SubResource,
@@ -83,7 +84,7 @@ func (e *engineImpl) Handle(request engine.EngineRequest, policy Policy, cacheRe
 	}
 
 	startTime := time.Now()
-	genReresponse := e.generate(context.TODO(), policy, attr, &request.Request, namespace, request.Context, string(object.GetUID()), cacheRestore)
+	genReresponse := e.generate(context.TODO(), policy, attr, &request.Request, namespace, request.Context, string(trigger.GetUID()), cacheRestore)
 	if genReresponse.Result != nil {
 		genReresponse.Result = ptr.To(genReresponse.Result.WithStats(engineapi.NewExecutionStats(startTime, time.Now())))
 	}

--- a/test/integration/gpol/handler_test.go
+++ b/test/integration/gpol/handler_test.go
@@ -12,6 +12,7 @@ import (
 	policiesv1alpha1 "github.com/kyverno/api/api/policies.kyverno.io/v1alpha1"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	"github.com/kyverno/kyverno/pkg/background/common"
 	celengine "github.com/kyverno/kyverno/pkg/cel/engine"
 	gpolengine "github.com/kyverno/kyverno/pkg/cel/policies/gpol/engine"
 	policiesv1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/policies.kyverno.io/v1beta1"
@@ -239,6 +240,60 @@ func TestGenerate_DeleteMatchingDeleteOpFiresGeneration(t *testing.T) {
 	specs := mock.GetSpecs()
 	require.Len(t, specs, 1)
 	assert.False(t, specs[0].RuleContext[0].DeleteDownstream, "should fire generation, not deletion")
+}
+
+func TestEngineHandle_DeleteGenOnDeleteSetsTriggerUIDLabel(t *testing.T) {
+	// On DELETE, request.Object is empty and the deleted resource is in OldObject.
+	// Handle() must still stamp trigger UID/namespace labels from the deleted trigger.
+	policy := &policiesv1beta1.GeneratingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "gen-delete-trigger-labels"},
+		Spec: policiesv1beta1.GeneratingPolicySpec{
+			MatchConstraints: framework.PodMatchRulesWithOps(admissionregistrationv1.Delete),
+			Variables: []admissionregistrationv1.Variable{
+				{
+					Name: "configmap",
+					Expression: `[{
+						"kind": dyn("ConfigMap"),
+						"apiVersion": dyn("v1"),
+						"metadata": dyn({"name": "generated-on-delete-" + request.name})
+					}]`,
+				},
+			},
+			Generation: []policiesv1beta1.Generation{
+				{Expression: `generator.Apply(request.namespace, variables.configmap)`},
+			},
+		},
+	}
+
+	createGpolWithCleanup(t, policy)
+	waitForGpolInLister(t, "gen-delete-trigger-labels")
+
+	processor := framework.NewURProcessor(gpolEngine, gpolProvider, testEnv.ContextProvider)
+	mock := framework.NewProcessingURGenerator(processor)
+	h := gpol.New(mock, gpolLister, ngpolLister, "")
+
+	ctx := framework.ContextWithPolicies(context.Background(), "gen-delete-trigger-labels")
+	resp := h.Generate(ctx, logr.Discard(), framework.PodAdmissionRequestWithOp("del-trigger-pod", "default", admissionv1.Delete, podJSON), "", time.Now())
+	assert.True(t, resp.Allowed)
+
+	require.Eventually(t, func() bool {
+		return len(mock.GetSpecs()) >= 1
+	}, 5*time.Second, 100*time.Millisecond, "UR not processed in time")
+
+	assert.Empty(t, mock.ProcessingErrors(), "processing should succeed without errors")
+
+	cm := &corev1.ConfigMap{}
+	err := testEnv.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: "default",
+		Name:      "generated-on-delete-del-trigger-pod",
+	}, cm)
+	require.NoError(t, err, "generated ConfigMap should exist in envtest")
+	assert.Equal(t, "abc-123", cm.Labels[common.GenerateTriggerUIDLabel])
+	assert.Equal(t, "default", cm.Labels[common.GenerateTriggerNSLabel])
+
+	t.Cleanup(func() {
+		testEnv.Client.Delete(context.Background(), cm)
+	})
 }
 
 func TestGenerate_UpdateWithSyncSetsSynchronize(t *testing.T) {


### PR DESCRIPTION
## Explanation

This PR fixes an issue in GPOL `gen-on-delete` handling where the trigger UID
and namespace can be lost when processing Kubernetes `DELETE` admission
requests.

For a `DELETE` admission request, Kubernetes provides the deleted resource
through `OldObject` while `Object` is empty. GPOL was obtaining the trigger
namespace and UID from `Object`, which can result in generated resources
receiving empty `generate.kyverno.io/trigger-uid` and
`generate.kyverno.io/trigger-namespace` labels.

This change fixes the existing behavior by using the admission request
namespace and the effective trigger object, including `OldObject` for
`DELETE` requests. Existing `CREATE` and `UPDATE` behavior is preserved.

A focused regression test has been added to verify that DELETE-triggered
generation preserves the UID and namespace of the resource that triggered
the generation.

## Related issue

Closes #17175

## Milestone of this PR

No specific release milestone is required for this bug fix.

## Documentation (required for features)

This PR is a bug fix to existing GPOL behavior rather than a new feature.
No separate user documentation change is required.

## What type of PR is this

/kind bug

## Proposed Changes

This PR fixes GPOL trigger metadata handling for Kubernetes `DELETE`
admission requests.

For `CREATE` and `UPDATE` requests, the existing trigger object remains the
source of the trigger UID.

For `DELETE` requests, Kubernetes places the deleted resource in
`OldObject`, while `Object` is empty. The GPOL engine now uses the effective
trigger object so that the deleted resource's UID is preserved.

The admission request namespace is also used when constructing the admission
attributes instead of obtaining the namespace from `Object`.

The resulting behavior is:

| Admission operation | Trigger source | Namespace source |
| --- | --- | --- |
| `CREATE` | `Object` | Admission request |
| `UPDATE` | `Object` | Admission request |
| `DELETE` | `OldObject` | Admission request |

For example, when a resource with UID `abc-123` in namespace `default` is
deleted, a resource generated by a matching GPOL now retains:

```text
generate.kyverno.io/trigger-uid: abc-123
generate.kyverno.io/trigger-namespace: default
```

instead of receiving empty trigger metadata.

### Regression Test

A focused regression test was added in:

`test/integration/gpol/handler_test.go`

The test:

1. Creates a `GeneratingPolicy` matching the `DELETE` operation.
2. Sends a DELETE admission request where `Object` is empty and `OldObject`
   contains the deleted resource.
3. Uses a deleted resource with UID `abc-123` in namespace `default`.
4. Generates a ConfigMap using DELETE-safe request information.
5. Verifies that the generated resource contains the correct trigger
   metadata.

The regression assertions verify:

```text
generate.kyverno.io/trigger-uid: abc-123
generate.kyverno.io/trigger-namespace: default
```

This specifically covers the previously untested DELETE trigger metadata
path.

### Proof Manifests

The regression scenario uses a resource equivalent to:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
  namespace: default
  uid: abc-123
```

The regression test exercises the DELETE admission path and verifies that the
generated resource preserves the deleted resource's trigger UID and
namespace.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the applicable process.
- [x] This is a bug fix and I have added regression test coverage that proves my fix is effective.

## Further Comments

The implementation is intentionally small and limited to the GPOL CEL engine
and its regression test.

No public APIs are changed and no unrelated behavior is modified.

The fix preserves the existing trigger behavior for `CREATE` and `UPDATE`
while correctly handling the `OldObject` trigger source for `DELETE`.

The issue is tracked in #17175.