### PR TITLE
fix(controllers/ttl): fix resController data race and premature loop exit

### DIFF
--- a/pkg/controllers/ttl/manager.go
+++ b/pkg/controllers/ttl/manager.go
@@ -72,6 +72,8 @@ func NewManager(
 
 func (m *manager) Run(ctx context.Context, worker int) {
 	defer func() {
+		m.lock.Lock()
+		defer m.lock.Unlock()
 		// Stop all informers and wait for them to finish
 		for gvr := range m.resController {
 			logger := m.logger.WithValues("gvr", gvr)
@@ -89,7 +91,6 @@ func (m *manager) Run(ctx context.Context, worker int) {
 		case <-ticker.C:
 			if err := m.reconcile(ctx, worker); err != nil {
 				m.logger.Error(err, "reconciliation failed")
-				return
 			}
 		}
 	}
@@ -106,6 +107,8 @@ func (m *manager) getDesiredState() (sets.Set[schema.GroupVersionResource], erro
 }
 
 func (m *manager) getObservedState() (sets.Set[schema.GroupVersionResource], error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
 	observedState := sets.New[schema.GroupVersionResource]()
 	for resource := range m.resController {
 		observedState.Insert(resource)

--- a/pkg/controllers/ttl/manager_test.go
+++ b/pkg/controllers/ttl/manager_test.go
@@ -1,0 +1,50 @@
+package ttl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kyverno/kyverno/pkg/logging"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestManager_getObservedState(t *testing.T) {
+	mgr := &manager{
+		resController: make(map[schema.GroupVersionResource]stopFunc),
+		logger:        logging.WithName(ControllerName),
+	}
+
+	gvr := schema.GroupVersionResource{Group: "testgroup", Version: "v1", Resource: "testresources"}
+	mgr.resController[gvr] = func() {}
+
+	observed, err := mgr.getObservedState()
+	assert.NoError(t, err)
+	assert.True(t, observed.Has(gvr))
+	assert.Equal(t, 1, observed.Len())
+}
+
+func TestManager_Run_Cleanup(t *testing.T) {
+	mgr := &manager{
+		resController: make(map[schema.GroupVersionResource]stopFunc),
+		logger:        logging.WithName(ControllerName),
+		interval:      time.Millisecond * 10,
+	}
+
+	stopCalled := false
+	gvr := schema.GroupVersionResource{Group: "testgroup", Version: "v1", Resource: "testresources"}
+	mgr.resController[gvr] = func() {
+		stopCalled = true
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel the context immediately so Run() exits after checking Done()
+	cancel()
+
+	// This should return immediately because ctx is canceled.
+	// We want to ensure it locks and executes the deferred cleanup.
+	mgr.Run(ctx, 1)
+
+	assert.True(t, stopCalled, "Expected stop function to be called on context cancel")
+}


### PR DESCRIPTION
## Description

This PR resolves a concrete data race and a resilience bug within the TTL controller manager (`pkg/controllers/ttl/manager.go`).

**Changes Made:**
1. **Data Race Fix:** The `m.resController` map was being accessed concurrently without synchronization. `getObservedState()` and the deferred cleanup in `Run()` iterated over the map without a lock, while the OpenTelemetry `report()` callback read the map under `m.lock`. I have added `m.lock.Lock()` and `defer m.lock.Unlock()` to both unprotected iteration blocks.
2. **Permanent TTL Shutdown Fix:** Previously, if `m.reconcile()` encountered a transient error (e.g., discovery failure), the `Run()` goroutine would hit a `return` statement and permanently exit, stopping all TTL cleanup until the pod restarted. I have removed the `return`, allowing the manager to log the error and retry on the next ticker interval.

Fixes #17178

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed all my commits using `git commit -s` (DCO requirement).
- [x] Code passes `make imports-check fmt-check`.
- [x] Local `go test` completes successfully.
- [x] (N/A) Added tests that prove my fix is effective or that my feature works. (Covered by existing TTL controller tests).
- [x] (N/A) Updated [documentation](https://github.com/kyverno/website) if applicable.
